### PR TITLE
fix: bind Custom endpoint status checks to profile secrets

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6952,6 +6952,9 @@ async function getStatusOpen() {
         $('.model_custom_select').empty();
         data.custom_url = oai_settings.custom_url;
         data.custom_include_headers = oai_settings.custom_include_headers;
+        if (selected_custom_endpoint_preset?.secretId) {
+            data.secret_id = selected_custom_endpoint_preset.secretId;
+        }
     }
 
     if (oai_settings.chat_completion_source === chat_completion_sources.AZURE_OPENAI) {

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -199,6 +199,23 @@ describe('OpenAI proxy preset wiring', () => {
         expect(fetchIndex).toBeGreaterThan(secretIdIndex);
     });
 
+    test('sends selected Custom endpoint secret id with status checks', () => {
+        const statusSource = getFunctionSource('getStatusOpen');
+        const customBranchIndex = statusSource.indexOf('if (oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {');
+        const customUrlIndex = statusSource.indexOf('data.custom_url = oai_settings.custom_url;', customBranchIndex);
+        const customHeadersIndex = statusSource.indexOf('data.custom_include_headers = oai_settings.custom_include_headers;', customBranchIndex);
+        const customSecretGuardIndex = statusSource.indexOf('selected_custom_endpoint_preset?.secretId', customBranchIndex);
+        const secretIdIndex = statusSource.indexOf('data.secret_id = selected_custom_endpoint_preset.secretId;', customBranchIndex);
+        const fetchIndex = statusSource.indexOf('const response = await fetch(\'/api/backends/chat-completions/status\', {');
+
+        expect(customBranchIndex).toBeGreaterThanOrEqual(0);
+        expect(customUrlIndex).toBeGreaterThan(customBranchIndex);
+        expect(customHeadersIndex).toBeGreaterThan(customUrlIndex);
+        expect(customSecretGuardIndex).toBeGreaterThan(customHeadersIndex);
+        expect(secretIdIndex).toBeGreaterThan(customSecretGuardIndex);
+        expect(fetchIndex).toBeGreaterThan(secretIdIndex);
+    });
+
     test('loads and persists Custom endpoint profiles with settings', () => {
         expect(scriptSource).toContain('await loadCustomEndpointPresets(settings);');
         expect(scriptSource).toContain('custom_endpoint_presets: custom_endpoint_presets');


### PR DESCRIPTION
## Summary
- Bind Custom backend status/model fetches to the selected endpoint profile secret id.
- Keep model fetching and generation on the same profile-scoped API key.

## Testing
- node --experimental-vm-modules /home/platinum/SillyBunny/tests/node_modules/jest/bin/jest.js --config jest.config.json --runTestsByPath openai-proxy-preset-wiring.test.js