### PR TITLE
fix(group_chat): fix group chat new messages + add greetings button QoL

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -63,15 +63,15 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-06-06 chat integrity rotation fix. |
 | Owner | Bugfix integrator. |
 
-### `public/script.js` and `public/scripts/group-chats.js` - group chat branch creation
+### `public/index.html`, `public/style.css`, `public/css/mobile-styles.css`, `public/script.js`, and `public/scripts/group-chats.js` - group chat branch creation
 | Field | Value |
 | --- | --- |
-| Area | Chat lifecycle. |
-| Divergence reason | SillyBunny's Start new chat menu path already flushes pending saves and clears the active chat before delegating to group chat creation, so the group branch creator must not run a second navigation-save guard that can abort and repaint the current chat. |
+| Area | Chat lifecycle and mobile shell. |
+| Divergence reason | SillyBunny's Start new chat menu path already flushes pending saves and clears the active chat before delegating to group chat creation, so the group branch creator must not run a second navigation-save guard that can abort and repaint the current chat. New group branches also need fresh integrity metadata and a member greeting before the first save, plus a compact group-greeting action beside Speak Now on desktop and mobile. |
 | Target seam | None yet; group chat branch creation still lives in the upstream-origin chat modules. |
-| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so validation trusts the active empty branch until its JSONL exists. Initialize empty, untainted group chats as fresh so first-time groups opened after creation still emit the group-created lifecycle event for greeting handlers. |
-| Protecting tests | Future focused group-chat new-branch coverage; current protection is static validation. |
-| Validation | `node --check public/scripts/group-chats.js`, `npm run lint`, `npm run test:unit --prefix tests -- group-chat-info.test.js`, `git diff --check`. |
+| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so validation trusts the active empty branch until its JSONL exists. Initialize empty, untainted group chats as fresh, seed one member greeting before the first save, emit first-message events after the chat-changed event, and keep the Add New Greeting button in the existing group speaker control row. |
+| Protecting tests | `tests/group-chat-greetings-qol.test.js`, `tests/group-chat-info.test.js`, static validation in `tests/chat-integrity-rotation.test.js`. |
+| Validation | `node --check public/scripts/group-chats.js`, `npm run test:unit --prefix tests -- group-chat-greetings-qol.test.js chat-integrity-rotation.test.js group-chat-info.test.js`, `npm run lint`, `git diff --check`. |
 | Rollback path | Revert the state-based fresh-chat detection, option plumbing, and newly-created load hint to restore the previous `createNewGroupChat(groupId)` path. |
 | Last reviewed | 2026-06-23 group chat greeting initialization fix. |
 | Owner | Bugfix integrator. |

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1930,8 +1930,8 @@
 
     .group_speaker_controls {
         display: grid !important;
-        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) !important;
-        grid-template-areas: "avatars speak" !important;
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) !important;
+        grid-template-areas: "avatars greeting speak" !important;
         gap: 5px !important;
         align-items: center !important;
         min-height: calc(var(--sb-mobile-touch-target, 44px) + 8px) !important;
@@ -2009,10 +2009,12 @@
     }
 
     .group_speaker_avatar span,
+    #group_add_greeting span,
     #group_speaker_now span {
         display: none !important;
     }
 
+    #group_add_greeting,
     #group_speaker_now {
         width: var(--sb-mobile-touch-target, 44px) !important;
         min-width: var(--sb-mobile-touch-target, 44px) !important;
@@ -2029,6 +2031,10 @@
         border-radius: 9px !important;
         box-sizing: border-box !important;
         font-size: 16px !important;
+    }
+
+    #group_add_greeting {
+        grid-area: greeting !important;
     }
 
     #group_speaker_now {

--- a/public/index.html
+++ b/public/index.html
@@ -8815,7 +8815,7 @@
                 <div id="group_typing_indicator" class="group_typing_indicator displayNone" aria-live="polite"></div>
                 <div class="group_speaker_list"></div>
                 <button type="button" id="group_add_greeting" class="menu_button menu_button_icon" title="Add New Greeting" data-i18n="[title]Add New Greeting">
-                    <i class="fa-solid fa-plus"></i>
+                    <i class="fa-solid fa-hand-sparkles"></i>
                     <span data-i18n="Add New Greeting">Add New Greeting</span>
                 </button>
                 <button type="button" id="group_speaker_now" class="menu_button menu_button_icon" title="Make selected character speak now" data-i18n="[title]Make selected character speak now">

--- a/public/index.html
+++ b/public/index.html
@@ -8814,6 +8814,10 @@
             <div id="group_speaker_controls" class="group_speaker_controls displayNone">
                 <div id="group_typing_indicator" class="group_typing_indicator displayNone" aria-live="polite"></div>
                 <div class="group_speaker_list"></div>
+                <button type="button" id="group_add_greeting" class="menu_button menu_button_icon" title="Add New Greeting" data-i18n="[title]Add New Greeting">
+                    <i class="fa-solid fa-plus"></i>
+                    <span data-i18n="Add New Greeting">Add New Greeting</span>
+                </button>
                 <button type="button" id="group_speaker_now" class="menu_button menu_button_icon" title="Make selected character speak now" data-i18n="[title]Make selected character speak now">
                     <i class="fa-solid fa-comment-dots"></i>
                     <span data-i18n="Speak Now">Speak Now</span>

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -291,6 +291,8 @@ function buildGroupGreetingMessage(avatarId) {
         name: character.name,
         is_user: false,
         is_system: false,
+        force_avatar: getThumbnailUrl('avatar', character.avatar),
+        original_avatar: character.avatar,
         send_date: getMessageTimeStamp(),
         mes: getRegexedString(firstMes, regex_placement.AI_OUTPUT),
         extra: {},

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -19,7 +19,7 @@ import {
     waitUntilCondition,
     uuidv4,
 } from './utils.js';
-import { RA_CountCharTokens, humanizedDateTime, dragElement, favsToHotswap } from './RossAscends-mods.js';
+import { RA_CountCharTokens, humanizedDateTime, dragElement, favsToHotswap, getMessageTimeStamp } from './RossAscends-mods.js';
 import { power_user, loadMovingUIState, sortEntitiesList } from './power-user.js';
 import { debounce_timeout } from './constants.js';
 
@@ -90,6 +90,7 @@ import { accountStorage } from './util/AccountStorage.js';
 import { compressRequest } from './request-compression.js';
 import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { chat_completion_sources, oai_settings } from './openai.js';
+import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
 
 export {
     selected_group,
@@ -278,6 +279,103 @@ function getSelectedGroupSpeakerChid(group) {
     return getCharacterIdByAvatar(selectedGroupSpeakerAvatar);
 }
 
+function buildGroupGreetingMessage(avatarId) {
+    const character = characters[getCharacterIdByAvatar(avatarId)];
+    if (!character) {
+        return null;
+    }
+
+    const firstMes = character.first_mes || '';
+    const alternateGreetings = character.data?.alternate_greetings;
+    const message = {
+        name: character.name,
+        is_user: false,
+        is_system: false,
+        send_date: getMessageTimeStamp(),
+        mes: getRegexedString(firstMes, regex_placement.AI_OUTPUT),
+        extra: {},
+    };
+
+    if (Array.isArray(alternateGreetings) && alternateGreetings.length > 0) {
+        const swipes = [message.mes, ...(alternateGreetings.map(greeting => getRegexedString(greeting, regex_placement.AI_OUTPUT)))];
+
+        if (!message.mes) {
+            swipes.shift();
+            message.mes = swipes[0];
+        }
+
+        message.swipe_id = 0;
+        message.swipes = swipes;
+        message.swipe_info = swipes.map(_ => ({
+            send_date: message.send_date,
+            gen_started: void 0,
+            gen_finished: void 0,
+            extra: {},
+        }));
+    }
+
+    return message.mes ? message : null;
+}
+
+function getGroupGreetingMember(group, preferredAvatar = '') {
+    const members = getGroupEnabledMembers(group);
+    const orderedMembers = members.includes(preferredAvatar)
+        ? [preferredAvatar, ...members.filter(avatarId => avatarId !== preferredAvatar)]
+        : members;
+
+    for (const avatarId of orderedMembers) {
+        const message = buildGroupGreetingMessage(avatarId);
+        if (message) {
+            return { avatarId, message };
+        }
+    }
+
+    return null;
+}
+
+async function emitGroupGreetingMessageEvents(messageId) {
+    await eventSource.emit(event_types.MESSAGE_RECEIVED, messageId, 'first_message');
+    await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, messageId, 'first_message');
+}
+
+function addFreshGroupGreeting(group) {
+    const greeting = getGroupGreetingMember(group, selectedGroupSpeakerAvatar);
+    if (!greeting) {
+        return -1;
+    }
+
+    const messageId = chat.length;
+    chat.push(greeting.message);
+    return messageId;
+}
+
+async function addSelectedGroupGreeting() {
+    if (!selected_group || !selectedGroupSpeakerAvatar) {
+        toastr.warning(t`Pick a group member first.`);
+        return;
+    }
+
+    const group = groups.find(x => x.id === selected_group);
+    if (!getGroupEnabledMembers(group).includes(selectedGroupSpeakerAvatar)) {
+        selectedGroupSpeakerAvatar = '';
+        updateGroupSpeakerControls();
+        toastr.warning(t`Pick a group member first.`);
+        return;
+    }
+
+    const message = buildGroupGreetingMessage(selectedGroupSpeakerAvatar);
+    if (!message) {
+        toastr.warning(t`Selected group member has no greeting.`);
+        return;
+    }
+
+    const messageId = chat.length;
+    chat.push(message);
+    await saveGroupChat(selected_group, false);
+    await printMessages();
+    await emitGroupGreetingMessageEvents(messageId);
+}
+
 function buildContextAwareGroupPrompt(speakerName, options = {}) {
     const targetName = options.targetName || '';
     const targetText = targetName ? ` The immediate call or message is directed at ${speakerName} by ${targetName}; ${speakerName} should answer ${targetName}.` : '';
@@ -424,6 +522,8 @@ function initGroupSpeakerControls() {
             Generate('normal', { force_chid: chid });
         }
     });
+
+    container.on('click', '#group_add_greeting', addSelectedGroupGreeting);
 }
 
 export const group_activation_strategy = {
@@ -666,12 +766,19 @@ export async function getGroupChat(groupId, reload = false, { switchMenu = true,
 
     await loadItemizedPrompts(getCurrentChatId());
 
+    let freshGroupGreetingMessageId = -1;
+
     if (group && Array.isArray(group.members) && freshChat) {
         chat.splice(0, chat.length);
         chatElement.find('.mes').remove();
+        freshGroupGreetingMessageId = addFreshGroupGreeting(group);
         metadata.tainted = true;
         updateChatMetadata(metadata, true);
-        await saveGroupChat(groupId, false);
+        const savedFreshGroupChat = await saveGroupChat(groupId, false);
+        if (savedFreshGroupChat && chat_metadata.integrity) {
+            metadata.integrity = chat_metadata.integrity;
+        }
+        await printMessages();
     } else if (Array.isArray(data) && data.length) {
         chat.splice(0, chat.length, ...data);
         chat.forEach(ensureMessageMediaIsArray);
@@ -687,6 +794,7 @@ export async function getGroupChat(groupId, reload = false, { switchMenu = true,
 
     await eventSource.emit(event_types.CHAT_CHANGED, getCurrentChatId());
     if (freshChat) await eventSource.emit(event_types.GROUP_CHAT_CREATED);
+    if (freshGroupGreetingMessageId !== -1) await emitGroupGreetingMessageEvents(freshGroupGreetingMessageId);
 }
 
 /**
@@ -2719,7 +2827,7 @@ export async function createNewGroupChat(groupId, { chatAlreadyPrepared = false 
     group.chats = Array.isArray(group.chats) ? group.chats : [];
     group.chats.push(newChatName);
     group.chat_id = newChatName;
-    updateChatMetadata({}, true);
+    updateChatMetadata({ integrity: uuidv4() }, true);
 
     await editGroup(group.id, true, false);
     await getGroupChat(group.id, false, { newlyCreated: true });

--- a/public/style.css
+++ b/public/style.css
@@ -7598,8 +7598,8 @@ body:not(.movingUI) .drawer-content.maximized {
 @media screen and (max-width: 600px) {
     .group_speaker_controls {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) 34px;
-        grid-template-areas: "typing typing" "avatars speak";
+        grid-template-columns: minmax(0, 1fr) 34px 34px;
+        grid-template-areas: "typing typing typing" "avatars greeting speak";
         align-items: center;
         gap: 4px;
         padding: 4px 6px;
@@ -7642,6 +7642,7 @@ body:not(.movingUI) .drawer-content.maximized {
     }
 
     .group_speaker_avatar span,
+    #group_add_greeting span,
     #group_speaker_now span {
         display: none;
     }
@@ -7651,6 +7652,7 @@ body:not(.movingUI) .drawer-content.maximized {
         height: 24px;
     }
 
+    #group_add_greeting,
     #group_speaker_now {
         width: 34px;
         min-width: 34px;
@@ -7664,6 +7666,10 @@ body:not(.movingUI) .drawer-content.maximized {
         font-size: calc(var(--mainFontSize) * 0.95);
     }
 
+    #group_add_greeting {
+        grid-area: greeting;
+    }
+
     #group_speaker_now {
         grid-area: speak;
     }
@@ -7672,9 +7678,10 @@ body:not(.movingUI) .drawer-content.maximized {
 
 @media screen and (max-width: 420px) {
     .group_speaker_controls {
-        grid-template-columns: minmax(0, 1fr) 30px;
+        grid-template-columns: minmax(0, 1fr) 30px 30px;
     }
 
+    #group_add_greeting,
     #group_speaker_now {
         width: 30px;
         min-width: 30px;

--- a/tests/group-chat-greetings-qol.test.js
+++ b/tests/group-chat-greetings-qol.test.js
@@ -1,0 +1,54 @@
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+describe('group chat greetings QoL', () => {
+    test('seeds fresh group chats with a member greeting before the first save', async () => {
+        const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
+        const getGroupChatBody = groupChatSource.slice(
+            groupChatSource.indexOf('export async function getGroupChat'),
+            groupChatSource.indexOf('/**\n * Retrieves the members of a group'),
+        );
+
+        expect(groupChatSource).toContain('import { getRegexedString, regex_placement } from \'./extensions/regex/engine.js\';');
+        expect(groupChatSource).toContain('function buildGroupGreetingMessage(avatarId)');
+        expect(groupChatSource).toContain('const greeting = getGroupGreetingMember(group, selectedGroupSpeakerAvatar);');
+        expect(getGroupChatBody).toContain('freshGroupGreetingMessageId = addFreshGroupGreeting(group);');
+        expect(getGroupChatBody.indexOf('freshGroupGreetingMessageId = addFreshGroupGreeting(group);'))
+            .toBeLessThan(getGroupChatBody.indexOf('const savedFreshGroupChat = await saveGroupChat(groupId, false);'));
+        expect(getGroupChatBody).toContain('metadata.integrity = chat_metadata.integrity;');
+        expect(getGroupChatBody.indexOf('metadata.integrity = chat_metadata.integrity;'))
+            .toBeLessThan(getGroupChatBody.lastIndexOf('updateChatMetadata(metadata, true);'));
+        expect(getGroupChatBody).toContain('if (freshGroupGreetingMessageId !== -1) await emitGroupGreetingMessageEvents(freshGroupGreetingMessageId);');
+    });
+
+    test('starts new group branches with fresh integrity metadata', async () => {
+        const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
+        const createNewGroupChatBody = groupChatSource.slice(
+            groupChatSource.indexOf('export async function createNewGroupChat'),
+            groupChatSource.indexOf('/**\n * Retrieves past chats for a specified group'),
+        );
+
+        expect(createNewGroupChatBody).toContain('group.chat_id = newChatName;');
+        expect(createNewGroupChatBody).toContain('updateChatMetadata({ integrity: uuidv4() }, true);');
+        expect(createNewGroupChatBody.indexOf('updateChatMetadata({ integrity: uuidv4() }, true);'))
+            .toBeLessThan(createNewGroupChatBody.indexOf('await getGroupChat(group.id, false, { newlyCreated: true });'));
+    });
+
+    test('wires the Add New Greeting button into desktop and mobile speaker controls', async () => {
+        const indexSource = await fs.readFile(fileURLToPath(new URL('../public/index.html', import.meta.url)), 'utf8');
+        const styleSource = await fs.readFile(fileURLToPath(new URL('../public/style.css', import.meta.url)), 'utf8');
+        const mobileStyleSource = await fs.readFile(fileURLToPath(new URL('../public/css/mobile-styles.css', import.meta.url)), 'utf8');
+        const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
+
+        expect(indexSource).toContain('id="group_add_greeting"');
+        expect(indexSource).toContain('class="fa-solid fa-plus"');
+        expect(indexSource).toContain('Add New Greeting');
+        expect(groupChatSource).toContain('container.on(\'click\', \'#group_add_greeting\', addSelectedGroupGreeting);');
+        expect(styleSource).toContain('grid-template-areas: "typing typing typing" "avatars greeting speak";');
+        expect(styleSource).toContain('#group_add_greeting span,');
+        expect(styleSource).toContain('#group_add_greeting {\n        grid-area: greeting;\n    }');
+        expect(mobileStyleSource).toContain('grid-template-areas: "avatars greeting speak" !important;');
+        expect(mobileStyleSource).toContain('#group_add_greeting span,');
+        expect(mobileStyleSource).toContain('#group_add_greeting {\n        grid-area: greeting !important;\n    }');
+    });
+});

--- a/tests/group-chat-greetings-qol.test.js
+++ b/tests/group-chat-greetings-qol.test.js
@@ -11,6 +11,8 @@ describe('group chat greetings QoL', () => {
 
         expect(groupChatSource).toContain('import { getRegexedString, regex_placement } from \'./extensions/regex/engine.js\';');
         expect(groupChatSource).toContain('function buildGroupGreetingMessage(avatarId)');
+        expect(groupChatSource).toContain('force_avatar: getThumbnailUrl(\'avatar\', character.avatar),');
+        expect(groupChatSource).toContain('original_avatar: character.avatar,');
         expect(groupChatSource).toContain('const greeting = getGroupGreetingMember(group, selectedGroupSpeakerAvatar);');
         expect(getGroupChatBody).toContain('freshGroupGreetingMessageId = addFreshGroupGreeting(group);');
         expect(getGroupChatBody.indexOf('freshGroupGreetingMessageId = addFreshGroupGreeting(group);'))
@@ -41,7 +43,7 @@ describe('group chat greetings QoL', () => {
         const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
 
         expect(indexSource).toContain('id="group_add_greeting"');
-        expect(indexSource).toContain('class="fa-solid fa-plus"');
+        expect(indexSource).toContain('class="fa-solid fa-hand-sparkles"');
         expect(indexSource).toContain('Add New Greeting');
         expect(groupChatSource).toContain('container.on(\'click\', \'#group_add_greeting\', addSelectedGroupGreeting);');
         expect(styleSource).toContain('grid-template-areas: "typing typing typing" "avatars greeting speak";');


### PR DESCRIPTION
# Summary
- The previous PR https://github.com/platberlitz/SillyBunny/pull/608 didn't quite work as intended.
- This PR hardens the creation of a new group chat so integrity checks where you have to refresh the page to not lose data or type OVERWRITE don't happen when you make a new group chat branch.
- It also adds an Add New Greeting button (font awesome sparkling hand icon) next to the "Speak Now" button to easily choose which greeting to use among the group members.