### PR TITLE
feat(in-chat-agents): add textarea fullscreen toggles

### DIFF
--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -92,6 +92,7 @@ import { collectRecentCompanionResults, initCompanionRunner } from './companion/
 import { initCompanionCardUi, updateCompanionButtonVisibility } from './companion/companion-ui.js';
 import { configureCompanionDashboard, initCompanionWandMenuItem, openCompanionDashboard } from './companion/companion-dashboard.js';
 import { configureCompanionPanel, initCompanionPanel, updateCompanionPanelHandleVisibility } from './companion/companion-panel.js';
+import { attachTextareaFullscreen, closeActiveTextareaFullscreen } from './textarea-fullscreen.js';
 
 const MODULE_NAME = 'in-chat-agents';
 const PATHFINDER_EXTENSIONS_HOST_ID = 'extension_settings_in_chat_agents_pathfinder';
@@ -2411,6 +2412,7 @@ async function openRegexScriptEditor(existingScript = null) {
     `);
 
     html.find('#ica--regex-substitute').val(String(regexScript.substituteRegex ?? AGENT_REGEX_SUBSTITUTE.NONE));
+    attachTextareaFullscreen(html);
 
     const result = await new Popup(html, POPUP_TYPE.CONFIRM, '', {
         okButton: 'Save Regex',
@@ -2418,6 +2420,7 @@ async function openRegexScriptEditor(existingScript = null) {
         wide: true,
         large: true,
     }).show();
+    closeActiveTextareaFullscreen();
 
     if (result !== POPUP_RESULT.AFFIRMATIVE) {
         return null;
@@ -2552,6 +2555,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         fullscreenButton.find('i').attr('class', `fa-solid ${editorFullscreen ? 'fa-compress' : 'fa-maximize'}`);
     };
     fullscreenButton.on('click', () => updateEditorFullscreenState(!editorFullscreen));
+    attachTextareaFullscreen(editorEl);
 
     // Injection
     editorEl.find('#ica--editor-position').val(agent.injection.position);
@@ -2990,11 +2994,13 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
                 <textarea id="ica--companion-maker-goal" class="text_pole textarea_compact" rows="8" placeholder="Example: Watch for continuity issues, unresolved promises, location changes, and character state shifts."></textarea>
             </div>
         `);
+        attachTextareaFullscreen(makerForm);
         const makerResult = await new Popup(makerForm, POPUP_TYPE.CONFIRM, '', {
             okButton: 'Generate Companion',
             cancelButton: 'Cancel',
             wide: true,
         }).show();
+        closeActiveTextareaFullscreen();
 
         if (makerResult !== POPUP_RESULT.AFFIRMATIVE) {
             return;
@@ -3198,6 +3204,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         large: true,
     }).show();
 
+    closeActiveTextareaFullscreen();
     document.body.classList.remove('ica--editor-fullscreen-active');
 
     if (result !== POPUP_RESULT.AFFIRMATIVE) return;
@@ -4098,6 +4105,7 @@ function buildTrackerPreviewPopupContent(generatedKit, sampleText, extraInstruct
 
     previewContent.find('.ica--tracker-preview-slot').replaceWith(buildTrackerHtmlPreviewNode(generatedKit, sampleText));
     previewContent.find('#ica--tracker-builder-extra-instructions').val(extraInstructions);
+    attachTextareaFullscreen(previewContent);
 
     return previewContent;
 }
@@ -5000,6 +5008,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     }
 
     $('#in_chat_agents_container').append(settingsHtml);
+    attachTextareaFullscreen($('#ica--settings'));
 
     const savedState = extension_settings.inChatAgents;
     const legacyGroups = Array.isArray(savedState?.groups)

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1008,6 +1008,99 @@ button.ica--card-pill--version-update {
     min-height: min(54vh, 620px);
 }
 
+.ica--textarea-fullscreen-wrapper {
+    position: relative;
+    display: block;
+    width: 100%;
+}
+
+.ica--textarea-fullscreen-wrapper textarea {
+    box-sizing: border-box;
+    padding-right: 42px;
+}
+
+.ica--textarea-fullscreen-toggle {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    z-index: 2;
+    width: 28px;
+    min-width: 28px;
+    height: 28px;
+    min-height: 28px;
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.72;
+}
+
+.ica--textarea-fullscreen-toggle:hover,
+.ica--textarea-fullscreen-wrapper:focus-within .ica--textarea-fullscreen-toggle {
+    opacity: 1;
+}
+
+.ica--textarea-fullscreen-active {
+    overflow: hidden;
+}
+
+.ica--textarea-fullscreen-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10060;
+    background: color-mix(in srgb, var(--SmartThemeShadowColor, #000) 42%, transparent);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+}
+
+.ica--textarea-fullscreen-wrapper textarea.ica--textarea-fullscreen-field {
+    --ica-textarea-fullscreen-top: max(10px, env(safe-area-inset-top, 0px));
+    --ica-textarea-fullscreen-right: max(10px, env(safe-area-inset-right, 0px));
+    --ica-textarea-fullscreen-bottom: max(10px, env(safe-area-inset-bottom, 0px));
+    --ica-textarea-fullscreen-left: max(10px, env(safe-area-inset-left, 0px));
+    position: fixed !important;
+    inset: var(--ica-textarea-fullscreen-top) var(--ica-textarea-fullscreen-right) var(--ica-textarea-fullscreen-bottom) var(--ica-textarea-fullscreen-left);
+    z-index: 10061;
+    width: calc(100vw - var(--ica-textarea-fullscreen-left) - var(--ica-textarea-fullscreen-right));
+    width: calc(100dvw - var(--ica-textarea-fullscreen-left) - var(--ica-textarea-fullscreen-right));
+    height: calc(100vh - var(--ica-textarea-fullscreen-top) - var(--ica-textarea-fullscreen-bottom));
+    height: calc(100dvh - var(--ica-textarea-fullscreen-top) - var(--ica-textarea-fullscreen-bottom));
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    padding: 16px 56px 16px 16px;
+    resize: none;
+    border-radius: 14px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 70%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 96%, var(--SmartThemeChatTintColor, #222) 4%);
+    box-shadow: 0 24px 80px color-mix(in srgb, var(--SmartThemeShadowColor) 42%, transparent);
+    line-height: 1.45;
+}
+
+.ica--textarea-fullscreen-wrapper.is-fullscreen .ica--textarea-fullscreen-toggle {
+    position: fixed;
+    top: calc(max(10px, env(safe-area-inset-top, 0px)) + 10px);
+    right: calc(max(10px, env(safe-area-inset-right, 0px)) + 10px);
+    z-index: 10062;
+    opacity: 1;
+}
+
+@media (max-width: 600px) {
+    .ica--textarea-fullscreen-wrapper textarea.ica--textarea-fullscreen-field {
+        --ica-textarea-fullscreen-top: max(6px, env(safe-area-inset-top, 0px));
+        --ica-textarea-fullscreen-right: max(6px, env(safe-area-inset-right, 0px));
+        --ica-textarea-fullscreen-bottom: max(6px, env(safe-area-inset-bottom, 0px));
+        --ica-textarea-fullscreen-left: max(6px, env(safe-area-inset-left, 0px));
+        padding: 14px 52px 14px 14px;
+        border-radius: 10px;
+        font-size: 16px;
+    }
+
+    .ica--textarea-fullscreen-wrapper.is-fullscreen .ica--textarea-fullscreen-toggle {
+        top: calc(max(6px, env(safe-area-inset-top, 0px)) + 8px);
+        right: calc(max(6px, env(safe-area-inset-right, 0px)) + 8px);
+    }
+}
+
 .ica--prompt-preview pre {
     white-space: pre-wrap;
     word-break: break-word;

--- a/public/scripts/extensions/in-chat-agents/textarea-fullscreen.js
+++ b/public/scripts/extensions/in-chat-agents/textarea-fullscreen.js
@@ -1,0 +1,158 @@
+const BODY_ACTIVE_CLASS = 'ica--textarea-fullscreen-active';
+const FIELD_ACTIVE_CLASS = 'ica--textarea-fullscreen-field';
+const WRAPPER_CLASS = 'ica--textarea-fullscreen-wrapper';
+const WRAPPER_ACTIVE_CLASS = 'is-fullscreen';
+const TOGGLE_CLASS = 'ica--textarea-fullscreen-toggle';
+const BACKDROP_CLASS = 'ica--textarea-fullscreen-backdrop';
+
+let activeController = null;
+
+/**
+ * Adds a per-textarea fullscreen toggle to every textarea found in the target.
+ * @param {HTMLElement|HTMLTextAreaElement|JQuery|Iterable<HTMLElement>} target
+ */
+export function attachTextareaFullscreen(target) {
+    for (const textarea of resolveTextareas(target)) {
+        enhanceTextarea(textarea);
+    }
+}
+
+export function closeActiveTextareaFullscreen() {
+    activeController?.close({ restoreFocus: false });
+}
+
+function resolveTextareas(target) {
+    if (!target) {
+        return [];
+    }
+
+    let roots;
+    if (target.jquery && typeof target.toArray === 'function') {
+        roots = target.toArray();
+    } else if (isIterable(target) && !(target instanceof HTMLElement)) {
+        roots = Array.from(target);
+    } else {
+        roots = [target];
+    }
+
+    return roots.flatMap(root => {
+        if (root instanceof HTMLTextAreaElement) {
+            return [root];
+        }
+
+        if (root instanceof HTMLElement) {
+            return Array.from(root.querySelectorAll('textarea'));
+        }
+
+        return [];
+    });
+}
+
+function isIterable(value) {
+    return Boolean(value && typeof value[Symbol.iterator] === 'function');
+}
+
+function enhanceTextarea(textarea) {
+    if (!(textarea instanceof HTMLTextAreaElement) || textarea.dataset.icaTextareaFullscreen === 'true' || !textarea.parentNode) {
+        return;
+    }
+
+    textarea.dataset.icaTextareaFullscreen = 'true';
+
+    const wrapper = document.createElement('span');
+    wrapper.className = WRAPPER_CLASS;
+    textarea.parentNode.insertBefore(wrapper, textarea);
+    wrapper.append(textarea);
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = `menu_button menu_button_icon ${TOGGLE_CLASS}`;
+    toggle.setAttribute('aria-label', 'Open textarea fullscreen');
+    toggle.setAttribute('aria-pressed', 'false');
+    toggle.title = 'Open textarea fullscreen';
+
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-maximize';
+    toggle.append(icon);
+    wrapper.append(toggle);
+
+    let backdrop = null;
+
+    const controller = {
+        close,
+    };
+
+    toggle.addEventListener('mousedown', event => {
+        event.preventDefault();
+        event.stopPropagation();
+    });
+
+    toggle.addEventListener('click', event => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (activeController === controller) {
+            close();
+            return;
+        }
+
+        open();
+    });
+
+    function open() {
+        if (activeController && activeController !== controller) {
+            activeController.close({ restoreFocus: false });
+        }
+
+        activeController = controller;
+        wrapper.style.minHeight = `${textarea.offsetHeight}px`;
+        wrapper.classList.add(WRAPPER_ACTIVE_CLASS);
+        textarea.classList.add(FIELD_ACTIVE_CLASS);
+        document.body.classList.add(BODY_ACTIVE_CLASS);
+
+        backdrop = document.createElement('div');
+        backdrop.className = BACKDROP_CLASS;
+        backdrop.addEventListener('click', close);
+        document.body.append(backdrop);
+        document.addEventListener('keydown', onKeyDown, true);
+        updateToggleState(true);
+        textarea.focus({ preventScroll: true });
+    }
+
+    function close({ restoreFocus = true } = {}) {
+        if (activeController !== controller) {
+            return;
+        }
+
+        activeController = null;
+        wrapper.style.minHeight = '';
+        wrapper.classList.remove(WRAPPER_ACTIVE_CLASS);
+        textarea.classList.remove(FIELD_ACTIVE_CLASS);
+        document.body.classList.remove(BODY_ACTIVE_CLASS);
+        document.removeEventListener('keydown', onKeyDown, true);
+        backdrop?.remove();
+        backdrop = null;
+        updateToggleState(false);
+
+        if (restoreFocus && textarea.isConnected) {
+            textarea.focus({ preventScroll: true });
+        }
+    }
+
+    function onKeyDown(event) {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        close();
+    }
+
+    function updateToggleState(isFullscreen) {
+        toggle.setAttribute('aria-pressed', String(isFullscreen));
+        toggle.setAttribute('aria-label', isFullscreen ? 'Exit textarea fullscreen' : 'Open textarea fullscreen');
+        toggle.title = isFullscreen ? 'Exit textarea fullscreen' : 'Open textarea fullscreen';
+        icon.className = `fa-solid ${isFullscreen ? 'fa-compress' : 'fa-maximize'}`;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a reusable In-Chat Agents textarea fullscreen helper with floating expand/compress controls.
- Wire the toggle into the agent editor, helper prefill settings, regex editor, companion maker, and tracker regeneration instructions.
- Add mobile-safe fullscreen styling with backdrop, scroll lock, Escape-to-close, and safe-area insets.

## Testing
- node --check public/scripts/extensions/in-chat-agents/index.js
- node --check public/scripts/extensions/in-chat-agents/textarea-fullscreen.js
- npx --yes eslint@8.57.1 --no-eslintrc --env browser,jquery,es2021 --parser-options ecmaVersion:latest --parser-options sourceType:module --rule 'no-unused-vars:["error",{"args":"none"}]' public/scripts/extensions/in-chat-agents/index.js public/scripts/extensions/in-chat-agents/textarea-fullscreen.js
- node scripts/check-frontend-budgets.js

## Notes
- The default local bun run lint is currently blocked by the installed ESLint 10 expecting eslint.config.* while the repo still uses .eslintrc.cjs.