### PR TITLE
chore: streamline PR workflow runs

### DIFF
--- a/.github/workflows/pr-auto-manager.yml
+++ b/.github/workflows/pr-auto-manager.yml
@@ -10,6 +10,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: pr-auto-manager-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   label-by-size:
     name: 🏷️ Label PR by Size

--- a/.github/workflows/pr-check-merge-conflicts.yaml
+++ b/.github/workflows/pr-check-merge-conflicts.yaml
@@ -12,6 +12,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: pr-merge-conflicts-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   check-merge-conflicts:
     name: ⚔️ Check Merge Conflicts

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,40 +2,20 @@ name: ✅ Pull Request Checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
 
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  validate-pr-metadata:
-    name: ✅ Validate PR Metadata
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Validate target branch
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          if [ "$BASE_REF" != "staging" ] && [ "$BASE_REF" != "TLD/mobile-refactor" ]; then
-            echo "Pull requests must target staging or TLD/mobile-refactor. Current target: $BASE_REF"
-            exit 1
-          fi
-
-      - name: Validate PR title prefix
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if ! grep -Eq '^(fix|chore|feat|sync|docs)(\([^)]+\))?!?:[[:space:]].+' <<< "$PR_TITLE"; then
-            echo "PR title must start with one of: fix:, chore:, feat:, sync:, docs:"
-            echo "Current title: $PR_TITLE"
-            exit 1
-          fi
-
   block-default-user-state:
     name: ✅ Block tracked default-user state
     runs-on: ubuntu-latest
-    if: always() && github.event.action != 'edited'
+    if: always()
 
     steps:
       - name: Checkout Repository
@@ -56,8 +36,7 @@ jobs:
   run-eslint:
     name: ✅ Check ESLint on PR
     runs-on: ubuntu-latest
-    # Only needs to run when code is changed
-    if: always() && github.event.action != 'edited'
+    if: always()
 
     steps:
       - name: Checkout Repository
@@ -84,8 +63,7 @@ jobs:
   run-tests:
     name: ✅ Run Unit Tests on PR
     runs-on: ubuntu-latest
-    # Only needs to run when code is changed
-    if: always() && github.event.action != 'edited'
+    if: always()
 
     steps:
       - name: Checkout Repository
@@ -115,7 +93,7 @@ jobs:
   frontend-budgets:
     name: ✅ Check Frontend Assets
     runs-on: ubuntu-latest
-    if: always() && github.event.action != 'edited'
+    if: always()
 
     steps:
       - name: Checkout Repository
@@ -141,7 +119,7 @@ jobs:
   run-bun-checks:
     name: ✅ Check Bun Runtime
     runs-on: ubuntu-latest
-    if: always() && github.event.action != 'edited'
+    if: always()
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,37 @@
+name: 🧾 PR Metadata
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-metadata-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pr-metadata:
+    name: ✅ Validate PR Metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate target branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ "$BASE_REF" != "staging" ] && [ "$BASE_REF" != "TLD/mobile-refactor" ]; then
+            echo "Pull requests must target staging or TLD/mobile-refactor. Current target: $BASE_REF"
+            exit 1
+          fi
+
+      - name: Validate PR title prefix
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if ! grep -Eq '^(fix|chore|feat|sync|docs)(\([^)]+\))?!?:[[:space:]].+' <<< "$PR_TITLE"; then
+            echo "PR title must start with one of: fix:, chore:, feat:, sync:, docs:"
+            echo "Current title: $PR_TITLE"
+            exit 1
+          fi


### PR DESCRIPTION
## What?
Improve PR workflow behavior so metadata-only edits do not rerun heavy code checks, and stale workflow runs cancel more reliably.

This change:
- adds a dedicated PR metadata workflow
- keeps heavy PR checks on code-change events only
- adds concurrency cancellation to key PR workflows

## Why?
Current PR automation can leave confusing stale runs on the same PR, especially after title edits or quick successive pushes. Metadata validation is cheap and should react to title edits; lint/test/build jobs are slower and should not.

## How?
- Added `.github/workflows/pr-metadata.yml` for branch-target and PR-title validation.
- Removed metadata validation from `.github/workflows/pr-checks.yml`.
- Narrowed `pr-checks.yml` triggers from `opened,synchronize,reopened,edited` to `opened,synchronize,reopened`.
- Added workflow-level `concurrency` blocks to:
  - `.github/workflows/pr-checks.yml`
  - `.github/workflows/pr-auto-manager.yml`
  - `.github/workflows/pr-check-merge-conflicts.yaml`

## Testing?
- Parsed modified workflow YAML files locally with `yaml` parser from repo deps.
- Ran `git diff --check`.
- Reviewed workflow diff for trigger, permission, and concurrency scope.

## Screenshots (optional)
None.

## Anything Else?
This stays intentionally small. It does not redesign the full CI stack.
