### PR TITLE
feat: show main LLM message before pre-generation intercept

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -319,6 +319,13 @@ export function cancelAgentGeneration() {
     return false;
 }
 
+function skipPostMainInterceptChanges() {
+    agentGenerationCancelRevision++;
+    abortActiveAgentRequests('Post-main intercept changes skipped by user.');
+    clearAllPromptTransformRunningToasts();
+    notifyAgentGenerationStateChanged();
+}
+
 function abortActiveAgentRequests(reason = 'Agent generation cancelled.') {
     const error = reason instanceof Error ? reason : new Error(String(reason));
 
@@ -2156,6 +2163,10 @@ function shouldShowPreInterceptNotifications(agent) {
     );
 }
 
+function shouldShowPostMainInterceptMessageFirst() {
+    return getGlobalSettings()?.postMainInterceptShowMessageFirst !== false;
+}
+
 function describePromptTransformTarget(profileId = '', runner = '') {
     if (runner === 'main') {
         return 'the main model';
@@ -2211,17 +2222,24 @@ function showPromptTransformRunningToast(agent, mode, profileId = '', options = 
     const applyMode = ['wrap', 'patch'].includes(String(options?.applyMode))
         ? String(options.applyMode)
         : 'replace';
-    const runningLabel = kind === 'preIntercept'
-        ? `Running pre-generation ${applyMode} intercept...`
-        : kind === 'postMainIntercept'
-            ? `Running post-main ${applyMode} intercept...`
-            : `Running ${modeLabel} via ${targetLabel}...`;
+    const skipChanges = Boolean(options?.skipChanges && kind === 'postMainIntercept');
+    const cancelHandler = typeof options?.onCancel === 'function'
+        ? options.onCancel
+        : cancelAgentGeneration;
+    const runningLabel = skipChanges
+        ? 'Generating main output for pre-generation intercept'
+        : kind === 'preIntercept'
+            ? `Running pre-generation ${applyMode} intercept...`
+            : kind === 'postMainIntercept'
+                ? `Running post-main ${applyMode} intercept...`
+                : `Running ${modeLabel} via ${targetLabel}...`;
+    const cancelLabel = skipChanges ? 'Skip changes' : 'Cancel Agent';
     const messageHtml = `
         <div>${escapeToastHtml(runningLabel)}</div>
         <div>${escapeToastHtml(`Order ${metadata.order} | Model: ${metadata.modelLabel}`)}</div>
         <button type="button" class="menu_button menu_button_icon caution ${cancelButtonClass}">
             <i class="fa-solid fa-stop"></i>
-            <span>Cancel Agent</span>
+            <span>${escapeToastHtml(cancelLabel)}</span>
         </button>
     `;
 
@@ -2237,7 +2255,7 @@ function showPromptTransformRunningToast(agent, mode, profileId = '', options = 
             cancelButton?.addEventListener('click', event => {
                 event.preventDefault();
                 event.stopPropagation();
-                cancelAgentGeneration();
+                cancelHandler();
             });
         },
     });
@@ -3647,8 +3665,23 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
         markPostProcessingRunProcessed(message, runKey, messageIndex, indexRunKey);
 
         const activeAgents = getActiveAgentsForMessage(generationType, resolvedActivationSnapshot);
+        let chatStateChanged = false;
+        let messageDisplayChanged = false;
+
+        const postDisplayInterceptResult = await runPostDisplayPostMainGenerationInterceptors(
+            message,
+            messageIndex,
+            generationType,
+            resolvedActivationSnapshot,
+        );
+        pendingPreGenerationInterceptRuns.push(...postDisplayInterceptResult.runs);
+        if (postDisplayInterceptResult.changed) {
+            chatStateChanged = true;
+            messageDisplayChanged = true;
+        }
+
         // Companions normally run last so they see the post-transform reply; the concurrent
-        // option trades that for speed and runs them against the raw reply alongside the passes.
+        // option trades that for speed and runs them against the current reply alongside the passes.
         const companionStageArgs = { messageIndex, message, generationType, activeAgents };
         const concurrentCompanionStage = getGlobalSettings().companionConcurrentWithPostGen && companionRuntime?.runCompanionStage
             ? companionRuntime.runCompanionStage(companionStageArgs).catch(error => {
@@ -3669,8 +3702,6 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
                 ),
             );
 
-        let chatStateChanged = false;
-        let messageDisplayChanged = false;
         if (storePreGenerationInterceptHistory(message, takePendingPreGenerationInterceptRuns())) {
             chatStateChanged = true;
             messageDisplayChanged = true;
@@ -4052,10 +4083,14 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
         buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat, timing),
     );
     const cancelRevision = agentGenerationCancelRevision;
-    const runningToast = shouldShowPreInterceptNotifications(agent)
+    const skipChanges = timing === POST_MAIN_GENERATION_INTERCEPT_TIMING && Boolean(options?.skipChanges);
+    const showRunningToast = skipChanges || shouldShowPreInterceptNotifications(agent);
+    const runningToast = showRunningToast
         ? showPromptTransformRunningToast(agent, applyMode, profileId, {
             kind: timing === POST_MAIN_GENERATION_INTERCEPT_TIMING ? 'postMainIntercept' : 'preIntercept',
             applyMode,
+            skipChanges,
+            onCancel: skipChanges ? options?.onCancel : null,
         })
         : null;
 
@@ -4295,7 +4330,7 @@ async function runPreGenerationInterceptorsOnChat(initialChatMessages, generatio
     return { chat: currentChatMessages, runs };
 }
 
-async function runPostMainGenerationInterceptorsOnText(initialOutputText, generationType) {
+async function runPostMainGenerationInterceptorsOnText(initialOutputText, generationType, options = {}) {
     if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
         return { text: initialOutputText, runs: [], cancelled: false };
     }
@@ -4309,7 +4344,9 @@ async function runPostMainGenerationInterceptorsOnText(initialOutputText, genera
         return { text: currentOutputText, runs: [], cancelled: true };
     }
 
-    const activationSnapshot = getGenerationContextSnapshot(generationType);
+    const activationSnapshot = options?.activationSnapshot
+        ? cloneActivationSnapshot(options.activationSnapshot, generationType)
+        : getGenerationContextSnapshot(generationType);
     const interceptAgents = getPostMainGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
     if (interceptAgents.length === 0) {
         return { text: currentOutputText, runs: [], cancelled: false };
@@ -4327,7 +4364,11 @@ async function runPostMainGenerationInterceptorsOnText(initialOutputText, genera
                 currentOutputText,
                 activationSnapshot.generationType,
                 'text',
-                { timing: POST_MAIN_GENERATION_INTERCEPT_TIMING },
+                {
+                    timing: POST_MAIN_GENERATION_INTERCEPT_TIMING,
+                    skipChanges: Boolean(options?.skipChanges),
+                    onCancel: options?.onCancel,
+                },
             );
 
             if (generationStopRequested || result.status === 'cancelled') {
@@ -4371,6 +4412,39 @@ async function runPostMainGenerationInterceptorsOnText(initialOutputText, genera
     }
 
     return { text: currentOutputText, runs, cancelled: false };
+}
+
+async function runPostDisplayPostMainGenerationInterceptors(message, messageIndex, generationType, activationSnapshot = null) {
+    if (!shouldShowPostMainInterceptMessageFirst()) {
+        return { runs: [], changed: false, cancelled: false };
+    }
+
+    const currentMessageText = unwrapAssistantResponseWrapper(message?.mes);
+    const result = await runPostMainGenerationInterceptorsOnText(currentMessageText, generationType, {
+        activationSnapshot,
+        skipChanges: true,
+        onCancel: skipPostMainInterceptChanges,
+    });
+
+    if (result.cancelled || generationStopRequested) {
+        const cancelledRuns = result.runs.map(run => ({
+            ...run,
+            status: 'cancelled',
+            changed: false,
+            afterText: currentMessageText,
+        }));
+        return { runs: cancelledRuns, changed: false, cancelled: true };
+    }
+
+    const nextMessageText = unwrapAssistantResponseWrapper(result.text);
+    if (nextMessageText === currentMessageText) {
+        return { runs: result.runs, changed: false, cancelled: false };
+    }
+
+    message.mes = nextMessageText;
+    await syncPromptTransformMessageStateAsync(message, messageIndex);
+
+    return { runs: result.runs, changed: true, cancelled: false };
 }
 
 function getPostMainGenerationInterceptorsForGeneration(generationType) {
@@ -4429,6 +4503,10 @@ async function onGenerationOutputBufferingDecision(eventData) {
 
     const interceptAgents = getPostMainGenerationInterceptorsForGeneration(eventData.type ?? currentMainGenerationType);
     if (interceptAgents.length > 0) {
+        if (shouldShowPostMainInterceptMessageFirst()) {
+            return;
+        }
+
         eventData.hasPostMainInterceptors = true;
         if (interceptAgents.some(shouldShowPreInterceptNotifications)) {
             showInitialGenerationToast();
@@ -4449,6 +4527,10 @@ async function onMainGenerationOutputReady(eventData) {
     }
 
     if (!isGenerationInProgress || typeof eventData.text !== 'string') {
+        return;
+    }
+
+    if (shouldShowPostMainInterceptMessageFirst()) {
         return;
     }
 

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -160,6 +160,7 @@ let globalSettings = {
     connectionProfile: '',
     companionConnectionProfile: '',
     promptTransformShowNotifications: true,
+    postMainInterceptShowMessageFirst: true,
     appendAgentsExecutionMode: 'parallel',
     companionExecutionMode: 'parallel',
     companionConcurrentWithPostGen: false,
@@ -168,7 +169,7 @@ let globalSettings = {
 
 /**
  * Returns the global settings.
- * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, appendAgentsExecutionMode: 'parallel'|'sequential', helperPrefillMessages: string }}
+ * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, postMainInterceptShowMessageFirst: boolean, appendAgentsExecutionMode: 'parallel'|'sequential', helperPrefillMessages: string }}
  */
 export function getGlobalSettings() {
     return globalSettings;
@@ -185,6 +186,7 @@ export function setGlobalSettings(update) {
 
     Object.assign(globalSettings, update);
     globalSettings.pathfinderEnabled = globalSettings.pathfinderEnabled !== false;
+    globalSettings.postMainInterceptShowMessageFirst = globalSettings.postMainInterceptShowMessageFirst !== false;
     globalSettings.enabledAgentIdsByChatType = normalizeScopedEnabledAgentIds(globalSettings.enabledAgentIdsByChatType);
     globalSettings.helperPrefillMessages = typeof globalSettings.helperPrefillMessages === 'string'
         ? globalSettings.helperPrefillMessages

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -4734,6 +4734,10 @@ function populateGlobalNotificationToggle() {
         'checked',
         Boolean(getGlobalSettings().promptTransformShowNotifications),
     );
+    $('#ica--postMainInterceptShowMessageFirst').prop(
+        'checked',
+        getGlobalSettings().postMainInterceptShowMessageFirst !== false,
+    );
 }
 
 function populatePathfinderSubmoduleToggle() {
@@ -5404,6 +5408,10 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     });
     $('#ica--promptTransformShowNotifications').on('change', function () {
         setGlobalSettings({ promptTransformShowNotifications: $(this).prop('checked') });
+        persistExtensionState();
+    });
+    $('#ica--postMainInterceptShowMessageFirst').on('change', function () {
+        setGlobalSettings({ postMainInterceptShowMessageFirst: $(this).prop('checked') });
         persistExtensionState();
     });
     $('#ica--pathfinderSubmoduleEnabled').on('change', async function () {

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -174,6 +174,10 @@
                 <input type="checkbox" id="ica--promptTransformShowNotifications" />
                 <span>Allow prompt pass toast notifications</span>
             </label>
+            <label class="checkbox_label" title="lorum ipsum">
+                <input type="checkbox" id="ica--postMainInterceptShowMessageFirst" />
+                <span>lorum ipsum</span>
+            </label>
             <label class="checkbox_label" title="Enable or disable the built-in Pathfinder submodule without disabling shared In-Chat Agents.">
                 <input type="checkbox" id="ica--pathfinderSubmoduleEnabled" />
                 <span>Enable Pathfinder submodule</span>

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -174,9 +174,9 @@
                 <input type="checkbox" id="ica--promptTransformShowNotifications" />
                 <span>Allow prompt pass toast notifications</span>
             </label>
-            <label class="checkbox_label" title="lorum ipsum">
+            <label class="checkbox_label" title="View main LLM output before pre-generation intercept">
                 <input type="checkbox" id="ica--postMainInterceptShowMessageFirst" />
-                <span>lorum ipsum</span>
+                <span>View main LLM output before pre-generation intercept</span>
             </label>
             <label class="checkbox_label" title="Enable or disable the built-in Pathfinder submodule without disabling shared In-Chat Agents.">
                 <input type="checkbox" id="ica--pathfinderSubmoduleEnabled" />

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -159,6 +159,7 @@ describe('in-chat agent post-processing runner', () => {
         globalThis.removeEventListener = jest.fn((event, handler) => removeListener(windowListeners, event, handler));
         globalThis.HTMLSelectElement = class HTMLSelectElement {};
         globalThis.HTMLTextAreaElement = class HTMLTextAreaElement {};
+        globalThis.HTMLElement = class HTMLElement {};
         globalThis.requestAnimationFrame = (callback) => setTimeout(callback, 0);
         globalThis.toastr = {
             clear: jest.fn(),
@@ -387,6 +388,7 @@ describe('in-chat agent post-processing runner', () => {
         delete globalThis.addEventListener;
         delete globalThis.removeEventListener;
         delete globalThis.HTMLSelectElement;
+        delete globalThis.HTMLElement;
         delete globalThis.requestAnimationFrame;
         delete globalThis.toastr;
         delete globalThis.$;
@@ -1965,10 +1967,26 @@ describe('in-chat agent post-processing runner', () => {
         expect(eventData.prompt).toBe('Original outgoing prompt');
     });
 
-    test('marks streaming output for buffering when post-main intercept agents are active', async () => {
+    test('keeps streaming output unbuffered by default when post-main intercept agents are active', async () => {
         enabledAgents = [createPreInterceptAgent({
             preProcess: { interceptTiming: 'post-main-generation' },
         })];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const eventData = { type: 'normal', isStreaming: true, hasPostMainInterceptors: false };
+        await eventSource.emit(eventTypes.GENERATION_OUTPUT_BUFFERING_DECISION, eventData);
+
+        expect(eventData.hasPostMainInterceptors).toBe(false);
+    });
+
+    test('marks streaming output for buffering when show-first post-main intercepts are disabled', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation' },
+        })];
+        globalSettings.postMainInterceptShowMessageFirst = false;
 
         const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
         initAgentRunner();
@@ -1993,10 +2011,112 @@ describe('in-chat agent post-processing runner', () => {
         expect(eventData.hasPostMainInterceptors).toBe(false);
     });
 
-    test('runs post-main intercepts before storing the assistant message', async () => {
+    test('runs post-main intercepts after storing the assistant message by default', async () => {
         enabledAgents = [createPreInterceptAgent({
             preProcess: { interceptTiming: 'post-main-generation', applyMode: 'replace' },
         })];
+        generateQuietPrompt.mockResolvedValue('intercepted assistant reply');
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const outputData = { type: 'normal', text: 'raw assistant reply', isStreaming: false, cancelled: false };
+        await eventSource.emit(eventTypes.MAIN_GENERATION_OUTPUT_READY, outputData);
+
+        expect(outputData.cancelled).toBe(false);
+        expect(outputData.text).toBe('raw assistant reply');
+        expect(generateQuietPrompt).not.toHaveBeenCalled();
+
+        chat.push({
+            name: 'Assistant',
+            mes: outputData.text,
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+        await waitFor(() => Array.isArray(chat[0].extra.inChatAgentPreGenerationInterceptHistory));
+
+        expect(chat[0].mes).toBe('intercepted assistant reply');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Main model output:');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('raw assistant reply');
+        expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+            agentId: 'agent-pre-intercept',
+            timing: 'post-main-generation',
+            beforeText: 'raw assistant reply',
+            outputText: 'intercepted assistant reply',
+            afterText: 'intercepted assistant reply',
+            changed: true,
+            status: 'changed',
+        })]);
+    });
+
+    test('keeps the shown assistant message when post-main intercept changes are skipped', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation', applyMode: 'replace' },
+        })];
+        let resolveQuietPrompt;
+        let skipClick;
+
+        generateQuietPrompt.mockImplementation(() => new Promise(resolve => {
+            resolveQuietPrompt = resolve;
+        }));
+        globalThis.toastr.info.mockImplementation((messageHtml, title, options = {}) => {
+            const button = {
+                addEventListener: jest.fn((eventName, handler) => {
+                    if (eventName === 'click') {
+                        skipClick = handler;
+                    }
+                }),
+            };
+            const toastElement = new globalThis.HTMLElement();
+            toastElement.querySelector = jest.fn(() => button);
+            options.onShown?.call(toastElement);
+
+            return { messageHtml, title };
+        });
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const outputData = { type: 'normal', text: 'raw assistant reply', isStreaming: false, cancelled: false };
+        await eventSource.emit(eventTypes.MAIN_GENERATION_OUTPUT_READY, outputData);
+        chat.push({
+            name: 'Assistant',
+            mes: outputData.text,
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+        await waitFor(() => typeof skipClick === 'function');
+
+        expect(globalThis.toastr.info.mock.calls[0][0]).toContain('Skip changes');
+        skipClick({ preventDefault: jest.fn(), stopPropagation: jest.fn() });
+        resolveQuietPrompt('intercepted assistant reply');
+        await waitFor(() => Array.isArray(chat[0].extra.inChatAgentPreGenerationInterceptHistory));
+
+        expect(chat[0].mes).toBe('raw assistant reply');
+        expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+            agentId: 'agent-pre-intercept',
+            timing: 'post-main-generation',
+            beforeText: 'raw assistant reply',
+            afterText: 'raw assistant reply',
+            changed: false,
+            status: 'cancelled',
+        })]);
+    });
+
+    test('runs post-main intercepts before storing the assistant message when show-first is disabled', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation', applyMode: 'replace' },
+        })];
+        globalSettings.postMainInterceptShowMessageFirst = false;
         generateQuietPrompt.mockResolvedValue('intercepted assistant reply');
 
         const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');


### PR DESCRIPTION
# Summary
Sometimes it takes ages for the pre-generation intercept to complete because it waits for the main LLM output first before changing it (intended behaviour).
To add more ease of mind psychologically and to increase user control, I added a toggle (on by default) to view the main LLM output before proceeding with pre-generation intercepts. User may just use it as is or proceed with the pre-generation intercept.