### PR TITLE
fix(mobile_ui): soften touch guards and re-allow scrolling

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -386,6 +386,9 @@ class PromptManager {
         this.sourcePromptTokenCounts = {};
         this.sourcePromptTokenUsage = 0;
 
+        // Monotonic render token used to discard stale async renders.
+        this.renderRequestId = 0;
+
         // Error state, contains error message.
         this.error = null;
 
@@ -1217,12 +1220,17 @@ class PromptManager {
         }
     }
 
+    #isRenderCurrent(renderRequestId) {
+        return renderRequestId === this.renderRequestId;
+    }
+
     /**
      * Main rendering function
      *
      * @param afterTryGenerate - Whether a dry run should be attempted before rendering
      */
     render(afterTryGenerate = true) {
+        const renderRequestId = ++this.renderRequestId;
         const renderState = resolvePromptManagerRenderState({
             mainApi: main_api,
             promptOrderStrategy: this.configuration.promptOrder.strategy,
@@ -1234,7 +1242,37 @@ class PromptManager {
         if (!renderState.shouldRender && !renderState.shouldWaitForGeneration) return;
         this.error = null;
 
+        const renderPromptManagerDom = async () => {
+            this.profileStart('render');
+            try {
+                const scrollPosition = this.#getScrollPosition();
+                await this.populateSourcePromptTokenCounts();
+                if (!this.#isRenderCurrent(renderRequestId)) {
+                    return;
+                }
+
+                const renderedPromptManager = await this.renderPromptManager(renderRequestId);
+                if (!renderedPromptManager || !this.#isRenderCurrent(renderRequestId)) {
+                    return;
+                }
+
+                const renderedListItems = await this.renderPromptManagerListItems(renderRequestId);
+                if (!renderedListItems || !this.#isRenderCurrent(renderRequestId)) {
+                    return;
+                }
+
+                this.makeDraggable();
+                this.#setScrollPosition(scrollPosition);
+            } finally {
+                this.profileEnd('render');
+            }
+        };
+
         waitUntilCondition(() => !is_send_press && !is_group_generating, 1024 * 1024, 100).then(async () => {
+            if (!this.#isRenderCurrent(renderRequestId)) {
+                return;
+            }
+
             const readyRenderState = resolvePromptManagerRenderState({
                 mainApi: main_api,
                 promptOrderStrategy: this.configuration.promptOrder.strategy,
@@ -1250,25 +1288,15 @@ class PromptManager {
                 this.profileStart('filling context');
                 this.tryGenerate().finally(async () => {
                     this.profileEnd('filling context');
-                    this.profileStart('render');
-                    const scrollPosition = this.#getScrollPosition();
-                    await this.populateSourcePromptTokenCounts();
-                    await this.renderPromptManager();
-                    await this.renderPromptManagerListItems();
-                    this.makeDraggable();
-                    this.#setScrollPosition(scrollPosition);
-                    this.profileEnd('render');
+                    if (!this.#isRenderCurrent(renderRequestId)) {
+                        return;
+                    }
+
+                    await renderPromptManagerDom();
                 });
             } else {
                 // Executed during live communication
-                this.profileStart('render');
-                const scrollPosition = this.#getScrollPosition();
-                await this.populateSourcePromptTokenCounts();
-                await this.renderPromptManager();
-                await this.renderPromptManagerListItems();
-                this.makeDraggable();
-                this.#setScrollPosition(scrollPosition);
-                this.profileEnd('render');
+                await renderPromptManagerDom();
             }
         }).catch(() => {
             console.log('Timeout while waiting for send press to be false');
@@ -2076,16 +2104,20 @@ class PromptManager {
 
     /**
      * Empties, then re-assembles the container containing the prompt list.
+     * @param {number} renderRequestId Current render request token.
+     * @returns {Promise<boolean>} True when the current render completed.
      */
-    async renderPromptManager() {
+    async renderPromptManager(renderRequestId = this.renderRequestId) {
+        if (!this.#isRenderCurrent(renderRequestId)) {
+            return false;
+        }
+
         let selectedPromptIndex = 0;
         const existingAppendSelect = document.getElementById(`${this.configuration.prefix}prompt_manager_footer_append_prompt`);
         if (existingAppendSelect instanceof HTMLSelectElement) {
             selectedPromptIndex = existingAppendSelect.selectedIndex;
         }
         const promptManagerDiv = this.containerElement;
-        this.restorePopupToOrigin();
-        promptManagerDiv.innerHTML = '';
 
         const errorDiv = this.error ? `
                 <div class="${this.configuration.prefix}prompt_manager_error">
@@ -2096,18 +2128,11 @@ class PromptManager {
         const totalActiveTokens = this.getDisplayTokenUsage();
 
         const headerHtml = await renderTemplateAsync('promptManagerHeader', { error: this.error, errorDiv, prefix: this.configuration.prefix, totalActiveTokens, dragLocked: power_user.prompt_manager_drag_locked });
-        promptManagerDiv.insertAdjacentHTML('beforeend', headerHtml);
-
-        this.listElement = promptManagerDiv.querySelector(`#${this.configuration.prefix}prompt_manager_list`);
-
-        if (this.selectedPromptId && !this.getPromptById(this.selectedPromptId)) {
-            this.hidePopup();
-            this.clearEditForm();
-            this.clearInspectForm();
-            this.selectedPromptId = null;
-            this.activePopupArea = '';
+        if (!this.#isRenderCurrent(renderRequestId)) {
+            return false;
         }
 
+        let footerHtml = '';
         if (null !== this.activeCharacter) {
             const prompts = [...this.serviceSettings.prompts]
                 .filter(prompt => prompt && !prompt?.system_prompt)
@@ -2122,7 +2147,27 @@ class PromptManager {
                 selectedPromptIndex = 0;
             }
 
-            const footerHtml = await renderTemplateAsync('promptManagerFooter', { promptsHtml, prefix: this.configuration.prefix });
+            footerHtml = await renderTemplateAsync('promptManagerFooter', { promptsHtml, prefix: this.configuration.prefix });
+            if (!this.#isRenderCurrent(renderRequestId)) {
+                return false;
+            }
+        }
+
+        if (this.selectedPromptId && !this.getPromptById(this.selectedPromptId)) {
+            this.hidePopup();
+            this.clearEditForm();
+            this.clearInspectForm();
+            this.selectedPromptId = null;
+            this.activePopupArea = '';
+        }
+
+        this.restorePopupToOrigin();
+        promptManagerDiv.innerHTML = '';
+        promptManagerDiv.insertAdjacentHTML('beforeend', headerHtml);
+
+        this.listElement = promptManagerDiv.querySelector(`#${this.configuration.prefix}prompt_manager_list`);
+
+        if (null !== this.activeCharacter) {
             const footerSlot = promptManagerDiv.querySelector(`.${this.configuration.prefix}prompt_manager_footer_slot`);
             footerSlot?.insertAdjacentHTML('beforeend', footerHtml);
 
@@ -2130,7 +2175,7 @@ class PromptManager {
             if (!(footerDiv instanceof HTMLElement)) {
                 this.bindDrawerPersistence();
                 this.bindDragLockButton();
-                return;
+                return true;
             }
 
             footerDiv?.querySelector('#prompt-manager-reset-character')?.addEventListener('click', this.handleCharacterReset);
@@ -2149,6 +2194,7 @@ class PromptManager {
         this.syncPopupPlacement();
         this.syncEditorPaneState();
         this.syncListSelection();
+        return true;
     }
 
     bindDragLockButton() {
@@ -2168,17 +2214,22 @@ class PromptManager {
 
     /**
      * Empties, then re-assembles the prompt list
+     * @param {number} renderRequestId Current render request token.
+     * @returns {Promise<boolean>} True when the current render completed.
      */
-    async renderPromptManagerListItems() {
-        if (!this.serviceSettings.prompts) return;
+    async renderPromptManagerListItems(renderRequestId = this.renderRequestId) {
+        if (!this.serviceSettings.prompts || !this.#isRenderCurrent(renderRequestId)) return false;
 
         const promptManagerList = this.listElement;
-        promptManagerList.innerHTML = '';
+        if (!(promptManagerList instanceof HTMLElement)) return false;
 
         const { prefix } = this.configuration;
         const displayTokenCounts = this.getActivePromptTokenCounts();
 
         let listItemHtml = await renderTemplateAsync('promptManagerListHeader', { prefix });
+        if (!this.#isRenderCurrent(renderRequestId) || promptManagerList !== this.listElement) {
+            return false;
+        }
 
         this.getPromptsForCharacter(this.activeCharacter).forEach(prompt => {
             if (!prompt) return;
@@ -2290,6 +2341,11 @@ class PromptManager {
             `;
         });
 
+        if (!this.#isRenderCurrent(renderRequestId) || promptManagerList !== this.listElement) {
+            return false;
+        }
+
+        promptManagerList.innerHTML = '';
         promptManagerList.insertAdjacentHTML('beforeend', listItemHtml);
 
         // Now that the new elements are in the DOM, you can add the event listeners.
@@ -2318,6 +2374,7 @@ class PromptManager {
         });
 
         this.syncListSelection();
+        return true;
     }
 
     /**

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -741,16 +741,16 @@ export const MOBILE_SHELL_VIEWPORT_SYNC_STEP = Object.freeze({
     SYNC_MOBILE_MODAL_STATE: 'sync-mobile-modal-state',
 });
 
-const MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR = [
-    '#chat',
+const MOBILE_DOCUMENT_PAN_GUARD_SELECTOR = [
+    '#nonQRFormItems',
     '#leftSendForm',
     '#qr--bar',
-    '#ica--tracker-panel',
-    '.scrollableInner',
-    '.scrollableInnerFull',
-    '.sb-shell-panel-scroller',
-    '.sb-shell-scroller',
-    '.popup-body',
+    '#rightSendForm',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR = [
+    '#leftSendForm',
+    '#qr--bar',
 ].join(', ');
 
 const MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR = [
@@ -818,7 +818,7 @@ function canElementScrollForGesture(element, delta) {
 }
 
 /**
- * Decides whether a mobile touchmove started on non-scrollable document chrome
+ * Decides whether a mobile touchmove started on non-scrollable composer chrome
  * should be cancelled before the browser pans the visual viewport.
  * @param {TouchEvent|object} event Touchmove-like event.
  * @param {object} [options] Options.
@@ -832,6 +832,10 @@ export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) 
 
     if (closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_OWNED_GESTURE_SELECTOR)
         || closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR)) {
+        return false;
+    }
+
+    if (!closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_GUARD_SELECTOR)) {
         return false;
     }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -13531,6 +13531,7 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
     const shellRoot = document.getElementById(shellConfig.rootPanelId);
     if (shellRoot instanceof HTMLElement && shellRoot.classList.contains('openDrawer')) {
         dispatchShellTabActivated(shellKey, activeTab);
+        queueMobileShellActivationRefresh();
     }
 }
 
@@ -13869,6 +13870,7 @@ function buildShell(shellKey) {
             const activeTab = shellState.tabs.get(shellState.activeTabId);
             activeTab?.onActivate?.();
             dispatchShellTabActivated(shellKey, activeTab);
+            queueMobileShellActivationRefresh();
             updateNavScrollIndicators();
             window.requestAnimationFrame(() => focusShellPanel(shellKey));
             queueMobileModalStateSync();
@@ -14341,6 +14343,15 @@ function dispatchShellTabActivated(shellKey, tabState) {
             label: tabState.label,
         },
     }));
+}
+
+function queueMobileShellActivationRefresh() {
+    if (!isMobileViewport()) {
+        return;
+    }
+
+    queueMobileShellDrawerBoundsSync();
+    queueMobileViewportStateSync();
 }
 
 function getInlineDrawerAutoCloseId(drawer, index = 0) {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -98,7 +98,7 @@ function getFunctionSource(name) {
 }
 
 describe('mobile shell lifecycle wiring', () => {
-    test('blocks mobile document panning from non-scrollable shell gaps only', () => {
+    test('blocks mobile document panning from non-scrollable composer chrome only', () => {
         expect(browserFixesSource).toContain('blockDocumentPanFromShellGaps');
         expect(browserFixesSource).toContain('captureDocumentPanStart');
         expect(browserFixesSource).toContain('document.addEventListener(\'touchmove\', blockDocumentPanFromShellGaps, { passive: false, capture: true });');
@@ -108,11 +108,15 @@ describe('mobile shell lifecycle wiring', () => {
             scrollHeight: 1200,
             clientHeight: 600,
         });
-        const composerGap = createElementStub();
+        const composerChrome = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#nonQRFormItems'),
+        });
+        const composerGap = createElementStub({ parentElement: composerChrome });
         const textarea = createElementStub({
             matches: selector => selector.includes('textarea'),
         });
         const quickReplyRail = createElementStub({
+            parentElement: composerChrome,
             matches: selector => selectorListIncludes(selector, '#leftSendForm'),
             scrollWidth: 600,
             clientWidth: 240,
@@ -124,11 +128,25 @@ describe('mobile shell lifecycle wiring', () => {
         const companionHandle = createElementStub({
             closest: selector => selectorListIncludes(selector, '#ica--tracker-panel-handle') ? companionHandle : null,
         });
+        const presetPopupBody = createElementStub({
+            matches: selector => selectorListIncludes(selector, '.popup-body'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+        });
+        const presetButton = createElementStub({ parentElement: presetPopupBody });
+        const characterDrawerScroller = createElementStub({
+            matches: selector => selectorListIncludes(selector, '.sb-shell-panel-scroller'),
+            scrollHeight: 1600,
+            clientHeight: 600,
+        });
+        const characterCard = createElementStub({ parentElement: characterDrawerScroller });
         const chatMove = createTouchMove(chatScroller, { y: -40 });
         const railHorizontalMove = createTouchMove(quickReplyButton, { x: 40, y: 2 });
         const railVerticalMove = createTouchMove(quickReplyButton, { x: 2, y: -40 });
         const gapMove = createTouchMove(composerGap, { y: -40 });
         const buttonMove = createTouchMove(genericButton, { y: -40 });
+        const presetMove = createTouchMove(presetButton, { y: -40 });
+        const characterDrawerMove = createTouchMove(characterCard, { y: -40 });
         const multiTouchMove = createTouchMove(composerGap, { touches: [{}, {}] });
         const nonCancelableMove = createTouchMove(composerGap, { cancelable: false });
 
@@ -138,7 +156,9 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(railVerticalMove.event, { touchStart: railVerticalMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(createTouchMove(companionHandle, { x: -40 }).event)).toBe(false);
         expect(shouldBlockMobileDocumentPan(gapMove.event, { touchStart: gapMove.touchStart })).toBe(true);
-        expect(shouldBlockMobileDocumentPan(buttonMove.event, { touchStart: buttonMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(buttonMove.event, { touchStart: buttonMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(presetMove.event, { touchStart: presetMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(characterDrawerMove.event, { touchStart: characterDrawerMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(multiTouchMove.event, { touchStart: multiTouchMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
     });

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -362,6 +362,18 @@ describe('mobile shell lifecycle wiring', () => {
         expect(queueMobileShellDrawerBoundsSyncSource).not.toContain('if (typeof window.requestAnimationFrame === \'function\') {');
     });
 
+    test('refreshes mobile shell layout after tab activation', () => {
+        const setActiveTabSource = getFunctionSource('setActiveTab');
+        const buildShellSource = getFunctionSource('buildShell');
+        const activationRefreshSource = getFunctionSource('queueMobileShellActivationRefresh');
+
+        expect(activationRefreshSource).toContain('if (!isMobileViewport()) {');
+        expect(activationRefreshSource).toContain('queueMobileShellDrawerBoundsSync();');
+        expect(activationRefreshSource).toContain('queueMobileViewportStateSync();');
+        expect(setActiveTabSource).toContain('dispatchShellTabActivated(shellKey, activeTab);\n        queueMobileShellActivationRefresh();');
+        expect(buildShellSource).toContain('dispatchShellTabActivated(shellKey, activeTab);\n            queueMobileShellActivationRefresh();');
+    });
+
     test('pins every mobile viewport sync step to a dispatch handler', () => {
         const syncMobileViewportStateSource = getFunctionSource('syncMobileViewportState');
 

--- a/tests/prompt-manager-lifecycle-wiring.test.js
+++ b/tests/prompt-manager-lifecycle-wiring.test.js
@@ -7,8 +7,11 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const promptManagerSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'PromptManager.js'), 'utf8');
 
 function getMethodSource(name) {
-    const marker = `\n    ${name}(`;
-    const start = promptManagerSource.indexOf(marker);
+    const markers = [`\n    ${name}(`, `\n    async ${name}(`];
+    const start = markers.reduce((match, marker) => {
+        const index = promptManagerSource.indexOf(marker);
+        return match === -1 || (index !== -1 && index < match) ? index : match;
+    }, -1);
 
     expect(start).toBeGreaterThanOrEqual(0);
 
@@ -86,5 +89,40 @@ describe('prompt manager lifecycle wiring', () => {
         expect(source).toContain('if (!readyRenderState.shouldRender)');
         expect(source).toContain('if (readyRenderState.shouldRunDryGenerate)');
         expect(source).not.toContain('if (true === afterTryGenerate)');
+    });
+
+    test('guards async render writes with a current render token', () => {
+        const renderSource = getMethodSource('render');
+        const promptManagerRenderSource = getMethodSource('renderPromptManager');
+        const promptListRenderSource = getMethodSource('renderPromptManagerListItems');
+
+        expect(promptManagerSource).toContain('this.renderRequestId = 0;');
+        expect(promptManagerSource).toContain('#isRenderCurrent(renderRequestId)');
+        expect(renderSource).toContain('const renderRequestId = ++this.renderRequestId;');
+        expect(renderSource).toContain('const renderedPromptManager = await this.renderPromptManager(renderRequestId);');
+        expect(renderSource).toContain('const renderedListItems = await this.renderPromptManagerListItems(renderRequestId);');
+        expect(renderSource).toContain('!this.#isRenderCurrent(renderRequestId)');
+
+        const headerAwaitIndex = promptManagerRenderSource.indexOf('const headerHtml = await renderTemplateAsync(\'promptManagerHeader\'');
+        const promptManagerClearIndex = promptManagerRenderSource.indexOf('promptManagerDiv.innerHTML = \'\';');
+        const promptManagerHeaderGuardIndex = promptManagerRenderSource.indexOf('if (!this.#isRenderCurrent(renderRequestId))', headerAwaitIndex);
+
+        expect(promptManagerRenderSource).toContain('async renderPromptManager(renderRequestId = this.renderRequestId)');
+        expect(headerAwaitIndex).toBeGreaterThanOrEqual(0);
+        expect(promptManagerHeaderGuardIndex).toBeGreaterThan(headerAwaitIndex);
+        expect(promptManagerClearIndex).toBeGreaterThan(promptManagerHeaderGuardIndex);
+        expect(promptManagerRenderSource).toContain('return false;');
+        expect(promptManagerRenderSource).toContain('return true;');
+
+        const listHeaderAwaitIndex = promptListRenderSource.indexOf('let listItemHtml = await renderTemplateAsync(\'promptManagerListHeader\'');
+        const promptListClearIndex = promptListRenderSource.indexOf('promptManagerList.innerHTML = \'\';');
+        const promptListGuardIndex = promptListRenderSource.indexOf('if (!this.#isRenderCurrent(renderRequestId) || promptManagerList !== this.listElement)', listHeaderAwaitIndex);
+
+        expect(promptListRenderSource).toContain('async renderPromptManagerListItems(renderRequestId = this.renderRequestId)');
+        expect(listHeaderAwaitIndex).toBeGreaterThanOrEqual(0);
+        expect(promptListGuardIndex).toBeGreaterThan(listHeaderAwaitIndex);
+        expect(promptListClearIndex).toBeGreaterThan(promptListGuardIndex);
+        expect(promptListRenderSource).toContain('return false;');
+        expect(promptListRenderSource).toContain('return true;');
     });
 });


### PR DESCRIPTION
# Summary

Issue:
A regression introduced in https://github.com/platberlitz/SillyBunny/pull/618 (Sorry I didn't catch it, please don't kill me) where the viewport mobile hardening worked in the Presets page *and* the Characters drawer. The bug, as I've noticed, seems to be that you have to wait a solid 5 seconds before you can scroll through touch again.

This PR ensures that the viewport hardening works only on the intended target (QR/GG bar) and not the Presets and Characters drawer.