### PR TITLE
fix: iOS keyboard raising window height

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -880,12 +880,12 @@
            The shell itself is resized via visualViewport, so the composer stays
            above the keyboard without the user having to scroll the page down. */
         body.sb-ios-keyboard-locked {
-            position: fixed !important;
-            width: 100% !important;
-            height: 100% !important;
-            overflow: hidden !important;
-            overscroll-behavior: none !important;
-            touch-action: none !important;
+            position: fixed;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            overscroll-behavior: none;
+            touch-action: none;
         }
 
         #left-nav-panel.openDrawer,

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -875,6 +875,19 @@
             min-height: 0 !important;
         }
 
+        /* SillyBunny: lock the document root while the iOS keyboard is open so
+           Safari cannot auto-pan the page when focusing an input near the bottom.
+           The shell itself is resized via visualViewport, so the composer stays
+           above the keyboard without the user having to scroll the page down. */
+        body.sb-ios-keyboard-locked {
+            position: fixed !important;
+            width: 100% !important;
+            height: 100% !important;
+            overflow: hidden !important;
+            overscroll-behavior: none !important;
+            touch-action: none !important;
+        }
+
         #left-nav-panel.openDrawer,
         #user-settings-block.openDrawer,
         .sb-shell-root.openDrawer,

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -753,7 +753,7 @@
         overflow-x: hidden !important;
         overscroll-behavior: contain !important;
         -webkit-overflow-scrolling: touch !important;
-        padding-bottom: max(24px, var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        padding-bottom: max(24px, calc(var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) + var(--sb-ios-keyboard-bottom-inset, 0px))) !important;
     }
 
     #right-nav-panel.openDrawer > .scrollableInner,
@@ -769,7 +769,7 @@
         box-sizing: border-box !important;
         scrollbar-gutter: stable !important;
         padding-inline-end: var(--sb-character-scroll-gutter, 8px) !important;
-        padding-bottom: max(24px, var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        padding-bottom: max(24px, calc(var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) + var(--sb-ios-keyboard-bottom-inset, 0px))) !important;
     }
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > .scrollableInner,
@@ -873,19 +873,6 @@
         body:not(.movingUI) #chat {
             flex: 1 1 auto !important;
             min-height: 0 !important;
-        }
-
-        /* SillyBunny: lock the document root while the iOS keyboard is open so
-           Safari cannot auto-pan the page when focusing an input near the bottom.
-           The shell itself is resized via visualViewport, so the composer stays
-           above the keyboard without the user having to scroll the page down. */
-        body.sb-ios-keyboard-locked {
-            position: fixed;
-            width: 100%;
-            height: 100%;
-            overflow: hidden;
-            overscroll-behavior: none;
-            touch-action: none;
         }
 
         #left-nav-panel.openDrawer,

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <title>SillyBunny</title>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-visual">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=overlays-content">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <title>SillyBunny</title>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-visual">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <title>SillyBunny</title>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=overlays-content">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-visual">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">

--- a/public/login.html
+++ b/public/login.html
@@ -4,7 +4,7 @@
 <head>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-visual">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=overlays-content">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">

--- a/public/login.html
+++ b/public/login.html
@@ -4,7 +4,7 @@
 <head>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-visual">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">

--- a/public/login.html
+++ b/public/login.html
@@ -4,7 +4,7 @@
 <head>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=overlays-content">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-visual">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2391,17 +2391,23 @@ function isVisualViewportKeyboardOpen(layoutViewport = getLayoutViewportSize(), 
     return keyboardHeight > 80 || visualViewportSize.top > 2;
 }
 
-function syncIOSKeyboardScrollLock() {
-    if (!isMobileViewport() || !isIOSWebKitPlatform()) {
-        document.body.classList.remove('sb-ios-keyboard-locked');
-        return;
+function syncIOSKeyboardBottomInset() {
+    const root = document.documentElement;
+    let bottomInset = 0;
+
+    if (isMobileViewport() && isIOSWebKitPlatform()) {
+        const layoutViewport = getLayoutViewportSize();
+        const visualViewportSize = getVisualViewportSize(layoutViewport);
+
+        if (isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
+            bottomInset = Math.max(0, Math.round(layoutViewport.height - visualViewportSize.top - visualViewportSize.height));
+        }
     }
 
-    const layoutViewport = getLayoutViewportSize();
-    const visualViewportSize = getVisualViewportSize(layoutViewport);
-    const isKeyboardOpen = isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize);
-
-    document.body.classList.toggle('sb-ios-keyboard-locked', isKeyboardOpen);
+    const value = `${bottomInset}px`;
+    if (root.style.getPropertyValue('--sb-ios-keyboard-bottom-inset') !== value) {
+        root.style.setProperty('--sb-ios-keyboard-bottom-inset', value);
+    }
 }
 
 function getShellViewportSize() {
@@ -15038,9 +15044,10 @@ function syncMobileViewportState() {
         handler();
     }
 
-    // SillyBunny: after all viewport sizing settles, freeze the iOS document
-    // scroll position so Safari cannot auto-pan the page for focused inputs.
-    syncIOSKeyboardScrollLock();
+    // SillyBunny: after viewport sizing settles, give iOS shell scrollers enough
+    // bottom inset to move focused bottom fields above the keyboard without
+    // locking the document and exposing a blank Safari background.
+    syncIOSKeyboardBottomInset();
 }
 
 let sbMobileViewportStateFrameId = 0;
@@ -16050,13 +16057,11 @@ function initAll() {
     // scroller is nudged manually (see scrollMobileFocusedInputIntoView).
     document.addEventListener('focusin', scrollMobileFocusedInputIntoView);
 
-    // SillyBunny: iOS Safari auto-pans the document when focusing inputs near the
-    // keyboard. Keep the scroll lock in sync with viewport and focus changes so the
-    // page cannot drift before our visualViewport-based shell sizing takes over.
+    // SillyBunny: keep iOS drawer scroller padding in sync with keyboard focus;
+    // this provides scroll range for bottom inputs without fixing the document.
     if (isIOSWebKitPlatform()) {
-        window.addEventListener('scroll', syncIOSKeyboardScrollLock, { passive: true });
-        document.addEventListener('focusin', syncIOSKeyboardScrollLock);
-        document.addEventListener('focusout', syncIOSKeyboardScrollLock);
+        document.addEventListener('focusin', syncIOSKeyboardBottomInset);
+        document.addEventListener('focusout', syncIOSKeyboardBottomInset);
     }
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -3,6 +3,7 @@ import {
     createMobileShellLifecycle,
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
 } from './mobile-shell-lifecycle/index.js';
+import { isIOSWebKitPlatform } from './mobile-send-button.js';
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
 import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { hasServerReturnedAfterRestart } from './server-restart-monitor.js';
@@ -2330,11 +2331,28 @@ function readFiniteViewportNumber(value, fallback = 0) {
     return Number.isFinite(number) ? number : fallback;
 }
 
-function getShellViewportSize() {
+function getLayoutViewportSize() {
     const doc = document.documentElement;
-    const visualViewport = window.visualViewport;
     const fallbackWidth = window.innerWidth || doc?.clientWidth || 0;
     const fallbackHeight = window.innerHeight || doc?.clientHeight || 0;
+
+    const width = Math.max(0, Math.round(readFiniteViewportNumber(fallbackWidth, 0)));
+    const height = Math.max(0, Math.round(readFiniteViewportNumber(fallbackHeight, 0)));
+
+    return {
+        width,
+        height,
+        left: 0,
+        top: 0,
+        right: width,
+        bottom: height,
+    };
+}
+
+function getVisualViewportSize(fallbackViewport = getLayoutViewportSize()) {
+    const visualViewport = window.visualViewport;
+    const fallbackWidth = fallbackViewport.width;
+    const fallbackHeight = fallbackViewport.height;
     const width = Math.max(0, Math.round(readFiniteViewportNumber(visualViewport?.width, fallbackWidth)));
     const height = Math.max(0, Math.round(readFiniteViewportNumber(visualViewport?.height, fallbackHeight)));
 
@@ -2346,6 +2364,40 @@ function getShellViewportSize() {
         right: width,
         bottom: height,
     };
+}
+
+function isEditableElement(element) {
+    return element instanceof HTMLElement
+        && (['INPUT', 'TEXTAREA', 'SELECT'].includes(element.tagName) || element.isContentEditable);
+}
+
+function isMobileShellPanelEditableElement(element) {
+    return isEditableElement(element)
+        && Boolean(element.closest('#left-nav-panel, #user-settings-block, .sb-shell-root, #right-nav-panel'));
+}
+
+function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
+    if (!isMobileViewport() || !isIOSWebKitPlatform() || !isMobileShellPanelEditableElement(document.activeElement)) {
+        return false;
+    }
+
+    return layoutViewport.height - visualViewportSize.height > 2
+        || visualViewportSize.top > 2
+        || visualViewportSize.left > 2;
+}
+
+function getShellViewportSize() {
+    const layoutViewport = getLayoutViewportSize();
+    const visualViewportSize = getVisualViewportSize(layoutViewport);
+
+    // SillyBunny: iOS keyboard edits inside shell panels should not resize or
+    // raise the Customize/Workspace windows. Keep shell geometry on the stable
+    // layout viewport while focused-input scrolling still uses visualViewport.
+    if (shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize)) {
+        return layoutViewport;
+    }
+
+    return visualViewportSize;
 }
 
 function syncShellViewportBounds() {
@@ -2366,8 +2418,8 @@ function syncShellViewportBounds() {
     setRootViewportProperty('--sb-shell-measured-top-offset', `${topOffset}px`);
     setRootViewportProperty('--sb-shell-available-height', `${Math.max(0, viewportSize.height - topOffset)}px`);
     // SillyBunny: iOS Safari shifts the visual viewport (visualViewport.offsetTop > 0)
-    // when the keyboard opens; without this var the shell stays anchored at
-    // the layout viewport top and the composer floats mid-screen.
+    // when the keyboard opens; composer-focused edits use that offset, while
+    // panel-focused edits keep the stable layout top so windows are not raised.
     setRootViewportProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
 }
 
@@ -2376,8 +2428,8 @@ function syncShellViewportBounds() {
  * focused input above the virtual keyboard the way a normal page would. When
  * focus enters an input inside a shell panel or drawer scroller, manually scroll
  * that scroller so the input sits above the keyboard. The chat composer itself
- * is already handled by the --sb-shell-viewport-height shell sizing; this covers
- * the remaining settings/drawer inputs (e.g. "Enter a Model ID").
+ * stays on visual-viewport shell sizing when it has focus; this covers the
+ * remaining settings/drawer inputs (e.g. "Enter a Model ID").
  */
 function scrollMobileFocusedInputIntoView(event) {
     if (!isMobileViewport()) {
@@ -2389,7 +2441,7 @@ function scrollMobileFocusedInputIntoView(event) {
         return;
     }
 
-    if (!['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) && !target.isContentEditable) {
+    if (!isEditableElement(target)) {
         return;
     }
 
@@ -2401,7 +2453,7 @@ function scrollMobileFocusedInputIntoView(event) {
     function tryScroll() {
         // visualViewport tracks the keyboard: top grows and height shrinks as the
         // keyboard rises, so (top + height) is the bottom of the visible area.
-        const viewportSize = getShellViewportSize();
+        const viewportSize = getVisualViewportSize();
         const viewportBottom = viewportSize.top + viewportSize.height;
         const rect = target.getBoundingClientRect();
         const overflow = rect.bottom - viewportBottom + 16;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2376,14 +2376,26 @@ function isMobileShellPanelEditableElement(element) {
         && Boolean(element.closest('#left-nav-panel, #user-settings-block, .sb-shell-root, #right-nav-panel'));
 }
 
+function isChatComposerEditableElement(element) {
+    return isEditableElement(element)
+        && Boolean(element.closest('#send_textarea, #send_form, #form_sheld'));
+}
+
+function hasOpenMobileShellDrawer() {
+    return getMobileShellBoundDrawers().some(drawer => drawer.classList.contains('openDrawer'));
+}
+
 function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
-    if (!isMobileViewport() || !isIOSWebKitPlatform() || !isMobileShellPanelEditableElement(document.activeElement)) {
+    if (!isMobileViewport() || !isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
         return false;
     }
 
-    return layoutViewport.height - visualViewportSize.height > 2
-        || visualViewportSize.top > 2
-        || visualViewportSize.left > 2;
+    const activeElement = document.activeElement;
+    if (isChatComposerEditableElement(activeElement)) {
+        return false;
+    }
+
+    return isMobileShellPanelEditableElement(activeElement) || hasOpenMobileShellDrawer();
 }
 
 function isVisualViewportKeyboardOpen(layoutViewport = getLayoutViewportSize(), visualViewportSize = getVisualViewportSize(layoutViewport)) {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2386,6 +2386,24 @@ function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
         || visualViewportSize.left > 2;
 }
 
+function syncIOSKeyboardScrollLock() {
+    if (!isMobileViewport() || !isIOSWebKitPlatform()) {
+        document.body.classList.remove('sb-ios-keyboard-locked');
+        return;
+    }
+
+    const layoutViewport = getLayoutViewportSize();
+    const visualViewportSize = getVisualViewportSize(layoutViewport);
+    const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);
+    const isKeyboardOpen = keyboardHeight > 80 || visualViewportSize.top > 2;
+
+    document.body.classList.toggle('sb-ios-keyboard-locked', isKeyboardOpen);
+
+    if (isKeyboardOpen && (window.scrollY > 0 || window.scrollX > 0)) {
+        window.scrollTo(0, 0);
+    }
+}
+
 function getShellViewportSize() {
     const layoutViewport = getLayoutViewportSize();
     const visualViewportSize = getVisualViewportSize(layoutViewport);
@@ -15013,6 +15031,10 @@ function syncMobileViewportState() {
 
         handler();
     }
+
+    // SillyBunny: after all viewport sizing settles, freeze the iOS document
+    // scroll position so Safari cannot auto-pan the page for focused inputs.
+    syncIOSKeyboardScrollLock();
 }
 
 let sbMobileViewportStateFrameId = 0;
@@ -16021,6 +16043,15 @@ function initAll() {
     // virtual keyboard. The fixed/clipped body blocks native scrolling, so the
     // scroller is nudged manually (see scrollMobileFocusedInputIntoView).
     document.addEventListener('focusin', scrollMobileFocusedInputIntoView);
+
+    // SillyBunny: iOS Safari auto-pans the document when focusing inputs near the
+    // keyboard. Keep the scroll lock in sync with viewport and focus changes so the
+    // page cannot drift before our visualViewport-based shell sizing takes over.
+    if (isIOSWebKitPlatform()) {
+        window.addEventListener('scroll', syncIOSKeyboardScrollLock, { passive: true });
+        document.addEventListener('focusin', syncIOSKeyboardScrollLock);
+        document.addEventListener('focusout', syncIOSKeyboardScrollLock);
+    }
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings
     // panels narrow alongside the chat container (matches standard ST behaviour).

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2386,6 +2386,11 @@ function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
         || visualViewportSize.left > 2;
 }
 
+function isVisualViewportKeyboardOpen(layoutViewport = getLayoutViewportSize(), visualViewportSize = getVisualViewportSize(layoutViewport)) {
+    const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);
+    return keyboardHeight > 80 || visualViewportSize.top > 2;
+}
+
 function syncIOSKeyboardScrollLock() {
     if (!isMobileViewport() || !isIOSWebKitPlatform()) {
         document.body.classList.remove('sb-ios-keyboard-locked');
@@ -2394,14 +2399,9 @@ function syncIOSKeyboardScrollLock() {
 
     const layoutViewport = getLayoutViewportSize();
     const visualViewportSize = getVisualViewportSize(layoutViewport);
-    const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);
-    const isKeyboardOpen = keyboardHeight > 80 || visualViewportSize.top > 2;
+    const isKeyboardOpen = isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize);
 
     document.body.classList.toggle('sb-ios-keyboard-locked', isKeyboardOpen);
-
-    if (isKeyboardOpen && (window.scrollY > 0 || window.scrollX > 0)) {
-        window.scrollTo(0, 0);
-    }
 }
 
 function getShellViewportSize() {
@@ -2471,7 +2471,13 @@ function scrollMobileFocusedInputIntoView(event) {
     function tryScroll() {
         // visualViewport tracks the keyboard: top grows and height shrinks as the
         // keyboard rises, so (top + height) is the bottom of the visible area.
-        const viewportSize = getVisualViewportSize();
+        const layoutViewport = getLayoutViewportSize();
+        const viewportSize = getVisualViewportSize(layoutViewport);
+
+        if (!isVisualViewportKeyboardOpen(layoutViewport, viewportSize)) {
+            return;
+        }
+
         const viewportBottom = viewportSize.top + viewportSize.height;
         const rect = target.getBoundingClientRect();
         const overflow = rect.bottom - viewportBottom + 16;

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -5,8 +5,17 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
+const loginHtml = readFileSync(path.join(repoRoot, 'public', 'login.html'), 'utf8');
 
 describe('mobile keyboard focused-input scroll wiring', () => {
+    test('keeps virtual keyboards from resizing the layout viewport', () => {
+        for (const html of [indexHtml, loginHtml]) {
+            expect(html).toContain('interactive-widget=resizes-visual');
+            expect(html).not.toContain('interactive-widget=resizes-content');
+        }
+    });
+
     test('defines the focusin scroll helper', () => {
         expect(tabsSource).toContain('function scrollMobileFocusedInputIntoView(');
     });
@@ -22,6 +31,8 @@ describe('mobile keyboard focused-input scroll wiring', () => {
     test('scrolls against the visual-viewport bottom so the input clears the keyboard', () => {
         // The visible area ends at (visualViewport.offsetTop + height); the helper
         // must push the scroller so the focused input's rect.bottom clears it.
+        expect(tabsSource).toContain('function getVisualViewportSize(');
+        expect(tabsSource).toMatch(/const viewportSize = getVisualViewportSize\(\);/);
         expect(tabsSource).toMatch(/viewportSize\.top \+ viewportSize\.height/);
         expect(tabsSource).toMatch(/scroller\.scrollTop \+= overflow/);
     });

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -11,10 +11,16 @@ const loginHtml = readFileSync(path.join(repoRoot, 'public', 'login.html'), 'utf
 describe('mobile keyboard focused-input scroll wiring', () => {
     test('keeps virtual keyboards from resizing the layout viewport', () => {
         for (const html of [indexHtml, loginHtml]) {
-            expect(html).toContain('interactive-widget=overlays-content');
+            expect(html).toContain('interactive-widget=resizes-visual');
             expect(html).not.toContain('interactive-widget=resizes-content');
-            expect(html).not.toContain('interactive-widget=resizes-visual');
+            expect(html).not.toContain('interactive-widget=overlays-content');
         }
+    });
+
+    test('locks iOS document scroll while the keyboard is open', () => {
+        expect(tabsSource).toContain('function syncIOSKeyboardScrollLock(');
+        expect(tabsSource).toContain('body.classList.toggle(\'sb-ios-keyboard-locked\'');
+        expect(tabsSource).toMatch(/window\.addEventListener\('scroll', syncIOSKeyboardScrollLock/);
     });
 
     test('defines the focusin scroll helper', () => {

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -11,8 +11,9 @@ const loginHtml = readFileSync(path.join(repoRoot, 'public', 'login.html'), 'utf
 describe('mobile keyboard focused-input scroll wiring', () => {
     test('keeps virtual keyboards from resizing the layout viewport', () => {
         for (const html of [indexHtml, loginHtml]) {
-            expect(html).toContain('interactive-widget=resizes-visual');
+            expect(html).toContain('interactive-widget=overlays-content');
             expect(html).not.toContain('interactive-widget=resizes-content');
+            expect(html).not.toContain('interactive-widget=resizes-visual');
         }
     });
 

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -20,6 +20,7 @@ describe('mobile keyboard focused-input scroll wiring', () => {
     test('locks iOS document scroll while the keyboard is open', () => {
         expect(tabsSource).toContain('function syncIOSKeyboardScrollLock(');
         expect(tabsSource).toContain('body.classList.toggle(\'sb-ios-keyboard-locked\'');
+        expect(tabsSource).not.toContain('window.scrollTo(0, 0)');
         expect(tabsSource).toMatch(/window\.addEventListener\('scroll', syncIOSKeyboardScrollLock/);
     });
 
@@ -39,7 +40,9 @@ describe('mobile keyboard focused-input scroll wiring', () => {
         // The visible area ends at (visualViewport.offsetTop + height); the helper
         // must push the scroller so the focused input's rect.bottom clears it.
         expect(tabsSource).toContain('function getVisualViewportSize(');
-        expect(tabsSource).toMatch(/const viewportSize = getVisualViewportSize\(\);/);
+        expect(tabsSource).toContain('function isVisualViewportKeyboardOpen(');
+        expect(tabsSource).toMatch(/const viewportSize = getVisualViewportSize\(layoutViewport\);/);
+        expect(tabsSource).toMatch(/if \(!isVisualViewportKeyboardOpen\(layoutViewport, viewportSize\)\) \{/);
         expect(tabsSource).toMatch(/viewportSize\.top \+ viewportSize\.height/);
         expect(tabsSource).toMatch(/scroller\.scrollTop \+= overflow/);
     });

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -17,11 +17,20 @@ describe('mobile keyboard focused-input scroll wiring', () => {
         }
     });
 
-    test('locks iOS document scroll while the keyboard is open', () => {
-        expect(tabsSource).toContain('function syncIOSKeyboardScrollLock(');
-        expect(tabsSource).toContain('body.classList.toggle(\'sb-ios-keyboard-locked\'');
+    test('adds iOS keyboard bottom inset without locking document scroll', () => {
+        expect(tabsSource).toContain('function syncIOSKeyboardBottomInset(');
+        expect(tabsSource).toContain('--sb-ios-keyboard-bottom-inset');
+        expect(tabsSource).toMatch(/layoutViewport\.height - visualViewportSize\.top - visualViewportSize\.height/);
+        expect(tabsSource).not.toContain('sb-ios-keyboard-locked');
         expect(tabsSource).not.toContain('window.scrollTo(0, 0)');
-        expect(tabsSource).toMatch(/window\.addEventListener\('scroll', syncIOSKeyboardScrollLock/);
+        expect(tabsSource).not.toMatch(/window\.addEventListener\('scroll', syncIOSKeyboardBottomInset/);
+    });
+
+    test('applies the iOS keyboard inset to mobile drawer scroller padding', () => {
+        const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+
+        expect(mobileShellCss).toContain('var(--sb-ios-keyboard-bottom-inset, 0px)');
+        expect(mobileShellCss).not.toContain('body.sb-ios-keyboard-locked');
     });
 
     test('defines the focusin scroll helper', () => {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -202,7 +202,10 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsSource).toContain('function getVisualViewportSize(');
         expect(tabsSource).toContain('function shouldUseStableIOSPanelViewport(');
         expect(tabsSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
-        expect(tabsSource).toContain('!isMobileViewport() || !isIOSWebKitPlatform() || !isMobileShellPanelEditableElement(document.activeElement)');
+        expect(tabsSource).toContain('function isChatComposerEditableElement(');
+        expect(tabsSource).toContain('function hasOpenMobileShellDrawer(');
+        expect(tabsSource).toContain('!isMobileViewport() || !isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)');
+        expect(tabsSource).toContain('return isMobileShellPanelEditableElement(activeElement) || hasOpenMobileShellDrawer();');
         expect(tabsSource).toContain('return layoutViewport;');
         expect(tabsSource).toContain('function syncShellViewportBounds(');
         expect(tabsSource).toContain('function syncMobileShellDrawerBounds(');

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -190,7 +190,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(getInlineDrawerStorageKeySource).not.toContain('`${SB_STORAGE_KEYS.settingsDrawerStatePrefix}:${contextSegments.join(\'/\')}:drawer:${drawerLabel}:${drawerIndex}`');
     });
 
-    test('clamps resizable shell panels against the visual viewport and panel top', () => {
+    test('clamps shell panels while keeping iOS keyboard edits on stable panel bounds', () => {
         const getResolvedShellTopbarOffsetSource = getFunctionSource('getResolvedShellTopbarOffset');
         const getDesktopShellResizeBoundsSource = getFunctionSource('getDesktopShellResizeBounds');
         const setShellSizeOverrideSource = getFunctionSource('setShellSizeOverride');
@@ -199,6 +199,11 @@ describe('mobile shell lifecycle wiring', () => {
         const syncMobileViewportStateSource = getFunctionSource('syncMobileViewportState');
 
         expect(tabsSource).toContain('function getShellViewportSize(');
+        expect(tabsSource).toContain('function getVisualViewportSize(');
+        expect(tabsSource).toContain('function shouldUseStableIOSPanelViewport(');
+        expect(tabsSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
+        expect(tabsSource).toContain('!isMobileViewport() || !isIOSWebKitPlatform() || !isMobileShellPanelEditableElement(document.activeElement)');
+        expect(tabsSource).toContain('return layoutViewport;');
         expect(tabsSource).toContain('function syncShellViewportBounds(');
         expect(tabsSource).toContain('function syncMobileShellDrawerBounds(');
         expect(tabsSource).toContain('function queueMobileShellDrawerBoundsSync(');


### PR DESCRIPTION
# Summary

On iOS, the keyboard always raises the window, treating it as though it were a desktop, making the bottom half inaccessible until closing the Customize and Workspace windows again. However, when trying to type on a text input, the keyboard just raises the window again.
