### PR TITLE
fix(nav): hide Workspace/Customize toggle in vertical nav layouts

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -4643,6 +4643,20 @@ input[type='range']::-moz-range-thumb {
     gap: 12px;
 }
 
+.sb-accent-profiles-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex: 1 1 auto;
+    min-width: 0;
+    cursor: pointer;
+}
+
+.sb-accent-profiles-toggle .inline-drawer-icon {
+    flex: 0 0 auto;
+}
+
 .sb-accent-profiles-copy {
     display: flex;
     flex-direction: column;
@@ -4665,6 +4679,10 @@ input[type='range']::-moz-range-thumb {
     min-height: var(--sb-control-min-height);
     flex: 0 0 auto;
     gap: 8px;
+}
+
+.sb-accent-profiles-content {
+    min-width: 0;
 }
 
 .sb-accent-profiles-list {
@@ -4837,6 +4855,10 @@ input[type='range']::-moz-range-thumb {
     .sb-accent-profiles-header {
         align-items: stretch;
         flex-direction: column;
+    }
+
+    .sb-accent-profiles-toggle {
+        width: 100%;
     }
 
     .sb-accent-profile-save {

--- a/public/index.html
+++ b/public/index.html
@@ -5149,7 +5149,7 @@
                                         </div>
                                     </div>
                                     <!-- SillyBunny: keep reusable accent pairs compact without hiding the Save Current action. -->
-                                    <div id="sb-accent-profiles-panel" class="inline-drawer sb-accent-profiles-panel">
+                                    <div id="sb-accent-profiles-panel" class="inline-drawer sb-accent-profiles-panel" data-settings-tab="appearance">
                                         <div class="inline-drawer-header sb-accent-profiles-header">
                                             <div class="inline-drawer-toggle sb-accent-profiles-toggle" aria-expanded="true">
                                                 <div class="sb-accent-profiles-copy">

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260620a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260609d" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
@@ -5148,19 +5148,25 @@
                                             <span class="sb-accent-picker-label">Secondary Accent</span>
                                         </div>
                                     </div>
-                                    <div class="sb-accent-profiles-panel">
-                                        <div class="sb-accent-profiles-header">
-                                            <div class="sb-accent-profiles-copy">
-                                                <span class="sb-accent-profile-title" data-i18n="Accent Profiles">Accent Profiles</span>
-                                                <small data-i18n="Save or reuse primary and secondary accent pairs.">Save or reuse primary and secondary accent pairs.</small>
+                                    <!-- SillyBunny: keep reusable accent pairs compact without hiding the Save Current action. -->
+                                    <div id="sb-accent-profiles-panel" class="inline-drawer sb-accent-profiles-panel">
+                                        <div class="inline-drawer-header sb-accent-profiles-header">
+                                            <div class="inline-drawer-toggle sb-accent-profiles-toggle" aria-expanded="true">
+                                                <div class="sb-accent-profiles-copy">
+                                                    <span class="sb-accent-profile-title" data-i18n="Accent Profiles">Accent Profiles</span>
+                                                    <small data-i18n="Save or reuse primary and secondary accent pairs.">Save or reuse primary and secondary accent pairs.</small>
+                                                </div>
+                                                <i class="fa-solid fa-circle-chevron-up inline-drawer-icon up" aria-hidden="true"></i>
                                             </div>
                                             <button type="button" id="sb-accent-profile-save" class="menu_button sb-accent-profile-save" title="Save current accent colors" data-i18n="[title]Save current accent colors">
                                                 <i class="fa-solid fa-floppy-disk"></i>
                                                 <span data-i18n="Save Current">Save Current</span>
                                             </button>
                                         </div>
-                                        <div id="sb-accent-profiles-list" class="sb-accent-profiles-list" role="list" aria-label="Accent color profiles"></div>
-                                        <small id="sb-accent-profiles-empty" class="sb-accent-profiles-empty" data-i18n="No saved accent profiles yet.">No saved accent profiles yet.</small>
+                                        <div class="inline-drawer-content sb-accent-profiles-content" style="display: block;">
+                                            <div id="sb-accent-profiles-list" class="sb-accent-profiles-list" role="list" aria-label="Accent color profiles"></div>
+                                            <small id="sb-accent-profiles-empty" class="sb-accent-profiles-empty" data-i18n="No saved accent profiles yet.">No saved accent profiles yet.</small>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -53,7 +53,7 @@ import { tokenizers } from './tokenizers.js';
 import { BIAS_CACHE } from './logit-bias.js';
 import { renderTemplateAsync } from './templates.js';
 
-import { countOccurrences, debounce, delay, download, getFileText, getSanitizedFilename, getStringHash, isOdd, isTrueBoolean, onlyUnique, resetScrollHeight, shuffle, sortMoments, stringToRange, timestampToMoment } from './utils.js';
+import { countOccurrences, debounce, delay, download, getFileText, getSanitizedFilename, getStringHash, isOdd, isTrueBoolean, onlyUnique, resetScrollHeight, shuffle, sortMoments, stringToRange, timestampToMoment, toggleDrawer } from './utils.js';
 import { FILTER_TYPES } from './filters.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
@@ -162,7 +162,8 @@ const SILLYBUNNY_PALETTE_BINDINGS = Object.freeze([
     ['shadow_color', '#shadow-color-picker', 'shadow'],
     ['border_color', '#border-color-picker', 'border'],
 ]);
-const SB_ACCENT_PROFILE_SEED_VERSION = 1;
+const SB_ACCENT_PROFILE_SEED_VERSION = 2;
+const SB_ACCENT_PROFILES_DRAWER_KEY = 'SBAccentProfilesDrawerExpanded';
 const MAX_SB_ACCENT_PROFILE_NAME_LENGTH = 40;
 const SILLYBUNNY_ACCENT_PROFILE_SEEDS = Object.freeze([
     { name: 'Warm Signal', quote_text_color: 'rgba(201, 198, 168, 1)', underline_text_color: 'rgba(166, 164, 147, 1)' },
@@ -179,6 +180,22 @@ const SILLYBUNNY_ACCENT_PROFILE_SEEDS = Object.freeze([
     { name: 'Seafoam', quote_text_color: 'rgba(45, 212, 191, 1)', underline_text_color: 'rgba(134, 239, 172, 1)' },
     { name: 'Orchid Static', quote_text_color: 'rgba(192, 132, 252, 1)', underline_text_color: 'rgba(103, 232, 249, 1)' },
     { name: 'Graphite Glow', quote_text_color: 'rgba(107, 114, 128, 1)', underline_text_color: 'rgba(209, 213, 219, 1)' },
+    { name: 'Aurora Veil', quote_text_color: 'rgba(52, 211, 153, 1)', underline_text_color: 'rgba(129, 140, 248, 1)' },
+    { name: 'Solar Flare', quote_text_color: 'rgba(249, 115, 22, 1)', underline_text_color: 'rgba(250, 204, 21, 1)' },
+    { name: 'Mint Glass', quote_text_color: 'rgba(110, 231, 183, 1)', underline_text_color: 'rgba(167, 243, 208, 1)' },
+    { name: 'Berry Stain', quote_text_color: 'rgba(190, 24, 93, 1)', underline_text_color: 'rgba(244, 114, 182, 1)' },
+    { name: 'Slate Mist', quote_text_color: 'rgba(148, 163, 184, 1)', underline_text_color: 'rgba(203, 213, 225, 1)' },
+    { name: 'Desert Bloom', quote_text_color: 'rgba(234, 88, 12, 1)', underline_text_color: 'rgba(244, 114, 182, 1)' },
+    { name: 'Glacier', quote_text_color: 'rgba(14, 165, 233, 1)', underline_text_color: 'rgba(186, 230, 253, 1)' },
+    { name: 'Coral Reef', quote_text_color: 'rgba(251, 113, 133, 1)', underline_text_color: 'rgba(45, 212, 191, 1)' },
+    { name: 'Plum Wine', quote_text_color: 'rgba(126, 34, 206, 1)', underline_text_color: 'rgba(216, 180, 254, 1)' },
+    { name: 'Sage Smoke', quote_text_color: 'rgba(74, 222, 128, 1)', underline_text_color: 'rgba(163, 163, 163, 1)' },
+    { name: 'Lichen', quote_text_color: 'rgba(132, 204, 22, 1)', underline_text_color: 'rgba(190, 242, 100, 1)' },
+    { name: 'Harvest Gold', quote_text_color: 'rgba(202, 138, 4, 1)', underline_text_color: 'rgba(253, 224, 71, 1)' },
+    { name: 'Indigo Dusk', quote_text_color: 'rgba(79, 70, 229, 1)', underline_text_color: 'rgba(165, 180, 252, 1)' },
+    { name: 'Pearl', quote_text_color: 'rgba(226, 232, 240, 1)', underline_text_color: 'rgba(148, 163, 184, 1)' },
+    { name: 'Mango Tango', quote_text_color: 'rgba(251, 146, 60, 1)', underline_text_color: 'rgba(253, 186, 116, 1)' },
+    { name: 'Neptune', quote_text_color: 'rgba(37, 99, 235, 1)', underline_text_color: 'rgba(34, 211, 238, 1)' },
 ]);
 const THEME_COLOR_PROPERTIES = Object.freeze([
     { key: 'main_text_color', selector: '#main-text-color-picker', type: 'main' },
@@ -1582,6 +1599,50 @@ function renderAccentProfiles() {
         applyButton.append(swatches, name);
         item.append(applyButton, deleteButton);
         list.append(item);
+    });
+}
+
+function getStoredSbAccentProfilesDrawerExpanded() {
+    const storedValue = accountStorage.getItem(SB_ACCENT_PROFILES_DRAWER_KEY);
+    if (storedValue === null) {
+        return null;
+    }
+
+    return storedValue === 'true';
+}
+
+function setStoredSbAccentProfilesDrawerExpanded(expanded) {
+    accountStorage.setItem(SB_ACCENT_PROFILES_DRAWER_KEY, String(Boolean(expanded)));
+}
+
+function syncSbAccentProfilesDrawerExpandedState(drawer, expanded) {
+    const toggle = drawer.querySelector(':scope > .inline-drawer-header .sb-accent-profiles-toggle');
+    if (toggle instanceof HTMLElement) {
+        toggle.setAttribute('aria-expanded', String(Boolean(expanded)));
+    }
+}
+
+function bindSbAccentProfilesDrawerPersistence() {
+    const drawer = document.getElementById('sb-accent-profiles-panel');
+    if (!(drawer instanceof HTMLElement) || drawer.dataset.sbAccentProfilesDrawerBound === 'true') {
+        return;
+    }
+
+    drawer.dataset.sbAccentProfilesDrawerBound = 'true';
+
+    const storedExpanded = getStoredSbAccentProfilesDrawerExpanded();
+    toggleDrawer(drawer, storedExpanded ?? true);
+    syncSbAccentProfilesDrawerExpandedState(drawer, storedExpanded ?? true);
+
+    drawer.addEventListener('inline-drawer-toggle', () => {
+        const icon = drawer.querySelector(':scope > .inline-drawer-header .inline-drawer-icon');
+        if (!(icon instanceof HTMLElement)) {
+            return;
+        }
+
+        const expanded = icon.classList.contains('up');
+        syncSbAccentProfilesDrawerExpandedState(drawer, expanded);
+        setStoredSbAccentProfilesDrawerExpanded(expanded);
     });
 }
 
@@ -4984,6 +5045,8 @@ jQuery(async () => {
             toastr.info('Accent colors applied.', 'SillyBunny palette');
         }
     });
+
+    bindSbAccentProfilesDrawerPersistence();
 
     $(document).on('click', '#sb-accent-profile-save', async function () {
         await saveAccentProfile();

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -12445,6 +12445,9 @@ function updateThemePickerUi() {
         }
         choice?.classList.toggle('is-selected', sbState.desktopNav.showCustomize);
         choice?.classList.toggle('is-disabled', false);
+        if (choice instanceof HTMLElement) {
+            choice.style.display = sbState.desktopNav.layout === 'vertical' ? 'none' : '';
+        }
     }
 
     if (desktopNavShowQuickActionsInput instanceof HTMLInputElement) {
@@ -12490,6 +12493,9 @@ function updateThemePickerUi() {
         }
         choice?.classList.toggle('is-selected', sbState.mobileNav.showCustomize);
         choice?.classList.toggle('is-disabled', false);
+        if (choice instanceof HTMLElement) {
+            choice.style.display = sbState.mobileNav.layout === 'vertical' ? 'none' : '';
+        }
     }
 
     if (mobileNavShowQuickActionsInput instanceof HTMLInputElement) {

--- a/tests/sillybunny-accent-profiles.test.js
+++ b/tests/sillybunny-accent-profiles.test.js
@@ -15,17 +15,20 @@ describe('SillyBunny accent color profiles', () => {
     test('ships a generous seeded profile set by default', () => {
         const seedNames = [...seedBlock.matchAll(/name: '([^']+)'/g)].map(match => match[1]);
 
-        expect(powerUserSource).toContain('const SB_ACCENT_PROFILE_SEED_VERSION = 1;');
+        expect(powerUserSource).toContain('const SB_ACCENT_PROFILE_SEED_VERSION = 2;');
         expect(powerUserSource).toContain('sb_accent_profiles: SILLYBUNNY_ACCENT_PROFILE_SEEDS.map(profile => ({ ...profile }))');
         expect(powerUserSource).toContain('sb_accent_profiles_seed_version: SB_ACCENT_PROFILE_SEED_VERSION');
         expect(powerUserSource).toContain('function normalizeAccentProfiles()');
-        expect(seedNames).toHaveLength(14);
+        expect(seedNames).toHaveLength(30);
         expect(seedNames).toEqual(expect.arrayContaining([
             'Warm Signal',
             'Story Moss',
             'Rose Glow',
             'Tidepool',
             'Graphite Glow',
+            'Aurora Veil',
+            'Solar Flare',
+            'Neptune',
         ]));
     });
 
@@ -48,13 +51,23 @@ describe('SillyBunny accent color profiles', () => {
 
     test('wires the appearance UI and responsive profile controls', () => {
         expect(indexSource).toContain('id="sb-accent-profile-save"');
+        expect(indexSource).toContain('id="sb-accent-profiles-panel"');
         expect(indexSource).toContain('id="sb-accent-profiles-list"');
         expect(indexSource).toContain('id="sb-accent-profiles-empty"');
-        expect(indexSource).toContain('css/sillybunny-theme.css?v=20260620a');
+        expect(indexSource).toContain('class="inline-drawer-toggle sb-accent-profiles-toggle"');
+        expect(indexSource).toContain('class="inline-drawer-content sb-accent-profiles-content"');
+        expect(indexSource).toContain('css/sillybunny-theme.css?v=20260621a');
+        expect(powerUserSource).toContain('const SB_ACCENT_PROFILES_DRAWER_KEY = \'SBAccentProfilesDrawerExpanded\';');
+        expect(powerUserSource).toContain('function bindSbAccentProfilesDrawerPersistence()');
+        expect(powerUserSource).toContain('accountStorage.getItem(SB_ACCENT_PROFILES_DRAWER_KEY)');
+        expect(powerUserSource).toContain('accountStorage.setItem(SB_ACCENT_PROFILES_DRAWER_KEY, String(Boolean(expanded)))');
+        expect(powerUserSource).toContain('toggleDrawer(drawer, storedExpanded ?? true);');
         expect(powerUserSource).toContain('$(document).on(\'click\', \'#sb-accent-profile-save\'');
         expect(powerUserSource).toContain('$(document).on(\'click\', \'.sb-accent-profile-apply\'');
         expect(powerUserSource).toContain('$(document).on(\'click\', \'.sb-accent-profile-delete\'');
         expect(themeCssSource).toContain('.sb-accent-profiles-panel');
+        expect(themeCssSource).toContain('.sb-accent-profiles-toggle');
+        expect(themeCssSource).toContain('.sb-accent-profiles-content');
         expect(themeCssSource).toContain('grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));');
         expect(themeCssSource).toContain('@media screen and (max-width: 768px)');
         expect(themeCssSource).toContain('.sb-accent-profiles-list {\n        grid-template-columns: 1fr;\n    }');

--- a/tests/sillybunny-accent-profiles.test.js
+++ b/tests/sillybunny-accent-profiles.test.js
@@ -52,6 +52,7 @@ describe('SillyBunny accent color profiles', () => {
     test('wires the appearance UI and responsive profile controls', () => {
         expect(indexSource).toContain('id="sb-accent-profile-save"');
         expect(indexSource).toContain('id="sb-accent-profiles-panel"');
+        expect(indexSource).toContain('data-settings-tab="appearance"');
         expect(indexSource).toContain('id="sb-accent-profiles-list"');
         expect(indexSource).toContain('id="sb-accent-profiles-empty"');
         expect(indexSource).toContain('class="inline-drawer-toggle sb-accent-profiles-toggle"');


### PR DESCRIPTION
This PR hides the 'Show Workspace and Customize' toggle when the navigation layout is set to vertical, since those shortcuts are hard-coded into the side rail in that mode.