### PR TITLE
fix(ui): persist Context Size, Character Name, and Custom Text options in Appearance

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -3675,6 +3675,7 @@ function setDesktopTopbarLabelPart(partId, enabled) {
 
     sbState.topbarLabel.desktopParts = normalizeTopbarLabelParts(Array.from(nextParts), []);
     safeSetItem(SB_STORAGE_KEYS.topbarLabelDesktopParts, JSON.stringify(sbState.topbarLabel.desktopParts));
+    flushSbStorageWrites();
     updateThemePickerUi();
     updateTopBarBrand();
     scheduleTopbarContextRefresh(0);
@@ -3690,6 +3691,7 @@ function setMobileTopbarLabelPart(partId, enabled) {
 
     sbState.topbarLabel.mobilePart = nextPart;
     safeSetItem(SB_STORAGE_KEYS.topbarLabelMobilePart, nextPart);
+    flushSbStorageWrites();
     updateThemePickerUi();
     updateTopBarBrand();
     scheduleTopbarContextRefresh(0);
@@ -3707,6 +3709,7 @@ function setTopbarCustomText(value) {
     }
 
     safeSetItem(SB_STORAGE_KEYS.topbarLabelCustomText, nextText);
+    flushSbStorageWrites();
     updateThemePickerUi();
     updateTopBarBrand();
 }

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -45,6 +45,12 @@ describe('topbar label tap cycle', () => {
         expect(previewSource).toContain('return getTopbarLabelPartOption(normalizedPart)?.label ?? \'\';');
     });
 
+    test('flushes configured label settings immediately after storage writes', () => {
+        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelDesktopParts, JSON.stringify(sbState.topbarLabel.desktopParts));\n    flushSbStorageWrites();');
+        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelMobilePart, nextPart);\n    flushSbStorageWrites();');
+        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelCustomText, nextText);\n    flushSbStorageWrites();');
+    });
+
     test('binds accessible pointer and keyboard activation on the title', () => {
         const bindSource = getFunctionSource('bindTopBarTitleCycle');
         expect(bindSource).toContain('title.addEventListener(\'click\'');

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const cssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
 const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+const normalizedTabsSource = tabsSource.replace(/\r\n/g, '\n');
 
 function getFunctionSource(name) {
     const match = tabsSource.match(new RegExp(`function ${name}\\([\\s\\S]*?\\n\\}`));
@@ -46,9 +47,9 @@ describe('topbar label tap cycle', () => {
     });
 
     test('flushes configured label settings immediately after storage writes', () => {
-        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelDesktopParts, JSON.stringify(sbState.topbarLabel.desktopParts));\n    flushSbStorageWrites();');
-        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelMobilePart, nextPart);\n    flushSbStorageWrites();');
-        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelCustomText, nextText);\n    flushSbStorageWrites();');
+        expect(normalizedTabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelDesktopParts, JSON.stringify(sbState.topbarLabel.desktopParts));\n    flushSbStorageWrites();');
+        expect(normalizedTabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelMobilePart, nextPart);\n    flushSbStorageWrites();');
+        expect(normalizedTabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarLabelCustomText, nextText);\n    flushSbStorageWrites();');
     });
 
     test('binds accessible pointer and keyboard activation on the title', () => {


### PR DESCRIPTION
# Summary

Issue:
The "Context Size", "Character Name", and "Custom Text" options in the Settings -> Appearance menu doesn't appear to save or persist when the page is refreshed.

This PR resolves this persistence issue and saves the toggled settings.
