### PR TITLE
fix: workspace and customize shortcuts toggle use intended behaviour

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -12445,6 +12445,9 @@ function updateThemePickerUi() {
         }
         choice?.classList.toggle('is-selected', sbState.desktopNav.showCustomize);
         choice?.classList.toggle('is-disabled', false);
+        if (choice instanceof HTMLElement) {
+            choice.style.display = sbState.desktopNav.layout === 'vertical' ? 'none' : '';
+        }
     }
 
     if (desktopNavShowQuickActionsInput instanceof HTMLInputElement) {
@@ -12490,6 +12493,9 @@ function updateThemePickerUi() {
         }
         choice?.classList.toggle('is-selected', sbState.mobileNav.showCustomize);
         choice?.classList.toggle('is-disabled', false);
+        if (choice instanceof HTMLElement) {
+            choice.style.display = sbState.mobileNav.layout === 'vertical' ? 'none' : '';
+        }
     }
 
     if (mobileNavShowQuickActionsInput instanceof HTMLInputElement) {
@@ -13844,7 +13850,7 @@ function syncMobileShellRailActions(shellKey = null) {
                     : null;
                 const railActionPlan = sbMobileShellLifecycle.railModel.resolveActionVisibility({
                     hasVerticalRail,
-                    showCustomize: navState.showCustomize,
+                    showCustomize: hasVerticalRail || navState.showCustomize,
                     showQuickActions: navState.showQuickActions,
                     builtInActions: getBuiltInRailActionsForShell(currentShellKey),
                     builtInActionKeys: Array.from(getAllBuiltInRailActionKeys()),


### PR DESCRIPTION
The Show Workspace and Customize shortcuts in each side rail toggle for Mobile and Desktop don't actually do anything. The idea is every single icon is on the vertical side rail regardless of what page you're in, hard-coded with Workspace on top and Customize at the bottom.

Fixed to do intended behaviour.