### PR TITLE
feat: make top bar title tappable to cycle label parts

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1184,10 +1184,33 @@ body:not(.movingUI) .drawer-content.maximized {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    margin: -2px -6px;
+    padding: 2px 6px;
+    border-radius: 999px;
     font-size: var(--sb-type-body);
     font-weight: var(--sb-weight-title);
     line-height: var(--sb-line-title);
     letter-spacing: 0;
+    cursor: pointer;
+    touch-action: manipulation;
+    -webkit-user-select: none;
+    user-select: none;
+    transition: background-color 160ms ease-out, box-shadow 160ms ease-out, opacity 160ms ease-out;
+}
+
+.sb-brand-title:hover,
+.sb-brand-title.is-previewing,
+.sb-brand-title:focus-visible {
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 9%, transparent);
+}
+
+.sb-brand-title:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 58%, transparent);
+}
+
+.sb-brand-title:active {
+    opacity: 0.82;
 }
 
 .sb-brand-title.is-chat {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -382,6 +382,7 @@ const SB_TOPBAR_LABEL_PARTS = Object.freeze([
 const SB_TOPBAR_LABEL_PART_ORDER = Object.freeze(SB_TOPBAR_LABEL_PARTS.map(part => part.id));
 const SB_TOPBAR_LABEL_PART_IDS = new Set(SB_TOPBAR_LABEL_PART_ORDER);
 const SB_TOPBAR_LABEL_CUSTOM_TEXT_MAX_LENGTH = 48;
+const SB_TOPBAR_LABEL_CYCLE_RESET_MS = 5000;
 const SB_TOPBAR_DRAG_X_RATIO = 0.36;
 const SB_TOPBAR_DRAG_Y_RATIO = 0.24;
 const SB_TOPBAR_CONTEXT_REFRESH_DEBOUNCE = 220;
@@ -743,6 +744,8 @@ const sbState = {
         refreshInFlight: false,
         refreshPending: false,
         refreshToken: 0,
+        cyclePart: '',
+        cycleResetTimer: 0,
         bindingRetryTimer: 0,
         boundEventSource: null,
         windowBindingsAttached: false,
@@ -3683,6 +3686,10 @@ function setTopbarCustomText(value) {
     }
 
     sbState.topbarLabel.customText = nextText;
+    if (!nextText && sbState.topbarLabel.cyclePart === 'custom') {
+        resetTopBarLabelCycle({ refresh: false });
+    }
+
     safeSetItem(SB_STORAGE_KEYS.topbarLabelCustomText, nextText);
     updateThemePickerUi();
     updateTopBarBrand();
@@ -4020,7 +4027,9 @@ function setTopbarContextTokens(tokens) {
 }
 
 function isTopbarContextLabelEnabled() {
-    return sbState.topbarLabel.desktopParts.includes('ctx') || sbState.topbarLabel.mobilePart === 'ctx';
+    return sbState.topbarLabel.desktopParts.includes('ctx')
+        || sbState.topbarLabel.mobilePart === 'ctx'
+        || sbState.topbarLabel.cyclePart === 'ctx';
 }
 
 function syncTopbarContextTokensFromPromptManager() {
@@ -4100,6 +4109,19 @@ function getConfiguredTopbarLabelParts() {
     return normalizeTopbarLabelParts(sbState.topbarLabel.desktopParts);
 }
 
+function getTopbarLabelPartOption(partId) {
+    return SB_TOPBAR_LABEL_PARTS.find(part => part.id === partId) ?? null;
+}
+
+function getTopbarLabelCycleParts() {
+    const cycleParts = ['', 'ctx', 'char'];
+    if (sbState.topbarLabel.customText) {
+        cycleParts.push('custom');
+    }
+
+    return cycleParts;
+}
+
 function getTopBarLabelPartText(partId, context = getSillyTavernContext()) {
     switch (partId) {
         case 'ctx':
@@ -4117,8 +4139,88 @@ function getTopBarLabelPartText(partId, context = getSillyTavernContext()) {
     }
 }
 
+function getTopBarLabelPreviewText(partId, context = getSillyTavernContext()) {
+    const normalizedPart = normalizeTopbarLabelPart(partId);
+    const labelText = normalizedPart ? getTopBarLabelPartText(normalizedPart, context) : '';
+    if (labelText) {
+        return labelText;
+    }
+
+    if (normalizedPart === 'ctx') {
+        return '...';
+    }
+
+    return getTopbarLabelPartOption(normalizedPart)?.label ?? '';
+}
+
+function resetTopBarLabelCycle({ refresh = true } = {}) {
+    const hadCyclePart = Boolean(sbState.topbarLabel.cyclePart);
+    window.clearTimeout(sbState.topbarLabel.cycleResetTimer);
+    sbState.topbarLabel.cycleResetTimer = 0;
+    sbState.topbarLabel.cyclePart = '';
+
+    if (hadCyclePart && refresh) {
+        updateTopBarBrand();
+    }
+}
+
+function scheduleTopBarLabelCycleReset() {
+    window.clearTimeout(sbState.topbarLabel.cycleResetTimer);
+    sbState.topbarLabel.cycleResetTimer = window.setTimeout(() => {
+        resetTopBarLabelCycle();
+    }, SB_TOPBAR_LABEL_CYCLE_RESET_MS);
+}
+
+function cycleTopBarLabel() {
+    const cycleParts = getTopbarLabelCycleParts();
+    const currentPart = normalizeTopbarLabelPart(sbState.topbarLabel.cyclePart, '');
+    const currentIndex = cycleParts.indexOf(currentPart);
+    const nextIndex = currentIndex >= 0 ? currentIndex + 1 : 1;
+    const nextPart = cycleParts[nextIndex % cycleParts.length];
+
+    sbState.topbarLabel.cyclePart = nextPart;
+    if (nextPart) {
+        scheduleTopBarLabelCycleReset();
+    } else {
+        window.clearTimeout(sbState.topbarLabel.cycleResetTimer);
+        sbState.topbarLabel.cycleResetTimer = 0;
+    }
+
+    if (nextPart === 'ctx') {
+        scheduleTopbarContextRefresh(0);
+    }
+
+    updateTopBarBrand();
+}
+
+function bindTopBarTitleCycle(title) {
+    if (!(title instanceof HTMLElement) || title.dataset.sbTopbarTitleCycleBound === 'true') {
+        return;
+    }
+
+    title.dataset.sbTopbarTitleCycleBound = 'true';
+    title.addEventListener('click', event => {
+        event.stopPropagation();
+        cycleTopBarLabel();
+    });
+    title.addEventListener('keydown', event => {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        cycleTopBarLabel();
+    });
+}
+
 function getTopBarLabel() {
     const context = getSillyTavernContext();
+    const previewPart = normalizeTopbarLabelPart(sbState.topbarLabel.cyclePart, '');
+    if (previewPart) {
+        return getTopBarLabelPreviewText(previewPart, context);
+    }
+
     const parts = getConfiguredTopbarLabelParts()
         .map(partId => normalizeTopbarLabelPart(partId))
         .filter(Boolean);
@@ -4142,9 +4244,12 @@ function updateTopBarBrand() {
     const label = getTopBarLabel();
     const isActiveChat = hasActiveTopBarChat(context);
 
+    bindTopBarTitleCycle(title);
     title.textContent = label;
     title.title = label;
+    title.setAttribute('aria-label', `${label}. Tap to preview top bar label options.`);
     title.classList.toggle('is-chat', isActiveChat);
+    title.classList.toggle('is-previewing', Boolean(sbState.topbarLabel.cyclePart));
     brand.dataset.brandState = isActiveChat ? 'chat' : 'idle';
 }
 
@@ -4203,6 +4308,24 @@ function bindTopBarBrand() {
         refresh();
         scheduleTopbarContextRefresh();
     };
+    const resetCycleAndRefreshWithContext = () => {
+        resetTopBarLabelCycle({ refresh: false });
+        refreshWithContext();
+    };
+    // SillyBunny: top-bar taps only preview alternate labels; chat/context moves restore configured text.
+    const resetCycleEvents = new Set([
+        eventTypes.APP_READY,
+        eventTypes.CHAT_CHANGED,
+        eventTypes.CHAT_CREATED,
+        eventTypes.GROUP_CHAT_CREATED,
+        eventTypes.CHARACTER_EDITED,
+        eventTypes.CHARACTER_RENAMED,
+        eventTypes.CHARACTER_DELETED,
+        eventTypes.GROUP_UPDATED,
+        eventTypes.PERSONA_CHANGED,
+        eventTypes.MAIN_API_CHANGED,
+        eventTypes.SETTINGS_UPDATED,
+    ].filter(Boolean));
     const events = [
         eventTypes.APP_READY,
         eventTypes.CHAT_CHANGED,
@@ -4222,7 +4345,8 @@ function bindTopBarBrand() {
     ].filter(Boolean);
 
     for (const eventName of new Set(events)) {
-        eventSource.on(eventName, refreshWithContext);
+        const eventHandler = resetCycleEvents.has(eventName) ? resetCycleAndRefreshWithContext : refreshWithContext;
+        eventSource.on(eventName, eventHandler);
     }
 
     if (eventTypes.CHAT_COMPLETION_PROMPT_READY) {
@@ -8824,7 +8948,7 @@ function buildTopBar() {
     }
 
     centerGroup.innerHTML = `
-        <div id="sb-topbar-title" class="sb-brand-title">${SB_IDLE_BRAND_LABEL}</div>
+        <div id="sb-topbar-title" class="sb-brand-title" role="button" tabindex="0" aria-label="Tap to preview top bar label options">${SB_IDLE_BRAND_LABEL}</div>
     `;
 
     leftGroup.append(mobileButton, leftButton, rightButton, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
+const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+
+function getFunctionSource(name) {
+    const match = tabsSource.match(new RegExp(`function ${name}\\([\\s\\S]*?\\n\\}`));
+    expect(match).not.toBeNull();
+    return match[0];
+}
+
+describe('topbar label tap cycle', () => {
+    test('keeps preview cycle state transient', () => {
+        expect(tabsSource).toContain('const SB_TOPBAR_LABEL_CYCLE_RESET_MS = 5000;');
+        expect(tabsSource).toContain("cyclePart: ''");
+        expect(tabsSource).toContain('cycleResetTimer: 0');
+        expect(tabsSource).toContain('function resetTopBarLabelCycle');
+        expect(tabsSource).toContain('window.clearTimeout(sbState.topbarLabel.cycleResetTimer);');
+    });
+
+    test('cycles configured, context size, character name, and custom text when applicable', () => {
+        const cyclePartsSource = getFunctionSource('getTopbarLabelCycleParts');
+        expect(cyclePartsSource).toContain("const cycleParts = ['', 'ctx', 'char'];");
+        expect(cyclePartsSource).toContain('if (sbState.topbarLabel.customText)');
+        expect(cyclePartsSource).toContain("cycleParts.push('custom');");
+
+        const cycleSource = getFunctionSource('cycleTopBarLabel');
+        expect(cycleSource).toContain('const nextPart = cycleParts[nextIndex % cycleParts.length];');
+        expect(cycleSource).toContain("if (nextPart === 'ctx')");
+        expect(cycleSource).toContain('scheduleTopbarContextRefresh(0);');
+    });
+
+    test('renders preview labels without changing configured label settings', () => {
+        const labelSource = getFunctionSource('getTopBarLabel');
+        expect(labelSource).toContain('const previewPart = normalizeTopbarLabelPart(sbState.topbarLabel.cyclePart, \'\');');
+        expect(labelSource).toContain('return getTopBarLabelPreviewText(previewPart, context);');
+
+        const previewSource = getFunctionSource('getTopBarLabelPreviewText');
+        expect(previewSource).toContain("if (normalizedPart === 'ctx')");
+        expect(previewSource).toContain("return '...';");
+        expect(previewSource).toContain('return getTopbarLabelPartOption(normalizedPart)?.label ?? \'\';');
+    });
+
+    test('binds accessible pointer and keyboard activation on the title', () => {
+        const bindSource = getFunctionSource('bindTopBarTitleCycle');
+        expect(bindSource).toContain("title.addEventListener('click'");
+        expect(bindSource).toContain("title.addEventListener('keydown'");
+        expect(bindSource).toContain("event.key !== 'Enter' && event.key !== ' '");
+        expect(bindSource).toContain('event.preventDefault();');
+        expect(bindSource).toContain('cycleTopBarLabel();');
+
+        expect(tabsSource).toContain('role="button"');
+        expect(tabsSource).toContain('tabindex="0"');
+        expect(tabsSource).toContain('title.setAttribute(\'aria-label\'');
+    });
+
+    test('resets preview on chat and context-changing events', () => {
+        const resetEventsMatch = tabsSource.match(/const resetCycleEvents = new Set\(\[[\s\S]*?\]\.filter\(Boolean\)\);/);
+        expect(resetEventsMatch).not.toBeNull();
+
+        const resetEventsSource = resetEventsMatch[0];
+        expect(resetEventsSource).toContain('eventTypes.CHAT_CHANGED');
+        expect(resetEventsSource).toContain('eventTypes.CHAT_CREATED');
+        expect(resetEventsSource).toContain('eventTypes.GROUP_CHAT_CREATED');
+        expect(resetEventsSource).toContain('eventTypes.MAIN_API_CHANGED');
+        expect(tabsSource).toContain('resetTopBarLabelCycle({ refresh: false });');
+    });
+
+    test('marks the title as a visible tappable affordance', () => {
+        const titleRuleMatch = cssSource.match(/\.sb-brand-title\s*\{[^}]*\}/);
+        expect(titleRuleMatch).not.toBeNull();
+
+        const titleRule = titleRuleMatch[0];
+        expect(titleRule).toContain('cursor: pointer;');
+        expect(titleRule).toContain('touch-action: manipulation;');
+        expect(titleRule).toContain('-webkit-user-select: none;');
+        expect(titleRule).toContain('user-select: none;');
+        expect(cssSource).toContain('.sb-brand-title:focus-visible');
+        expect(cssSource).toContain('.sb-brand-title.is-previewing');
+    });
+});


### PR DESCRIPTION
## Summary
- make the top bar title tappable to transiently preview configured, context size, character name, and custom text labels
- keep saved topbar label settings unchanged while previewing and reset previews on chat/context changes or after 5 seconds
- add accessible pointer/keyboard affordances and static unit coverage
- In essence: now you can just tap the top bar to go through Context Size, Character Name, or Custom Text (if applicable) in order to preserve top bar cleanliness.

## Testing
- npm run lint
- npm run test:unit --prefix tests
- npm run check:frontend-budgets
- npm run build:frontend