### PR TITLE
feat: add margin size slider

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5301,6 +5301,15 @@
                                             <input class="neo-range-input" type="number" min="0.8" max="2" step="0.05" data-for="line_spacing" id="line_spacing_counter">
                                         </div>
 
+                                        <div class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
+                                            <small>
+                                                <span data-i18n="Margin Size">Margin Size</span>
+                                                <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Horizontal padding around chat messages" title="Horizontal padding around chat messages"></div>
+                                            </small>
+                                            <input class="neo-range-slider" type="range" id="message_margin_size" name="message_margin_size" min="0.5" max="2" step="0.05">
+                                            <input class="neo-range-input" type="number" min="0.5" max="2" step="0.05" data-for="message_margin_size" id="message_margin_size_counter">
+                                        </div>
+
                                         <div id="blur-strength-block" class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
                                             <small>
                                                 <span data-i18n="Blur Strength">Blur Strength</span>

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -317,6 +317,7 @@ export const power_user = {
     sort_rule: null,
     font_scale: 1,
     line_spacing: 1.2, // SillyBunny: chat message line-spacing slider.
+    message_margin_size: 1, // SillyBunny: chat message margin-size slider.
     blur_strength: 10,
     shadow_width: 2,
     'customCSS-bg-blur': 0,
@@ -1984,6 +1985,24 @@ function applyLineSpacing(type) {
     $('#line_spacing').val(power_user.line_spacing);
 }
 
+function applyMessageMarginSize(type) {
+    const setMessageMarginSize = () => {
+        const marginSize = Number(power_user.message_margin_size);
+        const marginScale = Number.isFinite(marginSize) ? marginSize : 1;
+
+        document.documentElement.style.setProperty('--messageMarginScale', String(marginScale));
+    };
+
+    if (type === 'forced') {
+        setMessageMarginSize();
+    } else {
+        $('#message_margin_size').off('mouseup touchend').on('mouseup touchend', setMessageMarginSize);
+    }
+
+    $('#message_margin_size_counter').val(power_user.message_margin_size);
+    $('#message_margin_size').val(power_user.message_margin_size);
+}
+
 /**
  * Checks if the chat needs to be reloaded to apply media display settings.
  * @returns {boolean} True if the chat needs reload to apply media display settings
@@ -2073,6 +2092,7 @@ export function applyPowerUserSettings() {
     switchUiMode();
     applyFontScale('forced');
     applyLineSpacing('forced');
+    applyMessageMarginSize('forced');
     applyThemeColor();
     applyChatWidth('forced');
     applyAvatarStyle();
@@ -2398,6 +2418,9 @@ export async function loadPowerUserSettings(settings, data) {
 
     $('#line_spacing').val(power_user.line_spacing);
     $('#line_spacing_counter').val(power_user.line_spacing);
+
+    $('#message_margin_size').val(power_user.message_margin_size);
+    $('#message_margin_size_counter').val(power_user.message_margin_size);
 
     $('#blur_strength').val(power_user.blur_strength);
     $('#blur_strength_counter').val(power_user.blur_strength);
@@ -4266,6 +4289,14 @@ jQuery(async () => {
         power_user.line_spacing = Number($(this).val());
         $('#line_spacing_counter').val(power_user.line_spacing);
         applyLineSpacing(applyMode);
+        saveSettingsDebounced();
+    });
+
+    $('input[name="message_margin_size"]').on('input', async function (e, data) {
+        const applyMode = data?.forced ? 'forced' : 'normal';
+        power_user.message_margin_size = Number($(this).val());
+        $('#message_margin_size_counter').val(power_user.message_margin_size);
+        applyMessageMarginSize(applyMode);
         saveSettingsDebounced();
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -130,6 +130,7 @@
     --fontScale: 1;
     --lineSpacingDesktopLeading: .6rem;
     --lineSpacingMobileLeading: .504rem;
+    --messageMarginScale: 1;
     --mainFontSize: calc(var(--fontScale) * 15px);
     --mainFontFamily: 'Figtree', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', sans-serif;
     --monoFontFamily: 'Noto Sans Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
@@ -174,7 +175,7 @@
     --tool-cool-color-picker-btn-bg: transparent;
     --tool-cool-color-picker-btn-border-color: transparent;
 
-    --mes-right-spacing: 30px;
+    --mes-right-spacing: calc(30px * var(--messageMarginScale, 1));
 
     --avatar-base-height: 50px;
     --avatar-base-width: 50px;
@@ -1357,7 +1358,7 @@ body .panelControlBar {
     contain: layout paint style;
     contain-intrinsic-size: auto 180px;
     /* SillyBunny: keep chat text denser without collapsing message breathing room. */
-    padding: 8px 10px 3px 10px;
+    padding: 8px calc(10px * var(--messageMarginScale, 1)) 3px calc(10px * var(--messageMarginScale, 1));
     margin-top: 0;
     width: 100%;
     color: var(--SmartThemeBodyColor);
@@ -1689,7 +1690,7 @@ img[src*="sillybunny-pixel-logo"] {
 .mes_block {
     padding-top: 0;
     /* SillyBunny: reduce the avatar-to-text gutter for denser chat styles. */
-    padding-left: 8px;
+    padding-left: calc(8px * var(--messageMarginScale, 1));
     width: 100%;
     overflow-x: hidden;
     overflow-y: clip;


### PR DESCRIPTION
# Summary
Adds a Margin Size slider that reduces or increases the margins/left and right padding for chat messages under Settings -> Page Size & Clarity.
Default is 1.0.