### PR TITLE
fix(connection_profile): persist custom endpoint profiles secret

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -15,7 +15,7 @@ import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
 import { cancelDebounce, collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
 import { getSecretLabelById } from '../../secrets.js';
-import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset } from '../../openai.js';
+import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset, syncCustomEndpointPresetSelectionBySecretId } from '../../openai.js';
 import { performFuzzySearch } from '/scripts/power-user.js';
 import { StreamingDisplay } from '/scripts/streaming-display.js';
 import { ConnectionManagerRequestService } from '../shared.js';
@@ -54,6 +54,7 @@ const CC_COMMANDS = [
     'preset',
     // Do not fix; CC needs to set the API twice because it could be overridden by the preset
     'api',
+    'secret-id',
     'api-url',
     'model',
     'proxy',
@@ -74,7 +75,6 @@ const CC_COMMANDS = [
     'custom-reasoning-enabled-value',
     'custom-reasoning-disabled-value',
     'prompt-post-processing',
-    'secret-id',
     'regex-preset',
 ];
 
@@ -600,7 +600,21 @@ function getCustomEndpointProfileSecretId(mode) {
         return '';
     }
 
+    // SillyBunny: Custom endpoint profiles bind to their saved preset secret, not the active fallback key.
     return String(selected_custom_endpoint_preset?.secretId ?? '').trim();
+}
+
+function syncAppliedCustomEndpointProfileSecret(mode, secretId) {
+    if (
+        mode !== 'cc' ||
+        main_api !== 'openai' ||
+        oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM
+    ) {
+        return;
+    }
+
+    // SillyBunny: Custom status/model fetches read the selected preset secret after profile apply.
+    syncCustomEndpointPresetSelectionBySecretId(secretId);
 }
 
 /**
@@ -985,7 +999,10 @@ async function applyConnectionProfile(profile) {
                 // Keep persistence centralized in the explicit save after the full profile is applied.
                 cancelDebounce(saveSettingsDebounced);
                 try {
-                    await commandPromise;
+                    const result = await commandPromise;
+                    if (command === 'secret-id') {
+                        syncAppliedCustomEndpointProfileSecret(mode, result || argument);
+                    }
                 } finally {
                     cancelDebounce(saveSettingsDebounced);
                 }

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -15,6 +15,7 @@ import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
 import { cancelDebounce, collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
 import { getSecretLabelById } from '../../secrets.js';
+import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset } from '../../openai.js';
 import { performFuzzySearch } from '/scripts/power-user.js';
 import { StreamingDisplay } from '/scripts/streaming-display.js';
 import { ConnectionManagerRequestService } from '../shared.js';
@@ -589,6 +590,19 @@ function findProfileByName(value) {
     return bestMatch.item;
 }
 
+function getCustomEndpointProfileSecretId(mode) {
+    if (
+        mode !== 'cc' ||
+        main_api !== 'openai' ||
+        oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM ||
+        selected_custom_endpoint_preset?.name === 'None'
+    ) {
+        return '';
+    }
+
+    return String(selected_custom_endpoint_preset?.secretId ?? '').trim();
+}
+
 /**
  * Reads the connection profile from the commands.
  * @param {string} mode Mode of the connection profile
@@ -607,6 +621,14 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
 
             const allowEmpty = ALLOW_EMPTY.includes(command);
             const args = getNamedArguments();
+            if (command === 'secret-id') {
+                const customEndpointSecretId = getCustomEndpointProfileSecretId(mode);
+                if (customEndpointSecretId) {
+                    profile[command] = customEndpointSecretId;
+                    continue;
+                }
+            }
+
             const result = await SlashCommandParser.commands[command].callback(args, '');
             if (result || (allowEmpty && result === '')) {
                 profile[command] = result;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -9411,6 +9411,32 @@ function updateCustomEndpointKeyInput(preset, key) {
     $('#api_key_custom').removeAttr('placeholder').val(key);
 }
 
+// SillyBunny: connection profiles can rotate CUSTOM secrets without using the endpoint preset dropdown.
+export function syncCustomEndpointPresetSelectionBySecretId(secretId) {
+    const normalizedSecretId = String(secretId ?? '').trim();
+    if (!normalizedSecretId) {
+        return false;
+    }
+
+    const matchedPreset = custom_endpoint_presets.find(preset => preset.name !== 'None' && String(preset.secretId ?? '').trim() === normalizedSecretId);
+    if (matchedPreset) {
+        selected_custom_endpoint_preset = matchedPreset;
+        $('#custom_endpoint_preset').val(matchedPreset.name);
+        updateCustomEndpointKeyInput(matchedPreset, matchedPreset.key);
+        return true;
+    }
+
+    const selectedSecretId = String(selected_custom_endpoint_preset?.secretId ?? '').trim();
+    if (selectedSecretId && selectedSecretId !== normalizedSecretId) {
+        selected_custom_endpoint_preset = custom_endpoint_presets.find(preset => preset.name === 'None') ?? normalizeCustomEndpointPreset({ name: 'None' });
+        $('#custom_endpoint_preset').val(selected_custom_endpoint_preset.name);
+        updateCustomEndpointKeyInput(selected_custom_endpoint_preset, '');
+        return true;
+    }
+
+    return false;
+}
+
 async function setCustomEndpointPreset(name, url, key, model, { secretId = '', writeKey = true, reconnect = true } = {}) {
     const normalizedPreset = normalizeCustomEndpointPreset({ name, url, key, model, secretId });
     const preset = custom_endpoint_presets.find(p => p.name === normalizedPreset.name);

--- a/tests/connection-manager-profile-save.test.js
+++ b/tests/connection-manager-profile-save.test.js
@@ -49,4 +49,25 @@ describe('connection manager profile save wiring', () => {
         expect(readSource).toContain('if (cleanUp && CLEAR_ON_EMPTY_RESULT.includes(command)) {');
         expect(readSource).toContain('delete profile[command];');
     });
+
+    test('persists selected Custom endpoint profile secrets instead of active fallback secrets', () => {
+        const helperSource = getFunctionSource('getCustomEndpointProfileSecretId');
+        const readSource = getFunctionSource('readProfileFromCommands');
+
+        expect(connectionManagerSource).toContain('import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset } from \'../../openai.js\';');
+        expect(helperSource).toContain('mode !== \'cc\'');
+        expect(helperSource).toContain('oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM');
+        expect(helperSource).toContain('selected_custom_endpoint_preset?.name === \'None\'');
+        expect(helperSource).toContain('return String(selected_custom_endpoint_preset?.secretId ?? \'\').trim();');
+
+        const secretCommandIndex = readSource.indexOf('if (command === \'secret-id\') {');
+        const profileSecretIndex = readSource.indexOf('const customEndpointSecretId = getCustomEndpointProfileSecretId(mode);', secretCommandIndex);
+        const assignIndex = readSource.indexOf('profile[command] = customEndpointSecretId;', profileSecretIndex);
+        const fallbackIndex = readSource.indexOf('const result = await SlashCommandParser.commands[command].callback(args, \'\');');
+
+        expect(secretCommandIndex).toBeGreaterThanOrEqual(0);
+        expect(profileSecretIndex).toBeGreaterThan(secretCommandIndex);
+        expect(assignIndex).toBeGreaterThan(profileSecretIndex);
+        expect(fallbackIndex).toBeGreaterThan(assignIndex);
+    });
 });

--- a/tests/connection-manager-profile-save.test.js
+++ b/tests/connection-manager-profile-save.test.js
@@ -6,29 +6,38 @@ import path from 'node:path';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const normalizeSource = source => source.replace(/\r\n/g, '\n');
 const connectionManagerSource = normalizeSource(readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'connection-manager', 'index.js'), 'utf8'));
+const openAiSource = normalizeSource(readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8'));
 
-function getFunctionSource(name) {
+function getFunctionSourceFrom(source, name) {
     const marker = `function ${name}(`;
-    const start = connectionManagerSource.indexOf(marker);
+    const start = source.indexOf(marker);
 
     expect(start).toBeGreaterThanOrEqual(0);
 
-    const bodyStart = connectionManagerSource.indexOf('{', start);
+    const bodyStart = source.indexOf('{', start);
     let depth = 0;
 
-    for (let index = bodyStart; index < connectionManagerSource.length; index++) {
-        const char = connectionManagerSource[index];
+    for (let index = bodyStart; index < source.length; index++) {
+        const char = source[index];
         if (char === '{') {
             depth++;
         } else if (char === '}') {
             depth--;
             if (depth === 0) {
-                return connectionManagerSource.slice(start, index + 1);
+                return source.slice(start, index + 1);
             }
         }
     }
 
     throw new Error(`Unable to find function source for ${name}`);
+}
+
+function getFunctionSource(name) {
+    return getFunctionSourceFrom(connectionManagerSource, name);
+}
+
+function getOpenAiFunctionSource(name) {
+    return getFunctionSourceFrom(openAiSource, name);
 }
 
 describe('connection manager profile save wiring', () => {
@@ -54,7 +63,7 @@ describe('connection manager profile save wiring', () => {
         const helperSource = getFunctionSource('getCustomEndpointProfileSecretId');
         const readSource = getFunctionSource('readProfileFromCommands');
 
-        expect(connectionManagerSource).toContain('import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset } from \'../../openai.js\';');
+        expect(connectionManagerSource).toContain('import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset, syncCustomEndpointPresetSelectionBySecretId } from \'../../openai.js\';');
         expect(helperSource).toContain('mode !== \'cc\'');
         expect(helperSource).toContain('oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM');
         expect(helperSource).toContain('selected_custom_endpoint_preset?.name === \'None\'');
@@ -69,5 +78,36 @@ describe('connection manager profile save wiring', () => {
         expect(profileSecretIndex).toBeGreaterThan(secretCommandIndex);
         expect(assignIndex).toBeGreaterThan(profileSecretIndex);
         expect(fallbackIndex).toBeGreaterThan(assignIndex);
+    });
+
+    test('binds Custom endpoint profile secrets before endpoint and model refreshes', () => {
+        const applySource = getFunctionSource('applyConnectionProfile');
+        const syncSource = getFunctionSource('syncAppliedCustomEndpointProfileSecret');
+        const openAiSyncSource = getOpenAiFunctionSource('syncCustomEndpointPresetSelectionBySecretId');
+        const ccCommandsStart = connectionManagerSource.indexOf('const CC_COMMANDS = [');
+        const tcCommandsStart = connectionManagerSource.indexOf('const TC_COMMANDS = [');
+        const ccCommandsSource = connectionManagerSource.slice(ccCommandsStart, tcCommandsStart);
+
+        expect(syncSource).toContain('oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM');
+        expect(syncSource).toContain('syncCustomEndpointPresetSelectionBySecretId(secretId);');
+        expect(openAiSyncSource).toContain('preset.name !== \'None\'');
+        expect(openAiSyncSource).toContain('selected_custom_endpoint_preset = matchedPreset;');
+        expect(openAiSyncSource).toContain('selected_custom_endpoint_preset = custom_endpoint_presets.find(preset => preset.name === \'None\')');
+
+        const secretCommandIndex = ccCommandsSource.indexOf('\'secret-id\'');
+        const apiUrlCommandIndex = ccCommandsSource.indexOf('\'api-url\'');
+        const modelCommandIndex = ccCommandsSource.indexOf('\'model\'');
+
+        expect(secretCommandIndex).toBeGreaterThanOrEqual(0);
+        expect(apiUrlCommandIndex).toBeGreaterThan(secretCommandIndex);
+        expect(modelCommandIndex).toBeGreaterThan(secretCommandIndex);
+
+        const commandResultIndex = applySource.indexOf('const result = await commandPromise;');
+        const secretGuardIndex = applySource.indexOf('if (command === \'secret-id\') {', commandResultIndex);
+        const syncIndex = applySource.indexOf('syncAppliedCustomEndpointProfileSecret(mode, result || argument);', secretGuardIndex);
+
+        expect(commandResultIndex).toBeGreaterThanOrEqual(0);
+        expect(secretGuardIndex).toBeGreaterThan(commandResultIndex);
+        expect(syncIndex).toBeGreaterThan(secretGuardIndex);
     });
 });


### PR DESCRIPTION
# Summary

Issue:
"Custom endpoint profiles bugged
Adding keys doesn't link secrets, it links a new credential created when saving the profile instead of what exists
Model picker goes blank, fetch URL error "
This can be mitigated by using Authorization: Bearer (key) in Additional Parameters, but this is a hacky, strange solution.

This PR ensures keys aren't duplicated and whichever secret is used for the custom endpoint profile is actually saved and attached to the profile.
