### PR TITLE
feat: Conversation mode & general UI polish

### DIFF
--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1995,6 +1995,91 @@
 }
 
 /* Style Add DM picker popover options */
+.sb-conversation-add-dm-title {
+    display: block;
+    font-size: var(--sb-type-meta);
+    font-weight: var(--sb-weight-title);
+}
+
+.sb-conversation-add-dm-description {
+    margin-top: 4px;
+}
+
+.sb-conversation-add-dm-search {
+    inline-size: 100%;
+    margin-top: 8px;
+}
+
+.sb-conversation-group-list {
+    margin-top: 8px;
+    max-block-size: 220px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sb-conversation-group-picker-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-top: 10px;
+    min-inline-size: 0;
+}
+
+.sb-conversation-group-selected-count {
+    min-inline-size: 0;
+    flex: 1 1 auto;
+}
+
+.sb-conversation-group-picker-buttons {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-inline-size: 0;
+    max-inline-size: 100%;
+}
+
+.sb-conversation-group-picker-buttons > .menu_button {
+    min-inline-size: 0;
+    max-inline-size: 100%;
+    white-space: nowrap;
+}
+
+.sb-conversation-group-member-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    inline-size: 100%;
+    padding: 6px;
+    border-radius: var(--sb-radius-sm);
+    text-align: left;
+    cursor: pointer;
+    color: inherit;
+    background: none;
+    border: none;
+}
+
+.sb-conversation-group-member-avatar {
+    inline-size: 24px;
+    block-size: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.sb-conversation-group-member-name {
+    font-size: var(--sb-type-caption);
+}
+
+.sb-conversation-group-empty {
+    padding: 8px;
+    font-size: var(--sb-type-meta);
+    opacity: 0.7;
+}
+
 .sb-conversation-add-dm-option {
     transition: background-color 160ms ease-out, border-color 160ms ease-out;
 }
@@ -2069,6 +2154,22 @@
     border-color: color-mix(in srgb, var(--sb-color-danger) 60%, var(--sb-shell-border));
     background: color-mix(in srgb, var(--sb-color-danger) 18%, transparent);
     outline: none;
+}
+
+@media (max-width: 700px) {
+    .sb-conversation-group-picker-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .sb-conversation-group-picker-buttons {
+        inline-size: 100%;
+        justify-content: stretch;
+    }
+
+    .sb-conversation-group-picker-buttons > .menu_button {
+        flex: 1 1 0;
+    }
 }
 
 @media (min-width: 769px) {
@@ -2541,7 +2642,7 @@
 }
 
 /* Notification badges */
-#sb_character_tab_conversation {
+#sb_character_mode_toggle [data-sb-character-mode='conversation'] {
     position: relative;
 }
 .sb-tab-notification-badge {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1925,7 +1925,9 @@
     #right-nav-panel.openDrawer > .sb-character-shell-header {
         flex: 0 0 auto;
         gap: 3px;
-        padding: 10px 52px 8px 12px;
+        padding: 10px 104px 8px 12px;
+        min-height: 60px;
+        z-index: 3;
     }
 
     #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-close {
@@ -1935,6 +1937,27 @@
         min-width: var(--sb-mobile-touch-target, 44px);
         height: var(--sb-mobile-touch-target, 44px);
         min-height: var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-character-shell-mode-toggle {
+        top: 8px;
+        right: 56px;
+        min-height: var(--sb-mobile-touch-target, 44px);
+        padding: 3px;
+        gap: 2px;
+        z-index: 2;
+        pointer-events: auto;
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-character-shell-mode-button {
+        min-width: 36px;
+        min-height: 36px;
+        padding: 8px;
+        pointer-events: auto;
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-character-shell-mode-button .fa-solid {
+        width: 14px;
     }
 
     #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-kicker {
@@ -1957,6 +1980,8 @@
         padding: 7px var(--sb-shell-panel-padding-inline);
         border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 76%, transparent);
         box-sizing: border-box;
+        position: relative;
+        z-index: 1;
     }
 
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1913,7 +1913,7 @@ body.sb-shell-resizing * {
 
 #right-nav-panel.openDrawer > .sb-character-shell-header {
     gap: 4px;
-    padding: 8px calc(var(--sb-shell-panel-padding-inline) + 52px) 10px var(--sb-shell-panel-padding-inline);
+    padding: 8px calc(var(--sb-shell-panel-padding-inline) + 204px) 10px var(--sb-shell-panel-padding-inline);
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-kicker {
@@ -1927,13 +1927,137 @@ body.sb-shell-resizing * {
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-subtitle {
-    max-width: min(62ch, 100%);
     font-size: var(--sb-type-control);
     line-height: 1.36;
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-description {
     display: none;
+}
+
+.sb-shell-root-left .sb-shell-main > .sb-shell-header,
+.sb-shell-root-right .sb-shell-main > .sb-shell-header {
+    gap: 4px;
+    padding: 8px var(--sb-shell-panel-padding-inline) 10px;
+}
+
+.sb-shell-root-left .sb-shell-main > .sb-shell-header .sb-shell-kicker,
+.sb-shell-root-right .sb-shell-main > .sb-shell-header .sb-shell-kicker {
+    font-size: var(--sb-type-caption);
+    letter-spacing: var(--sb-tracking-label);
+}
+
+.sb-shell-root-left .sb-shell-main > .sb-shell-header .sb-shell-title,
+.sb-shell-root-right .sb-shell-main > .sb-shell-header .sb-shell-title {
+    font-size: calc(var(--mainFontSize) * 1.12);
+    line-height: 1.15;
+}
+
+.sb-shell-root-left .sb-shell-main > .sb-shell-header .sb-shell-subtitle,
+.sb-shell-root-right .sb-shell-main > .sb-shell-header .sb-shell-subtitle {
+    font-size: var(--sb-type-control);
+    line-height: 1.36;
+}
+
+.sb-shell-header .sb-shell-subtitle {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.sb-shell-root-left .sb-shell-main > .sb-shell-header .sb-shell-description,
+.sb-shell-root-right .sb-shell-main > .sb-shell-header .sb-shell-description {
+    display: none;
+}
+
+.sb-character-shell-mode-toggle {
+    position: absolute;
+    top: 18px;
+    right: 66px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 40px;
+    padding: 3px;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
+    border-radius: 999px;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-surface) 96%, rgba(255, 255, 255, 0.04)), color-mix(in srgb, var(--sb-shell-surface) 84%, transparent));
+    box-shadow: 0 12px 28px color-mix(in srgb, #000 18%, transparent), inset 0 1px 0 color-mix(in srgb, #fff 10%, transparent);
+    z-index: 1;
+}
+
+.sb-character-shell-mode-button {
+    border: 0;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: transparent;
+    color: var(--sb-shell-text-secondary);
+    font-size: var(--sb-type-meta);
+    font-weight: 700;
+    line-height: 1;
+    min-height: 32px;
+    padding: 8px 13px;
+    transition: background var(--sb-transition-fast), color var(--sb-transition-fast), box-shadow var(--sb-transition-fast), transform var(--sb-transition-fast), opacity var(--sb-transition-fast);
+    opacity: 0.72;
+}
+
+.sb-character-shell-mode-button .fa-solid {
+    font-size: 13px;
+    width: 14px;
+    text-align: center;
+}
+
+.sb-character-shell-mode-button:hover,
+.sb-character-shell-mode-button:focus-visible {
+    background: color-mix(in srgb, var(--sb-shell-surface) 70%, transparent);
+    color: var(--sb-shell-text);
+    opacity: 0.92;
+}
+
+.sb-character-shell-mode-button.is-active {
+    opacity: 1;
+    color: var(--sb-shell-text);
+    transform: translateY(-0.5px);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--sb-accent) 34%, var(--sb-shell-surface)), color-mix(in srgb, var(--sb-accent) 20%, var(--sb-shell-surface)));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sb-accent) 50%, transparent), 0 6px 14px color-mix(in srgb, var(--sb-accent) 18%, transparent);
+}
+
+.sb-character-shell-mode-toggle[data-active-mode='roleplay'] .sb-character-shell-mode-button[data-sb-character-mode='conversation'],
+.sb-character-shell-mode-toggle[data-active-mode='conversation'] .sb-character-shell-mode-button[data-sb-character-mode='roleplay'] {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sb-shell-border) 62%, transparent);
+}
+
+@media (max-width: 900px) {
+    #right-nav-panel.openDrawer > .sb-character-shell-header {
+        padding-right: calc(var(--sb-shell-panel-padding-inline) + 118px);
+    }
+
+    .sb-character-shell-mode-toggle {
+        top: 17px;
+        right: 66px;
+        min-height: 40px;
+        gap: 3px;
+        padding: 2px;
+    }
+
+    .sb-character-shell-mode-button {
+        min-width: 34px;
+        min-height: 34px;
+        padding: 9px;
+        justify-content: center;
+    }
+
+    .sb-character-shell-mode-button span {
+        display: none;
+    }
+
+    .sb-character-shell-mode-button .fa-solid {
+        width: auto;
+    }
 }
 
 .sb-shell-header.sb-shell-header-collapsed {
@@ -2521,7 +2645,6 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     font-size: var(--sb-type-control);
     line-height: var(--sb-line-body);
     opacity: 0.9;
-    max-width: 68ch;
 }
 
 .sb-shell-description {

--- a/public/index.html
+++ b/public/index.html
@@ -6473,10 +6473,6 @@
                             <i class="fa-solid fa-users" aria-hidden="true"></i>
                             <span class="sb-shell-tab-copy"><strong data-i18n="Groups">Groups</strong></span>
                         </button>
-                        <button id="sb_character_tab_conversation" class="sb-shell-tab" type="button" role="tab" aria-selected="false" aria-controls="sb_character_conversation_panel" data-sb-character-tab="conversation">
-                            <i class="fa-solid fa-comments" aria-hidden="true"></i>
-                            <span class="sb-shell-tab-copy"><strong data-i18n="Conversation">Conversation</strong></span>
-                        </button>
                         <button id="sb_character_tab_editor" class="sb-shell-tab" type="button" role="tab" aria-selected="false" data-sb-character-tab="editor">
                             <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
                             <span class="sb-shell-tab-copy"><strong data-i18n="Editor">Editor</strong></span>
@@ -6499,9 +6495,19 @@
                     <button id="sb_character_shell_close" class="sb-shell-close" type="button" title="Close Characters" aria-label="Close Characters">
                         <i class="fa-solid fa-xmark" aria-hidden="true"></i>
                     </button>
+                    <div id="sb_character_mode_toggle" class="sb-character-shell-mode-toggle" role="radiogroup" aria-label="Chat mode">
+                        <button type="button" class="sb-character-shell-mode-button is-active" data-sb-character-mode="roleplay" role="radio" aria-checked="true">
+                            <i class="fa-solid fa-masks-theater" aria-hidden="true"></i>
+                            <span>Roleplay</span>
+                        </button>
+                        <button type="button" class="sb-character-shell-mode-button" data-sb-character-mode="conversation" role="radio" aria-checked="false">
+                            <i class="fa-solid fa-comments" aria-hidden="true"></i>
+                            <span>Conversation</span>
+                        </button>
+                    </div>
                     <div class="sb-shell-kicker" data-i18n="Characters">Characters</div>
                     <h2 class="sb-shell-title" tabindex="-1" data-i18n="Character Menu">Character Menu</h2>
-                    <p class="sb-shell-subtitle" data-i18n="Browse, create, and tune the cast for your chats from one place.">Browse, create, and tune the cast for your chats from one place.</p>
+                    <p class="sb-shell-subtitle" data-i18n="View or create character cards here for your roleplays and chats!">View or create character cards here for your roleplays and chats!</p>
                     <p class="sb-shell-description" data-i18n="Move between characters, groups, personas, lore, and imports without leaving the writing workspace.">Move between characters, groups, personas, lore, and imports without leaving the writing workspace.</p>
                 </div>
                 <div id="CharListButtonAndHotSwaps" class="flex-container flexnowrap">
@@ -6582,8 +6588,8 @@
                     <div id="sb_character_editor_empty" class="sb-character-editor-empty" hidden>
                         <div class="sb-character-editor-empty-icon fa-solid fa-address-card" aria-hidden="true"></div>
                         <div class="sb-character-editor-empty-copy">
-                            <h3 data-i18n="Choose a character to edit">Choose a character to edit</h3>
-                            <p data-i18n="Pick someone from your cast, or start a fresh card with the editor defaults.">Pick someone from your cast, or start a fresh card with the editor defaults.</p>
+                            <h3 data-i18n="No character selected">No character selected</h3>
+                            <p data-i18n="Please pick a character card from the character menu, or create a new character.">Please pick a character card from the character menu, or create a new character.</p>
                         </div>
                         <div class="sb-character-editor-empty-actions">
                             <button id="sb_character_empty_browse" class="menu_button menu_button_icon" type="button">
@@ -6597,11 +6603,10 @@
                         </div>
                     </div>
                     <div id="sb_character_persona_panel" class="sb-character-persona-panel" hidden></div>
-                    <div id="sb_character_conversation_panel" class="sb-character-conversation-panel" role="tabpanel" aria-labelledby="sb_character_tab_conversation" aria-hidden="true" hidden></div>
                     <div id="sb_character_import_panel" class="sb-character-import-panel" hidden>
                         <div class="sb-character-import-intro">
-                            <h3 data-i18n="Bring in a character card">Bring in a character card</h3>
-                            <p data-i18n="Use a local file or paste a card link, then review the details before adding it to your cast.">Use a local file or paste a card link, then review the details before adding it to your cast.</p>
+                            <h3 data-i18n="Import a character card">Import a character card</h3>
+                            <p data-i18n="Upload a character card to SillyBunny using your method of choice.">Upload a character card to SillyBunny using your method of choice.</p>
                         </div>
                         <div class="sb-character-import-actions">
                             <button id="sb_character_import_file_action" class="sb-character-import-action" type="button">

--- a/public/scripts/sillybunny-conversation/attachments.js
+++ b/public/scripts/sillybunny-conversation/attachments.js
@@ -21,7 +21,7 @@ import { isCharacterMentionedInText } from './partners.js';
 import { formatConversationFileSize, formatPromptText } from './prompt.js';
 import { scheduleInterfaceRefresh } from './render-scheduler.js';
 import { escapeHtmlText } from './render-utils.js';
-import { getSettings } from './settings-store.js';
+import { getSettings, saveSettings } from './settings-store.js';
 import { conversationState, partnerReplyBusyKeys, sendQueue } from './state.js';
 import {
     appendConversationThreadMessage,
@@ -573,8 +573,13 @@ export async function submitConversationInput() {
     if (!pendingFiles) {
         return;
     }
-    if (!avatar || !settings.enabled || (!text && !pendingFiles.length)) {
+    if (!avatar || (!text && !pendingFiles.length)) {
         return;
+    }
+
+    if (!settings.enabled) {
+        settings.enabled = true;
+        saveSettings(avatar, settings, { groupId });
     }
 
     if (text.startsWith('/') && !pendingFiles.length) {

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -1,6 +1,6 @@
-import { characters } from '../../script.js';
+import { characters, selectCharacterById } from '../../script.js';
 import { loadStylesheetAsync } from '../dynamic-styles.js';
-import { selected_group } from '../group-chats.js';
+import { openGroupById, selected_group } from '../group-chats.js';
 import { isIOSWebKitPlatform } from '../mobile-send-button.js';
 import { setUserAvatar } from '../personas.js';
 import { shouldSendOnEnter } from '../RossAscends-mods.js';
@@ -129,6 +129,26 @@ function focusConversationInput({ skipIOS = false } = {}) {
     }
 }
 
+export async function selectConversationThread(avatar, { groupId = null, showToast = false } = {}) {
+    if (!avatar) {
+        return false;
+    }
+
+    const normalizedGroupId = groupId ? String(groupId) : '';
+    const didSyncRoleplaySelection = normalizedGroupId
+        ? await openGroupById(normalizedGroupId, { switchMenu: false })
+        : await selectCharacterById(characters.findIndex(character => character?.avatar === avatar), { switchMenu: false });
+
+    if (!didSyncRoleplaySelection) {
+        return false;
+    }
+
+    return openConversationWorkspaceForAvatar(avatar, {
+        groupId: normalizedGroupId || null,
+        showToast,
+    });
+}
+
 export function bindConversationChromeControls(sheld) {
     if (sheld.dataset.sbConversationChromeBound === 'true') {
         return;
@@ -173,7 +193,7 @@ export function bindConversationChromeControls(sheld) {
             const groupId = target.dataset.groupId || '';
             if (avatar) {
                 closePalsRail();
-                openConversationWorkspaceForAvatar(avatar, {
+                await selectConversationThread(avatar, {
                     groupId: groupId || null,
                     showToast: false,
                 });
@@ -199,9 +219,6 @@ export function bindConversationChromeControls(sheld) {
                 break;
             case 'close-settings':
                 closeConversationSettings();
-                break;
-            case 'return-roleplay':
-                disableConversationModeForCurrentCharacter();
                 break;
             case 'polish-character-message':
                 await handleCharacterMessagePolish(target.dataset.messageId, target);
@@ -271,7 +288,7 @@ export function bindConversationChromeControls(sheld) {
                         saveSettings(char.avatar, charSettings, { groupId: '' });
                         document.getElementById('sb_conversation_add_dm_picker')?.setAttribute('hidden', '');
                         closePalsRail();
-                        openConversationWorkspaceForAvatar(char.avatar, {
+                        await selectConversationThread(char.avatar, {
                             groupId: null,
                             showToast: false,
                         });
@@ -390,6 +407,7 @@ export function bindConversationChromeControls(sheld) {
                             scheduleInterfaceRefresh({ syncControls: true });
                         } else {
                             conversationState.conversationWorkspaceOpen = false;
+                            emitConversationWorkspaceStateChange();
                             scheduleInterfaceRefresh({ syncControls: false });
                         }
                     } else {
@@ -745,14 +763,24 @@ export function getDefaultConversationAvatar() {
     return (Array.isArray(characters) ? characters : []).find(character => character?.avatar)?.avatar || null;
 }
 
-export function openConversationWorkspaceForAvatar(avatar, { groupId = null, showToast = true } = {}) {
+function emitConversationWorkspaceStateChange() {
+    window.dispatchEvent(new CustomEvent('sb:conversation-workspace-state-changed', {
+        detail: {
+            open: Boolean(conversationState.conversationWorkspaceOpen),
+        },
+    }));
+}
+
+export function openConversationWorkspaceForAvatar(avatar, { groupId = null, showToast = true, enable = false } = {}) {
     const character = avatar ? getCharacterForAvatar(avatar) : null;
     const targetAvatar = character?.avatar || null;
     const targetGroupId = groupId && targetAvatar && isAvatarInConversationGroup(targetAvatar, groupId) ? String(groupId) : null;
     const threadChanged = conversationState.conversationSelectedAvatar !== targetAvatar || conversationState.conversationSelectedGroupId !== targetGroupId;
     conversationState.conversationWorkspaceOpen = true;
+    emitConversationWorkspaceStateChange();
     conversationState.conversationSelectedAvatar = targetAvatar;
     conversationState.conversationSelectedGroupId = targetGroupId;
+    conversationState.conversationUnavailableGroupId = null;
     if (threadChanged) {
         conversationState.conversationTimelineChannel = 'main';
         conversationState.conversationTimelineSearchQuery = '';
@@ -769,12 +797,14 @@ export function openConversationWorkspaceForAvatar(avatar, { groupId = null, sho
 
     const settings = getSettings(targetAvatar, { groupId: targetGroupId });
     const wasEnabled = Boolean(settings.enabled);
-    settings.enabled = true;
-    saveSettings(targetAvatar, settings, { groupId: targetGroupId });
+    if (enable && !settings.enabled) {
+        settings.enabled = true;
+        saveSettings(targetAvatar, settings, { groupId: targetGroupId });
+    }
     requestConversationRuntimeStart();
     applySettingsToPanel(settings);
     scheduleInterfaceRefresh({ syncControls: true });
-    if (showToast && !wasEnabled) {
+    if (showToast && enable && !wasEnabled) {
         toastr.info(`Conversation Mode activated for ${character.name || 'Character'}.`);
     }
     setTimeout(() => {
@@ -798,8 +828,10 @@ export function disableConversationModeForCurrentCharacter({ focusRoleplay = tru
     conversationState.conversationWorkspaceOpen = false;
     conversationState.conversationSelectedAvatar = null;
     conversationState.conversationSelectedGroupId = null;
+    conversationState.conversationUnavailableGroupId = null;
     conversationState.conversationTimelineChannel = 'main';
     conversationState.conversationTimelineSearchQuery = '';
+    emitConversationWorkspaceStateChange();
     scheduleInterfaceRefresh({ syncControls: false });
     if (focusRoleplay) {
         document.getElementById('send_textarea')?.focus?.({ preventScroll: false });

--- a/public/scripts/sillybunny-conversation/init.js
+++ b/public/scripts/sillybunny-conversation/init.js
@@ -11,7 +11,7 @@ import {
 } from './auto-engine.js';
 import { disableConversationModeForCurrentCharacter, getDefaultConversationAvatar, openConversationWorkspaceForAvatar } from './chrome.js';
 import { GROUP_ASIDE_RANDOM_CHANCE } from './constants.js';
-import { getCurrentCharAvatar, isAvatarInConversationGroup, migrateConversationLocalStorage } from './context.js';
+import { getCurrentCharAvatar, getRoleplayCurrentCharacter, isAvatarInConversationGroup, migrateConversationLocalStorage } from './context.js';
 import { loadCurrentPanelSettings } from './interface.js';
 import { sanitizeConversationUnreadCounts, updateConversationNotificationIndicators } from './notifications.js';
 import { getCharacterForGroupChatMessage, getCurrentGroupConversationMembers } from './pals-rail.js';
@@ -28,6 +28,44 @@ function scheduleInterfaceRefreshIfOpen() {
     if (conversationState.conversationWorkspaceOpen) {
         scheduleInterfaceRefresh({ syncControls: false });
     }
+}
+
+function syncConversationWorkspaceToRoleplaySelection() {
+    if (!conversationState.conversationWorkspaceOpen) {
+        return;
+    }
+
+    let targetAvatar = null;
+    const roleplayGroupId = selected_group ? String(selected_group) : null;
+
+    if (roleplayGroupId) {
+        const groupMembers = getCurrentGroupConversationMembers({ groupId: roleplayGroupId, requireEnabled: false });
+        targetAvatar = groupMembers[0]?.character?.avatar || null;
+    } else {
+        targetAvatar = getRoleplayCurrentCharacter()?.avatar || null;
+    }
+    const targetGroupId = roleplayGroupId && targetAvatar && isAvatarInConversationGroup(targetAvatar, roleplayGroupId)
+        ? roleplayGroupId
+        : null;
+
+    if (!targetAvatar) {
+        conversationState.conversationSelectedAvatar = null;
+        conversationState.conversationSelectedGroupId = null;
+        conversationState.conversationUnavailableGroupId = roleplayGroupId;
+        conversationState.conversationTimelineChannel = 'main';
+        conversationState.conversationTimelineSearchQuery = '';
+        scheduleInterfaceRefresh({ syncControls: false });
+        return;
+    }
+
+    conversationState.conversationUnavailableGroupId = null;
+
+    if (targetAvatar === conversationState.conversationSelectedAvatar
+        && targetGroupId === conversationState.conversationSelectedGroupId) {
+        return;
+    }
+
+    openConversationWorkspaceForAvatar(targetAvatar, { groupId: targetGroupId, showToast: false });
 }
 
 function ensureConversationRuntimeStarted() {
@@ -106,11 +144,13 @@ export function init() {
     });
     eventSource.on(event_types.CHAT_CHANGED, () => {
         if (conversationState.conversationWorkspaceOpen) {
+            syncConversationWorkspaceToRoleplaySelection();
             handleChatChanged();
         }
     });
     eventSource.on(event_types.CHAT_LOADED, () => {
         if (conversationState.conversationWorkspaceOpen) {
+            syncConversationWorkspaceToRoleplaySelection();
             handleChatChanged();
         }
     });

--- a/public/scripts/sillybunny-conversation/interface.js
+++ b/public/scripts/sillybunny-conversation/interface.js
@@ -1,7 +1,8 @@
-import { openConversationWorkspaceForAvatar, setConversationInterfaceActive } from './chrome.js';
+import { selectConversationThread, setConversationInterfaceActive } from './chrome.js';
 import { CHROME_IDS, DEFAULT_BRANCH_ID, DEFAULT_SETTINGS, SETTINGS_FIELDS } from './constants.js';
 import {
     getConversationBranches,
+    getConversationGroupById,
     getConversationGroupIdForAvatar,
     getConversationThreadStore,
     getCurrentCharacter,
@@ -281,6 +282,9 @@ export function updateConversationHeader(settings = getSettings()) {
     const effectiveStatus = current ? current.status : settings.availability;
 
     if (!avatar || !character) {
+        const unavailableGroup = conversationState.conversationUnavailableGroupId
+            ? getConversationGroupById(conversationState.conversationUnavailableGroupId)
+            : null;
         if (stage instanceof HTMLElement) {
             stage.dataset.ambientStatus = 'offline';
         }
@@ -289,10 +293,12 @@ export function updateConversationHeader(settings = getSettings()) {
         }
         renderHeaderParticipantStack(participantsContainer, [], { status: 'offline' });
         if (name instanceof HTMLElement) {
-            name.textContent = 'Conversation';
+            name.textContent = unavailableGroup?.name || 'Conversation';
         }
         if (status instanceof HTMLElement) {
-            status.textContent = 'Pick or start a DM from the Pals rail.';
+            status.textContent = unavailableGroup
+                ? 'No eligible Conversation members are available in this group yet.'
+                : 'Pick or start a DM from the Pals rail.';
         }
         return;
     }
@@ -314,7 +320,7 @@ export function updateConversationHeader(settings = getSettings()) {
         groupId,
         onAvatarClick: groupId ? (participant) => {
             if (participant?.avatar) {
-                openConversationWorkspaceForAvatar(participant.avatar, { groupId: null, showToast: false });
+                void selectConversationThread(participant.avatar, { groupId: null, showToast: false });
             }
         } : null,
     });
@@ -374,10 +380,6 @@ export function refreshConversationInterface({ syncControls = false } = {}) {
     const avatar = getCurrentCharAvatar();
     const groupId = getConversationGroupIdForAvatar(avatar);
     const settings = getSettings(avatar, { groupId });
-    if (conversationState.conversationWorkspaceOpen && avatar && !settings.enabled) {
-        settings.enabled = true;
-        saveSettings(avatar, settings, { groupId });
-    }
     const active = Boolean(conversationState.conversationWorkspaceOpen);
 
     setConversationInterfaceActive(active);
@@ -398,9 +400,16 @@ export function refreshConversationInterface({ syncControls = false } = {}) {
 
         const input = document.getElementById(CHROME_IDS.input);
         const send = document.getElementById(CHROME_IDS.send);
+        const unavailableGroup = conversationState.conversationUnavailableGroupId
+            ? getConversationGroupById(conversationState.conversationUnavailableGroupId)
+            : null;
         if (input instanceof HTMLTextAreaElement) {
             input.disabled = !avatar;
-            input.placeholder = avatar ? 'Type your message...' : 'Pick or start a DM from the Pals rail...';
+            input.placeholder = avatar
+                ? 'Type your message...'
+                : unavailableGroup
+                    ? 'This group has no eligible Conversation members yet...'
+                    : 'Pick or start a DM from the Pals rail...';
         }
         if (send instanceof HTMLButtonElement) {
             send.disabled = !avatar;

--- a/public/scripts/sillybunny-conversation/notifications.js
+++ b/public/scripts/sillybunny-conversation/notifications.js
@@ -1,5 +1,5 @@
 import { playMessageSound } from '../power-user.js';
-import { openConversationWorkspaceForAvatar } from './chrome.js';
+import { selectConversationThread } from './chrome.js';
 import { CHROME_IDS, DEFAULT_BRANCH_ID, SAFE_TOAST_OPTIONS } from './constants.js';
 import {
     clearLegacyConversationUnreadStorage,
@@ -215,15 +215,15 @@ export function updatePalsToggleBadge(totalUnread = getTotalUnreadCount()) {
 }
 
 export function updateConversationTabBadge(totalUnread = getTotalUnreadCount()) {
-    const tabButton = document.getElementById('sb_character_tab_conversation');
-    if (!tabButton) {
+    const modeButton = document.querySelector('#sb_character_mode_toggle [data-sb-character-mode="conversation"]');
+    if (!(modeButton instanceof HTMLElement)) {
         return;
     }
-    let badge = tabButton.querySelector('.sb-tab-notification-badge');
+    let badge = modeButton.querySelector('.sb-tab-notification-badge');
     if (!badge) {
         badge = document.createElement('span');
         badge.className = 'sb-tab-notification-badge';
-        tabButton.appendChild(badge);
+        modeButton.appendChild(badge);
     }
     badge.textContent = getBadgeLabel(totalUnread);
     badge.style.display = totalUnread > 0 ? 'inline-flex' : 'none';
@@ -282,9 +282,7 @@ export function isConversationActiveForAvatar(avatar) {
 }
 
 export function openConversationFromNotification(avatar, { groupId = null } = {}) {
-    if (!openConversationWorkspaceForAvatar(avatar, { groupId, showToast: false })) {
-        return;
-    }
+    void selectConversationThread(avatar, { groupId, showToast: false });
 }
 
 export function showConversationToast(avatar, message, { groupId = null } = {}) {

--- a/public/scripts/sillybunny-conversation/pals-rail.js
+++ b/public/scripts/sillybunny-conversation/pals-rail.js
@@ -60,7 +60,7 @@ export function getConversationRailItems() {
             const branchId = threadStore?.activeBranchId || DEFAULT_BRANCH_ID;
             const branch = normalizeConversationBranch(threadStore?.branches?.[branchId], branchId);
             const isEmptyThread = !branch.messages.length && !branch.unread && branch.preview === 'Conversation ready';
-            if (isEmptyThread && key !== activeKey) {
+            if (isEmptyThread) {
                 return;
             }
         }
@@ -108,8 +108,8 @@ export function getSelectedConversationGroup() {
     return getConversationGroupById(conversationState.conversationWorkspaceOpen ? conversationState.conversationSelectedGroupId : selected_group);
 }
 
-export function getCurrentGroupConversationMembers({ requireRoleplayReactions = false } = {}) {
-    const group = getSelectedConversationGroup();
+export function getCurrentGroupConversationMembers({ requireRoleplayReactions = false, groupId = null, requireEnabled = true } = {}) {
+    const group = groupId ? getConversationGroupById(groupId) : getSelectedConversationGroup();
     if (!group || !Array.isArray(group.members)) {
         return [];
     }
@@ -122,7 +122,7 @@ export function getCurrentGroupConversationMembers({ requireRoleplayReactions = 
             const settings = getConversationSettingsForCharacter(character, { groupId: String(group.id || '') });
             return { character, index, settings };
         })
-        .filter(item => item.character?.avatar && item.settings.enabled)
+        .filter(item => item.character?.avatar && (!requireEnabled || item.settings.enabled))
         .filter(item => !requireRoleplayReactions || item.settings.roleplay_reactions);
 }
 
@@ -148,7 +148,7 @@ export function getScheduleEditorTargets(baseAvatar = getCurrentCharAvatar()) {
             .forEach(character => addTarget(character, 'Conversation', baseGroupId));
     }
 
-    getCurrentGroupConversationMembers().forEach(({ character }) => addTarget(character, 'Group chat', getConversationGroupIdForAvatar(character?.avatar)));
+    getCurrentGroupConversationMembers({ requireEnabled: false }).forEach(({ character }) => addTarget(character, 'Group chat', getConversationGroupIdForAvatar(character?.avatar)));
 
     if (!targets.length && baseAvatar) {
         addTarget(getCharacterForAvatar(baseAvatar), 'Conversation', baseGroupId);

--- a/public/scripts/sillybunny-conversation/pickers.js
+++ b/public/scripts/sillybunny-conversation/pickers.js
@@ -9,7 +9,7 @@ import {
 } from '../../script.js';
 import { group_activation_strategy, group_generation_mode, groups } from '../group-chats.js';
 import { user_avatar } from '../personas.js';
-import { openConversationWorkspaceForAvatar } from './chrome.js';
+import { selectConversationThread } from './chrome.js';
 import { AVAILABILITY_COPY, CHROME_IDS, DEFAULT_BRANCH_ID, WEEKDAY_LABELS } from './constants.js';
 import {
     createConversationBranch,
@@ -317,8 +317,8 @@ export function toggleAddDmPicker() {
     picker.removeAttribute('hidden');
     picker.innerHTML = `
         <div class="sb-conversation-add-dm-header">
-            <span style="font-weight: var(--sb-weight-title); font-size: var(--sb-type-meta);">Open a solo DM</span>
-            <p class="sb-conversation-field-hint" style="margin: 4px 0 0;">This opens the character alone, even if they also have a group Conversation.</p>
+            <span style="font-weight: var(--sb-weight-title); font-size: var(--sb-type-meta);">Create a solo DM</span>
+            <p class="sb-conversation-field-hint" style="margin: 4px 0 0;">Create a new solo DM with a character card of your choice.</p>
             <input type="text" id="sb_conversation_add_dm_search" class="text_pole textarea_compact" placeholder="Search characters..." style="inline-size: 100%; margin-top: 8px;" />
         </div>
         <div class="sb-conversation-add-dm-list" id="sb_conversation_add_dm_list" style="margin-top: 8px; max-block-size: 200px; overflow-y: auto; display: flex; flex-direction: column; gap: 4px;"></div>
@@ -514,7 +514,7 @@ export async function createAndOpenConversationGroup(memberAvatars, { sourceAvat
 
     hideConversationStartPicker();
     closePalsRail();
-    const opened = openConversationWorkspaceForAvatar(targetAvatar, {
+    const opened = await selectConversationThread(targetAvatar, {
         groupId: String(group.id),
         showToast: false,
     });
@@ -566,21 +566,21 @@ export function toggleConversationGroupPicker({ sourceAvatar = '', sourceGroupId
 
     const title = sourceAvatar
         ? (normalizedSourceGroupId ? 'Add members to this group' : 'Add members to this DM')
-        : 'Start a group DM';
+        : 'Create a group DM';
     const description = sourceAvatar
         ? 'Selected members will open as a separate group Conversation with its own history and group controls.'
-        : 'Pick two or more characters to create a group Conversation independent of the active roleplay chat.';
+        : 'Create a new group chat with two or more of your character cards.';
 
     picker.innerHTML = `
         <div class="sb-conversation-add-dm-header">
-            <span style="font-weight: var(--sb-weight-title); font-size: var(--sb-type-meta);">${escapeHtmlText(title)}</span>
-            <p class="sb-conversation-field-hint" style="margin: 4px 0 0;">${escapeHtmlText(description)}</p>
-            <input type="text" id="sb_conversation_group_search" class="text_pole textarea_compact" placeholder="Search characters..." style="inline-size: 100%; margin-top: 8px;" />
+            <span class="sb-conversation-add-dm-title">${escapeHtmlText(title)}</span>
+            <p class="sb-conversation-field-hint sb-conversation-add-dm-description">${escapeHtmlText(description)}</p>
+            <input type="text" id="sb_conversation_group_search" class="text_pole textarea_compact sb-conversation-add-dm-search" placeholder="Search characters..." />
         </div>
-        <div class="sb-conversation-add-dm-list" id="sb_conversation_group_list" style="margin-top: 8px; max-block-size: 220px; overflow-y: auto; display: flex; flex-direction: column; gap: 4px;"></div>
-        <div class="sb-conversation-group-picker-actions" style="display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 10px;">
-            <span id="sb_conversation_group_selected_count" class="sb-conversation-field-hint" style="margin: 0;"></span>
-            <span style="display: flex; gap: 6px;">
+        <div class="sb-conversation-add-dm-list sb-conversation-group-list" id="sb_conversation_group_list"></div>
+        <div class="sb-conversation-group-picker-actions">
+            <span id="sb_conversation_group_selected_count" class="sb-conversation-field-hint sb-conversation-group-selected-count"></span>
+            <span class="sb-conversation-group-picker-buttons">
                 <button type="button" class="menu_button" data-sb-conversation-action="cancel-conversation-group">Cancel</button>
                 <button type="button" class="menu_button" data-sb-conversation-action="create-conversation-group">Create Group</button>
             </span>
@@ -615,17 +615,17 @@ export function toggleConversationGroupPicker({ sourceAvatar = '', sourceGroupId
             const disabled = lockedMembers.has(character.avatar) ? ' disabled' : '';
             const thumb = getThumbnailUrl('avatar', character.avatar);
             rows.push(`
-                <label class="sb-conversation-add-dm-option sb-conversation-group-member-option" style="display: flex; align-items: center; gap: 8px; inline-size: 100%; background: none; border: none; padding: 6px; border-radius: var(--sb-radius-sm); text-align: left; cursor: pointer; color: inherit;">
+                <label class="sb-conversation-add-dm-option sb-conversation-group-member-option">
                     <input type="checkbox" class="sb-conversation-group-member-checkbox" value="${escapeHtmlAttribute(character.avatar)}"${checked}${disabled} />
-                    <img src="${escapeHtmlAttribute(thumb)}" alt="" style="inline-size: 24px; block-size: 24px; border-radius: 50%; object-fit: cover;" loading="lazy" />
-                    <span style="font-size: var(--sb-type-caption);">${escapeHtmlText(name)}</span>
+                    <img src="${escapeHtmlAttribute(thumb)}" alt="" class="sb-conversation-group-member-avatar" loading="lazy" />
+                    <span class="sb-conversation-group-member-name">${escapeHtmlText(name)}</span>
                 </label>
             `);
         });
 
         listContainer.innerHTML = rows.length
             ? rows.join('')
-            : '<div class="sb-conversation-empty" style="padding: 8px; font-size: var(--sb-type-meta); opacity: 0.7;">No matching characters found.</div>';
+            : '<div class="sb-conversation-empty sb-conversation-group-empty">No matching characters found.</div>';
         syncSelectedMembers();
     }
 

--- a/public/scripts/sillybunny-conversation/settings-store.js
+++ b/public/scripts/sillybunny-conversation/settings-store.js
@@ -32,7 +32,6 @@ import { getConversationMessagePreviewText } from './thread-store.js';
 export { collectGroupConversationMemorySummaries, collectSoloConversationMemorySummary };
 
 const GROUP_CONVERSATION_FORCED_SETTINGS = Object.freeze({
-    enabled: true,
     multi_char: true,
     auto_character_chat: true,
 });

--- a/public/scripts/sillybunny-conversation/state.js
+++ b/public/scripts/sillybunny-conversation/state.js
@@ -14,6 +14,7 @@ export const conversationState = {
     conversationWorkspaceOpen: false,
     conversationSelectedAvatar: null,
     conversationSelectedGroupId: null,
+    conversationUnavailableGroupId: null,
     conversationTimelineChannel: 'main',
     conversationTimelineSearchQuery: '',
     imageGenerationActive: false,

--- a/public/scripts/sillybunny-conversation/timeline-render.js
+++ b/public/scripts/sillybunny-conversation/timeline-render.js
@@ -16,6 +16,7 @@ import {
 import {
     createConversationBranch,
     getActiveConversationBranch,
+    getConversationGroupById,
     getConversationBranches,
     getConversationGroupIdForAvatar,
     getConversationThreadStore,
@@ -328,7 +329,10 @@ export function renderConversationTimeline() {
     const previousMessageCount = conversationState.lastRenderedMessageCount;
 
     if (!avatar) {
-        const fingerprint = 'no-avatar';
+        const unavailableGroup = conversationState.conversationUnavailableGroupId
+            ? getConversationGroupById(conversationState.conversationUnavailableGroupId)
+            : null;
+        const fingerprint = unavailableGroup ? `no-avatar:${unavailableGroup.id}` : 'no-avatar';
         if (fingerprint === conversationState.lastTimelineFingerprint && timeline.dataset.sbConversationFingerprint === fingerprint) {
             updateConversationToolsState();
             return;
@@ -338,10 +342,12 @@ export function renderConversationTimeline() {
         timeline.dataset.sbConversationFingerprint = fingerprint;
         timeline.innerHTML = `
             <div class="sb-conversation-thread-empty">
-                <div class="sb-conversation-thread-empty-icon fa-solid fa-comments" aria-hidden="true"></div>
+                <div class="sb-conversation-thread-empty-icon fa-solid ${unavailableGroup ? 'fa-user-group' : 'fa-comments'}" aria-hidden="true"></div>
                 <div>
-                    <strong>Choose a DM to begin</strong>
-                    <p>Use the Pals rail plus button to start messaging a character without opening the character drawer.</p>
+                    <strong>${unavailableGroup ? 'No Conversation members available' : 'Choose a DM to begin'}</strong>
+                    <p>${unavailableGroup
+        ? `${escapeHtmlText(unavailableGroup.name || 'This group')} does not currently have any eligible Conversation members. Add or enable a member, then try again.`
+        : 'Use the Pals rail plus button to start messaging a character without opening the character drawer.'}</p>
                 </div>
             </div>
         `;
@@ -380,7 +386,7 @@ export function renderConversationTimeline() {
             <div class="sb-conversation-thread-empty-icon fa-solid fa-message" aria-hidden="true"></div>
             <div>
                 <strong>No DM messages yet</strong>
-                <p>Roleplay chat stays separate. Start a casual conversation here when you want direct messages.</p>
+                <p>Type a message to begin chatting with this character!</p>
             </div>
         `;
         timeline.appendChild(empty);
@@ -1268,10 +1274,6 @@ export function ensureConversationChrome() {
                 <button type="button" class="menu_button menu_button_icon" data-sb-conversation-action="new-chat" title="Clear DM History (New Chat)" aria-label="Clear DM History (New Chat)">
                     <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
                     <span>New Chat</span>
-                </button>
-                <button type="button" class="menu_button menu_button_icon" data-sb-conversation-action="return-roleplay" title="Return to roleplay chat" aria-label="Return to roleplay chat">
-                    <i class="fa-solid fa-masks-theater" aria-hidden="true"></i>
-                    <span>Roleplay</span>
                 </button>
                 <button type="button" class="menu_button menu_button_icon sb-conversation-header-settings" data-sb-conversation-action="open-settings" title="Conversation settings" aria-label="Conversation settings">
                     <i class="fa-solid fa-gear"></i>

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -6,11 +6,13 @@ import {
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
 import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { hasServerReturnedAfterRestart } from './server-restart-monitor.js';
+import { conversationState } from './sillybunny-conversation/state.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
 import { flushCharacterSaveDebounced, getOneCharacter, refreshCsrfToken, saveSettingsDebounced } from '../script.js';
 
 const sbMobileShellLifecycle = createMobileShellLifecycle();
 const sbPresetApiSyncLifecycle = createPresetApiSyncLifecycle();
+const SB_SHELL_SUBTITLE_PLACEHOLDER = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 
 const SB_STORAGE_KEYS = Object.freeze({
     leftTab: 'sb-left-tab',
@@ -447,40 +449,44 @@ const SB_MESSAGE_STYLES = Object.freeze([
     { id: '2', label: 'Document', icon: 'fa-file-lines' },
 ]);
 
+const SB_WORLD_INFO_SUBTITLE_HTML = 'Advanced: Modify lorebooks for character cards here. For more information, read the guide found <a class="notes-link" href="https://docs.sillytavern.app/usage/core-concepts/worldinfo/" target="_blank" rel="noopener noreferrer">here</a>.';
+const SB_SAMPLING_SUBTITLE_HTML = 'Modify model text parameters here - useful for dialing in responses! If you\'re unsure what these all mean, check out <a class="notes-link" href="https://rentry.org/samplersettings" target="_blank" rel="noopener noreferrer">Geechan\'s guide on sampling.</a>';
+
 const SB_CHARACTER_TAB_COPY = Object.freeze({
     characters: {
         title: 'Character Menu',
-        subtitle: 'Browse, create, and tune the cast for your chats from one place.',
+        subtitle: 'View or create character cards here for your roleplays and chats!',
         description: 'Move between characters, groups, personas, lore, and imports without leaving the writing workspace.',
     },
     groups: {
         title: 'Group Menu',
-        subtitle: 'Build and organize group casts for multi-character scenes.',
+        subtitle: 'View or create group chats here for your roleplays and chats!',
         description: 'Sort group chats, check members, and return to character cards without losing your place.',
     },
     conversation: {
         title: 'Conversation Mode',
-        subtitle: 'Configure Discord-style DMs, presence, and autonomous follow-ups for the active character.',
+        subtitle: SB_SHELL_SUBTITLE_PLACEHOLDER,
         description: 'Tune schedules, cooldowns, format prompts, and DM helpers without opening a group chat.',
     },
     editor: {
         title: 'Card Editor',
-        subtitle: 'Shape the selected card details, prompts, greetings, and metadata.',
+        subtitle: 'Edit your character cards or group chats in great detail here!',
         description: 'Use the subtabs to keep core identity, definitions, greetings, and metadata separated.',
     },
     'world-info': {
         title: 'World Info',
-        subtitle: 'Manage lorebooks and world details from the character workspace.',
+        subtitle: SB_WORLD_INFO_SUBTITLE_HTML,
+        subtitleIsHtml: true,
         description: 'Create, edit, import, and activate World Info entries without leaving the Characters menu.',
     },
     persona: {
         title: 'Persona',
-        subtitle: 'Choose how you appear in chat and connect personas to characters.',
+        subtitle: 'Edit your own persona here for roleplay and chats!',
         description: 'Edit persona details, locks, and defaults in the same flow as your character work.',
     },
     import: {
         title: 'Import',
-        subtitle: 'Add cards from files or links, then fold them into your local cast.',
+        subtitle: 'Directly import character cards here from various sources.',
         description: 'PNG, JSON, YAML, CHARX, BYAF, and supported URL imports stay one tab away.',
     },
 });
@@ -497,7 +503,6 @@ const SB_CHARACTER_EDITOR_SPOILER_FREE_VISIBLE_TABS = Object.freeze(['char-info'
 const SB_CHARACTER_PANEL_TABS = Object.freeze([
     { id: 'characters', label: 'Characters', icon: 'fa-address-book' },
     { id: 'groups', label: 'Groups', icon: 'fa-users' },
-    { id: 'conversation', label: 'Conversation', icon: 'fa-comments' },
     { id: 'editor', label: 'Editor', icon: 'fa-pen-to-square' },
     { id: 'world-info', label: 'World Info', icon: 'fa-book-atlas' },
     { id: 'persona', label: 'Persona', icon: 'fa-face-smile' },
@@ -525,6 +530,7 @@ const SB_SHELLS = Object.freeze({
             id: 'presets',
             label: 'Presets',
             icon: 'fa-sliders',
+            description: 'Change or modify your Chat Completion presets, settings, and/or prompts here. We recommend our included Geechan and Pura presets if you\'re unsure.',
         },
         embeddedTabs: [
             {
@@ -532,12 +538,14 @@ const SB_SHELLS = Object.freeze({
                 drawerId: 'sys-settings-button',
                 label: 'API',
                 icon: 'fa-plug',
+                description: 'Configure the model backend for all AI character responses. We recommend OpenRouter if you\'re unsure.',
             },
             {
                 id: 'advanced-formatting',
                 drawerId: 'advanced-formatting-button',
                 label: 'Formatting',
                 icon: 'fa-text-height',
+                description: 'Change Text Completion templates and system prompts here!',
             },
         ],
         customTabs: [
@@ -545,6 +553,8 @@ const SB_SHELLS = Object.freeze({
                 id: 'sampling',
                 label: 'Sampling',
                 icon: 'fa-wave-square',
+                description: SB_SAMPLING_SUBTITLE_HTML,
+                descriptionIsHtml: true,
                 searchPlaceholder: 'Search temperature, top p, repetition penalty, or backend samplers',
                 searchExamples: ['temperature', 'top p', 'repetition penalty'],
             },
@@ -552,6 +562,7 @@ const SB_SHELLS = Object.freeze({
                 id: 'agents',
                 label: 'Agents',
                 icon: 'fa-robot',
+                description: 'Enable, disable, or modify in-chat agents here. Can be configured as pre-gen, sidecar, or post-gen.',
             },
         ],
     },
@@ -573,6 +584,7 @@ const SB_SHELLS = Object.freeze({
             id: 'settings',
             label: 'Settings',
             icon: 'fa-screwdriver-wrench',
+            description: 'Modify and customise SillyBunny\'s general appearance and configuration here.',
             searchPlaceholder: 'Search Appearance, top bar, chat style, blur, or update notices',
             searchExamples: ['theme', 'top bar', 'Appearance', 'notify extension updates'],
         },
@@ -582,6 +594,7 @@ const SB_SHELLS = Object.freeze({
                 drawerId: 'extensions-settings-button',
                 label: 'Extensions',
                 icon: 'fa-cubes',
+                description: 'Install, manage, and configure SillyTavern extensions here. Backwards compatibility isn\'t guaranteed, but should be applicable.',
                 searchPlaceholder: 'Search themes, Quick Reply, Dialogue Colors, or Image Gen',
                 searchExamples: ['themes', 'Quick Reply', 'Dialogue Colors', 'Image Gen'],
             },
@@ -590,6 +603,7 @@ const SB_SHELLS = Object.freeze({
                 drawerId: 'backgrounds-button',
                 label: 'Background',
                 icon: 'fa-panorama',
+                description: 'Change the appearance of the background surrounding your chats here!',
                 searchPlaceholder: 'Search background names, blur, fit, or vibe words',
                 searchExamples: ['cozy', 'landscape', 'blur', 'fit'],
             },
@@ -599,6 +613,7 @@ const SB_SHELLS = Object.freeze({
                 id: 'server',
                 label: 'Server',
                 icon: 'fa-server',
+                description: 'Edit SillyBunny backend settings and configuration here.',
                 searchPlaceholder: 'Search update, restart, config.yaml, or branch',
                 searchExamples: ['update', 'restart', 'config.yaml', 'branch'],
             },
@@ -606,12 +621,27 @@ const SB_SHELLS = Object.freeze({
                 id: 'console-logs',
                 label: 'Console Logs',
                 icon: 'fa-terminal',
+                description: 'View all SillyBunny logs for easy troubleshooting here.',
                 searchPlaceholder: 'Search error, warning, npm, bun, or extension logs',
                 searchExamples: ['error', 'warning', 'npm', 'bun'],
             },
         ],
     },
 });
+
+function renderShellSubtitle(target, subtitle, { isHtml = false } = {}) {
+    if (!(target instanceof HTMLElement)) {
+        return;
+    }
+
+    target.textContent = '';
+    if (isHtml) {
+        target.insertAdjacentHTML('beforeend', subtitle || '');
+        return;
+    }
+
+    target.textContent = subtitle || '';
+}
 
 const SB_DRAWER_ROUTES = Object.freeze({
     'user-settings-button': { shell: 'right', tab: 'settings' },
@@ -6890,7 +6920,6 @@ async function showCharacterListView(view = 'characters') {
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
     const panel = getCharacterPanel();
     const normalizedView = view === 'groups' ? 'groups' : 'characters';
     sbState.characterDrawer.lastTab = normalizedView;
@@ -6929,7 +6958,6 @@ function showCharacterEditorEmptyState() {
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
     syncCharacterListControls('characters');
     setCharacterEditorEmptyState(true);
 
@@ -7069,15 +7097,6 @@ function setCharacterWorldInfoPanelVisible(visible) {
 
     if (content instanceof HTMLElement) {
         content.setAttribute('aria-hidden', String(!visible));
-    }
-}
-
-function setCharacterConversationPanelVisible(visible) {
-    const host = document.getElementById('sb_character_conversation_panel');
-
-    if (host instanceof HTMLElement) {
-        host.hidden = !visible;
-        host.setAttribute('aria-hidden', String(!visible));
     }
 }
 
@@ -7355,7 +7374,6 @@ function openCharacterWorldInfoTab() {
     setCharacterEditorEmptyState(false);
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
     syncCharacterListControls('characters');
     setCharacterWorldInfoPanelVisible(true);
     hideCharacterMainPanels();
@@ -7375,7 +7393,6 @@ function openCharacterPersonaTab() {
     setCharacterEditorEmptyState(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
     syncCharacterListControls('characters');
     setCharacterPersonaPanelVisible(true);
     hideCharacterMainPanels();
@@ -7392,7 +7409,6 @@ function openCharacterImportTab() {
     setCharacterEditorEmptyState(false);
     setCharacterPersonaPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
     syncCharacterListControls('characters');
     setCharacterImportPanelVisible(true);
     hideCharacterMainPanels();
@@ -7411,7 +7427,6 @@ function preserveCharacterImportTab() {
     setCharacterEditorEmptyState(false);
     setCharacterPersonaPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
     syncCharacterListControls('characters');
     setCharacterImportPanelVisible(true);
     hideCharacterMainPanels();
@@ -7419,19 +7434,57 @@ function preserveCharacterImportTab() {
     syncCharacterTitlebarVisibility();
 }
 
-function openCharacterConversationTab() {
-    if (sbState.characterDrawer.lastTab === 'conversation') {
-        sbState.characterDrawer.lastTab = 'characters';
+function syncCharacterModeToggle() {
+    const toggle = document.getElementById('sb_character_mode_toggle');
+
+    if (!(toggle instanceof HTMLElement)) {
+        return;
     }
-    window.dispatchEvent(new CustomEvent('sb:open-conversation-workspace'));
-    closeCharacterPanel();
+
+    const activeMode = conversationState.conversationWorkspaceOpen ? 'conversation' : 'roleplay';
+    toggle.dataset.activeMode = activeMode;
+    toggle.querySelectorAll('[data-sb-character-mode]').forEach((button) => {
+        if (!(button instanceof HTMLButtonElement)) {
+            return;
+        }
+
+        const isActive = button.dataset.sbCharacterMode === activeMode;
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-checked', String(isActive));
+    });
+}
+
+function setCharacterShellMode(mode) {
+    const normalizedMode = mode === 'conversation' ? 'conversation' : 'roleplay';
+    const isConversationMode = normalizedMode === 'conversation';
+    const mobileViewport = isMobileViewport();
+
+    if (conversationState.conversationWorkspaceOpen === isConversationMode) {
+        syncCharacterModeToggle();
+        if (mobileViewport) {
+            closeCharacterPanel();
+        }
+        return;
+    }
+
+    if (isConversationMode) {
+        window.dispatchEvent(new CustomEvent('sb:open-conversation-workspace', {
+            detail: { showToast: false },
+        }));
+    } else {
+        window.dispatchEvent(new CustomEvent('sb:close-conversation-workspace'));
+    }
+
+    syncCharacterModeToggle();
+
+    if (mobileViewport) {
+        closeCharacterPanel();
+    }
 }
 
 function openCharacterPanelTab(tabId) {
     const normalizedTabId = normalizeCharacterPanelTab(tabId);
-    if (normalizedTabId !== 'conversation') {
-        sbState.characterDrawer.lastTab = normalizedTabId;
-    }
+    sbState.characterDrawer.lastTab = normalizedTabId;
 
     if (normalizedTabId !== 'editor') {
         setCharacterEditorFullscreenState(false);
@@ -7467,9 +7520,6 @@ function openCharacterPanelTab(tabId) {
         } else if (normalizedTabId === 'world-info') {
             setCharacterPanelMenuType(panel, 'world-info');
             openCharacterWorldInfoTab();
-        } else if (normalizedTabId === 'conversation') {
-            setCharacterPanelMenuType(panel, 'conversation');
-            openCharacterConversationTab();
         } else {
             setCharacterPanelMenuType(panel, 'characters');
             void showCharacterListView();
@@ -7505,7 +7555,6 @@ async function openCharacterEditorTab() {
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
 
     if (await showActiveCharacterEditor()) {
         syncCharacterShellTabs('editor');
@@ -7528,19 +7577,16 @@ function syncCharacterShellTabs(activeTab = null) {
                     ? 'world-info'
                     : menuType === 'groups'
                         ? 'groups'
-                        : menuType === 'conversation'
-                            ? 'conversation'
-                            : ['character_edit', 'group_edit', 'create', 'group_create', 'editor_empty'].includes(menuType) ? 'editor' : 'characters');
+                        : ['character_edit', 'group_edit', 'create', 'group_create', 'editor_empty'].includes(menuType) ? 'editor' : 'characters');
 
-    if (normalizedTab !== 'conversation') {
-        sbState.characterDrawer.lastTab = normalizedTab;
-    }
+    sbState.characterDrawer.lastTab = normalizedTab;
 
     if (menuType === 'characters' || menuType === 'groups') {
         syncCharacterListControls(menuType);
     }
 
     syncCharacterHeaderCopy(normalizedTab);
+    syncCharacterModeToggle();
 
     panel?.querySelectorAll('[data-sb-character-tab]').forEach(tab => {
         if (!(tab instanceof HTMLElement)) {
@@ -7595,7 +7641,7 @@ function syncCharacterHeaderCopy(activeTab = 'characters') {
     }
 
     if (subtitle instanceof HTMLElement) {
-        subtitle.textContent = copy.subtitle;
+        renderShellSubtitle(subtitle, copy.subtitle, { isHtml: copy.subtitleIsHtml === true });
     }
 
     if (description instanceof HTMLElement) {
@@ -7656,7 +7702,6 @@ function resetCharacterPanelView() {
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    setCharacterConversationPanelVisible(false);
 
     if (listButton instanceof HTMLElement) {
         listButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -7741,7 +7786,6 @@ function bindCharacterDrawerStateObserver() {
             setCharacterPersonaPanelVisible(panel.dataset.menuType === 'persona');
             setCharacterImportPanelVisible(panel.dataset.menuType === 'import');
             setCharacterWorldInfoPanelVisible(panel.dataset.menuType === 'world-info');
-            setCharacterConversationPanelVisible(panel.dataset.menuType === 'conversation');
             syncCharacterEditorFullscreenAvailability();
             syncCharacterTitlebarVisibility();
             syncCharacterShellTabs();
@@ -12965,7 +13009,7 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
 
     const activeTab = shellState.tabs.get(tabId);
     shellState.headerTitle.textContent = activeTab.label;
-    shellState.headerSubtitle.textContent = activeTab.description ?? '';
+    renderShellSubtitle(shellState.headerSubtitle, activeTab.description ?? '', { isHtml: activeTab.descriptionIsHtml === true });
     scrollShellTabButtonIntoView(shellState.nav, activeTab.button, { smooth: focusButton });
     shellState.updateNavScrollIndicators?.();
 
@@ -13258,7 +13302,7 @@ function buildShell(shellKey) {
     });
     const eyebrow = createElement('div', { className: 'sb-shell-kicker', text: shellConfig.title });
     const title = createElement('h2', { className: 'sb-shell-title', text: shellConfig.baseTab.label, attrs: { tabindex: '-1' } });
-    const subtitle = createElement('p', { className: 'sb-shell-subtitle', text: shellConfig.baseTab.description ?? '' });
+    const subtitle = createElement('p', { className: 'sb-shell-subtitle' });
     const shellDescription = createElement('p', { className: 'sb-shell-description', text: shellConfig.subtitle });
     const panelBody = createElement('div', { className: 'sb-shell-body' });
     const resizeHandle = createElement('div', {
@@ -13269,6 +13313,7 @@ function buildShell(shellKey) {
     });
 
     closeButton.innerHTML = '<i class="fa-solid fa-xmark" aria-hidden="true"></i>';
+    renderShellSubtitle(subtitle, shellConfig.baseTab.description ?? '', { isHtml: shellConfig.baseTab.descriptionIsHtml === true });
     closeButton.addEventListener('click', () => closeShell(shellKey));
     shellRoot.addEventListener('keydown', event => {
         if (event.key !== 'Escape') {
@@ -14229,6 +14274,24 @@ function injectCharacterDrawerControls() {
         shellCloseButton.addEventListener('click', () => closeCharacterPanel());
     }
 
+    const modeToggle = document.getElementById('sb_character_mode_toggle');
+    if (modeToggle instanceof HTMLElement && modeToggle.dataset.sbBound !== 'true') {
+        modeToggle.dataset.sbBound = 'true';
+        modeToggle.querySelectorAll('[data-sb-character-mode]').forEach((button) => {
+            if (!(button instanceof HTMLButtonElement)) {
+                return;
+            }
+
+            button.addEventListener('click', () => setCharacterShellMode(button.dataset.sbCharacterMode));
+        });
+    }
+
+    if (document.documentElement.dataset.sbCharacterModeStateBound !== 'true') {
+        document.documentElement.dataset.sbCharacterModeStateBound = 'true';
+        window.addEventListener('sb:conversation-workspace-state-changed', syncCharacterModeToggle);
+    }
+    syncCharacterModeToggle();
+
     const charactersTab = document.getElementById('sb_character_tab_characters');
     if (charactersTab instanceof HTMLButtonElement && charactersTab.dataset.sbBound !== 'true') {
         charactersTab.dataset.sbBound = 'true';
@@ -14239,12 +14302,6 @@ function injectCharacterDrawerControls() {
     if (groupsTab instanceof HTMLButtonElement && groupsTab.dataset.sbBound !== 'true') {
         groupsTab.dataset.sbBound = 'true';
         groupsTab.addEventListener('click', () => { void showCharacterListView('groups'); });
-    }
-
-    const conversationTab = document.getElementById('sb_character_tab_conversation');
-    if (conversationTab instanceof HTMLButtonElement && conversationTab.dataset.sbBound !== 'true') {
-        conversationTab.dataset.sbBound = 'true';
-        conversationTab.addEventListener('click', () => openCharacterConversationTab());
     }
 
     const editorTab = document.getElementById('sb_character_tab_editor');

--- a/public/scripts/templates/welcomePanelOnboarding.html
+++ b/public/scripts/templates/welcomePanelOnboarding.html
@@ -57,11 +57,11 @@
                         <span>Chat with Assistant Nahida, our alternative assistant, for a more gentle and philosophical lens!</span>
                     </span>
                 </button>
-                <button class="menu_button menu_button_icon welcomeActionCard welcomeActionButton" data-action="open-conversation">
-                    <i class="fa-solid fa-comments"></i>
+                <button class="menu_button menu_button_icon welcomeActionCard welcomeActionButton" data-action="open-characters-menu">
+                    <i class="fa-solid fa-id-card"></i>
                     <span class="welcomeActionMeta">
-                        <strong>Open Conversation</strong>
-                        <span>Jump into direct-message chats without loading a roleplay thread first.</span>
+                        <strong>Open Characters</strong>
+                        <span>Open the character menu for directly interacting with your character cards.</span>
                     </span>
                 </button>
             </div>


### PR DESCRIPTION
This PR changes the following for a polish pass on Conversation mode and the UI:

- Changes the header bars for all menu navigation to be consistent with each other.
- Cleans up LLMisms found in various UI subtext surrounding Conversation mode and the menu navigation.
- Updated the homescreen action card to open the Character menu instead of Conversation.
- Removes the Conversation sub-tab in favour of a toggle that switches between roleplay/conversation modes in the character menu. Easier to access this way.
- Conversation mode slightly reworked so only DMs that have messages in them will appear in the sidebar.
- Conversation mode now properly remembers the last chosen character when switching between roleplay/conversation mode.