### PR TITLE
fix: restore mobile home shell state

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -3207,6 +3207,11 @@
         height: var(--sb-topbar-layout-offset);
     }
 
+    body.sb-mobile-home-open #form_sheld,
+    body.sb-mobile-home-open #sb-bottom-chat-bar {
+        display: none;
+    }
+
     /* Must beat upstream public/css/mobile-styles.css:165 #right-nav-panel #CharListButtonAndHotSwaps. */
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps {
         display: flex;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -7054,6 +7054,10 @@ function getActiveMobileModalRoots() {
     return getMobileModalRootCandidates().filter(root => isMobileModalRootOpen(root));
 }
 
+function hasActiveMobileModalRoot() {
+    return getActiveMobileModalRoots().length > 0;
+}
+
 function setElementInertForMobileModal(element, shouldInert) {
     if (!(element instanceof HTMLElement)) {
         return;
@@ -7149,6 +7153,7 @@ function syncMobileModalState() {
 
     setElementInertForMobileModal(document.getElementById('sheld'), modalState.shouldInertShell);
     setElementInertForMobileModal(document.getElementById('top-bar'), modalState.shouldInertTopBar);
+    syncHomeButtonState();
 }
 
 function queueMobileModalStateSync() {
@@ -8462,16 +8467,22 @@ function isLandingPageVisible() {
 }
 
 function syncHomeButtonState() {
+    const isHomeVisible = isLandingPageVisible();
+    const isMobile = isMobileViewport();
+    const hasActiveMobileModal = isMobile && hasActiveMobileModalRoot();
+    const isHomeCurrent = isHomeVisible && !hasActiveMobileModal;
+
+    document.body?.classList.toggle('sb-mobile-home-open', isMobile && isHomeCurrent);
+
     const homeButton = document.getElementById('sb-home-toggle');
     if (!(homeButton instanceof HTMLButtonElement)) {
         return;
     }
 
-    const isHomeVisible = isLandingPageVisible();
-    setButtonPressed(homeButton, isHomeVisible);
-    homeButton.classList.toggle('is-current', isHomeVisible);
+    setButtonPressed(homeButton, isHomeCurrent);
+    homeButton.classList.toggle('is-current', isHomeCurrent);
 
-    if (isHomeVisible) {
+    if (isHomeCurrent) {
         homeButton.setAttribute('aria-current', 'page');
     } else {
         homeButton.removeAttribute('aria-current');

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -51,8 +51,10 @@ function getMediaQueryPxValues(cssSource) {
 // Raised 4 -> 6: mobile-refactor port added two !important display overrides
 // for bottom-chat overflow toggle/source to beat unlayered sillybunny-tabs.css
 // and third-party extension CSS that forces display:flex on hidden buttons.
+// Raised 6 -> 11: 37f271cbc added five drawer-bound overrides to keep open
+// mobile shells locked to the visual viewport over upstream drawer rules.
 const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
-    'sillybunny-mobile-shell.css': 6,
+    'sillybunny-mobile-shell.css': 11,
     'sillybunny-tabs.css': 384,
     'sillybunny-chat-styles.css': 225,
     'sillybunny-theme.css': 137,
@@ -88,7 +90,9 @@ const FORK_UNLAYERED_GUARD_PINS = Object.freeze({
         '/* Must beat upstream public/css/tags.css:162 .rm_tag_controls. */',
     ],
 });
-const FORK_DISTINCT_BREAKPOINT_BUDGET = 7;
+// Raised 7 -> 8: the retained 1420px group schedule breakpoint keeps the
+// desktop-width two-step controls layout from ccea8982f.
+const FORK_DISTINCT_BREAKPOINT_BUDGET = 8;
 
 const forkSheetSources = Object.fromEntries(
     Object.keys(FORK_SHEET_IMPORTANT_BUDGETS).map(sheetName => [sheetName, readPublicFile('css', sheetName)]),

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -86,6 +86,21 @@ describe('mobile shell lifecycle wiring', () => {
         expect(syncMobileModalStateSource).not.toContain('activeRoots.some(root => root.id !== \'sb-mobile-nav\')');
     });
 
+    test('keeps mobile Home state exclusive with active modal surfaces', () => {
+        const syncHomeButtonStateSource = getFunctionSource('syncHomeButtonState');
+        const syncMobileModalStateSource = getFunctionSource('syncMobileModalState');
+
+        expect(tabsSource).toContain('function hasActiveMobileModalRoot()');
+        expect(syncHomeButtonStateSource).toContain('const hasActiveMobileModal = isMobile && hasActiveMobileModalRoot();');
+        expect(syncHomeButtonStateSource).toContain('const isHomeCurrent = isHomeVisible && !hasActiveMobileModal;');
+        expect(syncHomeButtonStateSource).toContain('document.body?.classList.toggle(\'sb-mobile-home-open\', isMobile && isHomeCurrent);');
+        expect(syncHomeButtonStateSource).toContain('setButtonPressed(homeButton, isHomeCurrent);');
+        expect(syncMobileModalStateSource).toContain('syncHomeButtonState();');
+        expect(mobileShellCssSource).toContain('body.sb-mobile-home-open #form_sheld,');
+        expect(mobileShellCssSource).toContain('body.sb-mobile-home-open #sb-bottom-chat-bar');
+        expect(mobileShellCssSource).toMatch(/body\.sb-mobile-home-open #form_sheld,[\s\S]*body\.sb-mobile-home-open #sb-bottom-chat-bar\s*\{[\s\S]*display:\s*none;/);
+    });
+
     test('routes mobile nav outside-click auto-close through the lifecycle seam', () => {
         const buildMobileNavSource = getFunctionSource('buildMobileNav');
 


### PR DESCRIPTION
## Summary
- make the mobile Home button current only when no mobile modal shell is active
- add a mobile Home body state that hides composer and bottom chat chrome while the welcome surface is current
- keep the ratchet budget notes for existing staging CSS state

## Tests
- bun test tests/mobile-shell-lifecycle-wiring.test.js
- bun test tests/mobile-