### PR TITLE
fix: viewport escaping out of bounds due to dragging in general

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -1,4 +1,5 @@
 import { getParsedUA, isMobile } from './RossAscends-mods.js';
+import { shouldBlockMobileDocumentPan } from './mobile-shell-lifecycle/index.js';
 
 const isFirefox = () => /firefox/i.test(navigator.userAgent);
 
@@ -124,6 +125,7 @@ function applyBrowserFixes() {
         let lastScale = viewport?.scale || 1;
         let lastSendInteractionAt = 0;
         let lastSendFocusedAt = 0;
+        let documentPanTouchStart = null;
 
         const updateViewportBaseline = () => {
             lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
@@ -170,6 +172,30 @@ function applyBrowserFixes() {
 
         const handleMobileViewportReset = (event) => {
             scheduleViewportReset({ restoreScroll: Boolean(event?.detail?.restoreScroll) });
+        };
+
+        const blockDocumentPanFromShellGaps = (event) => {
+            if (shouldBlockMobileDocumentPan(event, { touchStart: documentPanTouchStart })) {
+                event.preventDefault();
+            }
+        };
+
+        const captureDocumentPanStart = (event) => {
+            if (event.touches?.length !== 1) {
+                documentPanTouchStart = null;
+                return;
+            }
+
+            const touch = event.touches[0];
+            documentPanTouchStart = {
+                identifier: touch.identifier,
+                clientX: touch.clientX,
+                clientY: touch.clientY,
+            };
+        };
+
+        const clearDocumentPanStart = () => {
+            documentPanTouchStart = null;
         };
 
         const applyPositionFix = ({ force = false } = {}) => {
@@ -297,7 +323,11 @@ function applyBrowserFixes() {
             }
         };
         document.addEventListener('touchstart', blockMultiTouchZoom, { passive: false });
+        document.addEventListener('touchstart', captureDocumentPanStart, { passive: true, capture: true });
         document.addEventListener('touchmove', blockMultiTouchZoom, { passive: false });
+        document.addEventListener('touchmove', blockDocumentPanFromShellGaps, { passive: false, capture: true });
+        document.addEventListener('touchend', clearDocumentPanStart, { passive: true, capture: true });
+        document.addEventListener('touchcancel', clearDocumentPanStart, { passive: true, capture: true });
     }
 
     addMacOSPatch();

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -741,6 +741,108 @@ export const MOBILE_SHELL_VIEWPORT_SYNC_STEP = Object.freeze({
     SYNC_MOBILE_MODAL_STATE: 'sync-mobile-modal-state',
 });
 
+const MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR = [
+    '#chat',
+    '#leftSendForm',
+    '#qr--bar',
+    '#ica--tracker-panel',
+    '.scrollableInner',
+    '.scrollableInnerFull',
+    '.sb-shell-panel-scroller',
+    '.sb-shell-scroller',
+    '.popup-body',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR = [
+    'input',
+    'textarea',
+    'select',
+    '[contenteditable="true"]',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_OWNED_GESTURE_SELECTOR = '#ica--tracker-panel-handle';
+
+function closestMatchingElement(target, selector) {
+    let element = target;
+
+    while (element && typeof element === 'object') {
+        if (typeof element.matches === 'function' && element.matches(selector)) {
+            return element;
+        }
+
+        if (typeof element.closest === 'function') {
+            const closest = element.closest(selector);
+            if (closest) {
+                return closest;
+            }
+        }
+
+        element = element.parentElement ?? null;
+    }
+
+    return null;
+}
+
+function findTouchByIdentifier(touches, identifier) {
+    return Array.from(touches ?? []).find(touch => touch?.identifier === identifier) ?? null;
+}
+
+function getGestureDelta(event, touchStart) {
+    if (!touchStart) {
+        return null;
+    }
+
+    const currentTouch = findTouchByIdentifier(event.touches, touchStart.identifier) ?? event.touches?.[0] ?? null;
+    if (!currentTouch) {
+        return null;
+    }
+
+    return {
+        x: normalizeNumber(currentTouch.clientX) - normalizeNumber(touchStart.clientX),
+        y: normalizeNumber(currentTouch.clientY) - normalizeNumber(touchStart.clientY),
+    };
+}
+
+function canElementScrollForGesture(element, delta) {
+    if (!element || !delta) {
+        return false;
+    }
+
+    const absX = Math.abs(delta.x);
+    const absY = Math.abs(delta.y);
+    const wantsHorizontalScroll = absX > absY;
+    const canScrollX = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth) > 1;
+    const canScrollY = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight) > 1;
+
+    return wantsHorizontalScroll ? canScrollX : canScrollY;
+}
+
+/**
+ * Decides whether a mobile touchmove started on non-scrollable document chrome
+ * should be cancelled before the browser pans the visual viewport.
+ * @param {TouchEvent|object} event Touchmove-like event.
+ * @param {object} [options] Options.
+ * @param {{identifier: number, clientX: number, clientY: number}|null} [options.touchStart=null] Starting touch point.
+ * @returns {boolean}
+ */
+export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) {
+    if (!event?.cancelable || event.defaultPrevented || event.touches?.length !== 1) {
+        return false;
+    }
+
+    if (closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_OWNED_GESTURE_SELECTOR)
+        || closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR)) {
+        return false;
+    }
+
+    const scrollElement = closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR);
+    if (canElementScrollForGesture(scrollElement, getGestureDelta(event, touchStart))) {
+        return false;
+    }
+
+    return true;
+}
+
 function clampBoundNumber(value, min, max) {
     return Math.min(Math.max(normalizeNumber(value, min), min), max);
 }

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -3,13 +3,56 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-import { MOBILE_SHELL_VIEWPORT_SYNC_STEP } from '../public/scripts/mobile-shell-lifecycle/index.js';
+import {
+    MOBILE_SHELL_VIEWPORT_SYNC_STEP,
+    shouldBlockMobileDocumentPan,
+} from '../public/scripts/mobile-shell-lifecycle/index.js';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
 const browserFixesSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'browser-fixes.js'), 'utf8');
 const tabsCssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
 const mobileShellCssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+
+function createElementStub({
+    parentElement = null,
+    matches = () => false,
+    closest = () => null,
+    scrollWidth = 0,
+    clientWidth = 0,
+    scrollHeight = 0,
+    clientHeight = 0,
+} = {}) {
+    return {
+        parentElement,
+        matches,
+        closest,
+        scrollWidth,
+        clientWidth,
+        scrollHeight,
+        clientHeight,
+    };
+}
+
+function selectorListIncludes(selector, token) {
+    return String(selector ?? '')
+        .split(',')
+        .map(part => part.trim())
+        .includes(token);
+}
+
+function createTouchMove(target, { startX = 0, startY = 0, x = 0, y = 0, cancelable = true, touches = null } = {}) {
+    const touchStart = { identifier: 1, clientX: startX, clientY: startY };
+
+    return {
+        event: {
+            target,
+            cancelable,
+            touches: touches ?? [{ identifier: 1, clientX: x, clientY: y }],
+        },
+        touchStart,
+    };
+}
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;
@@ -55,6 +98,51 @@ function getFunctionSource(name) {
 }
 
 describe('mobile shell lifecycle wiring', () => {
+    test('blocks mobile document panning from non-scrollable shell gaps only', () => {
+        expect(browserFixesSource).toContain('blockDocumentPanFromShellGaps');
+        expect(browserFixesSource).toContain('captureDocumentPanStart');
+        expect(browserFixesSource).toContain('document.addEventListener(\'touchmove\', blockDocumentPanFromShellGaps, { passive: false, capture: true });');
+
+        const chatScroller = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#chat'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+        });
+        const composerGap = createElementStub();
+        const textarea = createElementStub({
+            matches: selector => selector.includes('textarea'),
+        });
+        const quickReplyRail = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#leftSendForm'),
+            scrollWidth: 600,
+            clientWidth: 240,
+        });
+        const quickReplyButton = createElementStub({ parentElement: quickReplyRail });
+        const genericButton = createElementStub({
+            matches: selector => selectorListIncludes(selector, 'button'),
+        });
+        const companionHandle = createElementStub({
+            closest: selector => selectorListIncludes(selector, '#ica--tracker-panel-handle') ? companionHandle : null,
+        });
+        const chatMove = createTouchMove(chatScroller, { y: -40 });
+        const railHorizontalMove = createTouchMove(quickReplyButton, { x: 40, y: 2 });
+        const railVerticalMove = createTouchMove(quickReplyButton, { x: 2, y: -40 });
+        const gapMove = createTouchMove(composerGap, { y: -40 });
+        const buttonMove = createTouchMove(genericButton, { y: -40 });
+        const multiTouchMove = createTouchMove(composerGap, { touches: [{}, {}] });
+        const nonCancelableMove = createTouchMove(composerGap, { cancelable: false });
+
+        expect(shouldBlockMobileDocumentPan(chatMove.event, { touchStart: chatMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(createTouchMove(textarea, { y: -40 }).event)).toBe(false);
+        expect(shouldBlockMobileDocumentPan(railHorizontalMove.event, { touchStart: railHorizontalMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(railVerticalMove.event, { touchStart: railVerticalMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(createTouchMove(companionHandle, { x: -40 }).event)).toBe(false);
+        expect(shouldBlockMobileDocumentPan(gapMove.event, { touchStart: gapMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(buttonMove.event, { touchStart: buttonMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(multiTouchMove.event, { touchStart: multiTouchMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
+    });
+
     test('imports the mobile shell lifecycle seam into the shell adapter', () => {
         expect(tabsSource).toContain('createMobileShellLifecycle');
         expect(tabsSource).toContain('MOBILE_SHELL_NAV_TOGGLE_ACTION');


### PR DESCRIPTION
This PR fixes the behavior where, when dragging between the QR/GG bar and chat input bar on mobile specifically, the viewport can be fully dragged to the top of the screen (where the keyboard would usually sit when triggered), as well as to the right, where the companion bar would pop out from (it was a large gutter on the bottom and the right side basically)

Tested as fixed by hardening the dragged touches on QR/GG/Composer gap/side edge etc on mobile (firefox latest, Android 16)