### PR TITLE
fix: PR unit test regression cleanup

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -163,12 +163,14 @@
 
     #right-nav-panel #CharListButtonAndHotSwaps {
         display: grid;
-        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
         align-items: center;
-        gap: 6px;
+        gap: 8px;
         width: 100%;
         box-sizing: border-box;
-        padding: 4px 0 6px;
+        min-height: 58px;
+        max-height: none;
+        padding: 6px var(--sb-character-mobile-edge, var(--sb-shell-panel-padding-inline, 12px));
     }
 
     #right-nav-panel #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
@@ -181,7 +183,12 @@
         min-width: var(--sb-mobile-touch-target, 44px);
     }
 
+    #right-nav-panel:not(:is([data-menu-type="character_edit"], [data-menu-type="create"])) #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
+        display: none;
+    }
+
     #right-nav-panel #HotSwapWrapper {
+        grid-column: 1;
         min-width: 0;
         width: auto;
         max-width: 100%;
@@ -221,19 +228,36 @@
     }
 
     #right-nav-panel #sb-character-right-lock {
-        grid-column: 3;
+        grid-column: 2;
     }
 
     #right-nav-panel #sb-character-back-to-list {
-        grid-column: 4;
+        grid-column: 3;
     }
 
     #right-nav-panel #sb-character-mobile-close {
-        grid-column: 4;
+        grid-column: 3;
     }
 
     #right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #CharListButtonAndHotSwaps {
-        grid-template-columns: 36px minmax(0, 1fr) 36px 36px 36px;
+        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
+        display: flex;
+        grid-column: 1;
+    }
+
+    #right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #rm_button_characters {
+        grid-column: 1;
+    }
+
+    #right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #sb-character-right-lock {
+        grid-column: 3;
+    }
+
+    #right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #sb-character-back-to-list {
+        grid-column: 4;
     }
 
     #right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #sb-character-mobile-close {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2150,17 +2150,24 @@
 
     #right-nav-panel.openDrawer:not([data-menu-type="character_edit"]):not([data-menu-type="create"]) #rm_button_selected_ch,
     #right-nav-panel.openDrawer:not([data-menu-type="character_edit"]):not([data-menu-type="create"]) #result_info {
-        display: none !important;
+        display: none;
     }
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) .sb-character-editor-controls-row {
         grid-template-columns: var(--sb-character-editor-avatar-size) minmax(0, 1fr);
         grid-template-areas:
             'avatar name'
-            'side-actions side-actions'
+            'avatar side-actions'
             'icon-actions icon-actions'
             'tags tags';
         gap: 6px;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #character-editor-pinned-actions,
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls,
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls > .form_create_bottom_buttons_block,
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls .char-button-toolbar {
+        display: contents !important;
     }
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1837,9 +1837,14 @@ body.sb-shell-resizing * {
 }
 
 .sb-shell-tab i {
+    --fa-display: inline-flex;
     width: 18px;
+    height: 18px;
     margin-top: 0;
     opacity: 0.82;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
     text-align: center;
 }
 
@@ -1936,7 +1941,7 @@ body.sb-shell-resizing * {
 
 #right-nav-panel.openDrawer > .sb-character-shell-header {
     gap: 4px;
-    padding: 8px calc(var(--sb-shell-panel-padding-inline) + 204px) 10px var(--sb-shell-panel-padding-inline);
+    padding: 8px calc(var(--sb-shell-panel-padding-inline) + 52px) 10px var(--sb-shell-panel-padding-inline);
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-kicker {
@@ -2542,11 +2547,13 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-character-import-action > i {
+    --fa-display: inline-flex;
     width: 48px;
     height: 48px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     border-radius: var(--sb-radius-md, 16px);
     background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
     color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 72%, var(--SmartThemeBodyColor));
@@ -5407,7 +5414,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 #right-nav-panel .sb-character-editor-controls-row #avatar_controls,
 #right-nav-panel .sb-character-editor-controls-row #avatar_controls > .form_create_bottom_buttons_block,
 #right-nav-panel .sb-character-editor-controls-row #avatar_controls .char-button-toolbar {
-    display: contents;
+    display: contents !important;
 }
 
 #right-nav-panel #avatar_controls .char-button-group-icons {
@@ -7718,7 +7725,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
     :root:not([data-sb-desktop-nav-layout='vertical']) #right-nav-panel.openDrawer .sb-character-shell-nav {
         justify-content: center !important;
-        padding-inline: max(var(--sb-shell-panel-padding-inline), 60px) !important;
+        padding-inline: var(--sb-shell-panel-padding-inline) !important;
     }
 
     :root[data-sb-desktop-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav {
@@ -7761,4 +7768,24 @@ body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block:not(.gr
         animation: none !important;
         transition-duration: 0.01ms !important;
     }
+}
+
+/* Unlayered fork cascade guards for upstream rules that beat layered shell layout rules. */
+/* Must beat unlayered public/css/sillybunny-theme.css icon-only button sizing. */
+#right-nav-panel .sb-character-create-bar #rm_button_create,
+#right-nav-panel .sb-character-create-bar #rm_button_group_chats {
+    width: auto;
+    inline-size: auto;
+    min-width: max-content;
+    min-inline-size: max-content;
+    max-width: none;
+    max-inline-size: none;
+    height: auto;
+    block-size: auto;
+    min-height: 44px;
+    max-height: none;
+    max-block-size: none;
+    padding: 0 var(--sb-shell-space-lg) !important;
+    aspect-ratio: auto;
+    flex: 0 0 auto;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -7741,3 +7741,59 @@ body:not(.movingUI) .drawer-content.maximized {
         opacity: 1;
     }
 }
+
+@media screen and (max-width: 768px) {
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) .sb-character-editor-side-actions {
+        width: 100%;
+        max-width: 100%;
+        align-self: start;
+        justify-self: stretch;
+        justify-content: flex-start;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) .sb-character-editor-side-actions #favorite_button {
+        flex: 0 0 auto;
+        width: auto;
+        min-width: max(var(--sb-mobile-touch-target, 44px), 4.5rem);
+        overflow: visible;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls {
+        grid-column: 1 / -1;
+        width: 100%;
+        min-width: 0;
+        height: auto;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        align-items: stretch;
+        justify-content: flex-start;
+        padding: 0;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls > .form_create_bottom_buttons_block,
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls .char-button-toolbar {
+        flex: 0 0 auto;
+        width: 100%;
+        min-width: 0;
+        align-items: stretch;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls .char-button-group-icons {
+        width: 100%;
+        max-width: 100%;
+        box-sizing: border-box;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        overflow-x: visible;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls .char-button-group-icons .menu_button {
+        flex: 0 0 40px;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #avatar_controls > #tags_div {
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
# Summary

Run Unit Tests on PR on staging regressed somehow and it keeps failing every time no matter what.

What was wrong: commit f3f178f05 ("revert: restore codex runtime baseline") reverted mobile CSS rules that the unit tests guard, but it did not revert the tests, so the CSS and tests fell out of sync.