### PR TITLE
fix: stop custom endpoint Connect from clobbering profile keys

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -8673,7 +8673,12 @@ async function onConnectButtonClick(e) {
     const config = apiSourceConfig[oai_settings.chat_completion_source];
     if (config) {
         const apiKey = String($(config.selector).val()).trim();
-        if (apiKey.length) {
+        const isBoundCustomEndpointProfile = oai_settings.chat_completion_source === chat_completion_sources.CUSTOM
+            && selected_custom_endpoint_preset?.name !== 'None'
+            && selected_custom_endpoint_preset?.secretId;
+
+        // SillyBunny: custom endpoint profiles keep their own secret ids; Connect must not mint duplicate active keys.
+        if (!isBoundCustomEndpointProfile && apiKey.length) {
             await writeSecret(config.key, apiKey);
         }
 
@@ -9407,6 +9412,16 @@ async function activateCustomEndpointPresetSecret(preset, { forceWrite = false }
     }
 }
 
+function updateCustomEndpointKeyInput(preset, key) {
+    if (preset?.secretId) {
+        // SillyBunny: saved profile secrets are write-only in the UI; avoid replaying stale plaintext copies.
+        $('#api_key_custom').val('').attr('placeholder', t`(saved secret)`);
+        return;
+    }
+
+    $('#api_key_custom').removeAttr('placeholder').val(key);
+}
+
 async function setCustomEndpointPreset(name, url, key, model, { secretId = '', writeKey = true, reconnect = true } = {}) {
     const normalizedPreset = normalizeCustomEndpointPreset({ name, url, key, model, secretId });
     const preset = custom_endpoint_presets.find(p => p.name === normalizedPreset.name);
@@ -9434,7 +9449,7 @@ async function setCustomEndpointPreset(name, url, key, model, { secretId = '', w
     if (writeKey) {
         await activateCustomEndpointPresetSecret(selected_custom_endpoint_preset);
     }
-    $('#api_key_custom').val(normalizedPreset.key);
+    updateCustomEndpointKeyInput(selected_custom_endpoint_preset, normalizedPreset.key);
 
     if (reconnect && oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {
         reconnectOpenAi();

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -165,7 +165,7 @@ describe('OpenAI proxy preset wiring', () => {
         const urlUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_url = normalizedPreset.url;');
         const modelUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_model = normalizedPreset.model;');
         const secretActivateIndex = setCustomEndpointSource.indexOf('await activateCustomEndpointPresetSecret(selected_custom_endpoint_preset);');
-        const keyInputIndex = setCustomEndpointSource.indexOf('$(\'#api_key_custom\').val(normalizedPreset.key);');
+        const keyInputIndex = setCustomEndpointSource.indexOf('updateCustomEndpointKeyInput(selected_custom_endpoint_preset, normalizedPreset.key);');
         const reconnectIndex = setCustomEndpointSource.indexOf('reconnectOpenAi();');
 
         expect(urlUpdateIndex).toBeGreaterThanOrEqual(0);
@@ -174,6 +174,28 @@ describe('OpenAI proxy preset wiring', () => {
         expect(keyInputIndex).toBeGreaterThan(secretActivateIndex);
         expect(reconnectIndex).toBeGreaterThan(keyInputIndex);
         expect(setCustomEndpointSource).not.toContain('writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key');
+    });
+
+    test('keeps bound Custom endpoint profile secrets on Connect', () => {
+        const connectSource = getFunctionSource('onConnectButtonClick');
+        const customGuardIndex = connectSource.indexOf('const isBoundCustomEndpointProfile = oai_settings.chat_completion_source === chat_completion_sources.CUSTOM');
+        const profileSecretIndex = connectSource.indexOf('selected_custom_endpoint_preset?.secretId;', customGuardIndex);
+        const writeGuardIndex = connectSource.indexOf('if (!isBoundCustomEndpointProfile && apiKey.length) {', customGuardIndex);
+        const writeIndex = connectSource.indexOf('await writeSecret(config.key, apiKey);', writeGuardIndex);
+
+        expect(customGuardIndex).toBeGreaterThanOrEqual(0);
+        expect(profileSecretIndex).toBeGreaterThan(customGuardIndex);
+        expect(writeGuardIndex).toBeGreaterThan(profileSecretIndex);
+        expect(writeIndex).toBeGreaterThan(writeGuardIndex);
+        expect(connectSource).not.toContain('await rotateSecret(SECRET_KEYS.CUSTOM, selected_custom_endpoint_preset.secretId);');
+    });
+
+    test('clears the Custom endpoint key input when a saved secret is bound', () => {
+        const inputSource = getFunctionSource('updateCustomEndpointKeyInput');
+
+        expect(inputSource).toContain('if (preset?.secretId) {');
+        expect(inputSource).toContain('$(\'#api_key_custom\').val(\'\').attr(\'placeholder\', t`(saved secret)`);');
+        expect(inputSource).toContain('$(\'#api_key_custom\').removeAttr(\'placeholder\').val(key);');
     });
 
     test('activates Custom endpoint profile secrets by id instead of duplicate writes', () => {


### PR DESCRIPTION
## Summary
- The bug was essentially: It would keep cloning the other custom endpoint profile key, and then it refused to be used on the apikey field. So you'd (I would) have to use the Authorization: Bearer (key) header. This fixes that.
- Prevent Custom Endpoint Profile Connect from writing a new active CUSTOM secret when the selected profile already has a bound secret id.
- Clear the visible Custom key field and show `(saved secret)` for bound profiles so stale plaintext copies are not replayed.
- Keep legacy/keyless profile behavior by restoring the key input when no secret id is bound.

## Testing
- `npm run test:unit -- openai-proxy-preset-wiring.test.js`
- `npm run lint`
- `npm run test:unit`
- `npm run check:frontend-budgets && npm run build:frontend`
- `bun src/server-init.js`