### PR TITLE
fix: mobile drawer bounds and startup loader regressions

### DIFF
--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -1,4 +1,6 @@
 #preloader {
+    --sb-loader-edge-gap: clamp(2px, 0.75vmin, 5px);
+    --sb-loader-border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 52%, var(--SmartThemeBorderColor) 48%);
     position: fixed;
     inset: 0;
     margin: 0;
@@ -21,6 +23,25 @@
     opacity: 1;
     overflow: hidden;
     overscroll-behavior: none;
+    isolation: isolate;
+}
+
+#preloader::before {
+    content: '';
+    position: absolute;
+    inset: var(--sb-loader-edge-gap);
+    z-index: 0;
+    border: 1px solid var(--sb-loader-border-color);
+    border-radius: clamp(14px, 4vmin, 26px);
+    box-shadow:
+        0 0 0 1px color-mix(in srgb, var(--sb-loader-border-color) 20%, transparent),
+        inset 0 0 48px color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 10%, transparent);
+    pointer-events: none;
+}
+
+#preloader > * {
+    position: relative;
+    z-index: 1;
 }
 
 #loader:not(.splash-screen) {
@@ -84,16 +105,17 @@
     align-items: center;
     justify-content: center;
     gap: 4rem;
-    width: min(100%, 420px);
-    min-height: min(520px, calc(100dvh - 32px));
-    height: auto;
+    width: 100%;
+    max-width: none;
+    min-height: 0;
+    height: 100%;
     margin: auto;
-    padding: 32px 24px;
+    padding: max(32px, calc(var(--sb-loader-edge-gap) + 24px)) 24px;
     box-sizing: border-box;
-    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor) 34%, var(--SmartThemeBorderColor) 66%);
-    border-radius: 28px;
-    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 94%, var(--SmartThemeBodyColor) 6%);
-    box-shadow: 0 24px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
     transition: all var(--sb-transition-slow);
 }
 

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -935,18 +935,28 @@ h3:not(.popup h3):not(#chat h3) {
 .inline-drawer-icon {
     inline-size: var(--sb-inline-drawer-icon-size);
     block-size: var(--sb-inline-drawer-icon-size);
+    aspect-ratio: 1;
     min-inline-size: var(--sb-inline-drawer-icon-size);
     min-block-size: var(--sb-inline-drawer-icon-size);
     max-inline-size: var(--sb-inline-drawer-icon-size);
     max-block-size: var(--sb-inline-drawer-icon-size);
     flex: 0 0 var(--sb-inline-drawer-icon-size);
+    align-self: center;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     margin-left: auto;
     border-radius: var(--sb-icon-control-radius);
+    font-size: clamp(14px, calc(var(--mainFontSize) * 1.05), 18px);
     line-height: 1;
-    overflow: hidden;
+    text-align: center;
+    vertical-align: middle;
+    overflow: visible;
+}
+
+.custom-drawer-icon::before,
+.inline-drawer-icon::before {
+    line-height: 1;
 }
 
 .drawer-icon.openIcon {
@@ -964,6 +974,38 @@ h3:not(.popup h3):not(#chat h3) {
     align-items: center;
 }
 
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 8px;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header):has(> :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon)),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header):has(> :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon)) {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header) > :is(b, strong, span, .title-container, .extension_name),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) > :is(b, strong, span, .title-container, .extension_name) {
+    min-width: 0;
+    align-self: center;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header) > :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) > :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon) {
+    align-self: center;
+    justify-self: end;
+    margin: 0;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header) > .inline-drawer-icon,
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) > .inline-drawer-icon {
+    justify-self: end;
+    margin-left: 0;
+}
+
 @media (pointer: coarse), screen and (max-width: 768px) {
     .inline-drawer-header {
         align-items: center;
@@ -973,6 +1015,7 @@ h3:not(.popup h3):not(#chat h3) {
         border-radius: 12px;
     }
 
+    .inline-drawer-icon,
     .inline-drawer-icon > :is(.fa, .fa-solid, .fa-regular, .fa-brands, i) {
         font-size: clamp(14px, calc(var(--mainFontSize) * 1.05), 18px);
     }
@@ -3300,9 +3343,9 @@ input[type='range']::-moz-range-thumb {
 
 @media (pointer: coarse) and (max-width: 1000px) {
     #left-nav-panel.openDrawer {
-        --sb-mobile-range-label-width: clamp(4.25rem, 24vw, 5.75rem);
+        --sb-mobile-range-label-width: clamp(6.75rem, 30vw, 7.75rem);
         --sb-mobile-range-counter-width: 3.25rem;
-        --sb-mobile-range-gap: 10px;
+        --sb-mobile-range-gap: 12px;
     }
 
     .sb-sampling-control-card > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider),
@@ -3370,6 +3413,33 @@ input[type='range']::-moz-range-thumb {
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) > .range-block-title,
     #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) > .range-block-title {
         min-height: 32px;
+    }
+
+    .sb-sampling-control-card > :is(.alignitemscenter, .alignItemsCenter).flex-container:has(> input[type='range'].neo-range-slider) > :is(small, label):has(> .fa-circle-info),
+    .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers]:has(> input[type='range'].neo-range-slider) > :is(small, label):has(> .fa-circle-info),
+    .sb-sampling-control-card > .range-block:has(> .range-block-range-and-counter) > .range-block-title:has(.fa-circle-info),
+    #left-nav-panel.openDrawer :is(#amount_gen_block, #max_context_block) > small:has(> .fa-circle-info),
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .range-block-range-and-counter) > .range-block-title:has(.fa-circle-info),
+    #left-nav-panel.openDrawer #range_block_openai > .range-block:has(> .wide100p > #openai_max_tokens) > .range-block-title:has(.fa-circle-info) {
+        display: grid;
+        grid-template-columns: minmax(0, auto) 28px;
+        align-items: center;
+        justify-content: start;
+        column-gap: 8px;
+        padding-inline-end: 8px;
+        min-width: 0;
+    }
+
+    .sb-sampling-control-card :is(small, label, .range-block-title) > .fa-circle-info,
+    #left-nav-panel.openDrawer :is(small, label, .range-block-title) > .fa-circle-info {
+        inline-size: 28px;
+        block-size: 28px;
+        min-inline-size: 28px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        line-height: 1;
     }
 
     @media screen and (max-width: 420px) {
@@ -6051,6 +6121,44 @@ input[type='range']::-moz-range-thumb {
 /* Must beat upstream public/style.css:6130 .inline-drawer-header. */
 .inline-drawer-header {
     background: var(--color-surface-strong, color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, var(--SmartThemeBodyColor) 10%));
+}
+
+/* Must beat upstream public/style.css:6130 .inline-drawer-header display. */
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header),
+#rm_extensions_block :is(.inline-drawer-toggle, .inline-drawer-header) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 8px;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header):has(> :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon)),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header):has(> :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon)),
+#rm_extensions_block :is(.inline-drawer-toggle, .inline-drawer-header):has(> :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon)) {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header) > :is(b, strong, span, .title-container, .extension_name),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) > :is(b, strong, span, .title-container, .extension_name),
+#rm_extensions_block :is(.inline-drawer-toggle, .inline-drawer-header) > :is(b, strong, span, .title-container, .extension_name) {
+    min-width: 0;
+    align-self: center;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header) > :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon),
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) > :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon),
+#rm_extensions_block :is(.inline-drawer-toggle, .inline-drawer-header) > :is([id$='_settings_popout_button'], [id$='settings_popout_button'], .menu_button, .menu_button_icon):not(.inline-drawer-icon) {
+    align-self: center;
+    justify-self: end;
+    margin: 0;
+}
+
+#extensions_settings :is(.inline-drawer-toggle, .inline-drawer-header) > .inline-drawer-icon,
+#extensions_settings2 :is(.inline-drawer-toggle, .inline-drawer-header) > .inline-drawer-icon,
+#rm_extensions_block :is(.inline-drawer-toggle, .inline-drawer-header) > .inline-drawer-icon {
+    justify-self: end;
+    margin-left: 0;
 }
 
 /* Must beat upstream public/style.css:971/978 #form_sheld. */

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,20 @@
             background-color: #1d2128;
         }
     </style>
-    <link rel="preload" as="style" href="style.css?v=20260610a">
+    <script>
+        (() => {
+            try {
+                const savedTheme = localStorage.getItem('sb-theme');
+                const knownThemes = new Set(['windows-aero', 'clean-minimal', 'macos-minimal', 'cozy-warm', 'hypr-glow', 'slate-flat']);
+                if (knownThemes.has(savedTheme)) {
+                    document.documentElement.dataset.sbTheme = savedTheme;
+                }
+            } catch {
+                // Keep the preloader on the default theme if storage is unavailable.
+            }
+        })();
+    </script>
+    <link rel="preload" as="style" href="style.css?v=20260620b">
     <link rel="modulepreload" href="script.js">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js">
     <link rel="modulepreload" href="scripts/sillybunny-conversation.js">
@@ -42,12 +55,12 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260610a">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260620b">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260620a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260620b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260609d" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
@@ -8904,7 +8917,7 @@
     <div id="secrets_datalists" class="displayNone"></div>
 
     <!-- Script includes -->
-    <script src="scripts/sillybunny-boot-guard.js?v=20260611a"></script>
+    <script src="scripts/sillybunny-boot-guard.js?v=20260620b"></script>
     <script src="lib/polyfill.js" defer></script>
     <script src="lib/jquery-3.5.1.min.js" defer></script>
     <script src="lib/jquery-ui.min.js" defer></script>

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -874,12 +874,11 @@ export function resolveMobileModalA11yState({
 } = {}) {
     const ids = Array.isArray(activeRootIds) ? activeRootIds : [];
     const hasActiveMobileModal = ids.length > 0;
-    const shouldInertTopBar = ids.some(id => id !== 'sb-mobile-nav');
 
     return {
         hasActiveMobileModal,
         shouldInertShell: hasActiveMobileModal,
-        shouldInertTopBar,
+        shouldInertTopBar: false,
     };
 }
 
@@ -892,6 +891,11 @@ export const MOBILE_SHELL_DRAWER_BOUND_ACTION = Object.freeze({
 export const MOBILE_SHELL_DRAWER_BOUND_STYLE_PROPERTIES = Object.freeze([
     'top',
     'bottom',
+    'left',
+    'right',
+    'width',
+    'min-width',
+    'max-width',
     'height',
     'max-height',
     'box-sizing',
@@ -922,20 +926,22 @@ function clampBoundNumber(value, min, max) {
  * @param {boolean} [options.isMobileViewport=false] Whether mobile shell policy is active.
  * @param {boolean} [options.isOpen=false] Whether the drawer has the openDrawer class.
  * @param {boolean} [options.isViewportBound=false] Whether the drawer carries the bound dataset marker.
+ * @param {number} [options.viewportWidth=0] Current shell viewport width in px.
  * @param {number} [options.viewportHeight=0] Current shell viewport height in px.
+ * @param {number} [options.viewportLeft=0] Current shell viewport left offset in px.
  * @param {number} [options.baseTopOffset=0] Resolved shell topbar offset in px.
  * @param {number} [options.shellGap=0] Drawer --sb-mobile-shell-gap value in px.
- * @param {number} [options.safeAreaBottom=0] Bottom safe-area inset reserved below the drawer.
  * @returns {{action: string, styleWrites: Array<{property: string, value: string, priority: string}>, styleRemovals: string[]}}
  */
 export function resolveMobileDrawerBounds({
     isMobileViewport = false,
     isOpen = false,
     isViewportBound = false,
+    viewportWidth = 0,
     viewportHeight = 0,
+    viewportLeft = 0,
     baseTopOffset = 0,
     shellGap = 0,
-    safeAreaBottom = 0,
 } = {}) {
     const shouldBind = Boolean(isMobileViewport) && Boolean(isOpen);
 
@@ -947,21 +953,23 @@ export function resolveMobileDrawerBounds({
         };
     }
 
+    const safeViewportWidth = Math.max(0, Math.round(normalizeNumber(viewportWidth)));
     const safeViewportHeight = Math.max(0, normalizeNumber(viewportHeight));
+    const safeViewportLeft = Math.round(normalizeNumber(viewportLeft));
     const safeBaseTopOffset = Math.max(0, Math.round(normalizeNumber(baseTopOffset)));
     const topOffset = clampBoundNumber(Math.round(safeBaseTopOffset + normalizeNumber(shellGap)), 0, safeViewportHeight);
-    const bottomInset = clampBoundNumber(
-        Math.round(normalizeNumber(safeAreaBottom)),
-        0,
-        Math.max(0, safeViewportHeight - topOffset),
-    );
-    const availableHeight = Math.max(0, safeViewportHeight - topOffset - bottomInset);
+    const availableHeight = Math.max(0, safeViewportHeight - topOffset);
 
     return {
         action: MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND,
         styleWrites: [
             { property: 'top', value: `${topOffset}px`, priority: 'important' },
             { property: 'bottom', value: 'auto', priority: 'important' },
+            { property: 'left', value: `${safeViewportLeft}px`, priority: 'important' },
+            { property: 'right', value: 'auto', priority: 'important' },
+            { property: 'width', value: `${safeViewportWidth}px`, priority: 'important' },
+            { property: 'min-width', value: `${safeViewportWidth}px`, priority: 'important' },
+            { property: 'max-width', value: `${safeViewportWidth}px`, priority: 'important' },
             { property: 'box-sizing', value: 'border-box', priority: 'important' },
             { property: 'height', value: `${availableHeight}px`, priority: 'important' },
             { property: 'max-height', value: `${availableHeight}px`, priority: 'important' },

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -155,6 +155,31 @@
         return Date.now() - bootStartedAt;
     }
 
+    function isRuntimeReady() {
+        try {
+            return Boolean(window.SillyBunnyShell && typeof window.SillyBunnyShell.openTab === 'function');
+        } catch (_error) {
+            return false;
+        }
+    }
+
+    function completeBoot() {
+        bootCompleted = true;
+        loaderRemovalGraceActive = false;
+        if (timeoutId) {
+            window.clearTimeout(timeoutId);
+        }
+    }
+
+    function completeBootSilently(removePreloader) {
+        completeBoot();
+
+        if (removePreloader) {
+            removeStartupLoaderArtifacts();
+            removeElement(document.getElementById('preloader'));
+        }
+    }
+
     function scheduleBootTimeout(delay) {
         timeoutId = window.setTimeout(handleBootTimeout, delay);
     }
@@ -164,14 +189,22 @@
             return;
         }
 
+        if (lastFailure) {
+            showFailure(lastFailure);
+            return;
+        }
+
+        if (isRuntimeReady()) {
+            completeBootSilently(true);
+            return;
+        }
+
         if (!lastFailure && isStartupLoaderActive()) {
             loaderRemovalGraceActive = false;
 
             if (!timeoutWarningShown && getElapsedBootTimeMs() >= MAX_BOOT_TIMEOUT_MS) {
                 timeoutWarningShown = true;
                 console.warn('SillyBunny startup is still waiting for the loader to finish; no startup error was captured.');
-                showFailure('Startup timed out before SillyBunny removed the preloader.');
-                return;
             }
 
             scheduleBootTimeout(BOOT_TIMEOUT_RETRY_MS);
@@ -184,7 +217,12 @@
             return;
         }
 
-        showFailure(lastFailure || 'Startup timed out after the preloader disappeared before SillyBunny finished booting.');
+        if (!timeoutWarningShown && getElapsedBootTimeMs() >= MAX_BOOT_TIMEOUT_MS) {
+            timeoutWarningShown = true;
+            console.warn('SillyBunny startup loader disappeared before boot completion, but no startup error was captured.');
+        }
+
+        completeBootSilently(true);
     }
 
     function showFailure(details) {
@@ -261,11 +299,7 @@
 
     window.SillyBunnyBootGuard = {
         bootCompleted: function () {
-            bootCompleted = true;
-            loaderRemovalGraceActive = false;
-            if (timeoutId) {
-                window.clearTimeout(timeoutId);
-            }
+            completeBoot();
         },
         showFailure: showFailure,
     };

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -205,7 +205,7 @@ function isSearchShortcutTarget(target) {
     return target === 'action:search';
 }
 
-function activateShortcutTarget(target) {
+function activateShortcutTarget(target, event = null) {
     if (isSearchShortcutTarget(target)) {
         const searchState = getUniversalSearchState();
 
@@ -237,12 +237,12 @@ function activateShortcutTarget(target) {
             void setCharacterListEntityView('characters');
         }
         preloadPanelStylesheets('characters', tab);
-        toggleShellPanel(shell, tab);
+        toggleShellPanel(shell, tab, { sourceEvent: event });
         return;
     }
 
     if (shell && tab) {
-        toggleShellPanel(shell, tab);
+        toggleShellPanel(shell, tab, { sourceEvent: event });
     }
 }
 
@@ -2439,29 +2439,6 @@ function applyMobileDrawerBoundsDecision(drawer, decision) {
     }
 }
 
-function getMobileSafeAreaBottomPx() {
-    const styles = window.getComputedStyle(document.documentElement);
-    const fallback = Number.parseFloat(styles.getPropertyValue('--sb-mobile-safe-area-bottom')) || 0;
-
-    if (!(document.body instanceof HTMLElement)) {
-        return fallback;
-    }
-
-    let probe = document.getElementById('sb-mobile-safe-area-bottom-probe');
-    if (!(probe instanceof HTMLElement)) {
-        probe = createElement('div', {
-            attrs: {
-                id: 'sb-mobile-safe-area-bottom-probe',
-                'aria-hidden': 'true',
-            },
-        });
-        probe.style.cssText = 'position:fixed;left:0;bottom:0;width:0;height:0;padding-bottom:var(--sb-mobile-safe-area-bottom,0px);pointer-events:none;visibility:hidden;contain:layout style size;';
-        document.body.appendChild(probe);
-    }
-
-    return Number.parseFloat(window.getComputedStyle(probe).paddingBottom) || fallback;
-}
-
 function syncMobileShellDrawerBounds() {
     const drawers = getMobileShellBoundDrawers();
 
@@ -2472,7 +2449,6 @@ function syncMobileShellDrawerBounds() {
     const mobileViewport = isMobileViewport();
     const viewportSize = mobileViewport ? getShellViewportSize() : null;
     const baseTopOffset = mobileViewport ? getResolvedShellTopbarOffset() : 0;
-    const safeAreaBottom = mobileViewport ? getMobileSafeAreaBottomPx() : 0;
 
     for (const drawer of drawers) {
         const isOpen = drawer.classList.contains('openDrawer');
@@ -2482,10 +2458,11 @@ function syncMobileShellDrawerBounds() {
             isMobileViewport: mobileViewport,
             isOpen,
             isViewportBound: drawer.dataset.sbMobileViewportBound === 'true',
+            viewportWidth: viewportSize?.width ?? 0,
             viewportHeight: viewportSize?.height ?? 0,
+            viewportLeft: viewportSize?.left ?? 0,
             baseTopOffset,
             shellGap: drawerStyles ? Number.parseFloat(drawerStyles.getPropertyValue('--sb-mobile-shell-gap')) || 0 : 0,
-            safeAreaBottom,
         }));
     }
 }
@@ -8368,7 +8345,7 @@ function closeAllDropdowns({ except = '', closeSurfaces = true } = {}) {
     document.getElementById('sb-persona-picker')?.remove();
 }
 
-function toggleShellPanel(shellKey, tabId = null) {
+function toggleShellPanel(shellKey, tabId = null, { sourceEvent = null } = {}) {
     if (shellKey === 'characters') {
         if (isCharacterPanelTabOpen(tabId)) {
             closeCharacterPanel();
@@ -8393,7 +8370,7 @@ function toggleShellPanel(shellKey, tabId = null) {
     preloadPanelStylesheets(shellKey, tabId);
 
     if (tabId ? isShellTabOpen(shellKey, tabId) : isShellOpen(shellKey)) {
-        if (wasShellJustOpened(shellKey)) {
+        if (wasShellJustOpened(shellKey) && !sourceEvent?.isTrusted) {
             return;
         }
 
@@ -8722,7 +8699,7 @@ function buildTopBar() {
             label: getShellConfig('left').proxyLabel,
             title: 'Open workspace tools',
         },
-        () => toggleShellPanel('left'),
+        event => toggleShellPanel('left', null, { sourceEvent: event }),
     );
 
     const homeButton = createProxyButton(
@@ -8745,7 +8722,7 @@ function buildTopBar() {
             label: getShellConfig('right').proxyLabel,
             title: 'Open customization tools',
         },
-        () => toggleShellPanel('right'),
+        event => toggleShellPanel('right', null, { sourceEvent: event }),
     );
 
     const charactersButton = createProxyButton(
@@ -8767,7 +8744,7 @@ function buildTopBar() {
             title: `Quick access: ${leftShortcutConfig.label}`,
             className: 'sb-proxy-button-icon-only',
         },
-        () => activateShortcutTarget(getShortcutTarget('left')),
+        event => activateShortcutTarget(getShortcutTarget('left'), event),
     );
     bindSearchShortcutPreFocus(leftShortcut, () => getShortcutTarget('left'));
 
@@ -8780,7 +8757,7 @@ function buildTopBar() {
             title: `Quick access: ${rightShortcutConfig.label}`,
             className: 'sb-proxy-button-icon-only',
         },
-        () => activateShortcutTarget(getShortcutTarget('right')),
+        event => activateShortcutTarget(getShortcutTarget('right'), event),
     );
     bindSearchShortcutPreFocus(rightShortcut, () => getShortcutTarget('right'));
 
@@ -8795,7 +8772,7 @@ function buildTopBar() {
                 title: `Quick access: ${shortcutConfig.label}`,
                 className: 'sb-proxy-button-icon-only sb-desktop-setting',
             },
-            () => activateShortcutTarget(getShortcutTarget(side)),
+            event => activateShortcutTarget(getShortcutTarget(side), event),
         );
         bindSearchShortcutPreFocus(shortcut, () => getShortcutTarget(side));
         desktopShortcutButtons[side] = shortcut;

--- a/tests/mobile-shell-lifecycle-drawer-bounds.test.js
+++ b/tests/mobile-shell-lifecycle-drawer-bounds.test.js
@@ -12,6 +12,11 @@ describe('mobile shell drawer bounds lifecycle', () => {
         expect(MOBILE_SHELL_DRAWER_BOUND_STYLE_PROPERTIES).toEqual([
             'top',
             'bottom',
+            'left',
+            'right',
+            'width',
+            'min-width',
+            'max-width',
             'height',
             'max-height',
             'box-sizing',
@@ -23,7 +28,9 @@ describe('mobile shell drawer bounds lifecycle', () => {
             isMobileViewport: true,
             isOpen: true,
             isViewportBound: false,
+            viewportWidth: 390,
             viewportHeight: 844,
+            viewportLeft: 4,
             baseTopOffset: 56,
             shellGap: 3,
         });
@@ -33,16 +40,22 @@ describe('mobile shell drawer bounds lifecycle', () => {
         expect(decision.styleWrites).toEqual([
             { property: 'top', value: '59px', priority: 'important' },
             { property: 'bottom', value: 'auto', priority: 'important' },
+            { property: 'left', value: '4px', priority: 'important' },
+            { property: 'right', value: 'auto', priority: 'important' },
+            { property: 'width', value: '390px', priority: 'important' },
+            { property: 'min-width', value: '390px', priority: 'important' },
+            { property: 'max-width', value: '390px', priority: 'important' },
             { property: 'box-sizing', value: 'border-box', priority: 'important' },
             { property: 'height', value: '785px', priority: 'important' },
             { property: 'max-height', value: '785px', priority: 'important' },
         ]);
     });
 
-    test('subtracts the mobile safe-area bottom from open drawer height', () => {
+    test('keeps an open drawer bound to the viewport bottom', () => {
         const decision = resolveMobileDrawerBounds({
             isMobileViewport: true,
             isOpen: true,
+            viewportWidth: 390,
             viewportHeight: 844,
             baseTopOffset: 56,
             shellGap: 3,
@@ -50,18 +63,18 @@ describe('mobile shell drawer bounds lifecycle', () => {
         });
 
         expect(decision.styleWrites).toContainEqual({ property: 'top', value: '59px', priority: 'important' });
-        expect(decision.styleWrites).toContainEqual({ property: 'height', value: '751px', priority: 'important' });
-        expect(decision.styleWrites).toContainEqual({ property: 'max-height', value: '751px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'height', value: '785px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'max-height', value: '785px', priority: 'important' });
     });
 
     test('clamps the top offset to the viewport and never yields negative height', () => {
         const decision = resolveMobileDrawerBounds({
             isMobileViewport: true,
             isOpen: true,
+            viewportWidth: 390,
             viewportHeight: 500,
             baseTopOffset: 480,
             shellGap: 200,
-            safeAreaBottom: 200,
         });
 
         expect(decision.action).toBe(MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND);
@@ -73,11 +86,15 @@ describe('mobile shell drawer bounds lifecycle', () => {
         const decision = resolveMobileDrawerBounds({
             isMobileViewport: true,
             isOpen: true,
+            viewportWidth: 390.4,
             viewportHeight: 844,
+            viewportLeft: 0.6,
             baseTopOffset: 55.6,
             shellGap: Number.NaN,
         });
 
+        expect(decision.styleWrites).toContainEqual({ property: 'left', value: '1px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'width', value: '390px', priority: 'important' });
         expect(decision.styleWrites).toContainEqual({ property: 'top', value: '56px', priority: 'important' });
         expect(decision.styleWrites).toContainEqual({ property: 'height', value: '788px', priority: 'important' });
     });

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -307,10 +307,14 @@ describe('mobile shell lifecycle wiring', () => {
         const toggleShellPanelSource = getFunctionSource('toggleShellPanel');
         const isCharacterPanelTabOpenSource = getFunctionSource('isCharacterPanelTabOpen');
 
-        expect(buildTopBarSource).toContain('activateShortcutTarget(getShortcutTarget(\'left\'))');
-        expect(buildTopBarSource).toContain('activateShortcutTarget(getShortcutTarget(\'right\'))');
-        expect(activateShortcutTargetSource).toContain('toggleShellPanel(shell, tab);');
+        expect(buildTopBarSource).toContain('event => toggleShellPanel(\'left\', null, { sourceEvent: event })');
+        expect(buildTopBarSource).toContain('event => toggleShellPanel(\'right\', null, { sourceEvent: event })');
+        expect(buildTopBarSource).toContain('event => activateShortcutTarget(getShortcutTarget(\'left\'), event)');
+        expect(buildTopBarSource).toContain('event => activateShortcutTarget(getShortcutTarget(\'right\'), event)');
+        expect(activateShortcutTargetSource).toContain('toggleShellPanel(shell, tab, { sourceEvent: event });');
         expect(activateShortcutTargetSource).not.toContain('openCharacterPanelTab(tab);');
+        expect(toggleShellPanelSource).toContain('{ sourceEvent = null } = {}');
+        expect(toggleShellPanelSource).toContain('wasShellJustOpened(shellKey) && !sourceEvent?.isTrusted');
         expect(toggleShellPanelSource).toContain('isCharacterPanelTabOpen(tabId)');
         expect(toggleShellPanelSource).toContain('closeCharacterPanel();');
         expect(isCharacterPanelTabOpenSource).toContain('getActiveCharacterPanelTab() === normalizeCharacterPanelTab(tabId)');
@@ -385,7 +389,6 @@ describe('mobile shell lifecycle wiring', () => {
 
     test('routes mobile drawer bound decisions through the lifecycle seam', () => {
         const applyDecisionSource = getFunctionSource('applyMobileDrawerBoundsDecision');
-        const safeAreaSource = getFunctionSource('getMobileSafeAreaBottomPx');
         const syncBoundsSource = getFunctionSource('syncMobileShellDrawerBounds');
 
         // The adapter is the single DOM writer for drawer bound styles.
@@ -395,17 +398,14 @@ describe('mobile shell lifecycle wiring', () => {
         expect(applyDecisionSource).toContain('decision.styleWrites');
         expect(applyDecisionSource).toContain('drawer.style.setProperty(property, value, priority);');
         expect(applyDecisionSource).toContain('drawer.style.removeProperty(property);');
-        expect(safeAreaSource).toContain('window.getComputedStyle(document.documentElement)');
-        expect(safeAreaSource).toContain('--sb-mobile-safe-area-bottom');
-        expect(safeAreaSource).toContain('sb-mobile-safe-area-bottom-probe');
-        expect(safeAreaSource).toContain('padding-bottom:var(--sb-mobile-safe-area-bottom,0px)');
-        expect(safeAreaSource).toContain('window.getComputedStyle(probe).paddingBottom');
 
         // The call site resolves decisions through the seam and applies via the adapter.
         expect(syncBoundsSource).toContain('sbMobileShellLifecycle.drawerBounds.resolveBounds({');
         expect(syncBoundsSource).toContain('applyMobileDrawerBoundsDecision(drawer,');
-        expect(syncBoundsSource).toContain('const safeAreaBottom = mobileViewport ? getMobileSafeAreaBottomPx() : 0;');
-        expect(syncBoundsSource).toContain('safeAreaBottom,');
+        expect(syncBoundsSource).toContain('viewportWidth: viewportSize?.width ?? 0,');
+        expect(syncBoundsSource).toContain('viewportLeft: viewportSize?.left ?? 0,');
+        expect(tabsSource).not.toContain('function getMobileSafeAreaBottomPx(');
+        expect(syncBoundsSource).not.toContain('safeAreaBottom');
 
         // The old inline style writes are gone from the call site.
         expect(syncBoundsSource).not.toContain('style.setProperty(\'top\'');

--- a/tests/mobile-shell-lifecycle.test.js
+++ b/tests/mobile-shell-lifecycle.test.js
@@ -413,7 +413,7 @@ describe('mobile shell lifecycle helper', () => {
         })).toBe(false);
     });
 
-    test('inerts shell for any active mobile modal and top bar for non-nav modals', () => {
+    test('inerts shell for active mobile modals while keeping the top bar operable', () => {
         expect(resolveMobileModalA11yState({
             activeRootIds: [],
         })).toEqual({
@@ -435,7 +435,7 @@ describe('mobile shell lifecycle helper', () => {
         })).toEqual({
             hasActiveMobileModal: true,
             shouldInertShell: true,
-            shouldInertTopBar: true,
+            shouldInertTopBar: false,
         });
     });
 

--- a/tests/sillybunny-accent-profiles.test.js
+++ b/tests/sillybunny-accent-profiles.test.js
@@ -50,7 +50,7 @@ describe('SillyBunny accent color profiles', () => {
         expect(indexSource).toContain('id="sb-accent-profile-save"');
         expect(indexSource).toContain('id="sb-accent-profiles-list"');
         expect(indexSource).toContain('id="sb-accent-profiles-empty"');
-        expect(indexSource).toContain('css/sillybunny-theme.css?v=20260620a');
+        expect(indexSource).toContain('css/sillybunny-theme.css?v=20260620b');
         expect(powerUserSource).toContain('$(document).on(\'click\', \'#sb-accent-profile-save\'');
         expect(powerUserSource).toContain('$(document).on(\'click\', \'.sb-accent-profile-apply\'');
         expect(powerUserSource).toContain('$(document).on(\'click\', \'.sb-accent-profile-delete\'');

--- a/tests/sillybunny-boot-guard.test.js
+++ b/tests/sillybunny-boot-guard.test.js
@@ -199,7 +199,7 @@ describe('SillyBunny boot guard', () => {
         expect(preloader.querySelector('button').textContent).toBe('Clear frontend cache and reload');
     });
 
-    test('defers timeout failures while the normal startup loader is active', () => {
+    test('does not show the recovery panel for loader-only startup timeouts', () => {
         const { document, setNow, timers } = createBootGuardHarness();
         const preloader = addPreloader(document);
         const loader = document.appendChild(new FakeElement('div', { id: 'loader' }));
@@ -222,7 +222,22 @@ describe('SillyBunny boot guard', () => {
         setNow(38000);
         timers.shift().callback();
 
-        expect(preloader.querySelector('button').textContent).toBe('Clear frontend cache and reload');
+        expect(preloader.querySelector('button')).toBeNull();
+        expect(document.getElementById('preloader')).toBeNull();
+    });
+
+    test('removes a stale startup loader when the shell runtime is ready', () => {
+        const { document, setNow, timers, window } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        document.appendChild(new FakeElement('div', { id: 'loader' }));
+        window.SillyBunnyShell = { openTab: jest.fn() };
+
+        setNow(26000);
+        timers.shift().callback();
+
+        expect(preloader.querySelector('button')).toBeNull();
+        expect(document.getElementById('loader')).toBeNull();
+        expect(document.getElementById('preloader')).toBeNull();
     });
 
     test('offers a dismiss button that removes the panel and suppresses later failures', () => {


### PR DESCRIPTION
## Summary
- Bind mobile shell drawers to the visual viewport on open, including width/left/max-width, and keep the top bar operable so shell toggles close on the second tap.
- Make the startup guard show the recovery panel only for captured first-party startup failures, while silently clearing stale loader overlays when the shell is ready.
- Move the splash border to the full viewport preloader frame, seed the saved SB theme before styles load, and normalize extension drawer expando/sampling-info spacing on mobile.

## Validation
- node --check on edited startup/mobile scripts
- Targeted ESLint on edited JS and test files
- Targeted Jest for mobile shell lifecycle, drawer bounds, lifecycle wiring, startup guard, accent profiles, frontend assets, and script module identity
- Frontend budget script
- Mobile Chromium verification at 393x852 for drawer geometry/toggle close, hard-refresh startup guard, sampling info spacing, extension expando alignment, and loader frame styles

## Notes
- The existing mobile CSS ratchet test still reports the current staging baseline for sillybunny-mobile-shell.css important-count drift; this change does not touch that file.