### PR TITLE
fix: backport shell polish and loading-state fixes

### DIFF
--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -652,3 +652,84 @@
 .bg_example[custom="true"] .jg-set-cover {
     display: none !important;
 }
+
+@media screen and (max-width: 768px) {
+    .bg-header-row-1,
+    .bg-header-row-2 {
+        justify-content: center;
+        text-align: center;
+    }
+
+    #bg-filter,
+    #bg-sort,
+    #background_fitting,
+    #auto_background,
+    #bg_add_folder_button,
+    #add_background_button_top {
+        flex: 1 1 100%;
+        width: 100%;
+    }
+
+    #bg_tabs {
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    #bg_tabs .bg_tabs_list {
+        overflow-x: auto;
+        padding-right: 0;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    #bg_tabs .bg_tabs_list::-webkit-scrollbar {
+        display: none;
+    }
+
+    #bg_tabs .bg_tab_panel {
+        padding: 10px 2px 14px;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    #bg_menu_content,
+    #bg_custom_content,
+    .bg_folder_grid.bg_list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        justify-items: stretch;
+        gap: 10px;
+    }
+
+    .bg_example,
+    .bg_folder_tile {
+        width: 100%;
+        max-width: none;
+        border-radius: 12px;
+        min-height: 112px;
+    }
+
+    .bg_example .BGSampleTitle,
+    .bg_folder_tile_overlay {
+        opacity: 1;
+        justify-content: center;
+        text-align: center;
+        padding: 20px 8px 8px;
+        font-size: calc(var(--mainFontSize) * 0.82);
+    }
+
+    .bg_example .jg-menu,
+    .bg_folder_tile .bg_folder_tile_menu {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+        top: 6px;
+        right: 6px;
+    }
+
+    .bg_example .jg-button,
+    .bg_folder_tile .jg-button {
+        width: 36px;
+        height: 36px;
+        padding: 0;
+    }
+}

--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -1,20 +1,42 @@
 #preloader {
     position: fixed;
+    inset: 0;
     margin: 0;
     padding: 0;
-    top: 0;
-    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     z-index: var(--sb-z-loader);
-    width: 100vw;
-    height: 100vh;
-    width: 100dvw;
-    height: 100dvh;
+    width: auto;
+    height: auto;
+    min-width: 100vw;
+    min-height: 100vh;
+    min-height: 100dvh;
+    box-sizing: border-box;
     background-color: var(--SmartThemeBlurTintColor);
     color: var(--SmartThemeBodyColor);
     /*for some reason the full screen blur does not work on iOS*/
     -webkit-backdrop-filter: blur(30px);
     backdrop-filter: blur(30px);
     opacity: 1;
+    overflow: hidden;
+    overscroll-behavior: none;
+}
+
+#loader:not(.splash-screen) {
+    position: relative;
+    width: min(100%, 320px);
+    min-height: 180px;
+    margin: auto;
+    padding: 32px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor) 34%, var(--SmartThemeBorderColor) 66%);
+    border-radius: 24px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 94%, var(--SmartThemeBodyColor) 6%);
+    box-shadow: 0 24px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
 }
 
 #load-spinner {
@@ -62,8 +84,16 @@
     align-items: center;
     justify-content: center;
     gap: 4rem;
-    width: 100%;
-    height: 100%;
+    width: min(100%, 420px);
+    min-height: min(520px, calc(100dvh - 32px));
+    height: auto;
+    margin: auto;
+    padding: 32px 24px;
+    box-sizing: border-box;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor) 34%, var(--SmartThemeBorderColor) 66%);
+    border-radius: 28px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 94%, var(--SmartThemeBodyColor) 6%);
+    box-shadow: 0 24px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
     transition: all var(--sb-transition-slow);
 }
 

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -619,7 +619,14 @@
 
     #bg_menu_content,
     #bg_custom_content {
-        grid-template-columns: repeat(var(--bg-thumb-columns, 3), 1fr);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        justify-items: stretch;
+    }
+
+    #bg_menu_content .bg_example,
+    #bg_custom_content .bg_example {
+        width: 100%;
+        max-width: none;
     }
 
     .bg_folder_grid {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1647,7 +1647,9 @@
 
     #sb-mobile-nav.sb-nav-open[aria-hidden='false'] {
         opacity: 1;
-        display: block;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
         visibility: visible;
         pointer-events: auto;
         z-index: var(--sb-z-modal);
@@ -1706,9 +1708,9 @@
     #sb-mobile-nav-content {
         position: relative;
         isolation: isolate;
-        width: min(100%, 620px);
-        max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 32px);
-        margin: 0 auto;
+        width: min(100%, 560px);
+        max-height: calc(100dvh - var(--sb-topbar-layout-offset) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) - 16px);
+        margin: 0 auto auto;
         padding: 14px;
         display: flex;
         flex-direction: column;
@@ -1718,6 +1720,28 @@
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
         background: transparent;
         box-shadow: 0 24px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
+        transform: translateY(10px);
+        transition: transform var(--sb-transition-fast);
+    }
+
+    :root[data-sb-mobile-quick-actions-placement='middle'] #sb-mobile-nav.sb-nav-open[aria-hidden='false'] {
+        align-items: center;
+    }
+
+    :root[data-sb-mobile-quick-actions-placement='bottom'] #sb-mobile-nav.sb-nav-open[aria-hidden='false'] {
+        align-items: flex-end;
+    }
+
+    :root[data-sb-mobile-quick-actions-placement='middle'] #sb-mobile-nav-content {
+        margin: auto;
+    }
+
+    :root[data-sb-mobile-quick-actions-placement='bottom'] #sb-mobile-nav-content {
+        margin: auto auto 0;
+    }
+
+    #sb-mobile-nav.sb-nav-open[aria-hidden='false'] #sb-mobile-nav-content {
+        transform: translateY(0);
     }
 
     #sb-mobile-nav-content::before {
@@ -2638,11 +2662,11 @@
     #right-nav-panel.openDrawer,
     #top-settings-holder #right-nav-panel.openDrawer,
     :root[data-sb-character-drawer-lock='right'] #right-nav-panel.openDrawer {
-        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
-        bottom: auto !important;
-        box-sizing: border-box !important;
-        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px));
+        bottom: auto;
+        box-sizing: border-box;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px));
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px));
     }
 }
 

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2695,6 +2695,21 @@
         --sb-message-icon-size: clamp(24px, calc(var(--bottomFormBlockSize, 44px) * 0.56), 30px);
     }
 
+    #left-nav-panel.openDrawer,
+    #user-settings-block.openDrawer,
+    .sb-shell-root.openDrawer,
+    .sb-shell-root.fillLeft.openDrawer,
+    .sb-shell-root.fillRight.openDrawer,
+    #right-nav-panel.openDrawer,
+    #top-settings-holder #right-nav-panel.openDrawer,
+    :root[data-sb-character-drawer-lock='right'] #right-nav-panel.openDrawer {
+        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
+        bottom: auto !important;
+        box-sizing: border-box !important;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px)) !important;
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px)) !important;
+    }
+
     :root[data-sb-compact-mode='true'] {
         --sb-topbar-primary-height-base: 32px;
         --sb-topbar-padding-x-base: 5px;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -3500,7 +3500,7 @@ input[type='range']::-moz-range-thumb {
 
     @media screen and (max-width: 420px) {
         .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) {
-            display: grid !important;
+            display: grid;
             grid-template-columns: minmax(0, 1fr) minmax(42px, auto);
             align-items: center;
             gap: 6px;
@@ -3520,7 +3520,7 @@ input[type='range']::-moz-range-thumb {
             width: 100%;
             max-width: none;
             min-width: 0;
-            margin: 0 !important;
+            margin: 0;
         }
 
         .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > .neo-range-input {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1001,6 +1001,25 @@ h3:not(.popup h3):not(#chat h3) {
     transition: color var(--sb-transition-fast), opacity var(--sb-transition-fast);
 }
 
+.inline-drawer-toggle,
+.inline-drawer-header {
+    align-items: center;
+}
+
+@media (pointer: coarse), screen and (max-width: 768px) {
+    .inline-drawer-header {
+        align-items: center;
+    }
+
+    .inline-drawer-icon {
+        border-radius: 12px;
+    }
+
+    .inline-drawer-icon > :is(.fa, .fa-solid, .fa-regular, .fa-brands, i) {
+        font-size: clamp(14px, calc(var(--mainFontSize) * 1.05), 18px);
+    }
+}
+
 .text_pole,
 textarea.text_pole,
 select.text_pole,
@@ -3210,7 +3229,7 @@ input[type='range']::-moz-range-thumb {
 
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) {
         display: grid;
-        grid-template-columns: minmax(92px, 0.34fr) minmax(52px, auto);
+        grid-template-columns: minmax(92px, 0.34fr) minmax(0, 1fr) minmax(52px, auto);
         align-items: center;
         gap: 8px;
         margin: 0;
@@ -3226,6 +3245,7 @@ input[type='range']::-moz-range-thumb {
     }
 
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) > .wide100p {
+        grid-column: 3;
         width: auto;
         justify-content: flex-end;
     }
@@ -3283,7 +3303,7 @@ input[type='range']::-moz-range-thumb {
     ) > .flex-container.flexFlowRow > div:has(> input[type='range'].neo-range-slider),
     .sb-sampling-multi-card > #contrastiveSearchBlock > .alignitemscenter:has(> input[type='range'].neo-range-slider),
     #left-nav-panel.openDrawer :is(#amount_gen_block, #max_context_block) {
-        grid-template-columns: minmax(72px, 0.32fr) minmax(0, 1fr) minmax(46px, auto);
+        grid-template-columns: minmax(58px, 0.24fr) minmax(0, 1fr) minmax(42px, auto);
         gap: 6px;
     }
 
@@ -3294,22 +3314,22 @@ input[type='range']::-moz-range-thumb {
     }
 
     .sb-sampling-control-card > .range-block:has(> .range-block-range-and-counter) {
-        grid-template-columns: minmax(76px, 0.34fr) minmax(0, 1fr);
+        grid-template-columns: minmax(62px, 0.28fr) minmax(0, 1fr) minmax(42px, auto);
     }
 
     .sb-sampling-control-card > .range-block:has(> .range-block-range-and-counter) > .range-block-range-and-counter {
-        grid-template-columns: minmax(0, 1fr) minmax(44px, auto);
+        grid-template-columns: minmax(0, 1fr) minmax(42px, auto);
         gap: 6px;
     }
 
     .sb-sampling-control-card > .range-block:has(> .range-block-range-and-counter) .neo-range-input {
-        width: 46px;
-        min-width: 46px;
+        width: 42px;
+        min-width: 42px;
         padding-inline: 4px;
     }
 
     .sb-sampling-control-card > #cfg_block_ooba > .alignitemscenter {
-        grid-template-columns: minmax(72px, 0.32fr) minmax(0, 1fr) minmax(46px, auto);
+        grid-template-columns: minmax(58px, 0.24fr) minmax(0, 1fr) minmax(42px, auto);
     }
 
     .sb-sampling-control-card > #cfg_block_ooba > .alignitemscenter > small {
@@ -3336,23 +3356,77 @@ input[type='range']::-moz-range-thumb {
     ) > .flex-container.flexFlowRow > div:has(> input[type='range'].neo-range-slider) > .neo-range-input,
     .sb-sampling-multi-card > #contrastiveSearchBlock > .alignitemscenter:has(> input[type='range'].neo-range-slider) > .neo-range-input,
     #left-nav-panel.openDrawer :is(#amount_gen_block, #max_context_block) > .wide100p > .neo-range-input {
-        width: 46px;
-        min-width: 46px;
+        width: 42px;
+        min-width: 42px;
         padding-inline: 4px;
     }
 
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) {
-        grid-template-columns: minmax(72px, 0.32fr) minmax(0, 1fr);
+        grid-template-columns: minmax(62px, 0.28fr) minmax(0, 1fr);
     }
 
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) {
-        grid-template-columns: minmax(72px, 0.32fr) minmax(46px, auto);
+        grid-template-columns: minmax(62px, 0.28fr) minmax(42px, auto);
+    }
+}
+
+@media screen and (max-width: 420px) {
+    .sb-sampling-control-card > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider),
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers]:has(> input[type='range'].neo-range-slider),
+    .sb-sampling-multi-card > :is(
+        #adaptive_p_block,
+        #smoothingBlock,
+        #xtc_block,
+        #dryBlock,
+        #dynatemp_block_ooba,
+        #mirostat_block_ooba,
+        #beamSearchBlock,
+        #contrastiveSearchBlock
+    ) > .flex-container.flexFlowRow > div:has(> input[type='range'].neo-range-slider),
+    .sb-sampling-multi-card > #contrastiveSearchBlock > .alignitemscenter:has(> input[type='range'].neo-range-slider),
+    #left-nav-panel.openDrawer :is(#amount_gen_block, #max_context_block) {
+        grid-template-columns: minmax(0, 1fr) minmax(42px, auto);
+    }
+
+    .sb-sampling-control-card > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > :is(small, label),
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers]:has(> input[type='range'].neo-range-slider) > :is(small, label),
+    .sb-sampling-multi-card > :is(
+        #adaptive_p_block,
+        #smoothingBlock,
+        #xtc_block,
+        #dryBlock,
+        #dynatemp_block_ooba,
+        #mirostat_block_ooba,
+        #beamSearchBlock,
+        #contrastiveSearchBlock
+    ) > .flex-container.flexFlowRow > div:has(> input[type='range'].neo-range-slider) > :is(small, label),
+    .sb-sampling-multi-card > #contrastiveSearchBlock > .alignitemscenter:has(> input[type='range'].neo-range-slider) > :is(small, label),
+    #left-nav-panel.openDrawer :is(#amount_gen_block, #max_context_block) > small {
+        grid-column: 1 / -1;
+    }
+
+    .sb-sampling-control-card > .range-block:has(> .range-block-range-and-counter),
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) > .range-block-range-and-counter {
+        width: 100%;
+    }
+
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) .neo-range-slider {
+        width: 100%;
+        min-width: 0;
+    }
+
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) {
+        grid-template-columns: minmax(0, 1fr) minmax(42px, auto);
     }
 }
 
 @media (pointer: coarse) and (max-width: 1000px) {
     #left-nav-panel.openDrawer {
-        --sb-mobile-range-label-width: clamp(5.75rem, 30vw, 7.25rem);
+        --sb-mobile-range-label-width: clamp(4.25rem, 24vw, 5.75rem);
         --sb-mobile-range-counter-width: 3.25rem;
         --sb-mobile-range-gap: 10px;
     }
@@ -3387,6 +3461,22 @@ input[type='range']::-moz-range-thumb {
         gap: var(--sb-mobile-range-gap, 10px);
     }
 
+    @media screen and (max-width: 420px) {
+        #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) {
+            grid-template-columns: minmax(0, 1fr);
+        }
+
+        #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) > .range-block-range-and-counter {
+            grid-column: 1 / -1;
+            width: 100%;
+        }
+    }
+
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) > .range-block-title {
+        grid-column: 1 / -1;
+        min-height: auto;
+    }
+
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) {
         grid-template-columns: minmax(var(--sb-mobile-range-label-width, 92px), 0.42fr) minmax(var(--sb-mobile-range-counter-width, 52px), auto);
         gap: var(--sb-mobile-range-gap, 10px);
@@ -3406,6 +3496,39 @@ input[type='range']::-moz-range-thumb {
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) > .range-block-title,
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) > .range-block-title {
         min-height: 32px;
+    }
+
+    @media screen and (max-width: 420px) {
+        .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) {
+            display: grid !important;
+            grid-template-columns: minmax(0, 1fr) minmax(42px, auto);
+            align-items: center;
+            gap: 6px;
+            width: 100%;
+            min-width: 0;
+        }
+
+        .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > :is(small, label) {
+            grid-column: 1 / -1;
+            min-height: auto;
+            min-width: 0;
+            margin: 0;
+            text-align: left;
+        }
+
+        .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > input[type='range'].neo-range-slider {
+            width: 100%;
+            max-width: none;
+            min-width: 0;
+            margin: 0 !important;
+        }
+
+        .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > .neo-range-input {
+            width: 42px;
+            min-width: 42px;
+            margin: 0;
+            padding-inline: 4px;
+        }
     }
 }
 
@@ -5786,15 +5909,17 @@ input[type='range']::-moz-range-thumb {
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_slope']:has(> input[type='range'].neo-range-slider),
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_frequency']:has(> input[type='range'].neo-range-slider),
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_presence']:has(> input[type='range'].neo-range-slider),
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider),
     .sb-sampling-multi-card > #smoothingBlock > .flex-container.flexFlowRow > div:has(> #smoothing_factor_textgenerationwebui),
     .sb-sampling-multi-card > #xtc_block > .flex-container.flexFlowRow > div[data-tg-samplers='xtc_threshold']:has(> input[type='range'].neo-range-slider) {
-        grid-template-columns: minmax(0, 1fr) minmax(46px, auto);
+        grid-template-columns: minmax(0, 1fr) 42px;
         gap: 5px 6px;
     }
 
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_slope']:has(> input[type='range'].neo-range-slider) > :is(small, label),
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_frequency']:has(> input[type='range'].neo-range-slider) > :is(small, label),
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_presence']:has(> input[type='range'].neo-range-slider) > :is(small, label),
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > :is(small, label),
     .sb-sampling-multi-card > #smoothingBlock > .flex-container.flexFlowRow > div:has(> #smoothing_factor_textgenerationwebui) > :is(small, label),
     .sb-sampling-multi-card > #xtc_block > .flex-container.flexFlowRow > div[data-tg-samplers='xtc_threshold']:has(> input[type='range'].neo-range-slider) > :is(small, label) {
         grid-column: 1 / -1;
@@ -5803,17 +5928,24 @@ input[type='range']::-moz-range-thumb {
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_slope']:has(> input[type='range'].neo-range-slider) > input[type='range'].neo-range-slider,
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_frequency']:has(> input[type='range'].neo-range-slider) > input[type='range'].neo-range-slider,
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_presence']:has(> input[type='range'].neo-range-slider) > input[type='range'].neo-range-slider,
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > input[type='range'].neo-range-slider,
     .sb-sampling-multi-card > #smoothingBlock > .flex-container.flexFlowRow > div:has(> #smoothing_factor_textgenerationwebui) > input[type='range'].neo-range-slider,
     .sb-sampling-multi-card > #xtc_block > .flex-container.flexFlowRow > div[data-tg-samplers='xtc_threshold']:has(> input[type='range'].neo-range-slider) > input[type='range'].neo-range-slider {
         grid-column: 1;
+        width: 100%;
+        max-width: none;
     }
 
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_slope']:has(> input[type='range'].neo-range-slider) > .neo-range-input,
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_frequency']:has(> input[type='range'].neo-range-slider) > .neo-range-input,
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers='rep_pen_presence']:has(> input[type='range'].neo-range-slider) > .neo-range-input,
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > .neo-range-input,
     .sb-sampling-multi-card > #smoothingBlock > .flex-container.flexFlowRow > div:has(> #smoothing_factor_textgenerationwebui) > .neo-range-input,
     .sb-sampling-multi-card > #xtc_block > .flex-container.flexFlowRow > div[data-tg-samplers='xtc_threshold']:has(> input[type='range'].neo-range-slider) > .neo-range-input {
         grid-column: 2;
+        width: 42px;
+        min-width: 42px;
+        padding-inline: 4px;
     }
 
     #left-nav-panel.openDrawer #max_context_block {

--- a/public/script.js
+++ b/public/script.js
@@ -15646,8 +15646,7 @@ function doDrawerOpenClick() {
     const targetDrawerID = $(this).attr('data-target');
     const drawer = $(`#${targetDrawerID}`);
     const drawerToggle = drawer.find('.drawer-toggle');
-    const drawerWasOpenAlready = drawerToggle.parent().find('.drawer-content').hasClass('openDrawer');
-    if (drawerWasOpenAlready || drawer.hasClass('resizing')) { return; }
+    if (drawer.hasClass('resizing')) { return; }
     doNavbarIconClick.call(drawerToggle);
 }
 

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -7,6 +7,7 @@
     var failureDismissed = false;
     var lastFailure = null;
     var timeoutId = null;
+    var timeoutWarningShown = false;
     var BOOT_TIMEOUT_MS = 25000;
     var BOOT_TIMEOUT_RETRY_MS = 10000;
     var MAX_BOOT_TIMEOUT_MS = 90000;
@@ -161,12 +162,16 @@
             return;
         }
 
-        if (!lastFailure && isStartupLoaderActive() && getElapsedBootTimeMs() < MAX_BOOT_TIMEOUT_MS) {
+        if (!lastFailure) {
+            if (!timeoutWarningShown && getElapsedBootTimeMs() >= MAX_BOOT_TIMEOUT_MS) {
+                timeoutWarningShown = true;
+                console.warn('SillyBunny startup is still waiting for the loader to finish; no startup error was captured.');
+            }
             scheduleBootTimeout(BOOT_TIMEOUT_RETRY_MS);
             return;
         }
 
-        showFailure(lastFailure || 'Startup timed out before SillyBunny removed the preloader.');
+        showFailure(lastFailure);
     }
 
     function showFailure(details) {

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -8,8 +8,10 @@
     var lastFailure = null;
     var timeoutId = null;
     var timeoutWarningShown = false;
+    var loaderRemovalGraceActive = false;
     var BOOT_TIMEOUT_MS = 25000;
     var BOOT_TIMEOUT_RETRY_MS = 10000;
+    var BOOT_TIMEOUT_LOADER_REMOVAL_GRACE_MS = 2000;
     var MAX_BOOT_TIMEOUT_MS = 90000;
     var bootStartedAt = Date.now();
 
@@ -162,16 +164,27 @@
             return;
         }
 
-        if (!lastFailure) {
+        if (!lastFailure && isStartupLoaderActive()) {
+            loaderRemovalGraceActive = false;
+
             if (!timeoutWarningShown && getElapsedBootTimeMs() >= MAX_BOOT_TIMEOUT_MS) {
                 timeoutWarningShown = true;
                 console.warn('SillyBunny startup is still waiting for the loader to finish; no startup error was captured.');
+                showFailure('Startup timed out before SillyBunny removed the preloader.');
+                return;
             }
+
             scheduleBootTimeout(BOOT_TIMEOUT_RETRY_MS);
             return;
         }
 
-        showFailure(lastFailure);
+        if (!lastFailure && !loaderRemovalGraceActive) {
+            loaderRemovalGraceActive = true;
+            scheduleBootTimeout(BOOT_TIMEOUT_LOADER_REMOVAL_GRACE_MS);
+            return;
+        }
+
+        showFailure(lastFailure || 'Startup timed out after the preloader disappeared before SillyBunny finished booting.');
     }
 
     function showFailure(details) {
@@ -249,6 +262,7 @@
     window.SillyBunnyBootGuard = {
         bootCompleted: function () {
             bootCompleted = true;
+            loaderRemovalGraceActive = false;
             if (timeoutId) {
                 window.clearTimeout(timeoutId);
             }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -54,6 +54,7 @@ const SB_STORAGE_KEYS = Object.freeze({
     mobileNavReplacementTarget: 'sb-mobile-nav-replacement-target',
     mobileQuickActions: 'sb-mobile-quick-actions-v2',
     mobileQuickActionsLegacy: 'sb-mobile-quick-actions',
+    mobileQuickActionsPlacement: 'sb-mobile-quick-actions-placement',
     settingsDrawerAutoClose: 'sb-settings-drawer-auto-close',
     compactMode: 'sb-compact-mode',
     frontendIcon: 'sb-frontend-icon',
@@ -653,6 +654,7 @@ const SB_MOBILE_NAV_CLOSED_ICON = 'fa-compass';
 const SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS = 350;
 const SB_FONT_AWESOME_STYLE_CLASSES = Object.freeze(new Set(['fa-solid', 'fa-regular', 'fa-brands']));
 const SB_MOBILE_NAV_LAYOUTS = Object.freeze(['horizontal', 'vertical']);
+const SB_MOBILE_QUICK_ACTION_PLACEMENTS = Object.freeze(['top', 'middle', 'bottom']);
 const SB_MOBILE_DEFAULT_QUICK_ACTIONS = Object.freeze([
     { type: 'tab', shellKey: 'left', tabId: 'presets', icon: 'fa-sliders', label: 'Presets' },
     { type: 'tab', shellKey: 'left', tabId: 'api', icon: 'fa-plug', label: 'API' },
@@ -753,6 +755,7 @@ const sbState = {
         showQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavShowQuickActions), false),
         replaceQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavReplaceQuickActions), false),
         replacementTarget: normalizeMobileNavReplacementTarget(safeGetItem(SB_STORAGE_KEYS.mobileNavReplacementTarget)),
+        quickActionsPlacement: normalizeMobileQuickActionsPlacement(safeGetItem(SB_STORAGE_KEYS.mobileQuickActionsPlacement)),
     },
     desktopNav: {
         layout: normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.desktopNavLayout)),
@@ -933,6 +936,11 @@ function normalizeStoredBoolean(value, fallback = false) {
 function normalizeMobileNavLayout(value) {
     const normalizedValue = normalizeText(value);
     return SB_MOBILE_NAV_LAYOUTS.includes(normalizedValue) ? normalizedValue : 'horizontal';
+}
+
+function normalizeMobileQuickActionsPlacement(value) {
+    const normalizedValue = normalizeText(value);
+    return SB_MOBILE_QUICK_ACTION_PLACEMENTS.includes(normalizedValue) ? normalizedValue : 'top';
 }
 
 function getNavState(mode) {
@@ -1387,6 +1395,7 @@ function restorePersistedTopbarState() {
     sbState.mobileNav.showQuickActions = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavShowQuickActions), sbState.mobileNav.showQuickActions);
     sbState.mobileNav.replaceQuickActions = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavReplaceQuickActions), sbState.mobileNav.replaceQuickActions);
     sbState.mobileNav.replacementTarget = normalizeMobileNavReplacementTarget(safeGetItem(SB_STORAGE_KEYS.mobileNavReplacementTarget));
+    sbState.mobileNav.quickActionsPlacement = normalizeMobileQuickActionsPlacement(safeGetItem(SB_STORAGE_KEYS.mobileQuickActionsPlacement));
     sbState.desktopNav.layout = normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.desktopNavLayout));
     sbState.desktopNav.iconOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavIconOnly), sbState.desktopNav.iconOnly);
     sbState.desktopNav.showCustomize = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowCustomize), sbState.desktopNav.showCustomize);
@@ -1519,6 +1528,7 @@ function applyMobileNavPreferences() {
     document.documentElement.dataset.sbMobileNavCustomize = sbState.mobileNav.showCustomize ? 'shown' : 'hidden';
     document.documentElement.dataset.sbMobileNavQuickActions = quickActionsShown ? 'shown' : 'hidden';
     document.documentElement.dataset.sbMobileNavReplacement = sbState.mobileNav.replaceQuickActions ? 'shown' : 'hidden';
+    document.documentElement.dataset.sbMobileQuickActionsPlacement = sbState.mobileNav.quickActionsPlacement;
 }
 
 function applyDesktopNavPreferences() {
@@ -1607,6 +1617,18 @@ function setMobileNavReplacementTarget(target, { persist = true } = {}) {
     }
 
     updateMobileNavButtonLabel();
+    updateThemePickerUi();
+}
+
+function setMobileQuickActionsPlacement(placement, { persist = true } = {}) {
+    const nextPlacement = normalizeMobileQuickActionsPlacement(placement);
+    sbState.mobileNav.quickActionsPlacement = nextPlacement;
+    applyMobileNavPreferences();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.mobileQuickActionsPlacement, nextPlacement);
+    }
+
     updateThemePickerUi();
 }
 
@@ -11670,6 +11692,42 @@ function createMobileNavDivider(label = '') {
     return divider;
 }
 
+function createMobileQuickActionsPlacementGroup() {
+    const group = createElement('div', {
+        className: 'sb-mobile-nav-dependent-group sb-mobile-quick-actions-placement-group',
+    });
+    const title = createElement('strong', {
+        className: 'sb-mobile-nav-dependent-title',
+        text: 'Quick Actions Position',
+    });
+    const grid = createElement('div', {
+        className: 'sb-mobile-nav-choice-grid sb-mobile-nav-choice-grid-compact',
+        attrs: {
+            role: 'radiogroup',
+            'aria-label': 'Mobile Quick Actions position',
+        },
+    });
+    const options = [
+        { value: 'top', label: 'Top', icon: 'fa-arrow-up' },
+        { value: 'middle', label: 'Middle', icon: 'fa-arrows-up-down' },
+        { value: 'bottom', label: 'Bottom', icon: 'fa-arrow-down' },
+    ];
+
+    for (const option of options) {
+        grid.appendChild(createMobileNavChoice({
+            id: `sb-mobile-quick-actions-placement-${option.value}`,
+            name: 'sb-mobile-quick-actions-placement',
+            value: option.value,
+            label: option.label,
+            icon: option.icon,
+            onChange: input => setMobileQuickActionsPlacement(input.value),
+        }));
+    }
+
+    group.append(title, grid);
+    return group;
+}
+
 function createNavigationSettingsGroup(mode = 'mobile') {
     const isDesktop = mode === 'desktop';
     const modeTitle = isDesktop ? 'Desktop' : 'Mobile';
@@ -11718,6 +11776,7 @@ function createNavigationSettingsGroup(mode = 'mobile') {
         icon: 'fa-map-location-dot',
         onChange: input => isDesktop ? setDesktopNavReplaceQuickActions(input.checked) : setMobileNavReplaceQuickActions(input.checked),
     });
+    const quickActionsPlacementGroup = isDesktop ? null : createMobileQuickActionsPlacementGroup();
     const replacementField = createElement('label', {
         className: 'sb-mobile-nav-replacement-field',
         attrs: {
@@ -11778,6 +11837,7 @@ function createNavigationSettingsGroup(mode = 'mobile') {
         createMobileNavDivider(),
         showCustomizeChoice,
         showQuickActionsChoice,
+        ...(quickActionsPlacementGroup ? [quickActionsPlacementGroup] : []),
         replaceQuickActionsChoice,
         replacementField,
     );
@@ -12338,10 +12398,31 @@ function updateThemePickerUi() {
         choice?.classList.toggle('is-selected', sbState.mobileNav.replaceQuickActions);
     }
 
+    const quickActionsPlacementGroup = document.querySelector('.sb-mobile-quick-actions-placement-group');
+    quickActionsPlacementGroup?.classList.toggle('is-disabled', !sbState.mobileNav.showQuickActions);
+
+    for (const input of document.querySelectorAll('input[name="sb-mobile-quick-actions-placement"]')) {
+        if (!(input instanceof HTMLInputElement)) {
+            continue;
+        }
+
+        input.disabled = !sbState.mobileNav.showQuickActions;
+    }
+
     if (mobileNavReplacementSelect instanceof HTMLSelectElement) {
         mobileNavReplacementSelect.value = normalizeMobileNavReplacementTarget(sbState.mobileNav.replacementTarget);
         mobileNavReplacementSelect.disabled = !sbState.mobileNav.replaceQuickActions;
         mobileNavReplacementSelect.closest('.sb-mobile-nav-replacement-field')?.classList.toggle('is-disabled', !sbState.mobileNav.replaceQuickActions);
+    }
+
+    for (const input of document.querySelectorAll('input[name="sb-mobile-quick-actions-placement"]')) {
+        if (!(input instanceof HTMLInputElement)) {
+            continue;
+        }
+
+        const isChecked = input.value === sbState.mobileNav.quickActionsPlacement;
+        input.checked = isChecked;
+        input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
     }
 
     for (const button of document.querySelectorAll('[data-sb-message-style]')) {

--- a/tests/openai-custom-favorites.test.js
+++ b/tests/openai-custom-favorites.test.js
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8').replace(/\r\n/g, '\n');
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;

--- a/tests/sillybunny-boot-guard.test.js
+++ b/tests/sillybunny-boot-guard.test.js
@@ -216,6 +216,12 @@ describe('SillyBunny boot guard', () => {
         setNow(36000);
         timers.shift().callback();
 
+        expect(preloader.querySelector('button')).toBeNull();
+        expect(timers[0].delay).toBe(2000);
+
+        setNow(38000);
+        timers.shift().callback();
+
         expect(preloader.querySelector('button').textContent).toBe('Clear frontend cache and reload');
     });
 


### PR DESCRIPTION
## What?
Backport the newest validated mobile shell QOL batch onto `staging`.

This backport includes:
- toggle-close behavior for the mobile top-bar drawers
- configurable mobile Quick Actions placement (`top`, `middle`, `bottom`)
- the cleaner two-column mobile background selector with centered labels/actions
- the startup guard fix that suppresses false load-failure dialogs on hard refresh
- loader framing, viewport coverage, expando alignment, and mobile sampling layout polish

## Why?
`staging` still benefits from these mobile fixes, but it does not need the entire `mobile-refactor` branch to pick them up. This PR keeps the runtime branch safer by carrying only the newest validated QOL slice.

## How?
- Cherry-picked `8fb9d1ba0` from `TLD/mobile-refactor` onto a fresh `origin/staging` worktree.
- Resolved the single conflict in `public/css/sillybunny-mobile-shell.css` by keeping the validated mobile nav/safe-area adjustments while preserving the surrounding `staging` branch context.

## Testing?
- `node --check public\scripts\sillybunny-tabs.js`
- `node --check public\scripts\sillybunny-boot-guard.js`
- `node --check public\script.js`
- `bun run build:frontend`
- Source commit behavior was validated locally with Playwright at `390x844` and a separate touch/mobile context before the backport

## Screenshots (optional)
Not attached. Validation used local Playwright checks rather than exported screenshot assets.

## Anything Else?
This is the staging-safe subset only. It does not reopen the older closed staging port PR and does not attempt to carry the full `mobile-refactor` branch.
