### PR TITLE
docs: update alt language README files

### DIFF
--- a/.github/readme-de_de.md
+++ b/.github/readme-de_de.md
@@ -1,5 +1,5 @@
-> [!IMPORTANT]  
-> Die hier veröffentlichten Informationen sind möglicherweise veraltet oder unvollständig. Für aktuelle Informationen nutzen Sie bitte die englische Version.
+> [!IMPORTANT]
+> Diese Seite kann langsamer aktualisiert werden als die englische Version. Aktuelle Informationen findest du in `README.md` im Projektstamm.
 
 <a name="readme-top"></a>
 
@@ -9,86 +9,29 @@
 
 [English](readme.md) | German | [中文](readme-zh_cn.md) | [繁體中文](readme-zh_tw.md) | [日本語](readme-ja_jp.md) | [Русский](readme-ru_ru.md) | [한국어](readme-ko_kr.md)
 
-[![GitHub Stars](https://img.shields.io/github/stars/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/forks)
-[![GitHub Issues](https://img.shields.io/github/issues/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/issues)
-[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/pulls)
-
 </div>
 
 ---
 
-SillyTavern bietet eine einheitliche Benutzeroberfläche für viele LLM-APIs (KoboldAI/CPP, Horde, NovelAI, Ooba, Tabby, OpenAI, OpenRouter, Claude, Mistral und mehr), ein mobilfreundliches Layout, einen Visual-Novel-Modus, die Integration von Automatic1111 & ComfyUI API zur Bilderzeugung, TTS, WorldInfo (Lorebooks), anpassbare UI, automatische Übersetzung, mehr Eingabeaufforderungsoptionen, als du jemals wolltest oder brauchst, und unendliches Wachstumspotenzial durch Drittanbietererweiterungen.
+SillyBunny ist ein Fork von [SillyTavern](https://github.com/SillyTavern/SillyTavern) mit einer saubereren grafischen Oberfläche, einem Bun-first-Backend, eingebauten Tutorials, Presets, Erweiterungen und einem Schnellstart-Dashboard. Die Daten-, Charakter-, Chat- und Preset-Formate bleiben mit dem Upstream kompatibel.
 
-Wir haben eine [Dokumentationswebsite](https://docs.sillytavern.app/), um die meisten deiner Fragen zu beantworten und dir den Einstieg zu erleichtern.
+## Was ist das?
 
-## Was ist SillyTavern?
+SillyBunny ist eine lokal installierte Oberfläche für Textmodelle, Bildgeneratoren und Sprachmodelle.
 
-SillyTavern (oder ST abgekürtz) ist eine lokal installierte Benutzeroberfläche, die es dir ermöglicht, mit Textgenerations-LLMs, Bildgenerierungsmaschinen und TTS-Sprachmodellen zu interagieren.
+## Wo fange ich an?
 
-Angefangen im Februar 2023 als Fork von TavernAI 1.2.8 hat SillyTavern nun über 200 Mitwirkende und 2 Jahre unabhängiger Entwicklung hinter sich und dient weiterhin als führende Software für versierte KI-Hobbyisten.
+1. Lies `README.md` im Projektstamm für die aktuellen Funktionen und die Installation.
+2. Lade die neueste Version herunter oder nutze die Startskripte des Projekts.
+3. Wenn du ein Problem findest, melde es bitte im Issue-Tracker dieses Repositories.
 
-## Unsere Vision
+## Installation und Updates
 
-1. Wir möchten die Nutzer mit so viel Nutzen und Kontrolle über ihre LLM-Prompts wie möglich ausstatten. Die steile Lernkurve ist Teil des Spaßes!
-2. Wir bieten weder Online- oder gehosteten Dienste an, noch verfolgen wir programmgesteuert Benutzerdaten.
-3. SillyTavern ist ein Herzensprojekt, das von einer engagierten Community von LLM-Enthusiasten unterstützt wird, und wird immer kostenlos und Open Source sein.
-
-## Brauche ich einen leistungsstarken PC, um SillyTavern auszuführen?
-
-Die Hardwareanforderungen sind minimal: Es läuft auf allem, was NodeJS 20 oder höher ausführen kann. Wenn du LLM-Inferenz auf deinem lokalen Rechner durchführen möchtest, empfehlen wir eine NVIDIA-Grafikkarte der 3000er-Serie mit mindestens 6 GB VRAM, aber die tatsächlichen Anforderungen können je nach Modell und Backend, das du verwendest, variieren.
-
-## Fragen oder Vorschläge?
-
-### Discord-Server
-
-| [![][discord-shield-badge]][discord-link] | [Tritt unserer Discord-Community bei!](https://discord.gg/sillytavern) Erhalte Unterstützung, teile deine Lieblingscharaktere und Prompts. |
-| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-
-Oder nimm direkt Kontakt mit den Entwicklern auf:
-
-* Discord: cohee, rossascends, wolfsblvt
-* Reddit: [/u/RossAscends](https://www.reddit.com/user/RossAscends/), [/u/sillylossy](https://www.reddit.com/user/sillylossy/), [u/Wolfsblvt](https://www.reddit.com/user/Wolfsblvt/)
-* [Erstelle ein GitHub-Issue](https://github.com/SillyTavern/SillyTavern/issues)
-
-### Ich mag dieses Projekt! Wie kann ich beitragen?
-
-1. Sende Pull-Requests. Lerne, wie du beitragen kannst: [CONTRIBUTING.md](../CONTRIBUTING.md)
-2. Sende Feature Requests und Issues unter Verwendung der bereitgestellten Vorlagen.
-3. Lies diese gesamte README-Datei und überprüfe zuerst die Dokumentationswebsite, um doppelte Issues zu vermeiden.
-
-## Screenshots
-
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/9b5f32f0-c3b3-4102-b3f5-0e9213c0f50f">
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/913fdbaa-7d33-42f1-ae2c-89dca41c53d1">
-
-## Installation
-
-Für detaillierte Installationsanweisungen besuche bitte unsere Dokumentation:
-
-* **[Windows Installationsanleitung](https://docs.sillytavern.app/installation/windows/)**
-* **[MacOS/Linux Installationsanleitung](https://docs.sillytavern.app/installation/linuxmacos/)**
-* **[Android (Termux) Installationsanleitung](https://docs.sillytavern.app/installation/android-(termux)/)**
-* **[Docker Installationsanleitung](https://docs.sillytavern.app/installation/docker/)**
+Bitte verwende den Installationsabschnitt und die Release-Hinweise in `README.md` im Projektstamm.
 
 ## Lizenz und Danksagungen
 
-**Dieses Programm wird in der Hoffnung verbreitet, dass es nützlich ist, aber OHNE JEGLICHE GARANTIE; nicht einmal die stillschweigende Garantie der MARKTFÄHIGKEIT oder EIGNUNG FÜR EINEN BESTIMMTEN ZWECK. Siehe die GNU Affero General Public License für weitere Details.**
-
-* [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8 von Humi: MIT-Lizenz
-* Teile von CncAnons TavernAITurbo-Mod werden mit Genehmigung verwendet
-* Visual Novel-Modus inspiriert von der Arbeit von PepperTaco (<https://github.com/peppertaco/Tavern/>)
-* Noto Sans-Schriftart von Google (OFL-Lizenz)
-* Symboldesign von Font Awesome <https://fontawesome.com> (Symbole: CC BY 4.0, Schriftarten: SIL OFL 1.1, Code: MIT-Lizenz)
-* Standardinhalt von @OtisAlejandro (Seraphina-Charakter und Lorebook) und @kallmeflocc (10.000 Discord-Benutzer-Feierhintergrund)
-* Docker-Anleitung von [@mrguymiah](https://github.com/mrguymiah) und [@Bronya-Rand](https://github.com/Bronya-Rand)
-* kokoro-js library by [@hexgrad](https://github.com/hexgrad) (Apache-2.0 License)
-
-## Top Contributors
-
-[![Contributors](https://contrib.rocks/image?repo=SillyTavern/SillyTavern)](https://github.com/SillyTavern/SillyTavern/graphs/contributors)
+SillyBunny behält kompatible Datenformate zum Upstream bei. Die vollständigen Danksagungen stehen im `README.md` im Projektstamm.
 
 <!-- LINK GROUP -->
 [cover]: https://github.com/user-attachments/assets/01a6ae9a-16aa-45f2-8bff-32b5dc587e44
-[discord-link]: https://discord.gg/sillytavern
-[discord-shield-badge]: https://img.shields.io/discord/1100685673633153084?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/.github/readme-ja_jp.md
+++ b/.github/readme-ja_jp.md
@@ -1,5 +1,5 @@
-> [!IMPORTANT]  
-> ここに掲載されている情報は、古かったり不完全であったりする可能性があります。最新の情報は英語版をご利用ください。
+> [!IMPORTANT]
+> ここは英語版より更新が遅れる場合があります。最新情報はルートの `README.md` をご確認ください。
 
 <a name="readme-top"></a>
 
@@ -9,86 +9,29 @@
 
 [English](readme.md) | [German](readme-de_de.md) | [中文](readme-zh_cn.md) | [繁體中文](readme-zh_tw.md) | 日本語 | [Русский](readme-ru_ru.md) | [한국어](readme-ko_kr.md)
 
-[![GitHub Stars](https://img.shields.io/github/stars/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/forks)
-[![GitHub Issues](https://img.shields.io/github/issues/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/issues)
-[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/pulls)
-
 </div>
 
 ---
 
-SillyTavernは、多くのLLM API（KoboldAI/CPP、Horde、NovelAI、Ooba、Tabby、OpenAI、OpenRouter、Claude、Mistralなど）に対応した統一インターフェース、モバイルフレンドリーなレイアウト、ビジュアルノベルモード、Automatic1111 & ComfyUI API画像生成連携、TTS、WorldInfo（伝承本）、カスタマイズ可能なUI、自動翻訳、必要以上に豊富なプロンプトオプション、そしてサードパーティ製拡張機能による無限の成長可能性を提供します。
+SillyBunny は、[SillyTavern](https://github.com/SillyTavern/SillyTavern) から派生したプロジェクトで、より整理されたグラフィカルシェル、Bun 優先のバックエンド、組み込みチュートリアル、プリセット、拡張機能、クイックスタート用ダッシュボードを備え、上流互換のデータ・キャラクター・チャット・プリセット形式を維持します。
 
-私たちは[ドキュメントウェブサイト](https://docs.sillytavern.app/)を用意しており、ほとんどの質問に答え、入門の手助けをします。
+## これは何ですか？
 
-## SillyTavernとは？
+SillyBunny は、テキストモデル、画像生成エンジン、音声モデルと一緒に使うローカルインストール型のフロントエンドです。
 
-SillyTavern（略してST）は、テキスト生成LLM、画像生成エンジン、TTS音声モデルと対話するための、ローカルにインストールされるユーザーインターフェースです。
+## どこから始めればいいですか？
 
-2023年2月にTavernAI 1.2.8のフォークとして始まり、SillyTavernは現在200人以上の貢献者と2年間の独立した開発を経て、知識豊富なAI愛好家のための主要なソフトウェアとして機能し続けています。
+1. 最新機能とインストール方法はルートの `README.md` を確認してください。
+2. 最新リリースを取得するか、プロジェクトの起動スクリプトを使ってください。
+3. 問題があれば、このリポジトリの issue tracker に報告してください。
 
-## 私たちのビジョン
+## インストールと更新
 
-1. 私たちは、ユーザーにできるだけ多くの実用性とLLMプロンプトの制御権限を与えることを目指しています。急な学習曲線も楽しみの一部です！
-2. 私たちはオンラインサービスやホストされたサービスを提供せず、プログラム的にユーザーデータを追跡することもありません。
-3. SillyTavernは、熱心なLLM愛好家のコミュニティによってもたらされた情熱的なプロジェクトであり、常に無料でオープンソースです。
+インストールと更新は、ルートの `README.md` と最新リリース案内を基準にしてください。
 
-## SillyTavernを実行するには強力なPCが必要ですか？
+## ライセンスと謝辞
 
-ハードウェア要件は最小限です。NodeJS 20以上を実行できるものであれば何でも動作します。ローカルマシンでLLM推論を行う場合は、少なくとも6GBのVRAMを搭載した3000シリーズのNVIDIAグラフィックスカードを推奨しますが、実際の要件は使用するモデルやバックエンドによって異なる場合があります。
-
-## 質問や提案はありますか？
-
-### Discordサーバー
-
-| [![][discord-shield-badge]][discord-link] | [私たちのDiscordコミュニティに参加してください！](https://discord.gg/sillytavern) サポートを受けたり、お気に入りのキャラクターやプロンプトを共有したりできます。 |
-| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-
-または、開発者に直接連絡してください：
-
-* Discord: cohee, rossascends, wolfsblvt
-* Reddit: [/u/RossAscends](https://www.reddit.com/user/RossAscends/), [/u/sillylossy](https://www.reddit.com/user/sillylossy/), [u/Wolfsblvt](https://www.reddit.com/user/Wolfsblvt/)
-* [GitHub issueを投稿](https://github.com/SillyTavern/SillyTavern/issues)
-
-### このプロジェクトが気に入りました！どうすれば貢献できますか？
-
-1. プルリクエストを送ってください。貢献する方法については、[CONTRIBUTING.md](../CONTRIBUTING.md)をご覧ください。
-2. 提供されたテンプレートを使用して、機能の提案や問題の報告を送ってください。
-3. 重複した問題を避けるために、まずこのreadmeファイル全体とドキュメントウェブサイトを確認してください。
-
-## スクリーンショット
-
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/9b5f32f0-c3b3-4102-b3f5-0e9213c0f50f">
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/913fdbaa-7d33-42f1-ae2c-89dca41c53d1">
-
-## インストール
-
-詳細なインストール手順については、私たちのドキュメントをご覧ください：
-
-* **[Windowsインストールガイド](https://docs.sillytavern.app/installation/windows/)**
-* **[MacOS/Linuxインストールガイド](https://docs.sillytavern.app/installation/linuxmacos/)**
-* **[Android (Termux)インストールガイド](https://docs.sillytavern.app/installation/android-(termux)/)**
-* **[Dockerインストールガイド](https://docs.sillytavern.app/installation/docker/)**
-
-## ライセンスとクレジット
-
-**このプログラムは有用であることを期待して配布されていますが、いかなる保証もありません。商品性または特定目的への適合性の黙示の保証さえもありません。詳細はGNU Affero General Public Licenseをご覧ください。**
-
-* [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8 by Humi: MITライセンス
-* CncAnonのTavernAITurbo modの一部を許可を得て使用
-* PepperTacoの作品に触発されたビジュアルノベルモード (<https://github.com/peppertaco/Tavern/>)
-* GoogleによるNoto Sansフォント (OFLライセンス)
-* Font Awesomeによるアイコンテーマ <https://fontawesome.com> (アイコン: CC BY 4.0, フォント: SIL OFL 1.1, コード: MITライセンス)
-* @OtisAlejandroによるデフォルトコンテンツ（Seraphinaキャラクターと伝承本）と@kallmefloccによる10K Discordユーザー記念背景
-* [@mrguymiah](https://github.com/mrguymiah)と[@Bronya-Rand](https://github.com/Bronya-Rand)によるDockerガイド
-* [@hexgrad](https://github.com/hexgrad)によるkokoro-jsライブラリ (Apache-2.0ライセンス)
-
-## トップコントリビューター
-
-[![Contributors](https://contrib.rocks/image?repo=SillyTavern/SillyTavern)](https://github.com/SillyTavern/SillyTavern/graphs/contributors)
+SillyBunny は上流互換のデータ形式を維持しています。詳細な謝辞はルートの `README.md` を参照してください。
 
 <!-- LINK GROUP -->
 [cover]: https://github.com/user-attachments/assets/01a6ae9a-16aa-45f2-8bff-32b5dc587e44
-[discord-link]: https://discord.gg/sillytavern
-[discord-shield-badge]: https://img.shields.io/discord/1100685673633153084?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/.github/readme-ko_kr.md
+++ b/.github/readme-ko_kr.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> 이곳에 게재된 정보는 오래되거나 불완전할 수 있습니다. 최신 정보는 영어 버전을 이용하십시오.
+> 이 문서는 영어판보다 늦게 갱신될 수 있습니다. 최신 정보는 루트 `README.md`를 확인해 주세요.
 
 <a name="readme-top"></a>
 
@@ -9,86 +9,29 @@
 
 [English](readme.md) | [German](readme-de_de.md) | [中文](readme-zh_cn.md) | [繁體中文](readme-zh_tw.md) | [日本語](readme-ja_jp.md) | [Русский](readme-ru_ru.md) | 한국어
 
-[![GitHub Stars](https://img.shields.io/github/stars/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/forks)
-[![GitHub Issues](https://img.shields.io/github/issues/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/issues)
-[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/pulls)
-
 </div>
 
 ---
 
-SillyTavern은 많은 LLM API(KoboldAI/CPP, Horde, NovelAI, Ooba, Tabby, OpenAI, OpenRouter, Claude, Mistral 등)에 대한 단일 통합 인터페이스, 모바일 친화적 레이아웃, 비주얼 노벨 모드, Automatic1111 & ComfyUI API 이미지 생성 통합, TTS, 월드 인포 (로어북), 커스텀 가능한 UI, 자동 번역, 필요 이상의 프롬프트 옵션, 그리고 서드파티 확장을 통한 무궁무진한 성장 가능성을 제공합니다.
+SillyBunny는 [SillyTavern](https://github.com/SillyTavern/SillyTavern)에서 분기된 프로젝트로, 더 깔끔한 그래픽 셸, Bun 우선 백엔드, 내장 튜토리얼, 프리셋, 확장 기능, 빠른 시작 대시보드를 제공하며 상위 버전과 호환되는 데이터, 캐릭터, 채팅, 프리셋 형식을 유지합니다.
 
-또한, 자주 묻는 질문에 대한 답변과, 시작하는 데 도움을 주기 위한 [문서 웹사이트](https://docs.sillytavern.app/)가 있습니다.
+## 이 프로젝트는 무엇인가요?
 
-## SillyTavern이 무엇인가요?
+SillyBunny는 텍스트 모델, 이미지 생성 엔진, 음성 모델과 함께 쓰는 로컬 설치형 프런트엔드입니다.
 
-SillyTavern(짧게는 ST)은 텍스트 생성 LLM, 이미지 생성 엔진, TTS 음성 모델 등과 상호작할 수 있는 로컬 설치형 UI 입니다.
+## 어디서 시작하나요?
 
-2023년 2월, TavernAI 1.2.8의 포크로 시작한 SillyTavern은 현재 200명이 넘는 기여자를 보유하고 있으며, 2년간의 독자적인 개발을 거쳐 숙련된 AI 애호가들을 위한 선도적인 소프트웨어로 자리매김하고 있습니다.
+1. 최신 기능과 설치 방법은 루트 `README.md`를 확인하세요.
+2. 최신 릴리스를 받거나 프로젝트의 실행 스크립트를 사용하세요.
+3. 문제가 있으면 이 저장소의 issue tracker에 알려 주세요.
 
-## 우리의 비전
+## 설치 및 업데이트
 
-1. 저희는 사용자가 LLM 프롬프트에 대한 최대한의 유용성과 제어 능력을 갖도록 하는 것을 목표로 합니다. 빠르게 배우는 것 역시 재미의 일부입니다!
-2. 저희는 어떠한 온라인 및 호스팅 서브시도 제공하지 않으며, 프로그래밍으로 사용자의 데이터를 추적하지 않습니다.
-3. SillyTavern은 헌신적인 LLM 커뮤니티가 여러분에게 제공하는 열정적인 프로젝트이며, 언제나 무료이며 오픈소스로 제공될 것입니다.
+설치와 업데이트는 루트 `README.md`와 최신 릴리스 안내를 기준으로 보시면 됩니다.
 
-## SillyTavern을 위해서 좋은 성능의 PC가 필요한가요?
+## 라이선스 및 감사
 
-하드웨어 요구 사항은 거의 없습니다: NodeJS 20 이상을 실행할 수 있는 모든 환경에서 작동합니다. 다만 로컬 LLM 모델을 사용할 경우, 최소 6GB VRAM 이상의 3000번대 NVIDIA 그래픽 카드를 권장하지만, 실제 요구 사항은 사용하는 모델과 백엔드에 따라 달라질 수 있습니다.
-
-## 질문이나 제안이 있으신가요?
-
-### 디스코드 서버
-
-| [![][discord-shield-badge]][discord-link] | [저희의 디스코드에 참여하세요!](https://discord.gg/sillytavern) 지원을 받고, 좋아하는 캐릭터와 프롬프트를 공유하세요. |
-| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-
-혹은 저희의 개발자들과 직접 연락할 수 있습니다:
-
-* 디스코드: cohee, rossascends, wolfsblvt
-* 레딧: [/u/RossAscends](https://www.reddit.com/user/RossAscends/), [/u/sillylossy](https://www.reddit.com/user/sillylossy/), [u/Wolfsblvt](https://www.reddit.com/user/Wolfsblvt/)
-* [GitHub issue를 작성하세요](https://github.com/SillyTavern/SillyTavern/issues)
-
-### 이 프로젝트가 마음에 들어요! 어떻게 기여할 수 있을까요?
-
-1. PULL REQUEST를 생성하세요. 기여 방법에 대해서는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요.
-2. 제공된 탬플릿에 따라 기능 제안이나 이슈 리포트를 생성하세요.
-3. 중복된 이슈를 생성하지 않도록 이 README 파일 전체를 읽고 문서 웹사이트를 먼저 확인하세요.
-
-## 스크린샷
-
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/9b5f32f0-c3b3-4102-b3f5-0e9213c0f50f">
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/913fdbaa-7d33-42f1-ae2c-89dca41c53d1">
-
-## 설치
-
-자세한 설치 방법은 저희의 문서를 확인하세요:
-
-* **[Windows 설치 가이드](https://docs.sillytavern.app/installation/windows/)**
-* **[MacOS/Linux 설치 가이드](https://docs.sillytavern.app/installation/linuxmacos/)**
-* **[Android (Termux) 설치 가이드](https://docs.sillytavern.app/installation/android-(termux)/)**
-* **[Docker 설치 가이드](https://docs.sillytavern.app/installation/docker/)**
-
-## 라이센스 및 크레딧
-
-**이 프로그램은 유용할 것이라는 희망으로 배포되지만, 어떠한 보증도 제공하지 않습니다. 상품성 또는 특정 목적에의 적합성에 대한 묵시적인 보증조차도 제공하지 않습니다. 자세한 내용은 GNU Affero 일반 공중 사용 허가서를 참조하십시오.**
-
-* Humi의 [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8: MIT 라이선스
-* CncAnon의 TavernAITurbo 모드의 일부는 허가를 받아 사용됨
-* PepperTaco의 작업(<https://github.com/peppertaco/Tavern/>)에 영감을 받은 비주얼 노벨 모드
-* Noto Sans Font by Google (OFL 라이선스)
-* Font Awesome의 아이콘 테마 <https://fontawesome.com> (아이콘: CC BY 4.0, 폰트: SIL OFL 1.1, 코드: MIT 라이선스)
-* 기본 콘텐츠는 @OtisAlejandro (Seraphina 캐릭터 및 로어북)와 @kallmeflocc (10K 디스코드 사용자 축전 배경화면)가 제공함
-* [@mrguymiah](https://github.com/mrguymiah)와 [@Bronya-Rand](https://github.com/Bronya-Rand)의 Docker 가이드
-* [@hexgrad](https://github.com/hexgrad)의 kokoro-js 라이브러리 (Apache-2.0 라이선스)
-
-## 상위 기여자
-
-[![Contributors](https://contrib.rocks/image?repo=SillyTavern/SillyTavern)](https://github.com/SillyTavern/SillyTavern/graphs/contributors)
+SillyBunny는 상위 프로젝트와 호환되는 데이터 형식을 유지하며, 자세한 감사 내용은 루트 `README.md`에 있습니다.
 
 <!-- LINK GROUP -->
 [cover]: https://github.com/user-attachments/assets/01a6ae9a-16aa-45f2-8bff-32b5dc587e44
-[discord-link]: https://discord.gg/sillytavern
-[discord-shield-badge]: https://img.shields.io/discord/1100685673633153084?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/.github/readme-ru_ru.md
+++ b/.github/readme-ru_ru.md
@@ -1,5 +1,5 @@
-> [!IMPORTANT]  
-> Приведенная здесь информация может быть устаревшей или неполной и предоставляется только для вашего удобства. Пожалуйста, используйте английскую версию для получения наиболее актуальной информации.
+> [!IMPORTANT]
+> Содержимое здесь может обновляться медленнее, чем английская версия. За актуальной информацией обращайтесь к корневому `README.md`.
 
 <a name="readme-top"></a>
 
@@ -9,86 +9,29 @@
 
 [English](readme.md) | [German](readme-de_de.md) | [中文](readme-zh_cn.md) | [繁體中文](readme-zh_tw.md) | [日本語](readme-ja_jp.md) | Русский | [한국어](readme-ko_kr.md)
 
-[![GitHub Stars](https://img.shields.io/github/stars/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/forks)
-[![GitHub Issues](https://img.shields.io/github/issues/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/issues)
-[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/pulls)
-
 </div>
 
 ---
 
-SillyTavern предоставляет единый интерфейс для многих LLM API (KoboldAI/CPP, Horde, NovelAI, Ooba, Tabby, OpenAI, OpenRouter, Claude, Mistral и других), мобайл-френдли макет, режим визуальной новеллы, интеграцию с генерацией изображений через API Automatic1111 и ComfyUI, TTS, WorldInfo (лорбуки), кастомизируемый UI, автоперевод, тончайшую настройку промптов, и возможность устанавливать расширения.
+SillyBunny — это форк [SillyTavern](https://github.com/SillyTavern/SillyTavern) с более чистой графической оболочкой, Bun-first backend, встроенными туториалами, пресетами, расширениями и панелью быстрого старта, при этом он сохраняет совместимость с данными, персонажами, чатами и пресетами upstream.
 
-Чтобы помочь вам быстрее разобраться в SillyTavern, мы создали [сайт с документацией](https://docs.sillytavern.app/). Ответы на большинство вопросов можно найти там.
+## Что это такое?
 
-## Что такое SillyTavern?
+SillyBunny — это локально устанавливаемый интерфейс для текстовых моделей, генерации изображений и голосовых моделей.
 
-SillyTavern (или сокращенно ST) - это локально устанавливаемый пользовательский интерфейс, который позволяет вам взаимодействовать с LLM для генерации текста, движками для генерации изображений и моделями голоса TTS.
+## С чего начать?
 
-Начавшись в феврале 2023 года как форк TavernAI 1.2.8, SillyTavern теперь насчитывает более 200 контрибьюторов и 2 года независимой разработки, и продолжает служить ведущим программным обеспечением для опытных энтузиастов ИИ.
+1. Прочитайте корневой `README.md`, чтобы увидеть актуальные функции и установку.
+2. Скачайте последний релиз или запустите проект через скрипты запуска.
+3. Если нашли проблему, сообщите о ней в issue tracker этого репозитория.
 
-## Наше видение
+## Установка и обновление
 
-1. Мы стремимся предоставить пользователям как можно больше полезности и контроля над их промптами LLM. Крутая кривая обучения - это часть веселья!
-2. Мы не предоставляем никаких онлайн или хостинговых услуг, а также программно не отслеживаем данные пользователей.
-3. SillyTavern - это проект, созданный преданным сообществом энтузиастов LLM, и он всегда будет бесплатным и с открытым исходным кодом.
-
-## Нужен ли мне мощный компьютер для запуска SillyTavern?
-
-Требования к оборудованию минимальны: он будет работать на всем, что может запустить NodeJS 20 или выше. Если вы собираетесь выполнять инференс LLM на своем локальном компьютере, мы рекомендуем видеокарту NVIDIA 3000-й серии с не менее чем 6 ГБ видеопамяти, но фактические требования могут варьироваться в зависимости от модели и используемого вами бэкенда.
-
-## Вопросы или предложения?
-
-### Сервер в Discord
-
-| [![][discord-shield-badge]][discord-link] | [Вступайте в наше Discord-сообщество!](https://discord.gg/sillytavern) Получайте поддержку, делитесь любимыми персонажами и промптами. |
-| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-
-Или свяжитесь с разработчиками напрямую:
-
-* Discord: cohee, rossascends, wolfsblvt
-* Reddit: [/u/RossAscends](https://www.reddit.com/user/RossAscends/), [/u/sillylossy](https://www.reddit.com/user/sillylossy/), [u/Wolfsblvt](https://www.reddit.com/user/Wolfsblvt/)
-* [Опубликовать issue на GitHub](https://github.com/SillyTavern/SillyTavern/issues)
-
-### Мне нравится ваш проект! Как я могу внести свой вклад?
-
-1. Отправляйте пулл-реквесты. Узнайте, как внести свой вклад: [CONTRIBUTING.md](../CONTRIBUTING.md)
-2. Отправляйте предложения по функциям и отчеты о проблемах, используя предоставленные шаблоны.
-3. Прочтите весь этот файл readme и сайт документации, чтобы избежать отправки дублирующихся проблем.
-
-## Скриншоты
-
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/9b5f32f0-c3b3-4102-b3f5-0e9213c0f50f">
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/913fdbaa-7d33-42f1-ae2c-89dca41c53d1">
-
-## Установка
-
-Для получения подробных инструкций по установке, пожалуйста, посетите нашу документацию:
-
-* **[Руководство по установке для Windows](https://docs.sillytavern.app/installation/windows/)**
-* **[Руководство по установке для MacOS/Linux](https://docs.sillytavern.app/installation/linuxmacos/)**
-* **[Руководство по установке для Android (Termux)](https://docs.sillytavern.app/installation/android-(termux)/)**
-* **[Руководство по установке Docker](https://docs.sillytavern.app/installation/docker/)**
+Пожалуйста, ориентируйтесь на раздел установки в корневом `README.md` и на заметки в последнем релизе.
 
 ## Лицензия и благодарности
 
-**Эта программа распространяется в надежде, что она будет полезна, но БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ; даже без подразумеваемой гарантии ТОВАРНОЙ ПРИГОДНОСТИ или ПРИГОДНОСТИ ДЛЯ ОПРЕДЕЛЕННОЙ ЦЕЛИ. Смотрите GNU Affero General Public License для получения более подробной информации.**
-
-* [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8 от Humi: лицензия MIT
-* Части мода CncAnon TavernAITurbo используются с разрешения
-* Режим визуальной новеллы вдохновлен работой PepperTaco (<https://github.com/peppertaco/Tavern/>)
-* Шрифт Noto Sans от Google (лицензия OFL)
-* Тема иконок от Font Awesome <https://fontawesome.com> (Иконки: CC BY 4.0, Шрифты: SIL OFL 1.1, Код: лицензия MIT)
-* Стандартный контент от @OtisAlejandro (персонаж Seraphina и лорбук) и @kallmeflocc (фон в честь 10 тысяч пользователей Discord)
-* Руководство по Docker от [@mrguymiah](https://github.com/mrguymiah) и [@Bronya-Rand](https://github.com/Bronya-Rand)
-* Библиотека kokoro-js от [@hexgrad](https://github.com/hexgrad) (лицензия Apache-2.0)
-
-## Ведущие контрибьюторы
-
-[![Contributors](https://contrib.rocks/image?repo=SillyTavern/SillyTavern)](https://github.com/SillyTavern/SillyTavern/graphs/contributors)
+SillyBunny сохраняет совместимые форматы и данные upstream; полный список благодарностей см. в корневом `README.md`.
 
 <!-- LINK GROUP -->
 [cover]: https://github.com/user-attachments/assets/01a6ae9a-16aa-45f2-8bff-32b5dc587e44
-[discord-link]: https://discord.gg/sillytavern
-[discord-shield-badge]: https://img.shields.io/discord/1100685673633153084?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/.github/readme-zh_cn.md
+++ b/.github/readme-zh_cn.md
@@ -1,5 +1,5 @@
-> [!IMPORTANT]  
-> 这里的信息可能已经过时或不完整，仅供您参考。请使用英文版本获取最新信息。
+> [!IMPORTANT]
+> 这里的内容可能比英文版更新更慢。最新信息请以根目录 `README.md` 为准。
 
 <a name="readme-top"></a>
 
@@ -9,86 +9,29 @@
 
 [English](readme.md) | [German](readme-de_de.md) | 中文 | [繁體中文](readme-zh_tw.md) | [日本語](readme-ja_jp.md) | [Русский](readme-ru_ru.md) | [한국어](readme-ko_kr.md)
 
-[![GitHub Stars](https://img.shields.io/github/stars/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/forks)
-[![GitHub Issues](https://img.shields.io/github/issues/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/issues)
-[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/pulls)
-
 </div>
 
 ---
 
-SillyTavern 为众多 LLM API（KoboldAI/CPP、Horde、NovelAI、Ooba、Tabby、OpenAI、OpenRouter、Claude、Mistral 等）提供统一界面，拥有移动设备友好的布局、视觉小说模式、Automatic1111 & ComfyUI API 图像生成集成、TTS、世界书（lorebooks）、可自定义的 UI、自动翻译、超乎您想象的丰富 Prompt 选项，以及通过第三方扩展实现的无限增长潜力。
+SillyBunny 是一个从 [SillyTavern](https://github.com/SillyTavern/SillyTavern) 分支而来的项目，主打更干净的图形化外壳、Bun 优先后端、内建教程、预设、扩展与快速开始仪表板，并保持与上游兼容的数据、角色、聊天和预设格式。
 
-我们有一个[文档网站](https://docs.sillytavern.app/)来回答您的大部分问题并帮助您入门。
+## 这是什么？
 
-## SillyTavern 是什么？
+SillyBunny 是一个本地安装的前端界面，可配合文本模型、图像生成引擎和语音模型使用。
 
-SillyTavern（简称 ST）是一个本地安装的用户界面，允许您与文本生成 LLM、图像生成引擎和 TTS 语音模型进行交互。
+## 从哪里开始？
 
-SillyTavern 于 2023 年 2 月作为 TavernAI 1.2.8 的一个分支开始，如今已拥有超过 200 名贡献者和 2 年的独立开发经验，并继续作为资深 AI 爱好者领先的软件。
+1. 阅读根目录 `README.md` 获取最新功能和安装方式。
+2. 下载最新发布版，或按项目中的启动脚本运行。
+3. 如遇到问题，请在本项目的 issue tracker 中反馈。
 
-## 我们的愿景
+## 安装与更新
 
-1.  我们的目标是尽可能为用户提供 LLM Prompt 的最大效用和控制权。陡峭的学习曲线是乐趣的一部分！
-2.  我们不提供任何在线或托管服务，也不会以编程方式跟踪任何用户数据。
-3.  SillyTavern 是一个由专注的 LLM 爱好者社区为您带来的充满激情的项目，并且将永远是免费和开源的。
+请以根目录 `README.md` 的安装章节和最新发布说明为准。
 
-## 我需要一台性能强大的电脑来运行 SillyTavern 吗？
+## 许可与致谢
 
-硬件要求很低：任何可以运行 NodeJS 20 或更高版本的设备都可以运行它。如果您打算在本地计算机上进行 LLM 推理，我们建议使用至少具有 6GB VRAM 的 3000 系列 NVIDIA 显卡，但实际要求可能会根据模型和您使用的后端而有所不同。
-
-## 有问题或建议？
-
-### Discord 服务器
-
-| [![][discord-shield-badge]][discord-link] | [加入我们的 Discord 社区！](https://discord.gg/sillytavern) 获取支持，分享喜爱的角色和 Prompt。 |
-| :---------------------------------------- | :---------------------------------------------------------------------------------------------- |
-
-或者直接与开发人员联系：
-
-* Discord: cohee, rossascends, wolfsblvt
-* Reddit: [/u/RossAscends](https://www.reddit.com/user/RossAscends/), [/u/sillylossy](https://www.reddit.com/user/sillylossy/), [u/Wolfsblvt](https://www.reddit.com/user/Wolfsblvt/)
-* [提交 GitHub 问题](https://github.com/SillyTavern/SillyTavern/issues)
-
-### 我喜欢你的项目！我该如何贡献自己的力量？
-
-1.  发送 Pull Request。学习如何贡献：[CONTRIBUTING.md](../CONTRIBUTING.md)
-2.  使用提供的模板发送功能建议和问题报告。
-3.  请先阅读整个 readme 文件并查看文档网站，以避免提交重复的问题。
-
-## 屏幕截图
-
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/9b5f32f0-c3b3-4102-b3f5-0e9213c0f50f">
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/913fdbaa-7d33-42f1-ae2c-89dca41c53d1">
-
-## 安装
-
-有关详细的安装说明，请访问我们的文档：
-
-* **[Windows 安装指南](https://docs.sillytavern.app/installation/windows/)**
-* **[MacOS/Linux 安装指南](https://docs.sillytavern.app/installation/linuxmacos/)**
-* **[Android (Termux) 安装指南](https://docs.sillytavern.app/installation/android-(termux)/)**
-* **[Docker 安装指南](https://docs.sillytavern.app/installation/docker/)**
-
-## 许可证和致谢
-
-**本程序的分发是希望它能有用，但不提供任何保证；甚至没有对适销性或特定用途适用性的默示保证。有关更多详细信息，请参阅 GNU Affero 通用公共许可证。**
-
-* [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8 by Humi: MIT 许可证
-* CncAnon 的 TavernAITurbo mod 的部分内容经许可使用
-* 视觉小说模式的灵感来自 PepperTaco 的工作 (<https://github.com/peppertaco/Tavern/>)
-* Noto Sans 字体 by Google (OFL 许可证)
-* 图标主题 by Font Awesome <https://fontawesome.com> (图标: CC BY 4.0, 字体: SIL OFL 1.1, 代码: MIT 许可证)
-* 默认内容由 @OtisAlejandro (Seraphina 角色和世界书) 和 @kallmeflocc (10K Discord 用户庆祝背景) 提供
-* Docker 指南由 [@mrguymiah](https://github.com/mrguymiah) 和 [@Bronya-Rand](https://github.com/Bronya-Rand) 提供
-* kokoro-js 库由 [@hexgrad](https://github.com/hexgrad) 提供 (Apache-2.0 许可证)
-
-## 主要贡献者
-
-[![Contributors](https://contrib.rocks/image?repo=SillyTavern/SillyTavern)](https://github.com/SillyTavern/SillyTavern/graphs/contributors)
+SillyBunny 仍然保持与上游兼容的数据与格式，完整致谢信息请查看根目录 `README.md`。
 
 <!-- LINK GROUP -->
 [cover]: https://github.com/user-attachments/assets/01a6ae9a-16aa-45f2-8bff-32b5dc587e44
-[discord-link]: https://discord.gg/sillytavern
-[discord-shield-badge]: https://img.shields.io/discord/1100685673633153084?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/.github/readme-zh_tw.md
+++ b/.github/readme-zh_tw.md
@@ -1,5 +1,5 @@
-> [!IMPORTANT]  
-> 此處資訊可能已經過時或不完整，僅供您參考。請使用英文版本以取得最新資訊。
+> [!IMPORTANT]
+> 這裡的內容可能更新得比英文版慢。最新資訊請以根目錄 `README.md` 為準。
 
 <a name="readme-top"></a>
 
@@ -7,88 +7,31 @@
 
 <div align="center">
 
-[English](readme.md)  | [German](readme-de_de.md) | [中文](readme-zh_cn.md) | 繁體中文 | [日本語](readme-ja_jp.md) | [Русский](readme-ru_ru.md) | [한국어](readme-ko_kr.md)
-
-[![GitHub 星標](https://img.shields.io/github/stars/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/stargazers)
-[![GitHub 分支](https://img.shields.io/github/forks/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/forks)
-[![GitHub 問題](https://img.shields.io/github/issues/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/issues)
-[![GitHub 拉取請求](https://img.shields.io/github/issues-pr/SillyTavern/SillyTavern.svg)](https://github.com/SillyTavern/SillyTavern/pulls)
+[English](readme.md) | [German](readme-de_de.md) | [中文](readme-zh_cn.md) | 繁體中文 | [日本語](readme-ja_jp.md) | [Русский](readme-ru_ru.md) | [한국어](readme-ko_kr.md)
 
 </div>
 
 ---
 
-SillyTavern 提供一個統一的前端介面，整合多種大型語言模型的 API（包括：KoboldAI/CPP、Horde、NovelAI、Ooba、Tabby、OpenAI、OpenRouter、Claude、Mistral 等）。同時具備對行動裝置友善的佈局、視覺小說模式（Visual Novel Mode）、Automatic1111 與 ComfyUI 的影像生成 API 整合、TTS（語音合成）、世界資訊（Lorebook）、可自訂 UI、自動翻譯功能，以及強大的提示詞（prompt）設定選項和無限的第三方擴充潛力。
+SillyBunny 是一個從 [SillyTavern](https://github.com/SillyTavern/SillyTavern) 分支而來的專案，主打更乾淨的圖形化外殼、Bun 優先後端、內建教學、預設集、擴充功能與快速開始儀表板，也支援與上游兼容的資料、角色、聊天與預設格式。
 
-我們擁有一個 [官方文件網站](https://docs.sillytavern.app/) 可以幫助解答絕大多數的使用問題，並幫助您順利入門。
+## 這個專案是什麼？
 
-## SillyTavern 是什麼？
+SillyBunny 是一個本地安裝的前端介面，可搭配文字模型、圖片生成引擎與語音模型使用。
 
-SillyTavern（簡稱 ST）是一款本地安裝的使用者介面，讓您能與大型語言模型（LLM）、影像生成引擎以及語音合成模型互動的前端。
+## 我該從哪裡開始？
 
-SillyTavern 起源於 2023 年 2 月，作為 TavernAI 1.2.8 的分支版本發展至今。目前已有超過 200 位貢獻者，並擁有超過兩年的獨立開發歷史。如今，它已成為 AI 愛好者中備受推崇的軟體之一。
+1. 閱讀根目錄 `README.md` 了解最新功能與安裝方式。
+2. 下載最新發行版，或依照專案中的啟動腳本啟動。
+3. 若遇到問題，請在本專案的 issue tracker 回報。
 
-## 我們的願景
+## 安裝與更新
 
-1. 我們致力於賦予使用者對 LLM 提示詞的最大控制權與實用性，並認為學習過程中的挑戰是樂趣的一部分。
-2. 我們不提供任何線上或託管服務，也不會程式化追蹤任何使用者數據。
-3. SillyTavern 是由一群熱衷於 LLM 的開發者社群所打造的專案，並將永遠保持免費與開源。
-
-## 我需要高效能電腦才能運行 SillyTavern 嗎？
-
-SillyTavern 的硬體需求相當低。任何能夠運行 NodeJS 20 或更高版本的設備都可以執行。若您打算在本地機器上進行 LLM 推理，我們建議使用擁有至少 6GB VRAM 的 3000 系列 NVIDIA 顯示卡，但實際需求可能因模型和您使用的後端而異。
-
-## 有任何問題或建議？
-
-### 歡迎加入我們的 Discord 伺服器
-
-| [![][discord-shield-badge]][discord-link] | [加入我們的 Disocrd 伺服器](https://discord.gg/sillytavern) 以獲得技術支援、分享您喜愛的角色與提示詞。 |
-| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-
-或直接聯繫開發者：
-
-* Discord: cohee, rossascends, wolfsblvt
-* Reddit: [/u/RossAscends](https://www.reddit.com/user/RossAscends/), [/u/sillylossy](https://www.reddit.com/user/sillylossy/), [u/Wolfsblvt](https://www.reddit.com/user/Wolfsblvt/)
-* [提交 GitHub 問題](https://github.com/SillyTavern/SillyTavern/issues)
-
-### 我喜歡這個專案，我該如何貢獻呢？
-
-1. **提交拉取要求（Pull Request）**：想了解如何貢獻，請參閱 [CONTRIBUTING.md](../CONTRIBUTING.md)。 
-2. **提供功能建議與問題報告**：使用本專案所提供的模板提交建議或問題報告。
-3. **仔細閱讀此 README 文件及相關文檔**：請避免提出重複問題或建議。
-
-## 螢幕截圖
-
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/9b5f32f0-c3b3-4102-b3f5-0e9213c0f50f">
-<img width="500" alt="image" src="https://github.com/user-attachments/assets/913fdbaa-7d33-42f1-ae2c-89dca41c53d1">
-
-## 安裝指南
-
-有關詳細的安裝說明，請訪問我們的文檔：
-
-* **[Windows 安裝指南](https://docs.sillytavern.app/installation/windows/)**
-* **[MacOS/Linux 安裝指南](https://docs.sillytavern.app/installation/linuxmacos/)**
-* **[Android (Termux) 安裝指南](https://docs.sillytavern.app/installation/android-(termux)/)**
-* **[Docker 安裝指南](https://docs.sillytavern.app/installation/docker/)**
+請以根目錄 `README.md` 的安裝章節與最新發行版說明為準。
 
 ## 授權與致謝
 
-**本程式（SillyTavern）的發布是基於其可能對使用者有所幫助的期許，但不提供任何形式的保證；包括但不限於對可銷售性（marketability）或特定用途適用性的隱含保證。如需更多詳情，請參閱 GNU Affero 通用公共許可證。**
-
-* [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8 由 Humi 提供：MIT 許可
-* 經授權使用部分來自 CncAnon 的 TavernAITurbo 模組
-* 視覺小說模式（Visual Novel Mode）的靈感，來源於 PepperTaco 的貢獻（<https://github.com/peppertaco/Tavern/>）
-* Noto Sans 字體由 Google 提供（OFL 許可）
-* 主題圖示由 Font Awesome <https://fontawesome.com> 提供（圖示：CC BY 4.0，字體：SIL OFL 1.1，程式碼：MIT 許可）
-* 預設資源來源於 @OtisAlejandro（包含角色 Seraphina 與知識書）與 @kallmeflocc（SillyTavern 官方 Discord 伺服器成員突破 10K 的慶祝背景）
-* Docker 安裝指南由 [@mrguymiah](https://github.com/mrguymiah) 和 [@Bronya-Rand](https://github.com/Bronya-Rand) 編寫
-* kokoro-js 函式庫由 [@hexgrad](https://github.com/hexgrad) 提供 (Apache-2.0 許可)
-
-## 主要貢獻者
-
-[![Contributors](https://contrib.rocks/image?repo=SillyTavern/SillyTavern)](https://github.com/SillyTavern/SillyTavern/graphs/contributors)
+SillyBunny 仍保留與上游相容的資料與格式，並延續原始專案的相關致謝；完整細節請見根目錄 `README.md`。
 
 <!-- LINK GROUP -->
 [cover]: https://github.com/user-attachments/assets/01a6ae9a-16aa-45f2-8bff-32b5dc587e44
-[discord-link]: https://discord.gg/sillytavern
-[discord-shield-badge]: https://img.shields.io/discord/1100685673633153084?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 <img src="screenshots/banner.jpg" width="100%">
 </div>
 
+<div align="center">
+
+English | [Deutsch](.github/readme-de_de.md) | [中文](.github/readme-zh_cn.md) | [繁體中文](.github/readme-zh_tw.md) | [日本語](.github/readme-ja_jp.md) | [Русский](.github/readme-ru_ru.md) | [한국어](.github/readme-ko_kr.md)
+
+</div>
+
 ---
 
 An elegant fork of [SillyTavern](https://github.com/SillyTavern/SillyTavern), designed with a cleaner, graphical shell UI; Bun-based backend; built-in tutorials, presets, extensions, and a quick-start dashboard; and a lightweight agentic system to facilitate modern agent functionality.


### PR DESCRIPTION
Changes all alternative language README files to actually be about SillyBunny instead of following upstream SillyTavern docs, while letting the main README.md file point to these alt language options.

These alt language files are kept shorter than the main README.md file for now since they're basic LLM translations. They mainly serve to remove irrelevant content that mentions the project being SillyTavern.

No obligation to keep them updated, but should be do-able with LLM translations everytime the README gets updated.