### PR TITLE
fix: make regex HTMLs work universally on ICA

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -451,7 +451,7 @@ function buildPanelEntryBody(agentId, entry) {
         return `<div class="ica--companion-error">${escapeHtml(entry.result.error || 'Companion run failed.')}</div>`;
     }
 
-    return formatCompanionContent(agentId, entry.result, chat[entry.messageIndex]);
+    return formatCompanionContent(agentId, entry.result, chat[entry.messageIndex], '.ica--tpanel-agent-body ');
 }
 
 function buildChatOnlyComposer(state) {

--- a/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
@@ -1,5 +1,6 @@
 import { DOMPurify, showdown } from '../../../../lib.js';
 import { chat, saveChatDebounced, substituteParams, substituteParamsExtended } from '../../../../script.js';
+import { encodeStyleTags, decodeStyleTags } from '../../../chats.js';
 import { eventSource, event_types } from '../../../events.js';
 import { Popup, POPUP_RESULT, POPUP_TYPE } from '../../../popup.js';
 import { escapeHtml } from '../../../utils.js';
@@ -198,10 +199,14 @@ function getMessageIndexFromElement(element) {
     return Number.isFinite(messageIndex) ? messageIndex : -1;
 }
 
-function sanitizeCompanionHtml(html = '') {
-    return DOMPurify.sanitize(String(html ?? ''), {
-        ADD_ATTR: ['target', 'rel'],
+function sanitizeCompanionHtml(html = '', { prefix = '.ica--companion-body ' } = {}) {
+    const encoded = encodeStyleTags(String(html ?? ''));
+    const sanitized = DOMPurify.sanitize(encoded, {
+        MESSAGE_SANITIZE: true,
+        ADD_TAGS: ['custom-style'],
+        ADD_ATTR: ['style', 'target', 'rel'],
     });
+    return decodeStyleTags(sanitized, { prefix });
 }
 
 function applyAgentRegexToCompanionContent(agentId, content, message) {
@@ -222,7 +227,7 @@ function applyAgentRegexToCompanionContent(agentId, content, message) {
     });
 }
 
-export function formatCompanionContent(agentId, result = {}, message = null) {
+export function formatCompanionContent(agentId, result = {}, message = null, stylePrefix = '.ica--companion-body ') {
     const rawContent = String(result.content ?? '').trim();
     if (isSuppressedCompanionResult(agentId, result)) {
         return '';
@@ -233,16 +238,17 @@ export function formatCompanionContent(agentId, result = {}, message = null) {
     }
 
     const content = applyAgentRegexToCompanionContent(agentId, rawContent, message);
+    const sanitizeOptions = { prefix: stylePrefix };
 
     if (result.format === 'html') {
-        return decorateChoiceLines(sanitizeCompanionHtml(content));
+        return decorateChoiceLines(sanitizeCompanionHtml(content, sanitizeOptions));
     }
 
     if (result.format === 'text') {
         return `<pre class="ica--companion-text">${escapeHtml(content)}</pre>`;
     }
 
-    return decorateChoiceLines(sanitizeCompanionHtml(getMarkdownConverter().makeHtml(content)));
+    return decorateChoiceLines(sanitizeCompanionHtml(getMarkdownConverter().makeHtml(content), sanitizeOptions));
 }
 
 function getResultStatus(result = {}) {

--- a/tests/in-chat-agents-companion.test.js
+++ b/tests/in-chat-agents-companion.test.js
@@ -33,11 +33,19 @@ describe('companion card ui', () => {
     let eventTypes;
     let agents;
     let sanitize;
+    let encodeStyleTags;
+    let decodeStyleTags;
 
     async function importCompanionUi() {
         jest.resetModules();
 
         sanitize = jest.fn(html => String(html));
+        encodeStyleTags = jest.fn(text => String(text).replaceAll(/<style>(.+?)<\/style>/gims, (_, match) => {
+            return `<custom-style>${encodeURIComponent(match)}</custom-style>`;
+        }));
+        decodeStyleTags = jest.fn((text, { prefix } = {}) => String(text).replaceAll(/<custom-style>(.+?)<\/custom-style>/gms, (_, match) => {
+            return `<style data-prefix="${prefix}">${decodeURIComponent(match)}</style>`;
+        }));
 
         await jest.unstable_mockModule('../public/lib.js', () => ({
             DOMPurify: { sanitize },
@@ -48,6 +56,11 @@ describe('companion card ui', () => {
                     }
                 },
             },
+        }));
+
+        await jest.unstable_mockModule('../public/scripts/chats.js', () => ({
+            encodeStyleTags,
+            decodeStyleTags,
         }));
 
         await jest.unstable_mockModule('../public/script.js', () => ({
@@ -228,6 +241,56 @@ describe('companion card ui', () => {
 
         expect(html).toBe('<div class="status">calm</div>');
         expect(sanitize).toHaveBeenCalledWith('<div class="status">calm</div>', expect.anything());
+    });
+
+    test('preserves style tags emitted by regex scripts in card bodies', async () => {
+        agents[0].regexScripts = [{
+            id: 'styled-card',
+            scriptName: 'Styled Card',
+            findRegex: '/\\[STYLE\\]/g',
+            replaceString: '<style>.terminal { color: red; }</style><div class="terminal">stats</div>',
+            placement: [2],
+            disabled: false,
+            markdownOnly: true,
+            promptOnly: false,
+            substituteRegex: 0,
+        }];
+        const { formatCompanionContent } = await importCompanionUi();
+
+        const html = formatCompanionContent('companion-tracker', {
+            content: '[STYLE]',
+            format: 'html',
+        }, { name: 'Aria' });
+
+        expect(html).toContain('<style data-prefix=".ica--companion-body ">');
+        expect(html).toContain('.terminal { color: red; }');
+        expect(html).toContain('<div class="terminal">stats</div>');
+        expect(sanitize).toHaveBeenCalledWith(expect.stringContaining('<custom-style>'), expect.anything());
+        expect(encodeStyleTags).toHaveBeenCalled();
+        expect(decodeStyleTags).toHaveBeenCalledWith(expect.stringContaining('<custom-style>'), { prefix: '.ica--companion-body ' });
+    });
+
+    test('scopes panel bodies with the tracker panel CSS prefix', async () => {
+        agents[0].regexScripts = [{
+            id: 'styled-card',
+            scriptName: 'Styled Card',
+            findRegex: '/\\[STYLE\\]/g',
+            replaceString: '<style>.terminal { color: red; }</style><div class="terminal">stats</div>',
+            placement: [2],
+            disabled: false,
+            markdownOnly: true,
+            promptOnly: false,
+            substituteRegex: 0,
+        }];
+        const { formatCompanionContent } = await importCompanionUi();
+
+        const html = formatCompanionContent('companion-tracker', {
+            content: '[STYLE]',
+            format: 'html',
+        }, { name: 'Aria' }, '.ica--tpanel-agent-body ');
+
+        expect(html).toContain('<style data-prefix=".ica--tpanel-agent-body ">');
+        expect(decodeStyleTags).toHaveBeenCalledWith(expect.stringContaining('<custom-style>'), { prefix: '.ica--tpanel-agent-body ' });
     });
 
     test('normalizes markerless Chatroom pipe streams before rendering', async () => {


### PR DESCRIPTION
# Summary
- The regexes from the User Stat Agent and the Level Up Companion aren't rendering properly as actual HTML when they're on the Companions Panel. The same regexes work on ICA inline agents when rendered on the chat itself.