### PR TITLE
feat: add custom CSS AI wand

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5907,7 +5907,7 @@
                                 <div class="inline-drawer-content sb-settings-subdrawer-body" style="display:none">
                                     <div class="sb-settings-subdrawer-toolbar">
                                         <small>Layer your own polish on top of the active SillyBunny palette.</small>
-                                        <div class="flex-container alignitemscenter flexGap5">
+                                        <div class="flex-container flexnowrap alignitemscenter flexGap5">
                                             <!-- SillyBunny: AI shortcut for Custom CSS generation. -->
                                             <div id="custom_css_ai_wand" class="menu_button menu_button_icon margin0" role="button" tabindex="0" title="Generate CSS with AI" aria-label="Generate CSS with AI" data-i18n="[title]Generate CSS with AI">
                                                 <i class="fa-solid fa-wand-magic-sparkles"></i>

--- a/public/index.html
+++ b/public/index.html
@@ -5907,7 +5907,13 @@
                                 <div class="inline-drawer-content sb-settings-subdrawer-body" style="display:none">
                                     <div class="sb-settings-subdrawer-toolbar">
                                         <small>Layer your own polish on top of the active SillyBunny palette.</small>
-                                        <i class="editor_maximize fa-solid fa-maximize right_menu_button" data-for="customCSS" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
+                                        <div class="flex-container alignitemscenter flexGap5">
+                                            <!-- SillyBunny: AI shortcut for Custom CSS generation. -->
+                                            <div id="custom_css_ai_wand" class="menu_button menu_button_icon margin0" role="button" tabindex="0" title="Generate CSS with AI" aria-label="Generate CSS with AI" data-i18n="[title]Generate CSS with AI">
+                                                <i class="fa-solid fa-wand-magic-sparkles"></i>
+                                            </div>
+                                            <i class="editor_maximize fa-solid fa-maximize right_menu_button" data-for="customCSS" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
+                                        </div>
                                     </div>
                                     <div id="CustomCSS-textAreaBlock" class="flex-container flexnowrap alignitemscenter">
                                         <textarea id="customCSS" class="text_pole margin0 margin-r5 textarea_compact monospace" rows="8"></textarea>

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -26,6 +26,8 @@ import {
     entitiesFilter,
     doNewChat,
     online_status,
+    activateSendButtons,
+    deactivateSendButtons,
     messageFormatting,
     extension_prompt_types,
     extension_prompt_roles,
@@ -59,7 +61,7 @@ import { PARSER_FLAG } from './slash-commands/SlashCommandParser.js';
 import { AUTOCOMPLETE_SELECT_KEY, AUTOCOMPLETE_STATE, AUTOCOMPLETE_WIDTH } from './autocomplete/AutoComplete.js';
 import { SlashCommandEnumValue, enumTypes } from './slash-commands/SlashCommandEnumValue.js';
 import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
-import { POPUP_TYPE, callGenericPopup, fixToastrForDialogs } from './popup.js';
+import { POPUP_RESULT, POPUP_TYPE, callGenericPopup, fixToastrForDialogs } from './popup.js';
 import { loadSystemPrompts } from './sysprompt.js';
 import { fuzzySearchCategories } from './filters.js';
 import { accountStorage } from './util/AccountStorage.js';
@@ -71,6 +73,8 @@ import { t } from './i18n.js';
 import { getBackgroundPath, isCustomBackgroundUrl } from './backgrounds.js';
 import { setSlashCommandParserSettingsGetter } from './slash-commands/SlashCommandParserConfig.js';
 import { persona_description_positions as _persona_description_positions } from './personas.js';
+import { generateCustomCssWithAI, resolveCustomCssAIProfile } from './sillybunny-custom-css-ai.js';
+import { populateConnectionProfileSelect } from './extensions/in-chat-agents/profile-utils.js';
 
 export const toastPositionClasses = [
     'toast-top-left',
@@ -1707,6 +1711,124 @@ function applyCustomCSS() {
     }
     style.innerHTML = power_user.custom_css;
     applyCustomThemeStyleEntries();
+}
+
+function buildCustomCssAiPopup(currentCss) {
+    const content = $(`
+        <div class="flex-container flexFlowColumn flexGap5">
+            <h3>Generate Custom CSS</h3>
+            <label for="custom_css_ai_instruction"><small>Describe what you want the CSS to change</small></label>
+            <textarea id="custom_css_ai_instruction" class="text_pole textarea_compact monospace" rows="6" placeholder="Example: Make message cards softer, with rounded corners and subtle accent borders."></textarea>
+            <label for="custom_css_ai_profile"><small>Connection profile</small></label>
+            <select id="custom_css_ai_profile" class="text_pole margin0 wide100p"></select>
+            <div class="flex-container flexFlowColumn flexGap5">
+                <label class="checkbox_label"><input type="radio" name="custom_css_ai_apply_mode" value="replace" checked><span>Replace current CSS</span></label>
+                <label class="checkbox_label"><input type="radio" name="custom_css_ai_apply_mode" value="append"><span>Append below current CSS</span></label>
+            </div>
+            <small>The AI sees your current Custom CSS and the active SillyBunny theme variables. It should return raw CSS only.</small>
+            <small>Current Custom CSS length: ${String(currentCss ?? '').length.toLocaleString()} characters.</small>
+        </div>
+    `);
+
+    const activeProfileId = resolveCustomCssAIProfile('');
+    populateConnectionProfileSelect(content.find('#custom_css_ai_profile').get(0), {
+        emptyLabel: 'Use active connection profile',
+        selectedValue: activeProfileId,
+    });
+
+    return content;
+}
+
+function setCustomCssAiWandBusy(isBusy) {
+    const button = $('#custom_css_ai_wand');
+    const icon = button.find('i').first();
+
+    button.toggleClass('is-busy disabled', isBusy)
+        .attr('aria-busy', String(isBusy))
+        .attr('aria-disabled', String(isBusy));
+    icon.toggleClass('fa-wand-magic-sparkles', !isBusy)
+        .toggleClass('fa-spinner fa-spin', isBusy);
+}
+
+async function handleCustomCssAiWandClick() {
+    const button = $('#custom_css_ai_wand');
+    if (button.hasClass('is-busy')) {
+        return;
+    }
+
+    const currentCss = String($('#customCSS').val() ?? '');
+    const content = buildCustomCssAiPopup(currentCss);
+    const result = await callGenericPopup(content, POPUP_TYPE.CONFIRM, '', {
+        okButton: 'Generate CSS',
+        cancelButton: 'Cancel',
+        wide: true,
+        leftAlign: true,
+        allowVerticalScrolling: true,
+        onOpen: () => content.find('#custom_css_ai_instruction').trigger('focus'),
+        onClosing: popup => {
+            if (popup.result !== POPUP_RESULT.AFFIRMATIVE) {
+                return true;
+            }
+
+            if (!String(content.find('#custom_css_ai_instruction').val() ?? '').trim()) {
+                globalThis.toastr?.warning?.('Describe the CSS change first.');
+                return false;
+            }
+
+            return true;
+        },
+    });
+
+    if (result !== POPUP_RESULT.AFFIRMATIVE) {
+        return;
+    }
+
+    const instruction = String(content.find('#custom_css_ai_instruction').val() ?? '').trim();
+    const selectedProfileId = String(content.find('#custom_css_ai_profile').val() ?? '').trim();
+    const effectiveProfileId = resolveCustomCssAIProfile(selectedProfileId);
+    const applyMode = String(content.find('input[name="custom_css_ai_apply_mode"]:checked').val() ?? 'replace');
+
+    if (!effectiveProfileId && online_status === 'no_connection') {
+        globalThis.toastr?.warning?.('Connect to an API or select a usable connection profile first.');
+        return;
+    }
+
+    setCustomCssAiWandBusy(true);
+    globalThis.toastr?.info?.('Generating custom CSS...', '', { timeOut: 0, extendedTimeOut: 0 });
+    deactivateSendButtons({ markBodyGenerating: false });
+
+    try {
+        const generatedCss = await generateCustomCssWithAI({
+            instruction,
+            currentCss,
+            profileId: effectiveProfileId,
+        });
+
+        if (!generatedCss.trim()) {
+            globalThis.toastr?.clear?.();
+            globalThis.toastr?.error?.('AI returned an empty CSS response.');
+            return;
+        }
+
+        const nextCss = applyMode === 'append' && currentCss.trim()
+            ? `${currentCss.trimEnd()}\n\n${generatedCss}`
+            : generatedCss;
+
+        $('#customCSS').val(nextCss);
+        power_user.custom_css = nextCss;
+        applyCustomCSS();
+        saveSettingsDebounced();
+        globalThis.toastr?.clear?.();
+        globalThis.toastr?.success?.('Generated custom CSS.');
+    } catch (error) {
+        globalThis.toastr?.clear?.();
+        if (!String(error?.message ?? error ?? '').match(/abort|cancel/i)) {
+            globalThis.toastr?.error?.(`Custom CSS generation failed: ${error?.message ?? error}`);
+        }
+    } finally {
+        activateSendButtons();
+        setCustomCssAiWandBusy(false);
+    }
 }
 
 function getGoogleFontStylesheetId() {
@@ -3980,6 +4102,16 @@ jQuery(async () => {
         power_user.custom_css = String($('#customCSS').val());
         saveSettingsDebounced();
         applyCustomCSS();
+    });
+
+    // SillyBunny: Custom CSS AI wand uses the active Connection Manager profile without swapping global state.
+    $('#custom_css_ai_wand').on('click', () => { void handleCustomCssAiWandClick(); });
+    $('#custom_css_ai_wand').on('keydown', event => {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+            return;
+        }
+        event.preventDefault();
+        $('#custom_css_ai_wand').trigger('click');
     });
 
     $('#google_font_preset').on('change', function () {

--- a/public/scripts/sillybunny-custom-css-ai.js
+++ b/public/scripts/sillybunny-custom-css-ai.js
@@ -1,0 +1,140 @@
+import { generateRaw } from '../script.js';
+import { resolveConnectionProfile } from './extensions/in-chat-agents/agent-store.js';
+import { extractProfileResponseText } from './extensions/in-chat-agents/llm-utils.js';
+import { getConnectionManagerRequestService } from './extensions/in-chat-agents/profile-utils.js';
+
+export const CUSTOM_CSS_AI_MAX_TOKENS = 3072;
+
+export const CUSTOM_CSS_AI_PALETTE_VARIABLES = Object.freeze([
+    '--SmartThemeBodyColor',
+    '--SmartThemeEmColor',
+    '--SmartThemeUnderlineColor',
+    '--SmartThemeQuoteColor',
+    '--SmartThemeBlurTintColor',
+    '--SmartThemeChatTintColor',
+    '--SmartThemeUserMesBlurTintColor',
+    '--SmartThemeBotMesBlurTintColor',
+    '--SmartThemeShadowColor',
+    '--SmartThemeBorderColor',
+    '--customCSS-bg-blur',
+    '--customCSS-bg-opacity',
+]);
+
+export const CUSTOM_CSS_AI_SYSTEM_PROMPT = [
+    'You are a CSS specialist for SillyBunny, a SillyTavern fork.',
+    'Generate custom CSS for the Custom CSS editor.',
+    'Output ONLY raw CSS. Do not include markdown fences, prose, HTML, <style> tags, JavaScript, @import, or external URLs.',
+    'Prefer stable SillyTavern/SillyBunny selectors and CSS custom properties. Keep desktop and mobile usable.',
+    'Scope risky changes narrowly. Short CSS comments are allowed only when they clarify non-obvious rules.',
+].join(' ');
+
+export function isAbortLikeError(error, signal = null) {
+    return Boolean(
+        signal?.aborted
+        || error?.name === 'AbortError'
+        || /abort|cancel/i.test(String(error?.message ?? error ?? '')),
+    );
+}
+
+export function stripCssMarkdownFences(text = '') {
+    const value = String(text ?? '').trim();
+    const fencedBlock = value.match(/```(?:css)?\s*([\s\S]*?)```/i);
+    if (fencedBlock) {
+        return fencedBlock[1].trim();
+    }
+
+    return value
+        .replace(/^```(?:css)?\s*/i, '')
+        .replace(/\s*```$/i, '')
+        .trim();
+}
+
+export function normalizeGeneratedCustomCss(text = '') {
+    return stripCssMarkdownFences(text)
+        .replace(/^<style[^>]*>/i, '')
+        .replace(/<\/style>$/i, '')
+        .trim();
+}
+
+export function getCustomCssPaletteSnapshot(root = typeof document === 'undefined' ? null : document.documentElement) {
+    if (!root || typeof getComputedStyle !== 'function') {
+        return '';
+    }
+
+    const computedStyle = getComputedStyle(root);
+    return CUSTOM_CSS_AI_PALETTE_VARIABLES
+        .map(name => [name, String(computedStyle.getPropertyValue(name) ?? '').trim()])
+        .filter(([, value]) => value)
+        .map(([name, value]) => `${name}: ${value};`)
+        .join('\n');
+}
+
+export function buildCustomCssAIMessages({ instruction = '', currentCss = '', paletteSnapshot = getCustomCssPaletteSnapshot() } = {}) {
+    const request = String(instruction ?? '').trim();
+    const current = String(currentCss ?? '').trim();
+    const palette = String(paletteSnapshot ?? '').trim();
+
+    const userContent = [
+        `Request:\n${request}`,
+        `Current custom CSS:\n${current || '/* No custom CSS is currently set. */'}`,
+        palette ? `Current theme CSS variables:\n${palette}` : '',
+        'Return CSS that can be pasted directly into the Custom CSS textarea.',
+    ].filter(Boolean).join('\n\n');
+
+    return [
+        { role: 'system', content: CUSTOM_CSS_AI_SYSTEM_PROMPT },
+        { role: 'user', content: userContent },
+    ];
+}
+
+export function resolveCustomCssAIProfile(profileId = '') {
+    return resolveConnectionProfile(profileId);
+}
+
+export async function generateCustomCssWithAI({
+    instruction = '',
+    currentCss = '',
+    profileId = '',
+    maxTokens = CUSTOM_CSS_AI_MAX_TOKENS,
+    signal = null,
+    paletteSnapshot = getCustomCssPaletteSnapshot(),
+} = {}) {
+    if (!String(instruction ?? '').trim()) {
+        throw new Error('Instruction is required to generate custom CSS.');
+    }
+
+    const messages = buildCustomCssAIMessages({ instruction, currentCss, paletteSnapshot });
+    const resolvedProfileId = resolveCustomCssAIProfile(profileId);
+    const CMRS = getConnectionManagerRequestService();
+
+    if (resolvedProfileId && CMRS && typeof CMRS.sendRequest === 'function') {
+        try {
+            const response = await CMRS.sendRequest(resolvedProfileId, messages, maxTokens, {
+                extractData: true,
+                includePreset: true,
+                includeInstruct: true,
+                stream: false,
+                signal,
+            });
+            const profileText = typeof response === 'string' ? response : extractProfileResponseText(response);
+            const css = normalizeGeneratedCustomCss(profileText);
+            if (css) {
+                return css;
+            }
+        } catch (error) {
+            if (isAbortLikeError(error, signal)) {
+                throw error;
+            }
+            console.warn(`[CustomCssAI] Profile "${resolvedProfileId}" request failed, falling back to the main model.`, error);
+        }
+    }
+
+    const fallbackText = await generateRaw({
+        prompt: messages,
+        responseLength: maxTokens,
+        trimNames: false,
+        signal,
+        cacheScope: 'auxiliary',
+    });
+    return normalizeGeneratedCustomCss(fallbackText);
+}

--- a/tests/sillybunny-custom-css-ai.test.js
+++ b/tests/sillybunny-custom-css-ai.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+async function importHelper({ resolvedProfileId = 'profile-1', profileResponse = { content: '.profile { color: red; }' }, fallbackResponse = '.fallback { color: blue; }', sendRequestImpl = null } = {}) {
+    jest.resetModules();
+
+    const sendRequest = sendRequestImpl ?? jest.fn(async () => profileResponse);
+    const generateRaw = jest.fn(async () => fallbackResponse);
+    const resolveConnectionProfile = jest.fn(profileId => String(profileId || resolvedProfileId).trim());
+    const extractProfileResponseText = jest.fn(response => String(response?.content ?? response ?? ''));
+
+    await jest.unstable_mockModule('../public/script.js', () => ({ generateRaw }));
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ resolveConnectionProfile }));
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({
+        getConnectionManagerRequestService: jest.fn(() => ({ sendRequest })),
+    }));
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/llm-utils.js', () => ({ extractProfileResponseText }));
+
+    const helper = await import('../public/scripts/sillybunny-custom-css-ai.js');
+    return { helper, sendRequest, generateRaw, resolveConnectionProfile, extractProfileResponseText };
+}
+
+describe('SillyBunny Custom CSS AI helper', () => {
+    test('normalizes fenced CSS and style tags', async () => {
+        const { helper } = await importHelper();
+
+        expect(helper.normalizeGeneratedCustomCss('```css\n<style>\n.mes { border-radius: 12px; }\n</style>\n```'))
+            .toBe('.mes { border-radius: 12px; }');
+    });
+
+    test('builds messages with request, current CSS, and theme variables', async () => {
+        const { helper } = await importHelper();
+        const messages = helper.buildCustomCssAIMessages({
+            instruction: 'Make chat bubbles softer.',
+            currentCss: '.mes { padding: 1rem; }',
+            paletteSnapshot: '--SmartThemeBodyColor: white;',
+        });
+
+        expect(messages).toHaveLength(2);
+        expect(messages[0].role).toBe('system');
+        expect(messages[0].content).toContain('Output ONLY raw CSS');
+        expect(messages[1].content).toContain('Make chat bubbles softer.');
+        expect(messages[1].content).toContain('.mes { padding: 1rem; }');
+        expect(messages[1].content).toContain('--SmartThemeBodyColor: white;');
+    });
+
+    test('uses the resolved connection profile before falling back', async () => {
+        const { helper, sendRequest, generateRaw } = await importHelper({
+            profileResponse: { content: '```css\n.profile { color: red; }\n```' },
+        });
+
+        const css = await helper.generateCustomCssWithAI({
+            instruction: 'Use red accents.',
+            currentCss: '',
+            profileId: 'profile-2',
+            paletteSnapshot: '',
+        });
+
+        expect(css).toBe('.profile { color: red; }');
+        expect(sendRequest).toHaveBeenCalledWith(
+            'profile-2',
+            expect.any(Array),
+            helper.CUSTOM_CSS_AI_MAX_TOKENS,
+            expect.objectContaining({ extractData: true, includePreset: true, includeInstruct: true, stream: false }),
+        );
+        expect(generateRaw).not.toHaveBeenCalled();
+    });
+
+    test('falls back to the main model when the profile request fails', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { helper, sendRequest, generateRaw } = await importHelper({
+            sendRequestImpl: jest.fn(async () => { throw new Error('profile failed'); }),
+            fallbackResponse: '```css\n.fallback { color: blue; }\n```',
+        });
+
+        const css = await helper.generateCustomCssWithAI({
+            instruction: 'Use blue accents.',
+            currentCss: '',
+            paletteSnapshot: '',
+        });
+
+        expect(css).toBe('.fallback { color: blue; }');
+        expect(sendRequest).toHaveBeenCalledTimes(1);
+        expect(generateRaw).toHaveBeenCalledWith(expect.objectContaining({ prompt: expect.any(Array), trimNames: false, cacheScope: 'auxiliary' }));
+        warnSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- Add a Custom CSS toolbar wand button. This makes it so you can just directly ask the LLM in the UI to make a custom CSS for you, right there. Great for people who don't want to switch tabs and just wanna see it immediately. (Like me)
- Add a popup for instruction, connection profile picker, and replace/append mode.
- Route CSS generation through the selected/current Connection Manager profile with fallback to the main model, then normalize raw CSS output before applying it.
- Add targeted tests for prompt building, CSS normalization, profile generation, and fallback generation.

## Verification
- PASS: `node --experimental-vm-modules "/home/platinum/SillyBunny/tests/node_modules/jest/bin/jest.js" --config "tests/jest.config.json" "tests/sillybunny-custom-css-ai.test.js"`
- PASS: `/home/platinum/SillyBunny/node_modules/.bin/eslint --resolve-plugins-relative-to "/home/platinum/SillyBunny" "public/scripts/sillybunny-custom-css-ai.js" "public/scripts/power-user.js"`
- PASS: `/home/platinum/SillyBunny/tests/node_modules/.bin/eslint --resolve-plugins-relative-to "/home/platinum/SillyBunny/tests" "sillybunny-custom-css-ai.test.js"`
- PASS: `git diff --check`