### PR TITLE
fix: let in-chat agent trim regex actually work

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6981,6 +6981,18 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let regexType = chatItem.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
         let options = { isPrompt: true, depth: (coreChat.length - index - (isContinue ? 2 : 1)) };
 
+        // SillyBunny: apply in-chat agent regex scripts (e.g. CYOA "Trim Choices") in prompt mode
+        const agentRegexScripts = resolveRegexScriptsForSnapshot(chatItem?.extra?.inChatAgents);
+        if (agentRegexScripts.length > 0) {
+            const agentPlacement = chatItem.is_user ? AGENT_REGEX_PLACEMENT.USER_INPUT : AGENT_REGEX_PLACEMENT.AI_OUTPUT;
+            message = applyRegexScriptList(message, agentRegexScripts, agentPlacement, {
+                ...options,
+                characterOverride: name2,
+                substituteParamsFn: substituteParams,
+                substituteParamsExtendedFn: substituteParamsExtended,
+            });
+        }
+
         let regexedMessage = getRegexedString(message, regexType, options);
         regexedMessage = await appendFileContent(chatItem, regexedMessage);
 

--- a/tests/cyoa-regex-bundle.test.js
+++ b/tests/cyoa-regex-bundle.test.js
@@ -14,6 +14,8 @@ const {
     applyRegexScriptList,
 } = await import('../public/scripts/extensions/in-chat-agents/regex-scripts.js');
 
+const { resolveRegexScriptsForSnapshot } = await import('../public/scripts/extensions/in-chat-agents/regex-snapshot-store.js');
+
 const regexBundles = JSON.parse(readFileSync(new URL('../public/scripts/extensions/in-chat-agents/templates/regex-bundles.json', import.meta.url), 'utf8'));
 const cyoaChoiceScripts = regexBundles['tpl-cyoa-choices'];
 
@@ -67,5 +69,38 @@ describe('CYOA choices bundled regex', () => {
         });
 
         expect(promptText).toBe('');
+    });
+
+    test('trims choices via the prompt-assembly wiring (snapshot -> resolve -> apply)', () => {
+        const snapshot = { regexScripts: cyoaChoiceScripts };
+        const resolvedScripts = resolveRegexScriptsForSnapshot(snapshot);
+        expect(resolvedScripts).toHaveLength(cyoaChoiceScripts.length);
+
+        const message = '[CHOICES]\n1. Go\n2. Stay\n3. Wait\n[/CHOICES]';
+        const trimmed = applyRegexScriptList(message, resolvedScripts, AGENT_REGEX_PLACEMENT.AI_OUTPUT, {
+            isPrompt: true,
+            depth: 2,
+        });
+
+        expect(trimmed).toBe('');
+    });
+
+    test('does not trim choices below the configured min depth', () => {
+        const snapshot = { regexScripts: cyoaChoiceScripts };
+        const resolvedScripts = resolveRegexScriptsForSnapshot(snapshot);
+        const message = '[CHOICES]\n1. Go\n2. Stay\n3. Wait\n[/CHOICES]';
+
+        const shallowDepth = applyRegexScriptList(message, resolvedScripts, AGENT_REGEX_PLACEMENT.AI_OUTPUT, {
+            isPrompt: true,
+            depth: 1,
+        });
+
+        expect(shallowDepth).toBe(message);
+    });
+
+    test('leaves the prompt untouched when no in-chat agent snapshot is present', () => {
+        expect(resolveRegexScriptsForSnapshot(undefined)).toEqual([]);
+        expect(resolveRegexScriptsForSnapshot(null)).toEqual([]);
+        expect(resolveRegexScriptsForSnapshot({})).toEqual([]);
     });
 });


### PR DESCRIPTION
# Summary
I only noticed just now Trim Regexes in ICA doesn't work, FML. The stuff I'm trying to trim like CHOICES blocks, which should be trimmed at Min Depth 2, didn't get trimmed in context. Now it is. Yay