### PR TITLE
fix: use set group chat greetings + harden group chat creation

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -69,11 +69,11 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Area | Chat lifecycle. |
 | Divergence reason | SillyBunny's Start new chat menu path already flushes pending saves and clears the active chat before delegating to group chat creation, so the group branch creator must not run a second navigation-save guard that can abort and repaint the current chat. |
 | Target seam | None yet; group chat branch creation still lives in the upstream-origin chat modules. |
-| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so validation trusts the active empty branch until its JSONL exists. |
+| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so validation trusts the active empty branch until its JSONL exists. Initialize empty, untainted group chats as fresh so first-time groups opened after creation still emit the group-created lifecycle event for greeting handlers. |
 | Protecting tests | Future focused group-chat new-branch coverage; current protection is static validation. |
-| Validation | `node --check public/script.js`, `node --check public/scripts/group-chats.js`, `npm run lint`, `git diff --check`. |
-| Rollback path | Revert the option plumbing and newly-created load hint to restore the previous `createNewGroupChat(groupId)` path. |
-| Last reviewed | 2026-06-10 group chat Start new chat validation fix. |
+| Validation | `node --check public/scripts/group-chats.js`, `npm run lint`, `npm run test:unit --prefix tests -- group-chat-info.test.js`, `git diff --check`. |
+| Rollback path | Revert the state-based fresh-chat detection, option plumbing, and newly-created load hint to restore the previous `createNewGroupChat(groupId)` path. |
+| Last reviewed | 2026-06-23 group chat greeting initialization fix. |
 | Owner | Bugfix integrator. |
 
 ### `public/style.css` - message containment and scroll anchoring

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -639,26 +639,25 @@ export async function getGroupChat(groupId, reload = false, { switchMenu = true,
     await validateGroup(group, { trustActiveChat: newlyCreated });
     await unshallowGroupMembers(groupId);
 
-    let createdChat = newlyCreated;
-
     if (!group.chat_id) {
         const freshChatId = humanizedDateTime();
         group.chat_id = freshChatId;
         group.chats = Array.isArray(group.chats) ? group.chats : [];
         group.chats.push(freshChatId);
         await editGroup(group.id, true, false);
-        createdChat = true;
     }
 
     const chat_id = group.chat_id;
     const data = await loadGroupChat(chat_id);
     const metadata = data?.[0]?.chat_metadata ?? {};
-    const freshChat = createdChat && !metadata.tainted && (!Array.isArray(data) || !data.length);
 
     // Remove chat file header if present
     if (Array.isArray(data) && data.length && Object.hasOwn(data[0], 'chat_metadata')) {
         data.shift();
     }
+
+    // SillyBunny: initialize empty, untainted group chats even when the chat id was created before this load.
+    const freshChat = !metadata.tainted && (!Array.isArray(data) || !data.length);
 
     // Add integrity slug if missing
     if (!metadata.integrity) {


### PR DESCRIPTION
# Summary
- User reported: "yea, it doesn't show the greeting for groups I'm chatting with for the first time and actually the overwrite noti only shows up when i make new chats for groups I already had past chats with "
- This PR hardens group chat creation and ensures that group chat greetings are used.