### PR TITLE
fix: Hardening viewport escaping across the board

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -11893,7 +11893,7 @@ async function promptForMessageScreenshotRange(messageId) {
         onOpen: function () {
             const startInput = popup.dlg.querySelector(`#${MESSAGE_SCREENSHOT_INPUT_IDS.start}`);
             if (startInput instanceof HTMLInputElement) {
-                startInput.focus();
+                startInput.focus({ preventScroll: true });
                 startInput.select();
             }
         },
@@ -11911,7 +11911,7 @@ async function promptForMessageScreenshotRange(messageId) {
             if (!range) {
                 toastr.warning(t`Enter message IDs between 0 and ${maximumMessageId}.`, t`Screenshot messages`);
                 if (startInput instanceof HTMLInputElement) {
-                    startInput.focus();
+                    startInput.focus({ preventScroll: true });
                     startInput.select();
                 }
                 return false;
@@ -12139,11 +12139,7 @@ export async function messageEdit(editMessageId) {
         }
     };
 
-    try {
-        editTextArea.focus({ preventScroll: true });
-    } catch {
-        editTextArea.focus();
-    }
+    editTextArea.focus({ preventScroll: true });
 
     // Sets the cursor at the end of the text
     editTextArea.setSelectionRange(text.length, text.length);

--- a/public/scripts/autocomplete/AutoComplete.js
+++ b/public/scripts/autocomplete/AutoComplete.js
@@ -754,7 +754,7 @@ export class AutoComplete {
             const nextCursor = effectiveStart + replacementText.length;
             const supportsExecCommand = !this.isNativeReplacing && !this.isComposing && typeof document.execCommand === 'function';
 
-            this.textarea.focus();
+            this.textarea.focus({ preventScroll: true });
             this.textarea.setSelectionRange(effectiveStart, replaceEnd);
 
             if (supportsExecCommand && document.execCommand('insertText', false, replacementText)) {

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -109,10 +109,48 @@ function isEditableFocusTarget(element) {
         || (element instanceof HTMLElement && element.isContentEditable);
 }
 
+function addDocumentViewportAnchorPatch() {
+    let resetScheduled = false;
+
+    const resetDocumentScroll = () => {
+        const scrollingElement = document.scrollingElement;
+        const scrollLeft = Math.max(window.scrollX || 0, scrollingElement?.scrollLeft || 0);
+        const scrollTop = Math.max(window.scrollY || 0, scrollingElement?.scrollTop || 0);
+
+        if (scrollLeft <= 0 && scrollTop <= 0) {
+            return;
+        }
+
+        if (scrollingElement instanceof Element) {
+            scrollingElement.scrollLeft = 0;
+            scrollingElement.scrollTop = 0;
+        }
+
+        window.scrollTo(0, 0);
+    };
+
+    const scheduleDocumentScrollReset = () => {
+        if (resetScheduled) {
+            return;
+        }
+
+        resetScheduled = true;
+        requestAnimationFrame(() => {
+            resetDocumentScroll();
+            resetScheduled = false;
+        });
+    };
+
+    resetDocumentScroll();
+    window.addEventListener('scroll', scheduleDocumentScrollReset, { passive: true });
+}
+
 function applyBrowserFixes() {
     if (isFirefox()) {
         sanitizeInlineQuotationOnCopy();
     }
+
+    addDocumentViewportAnchorPatch();
 
     if (isMobile()) {
         const viewport = window.visualViewport;

--- a/public/scripts/extensions/in-chat-agents/companion/companion-dashboard.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-dashboard.js
@@ -51,6 +51,23 @@ function isSuppressedDashboardResult(agentId, result = {}) {
 let dashboardHooks = null;
 let activeDashboardPopup = null;
 
+function scrollChatMessageIntoView(messageElement) {
+    const chatRoot = document.getElementById('chat');
+
+    if (!(messageElement instanceof HTMLElement) || !(chatRoot instanceof HTMLElement) || !chatRoot.contains(messageElement)) {
+        return;
+    }
+
+    const chatRect = chatRoot.getBoundingClientRect();
+    const messageRect = messageElement.getBoundingClientRect();
+    const delta = (messageRect.top - chatRect.top) - ((chatRect.height - messageRect.height) / 2);
+
+    chatRoot.scrollTo({
+        top: Math.min(Math.max(chatRoot.scrollTop + delta, 0), Math.max(0, chatRoot.scrollHeight - chatRoot.clientHeight)),
+        behavior: 'smooth',
+    });
+}
+
 export function configureCompanionDashboard(hooks) {
     dashboardHooks = hooks;
 }
@@ -234,7 +251,7 @@ async function closeDashboard() {
 function jumpToMessage(messageIndex) {
     const messageElement = document.querySelector(`.mes[mesid="${messageIndex}"]`);
     if (messageElement) {
-        messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        scrollChatMessageIntoView(messageElement);
     } else {
         toastr.info('That message is above the rendered window. Scroll up in the chat to load it.');
     }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -57,6 +57,24 @@ let panelLocked = getStoredPanelLocked();
 let panelOpenedAt = 0;
 let suppressHandleClickUntil = 0;
 let handleNode = null;
+
+function scrollChatMessageIntoView(messageElement) {
+    const chatRoot = document.getElementById('chat');
+
+    if (!(messageElement instanceof HTMLElement) || !(chatRoot instanceof HTMLElement) || !chatRoot.contains(messageElement)) {
+        return;
+    }
+
+    const chatRect = chatRoot.getBoundingClientRect();
+    const messageRect = messageElement.getBoundingClientRect();
+    const delta = (messageRect.top - chatRect.top) - ((chatRect.height - messageRect.height) / 2);
+
+    chatRoot.scrollTo({
+        top: Math.min(Math.max(chatRoot.scrollTop + delta, 0), Math.max(0, chatRoot.scrollHeight - chatRoot.clientHeight)),
+        behavior: 'smooth',
+    });
+}
+
 /** Behavior owned by index.js (the agent editor) arrives through this seam — no import cycle. */
 let panelHooks = null;
 
@@ -890,7 +908,7 @@ async function handlePanelAction(event) {
         closeCompanionPanel();
         const messageElement = document.querySelector(`.mes[mesid="${messageIndex}"]`);
         if (messageElement) {
-            messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            scrollChatMessageIntoView(messageElement);
         } else {
             toastr.info('That message is above the rendered window. Scroll up in the chat to load it.');
         }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
@@ -505,7 +505,7 @@ export function insertChoiceIntoMessageInput(rawText) {
     textarea.value = current.trim() ? `${current.replace(/\s+$/, '')}\n${choice}` : choice;
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
     globalThis.$?.(textarea).trigger('input');
-    textarea.focus();
+    textarea.focus({ preventScroll: true });
     toastr.success('Added to the message box.');
     return true;
 }

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -4846,7 +4846,7 @@ function scrollElementIntoNearestPanelScroller(element, { block = 'nearest' } = 
 
     const scroller = element.closest('.sb-shell-panel-scroller, .scrollableInner, .scrollableInnerFull');
     if (!(scroller instanceof HTMLElement) || scroller.clientHeight <= 0) {
-        element.focus?.({ preventScroll: true });
+        element.scrollIntoView({ block, inline: 'nearest', behavior: 'smooth' });
         return;
     }
 

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -4839,6 +4839,41 @@ function schedulePathfinderExtensionsMount() {
     return pathfinderExtensionsMountPromise;
 }
 
+function scrollElementIntoNearestPanelScroller(element, { block = 'nearest' } = {}) {
+    if (!(element instanceof HTMLElement)) {
+        return;
+    }
+
+    const scroller = element.closest('.sb-shell-panel-scroller, .scrollableInner, .scrollableInnerFull');
+    if (!(scroller instanceof HTMLElement) || scroller.clientHeight <= 0) {
+        element.focus?.({ preventScroll: true });
+        return;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const topOverflow = elementRect.top - scrollerRect.top;
+    const bottomOverflow = elementRect.bottom - scrollerRect.bottom;
+    let delta = 0;
+
+    if (block === 'start') {
+        delta = topOverflow;
+    } else if (block === 'center') {
+        delta = topOverflow - ((scrollerRect.height - elementRect.height) / 2);
+    } else if (topOverflow < 0) {
+        delta = topOverflow;
+    } else if (bottomOverflow > 0) {
+        delta = bottomOverflow;
+    }
+
+    if (Math.abs(delta) > 1) {
+        scroller.scrollTo({
+            top: Math.min(Math.max(scroller.scrollTop + delta, 0), Math.max(0, scroller.scrollHeight - scroller.clientHeight)),
+            behavior: 'smooth',
+        });
+    }
+}
+
 function openPathfinderExtensionsDrawer(host) {
     const clickEvent = () => new (globalThis.MouseEvent ?? Event)('click', { bubbles: true });
     const drawer = document.getElementById('extensions-settings-button');
@@ -4855,7 +4890,7 @@ function openPathfinderExtensionsDrawer(host) {
     }
 
     globalThis.setTimeout(() => {
-        host?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        scrollElementIntoNearestPanelScroller(host, { block: 'start' });
         host?.querySelector('input, button, select, textarea')?.focus?.({ preventScroll: true });
     }, 100);
 }

--- a/public/scripts/extensions/input-history/index.js
+++ b/public/scripts/extensions/input-history/index.js
@@ -169,7 +169,7 @@ const showHistoryMenu = async () => {
                 item.addEventListener('click', async () => {
                     hideHistoryMenu();
                     ta.value = c;
-                    ta.focus();
+                    ta.focus({ preventScroll: true });
                 });
                 historyMenu.append(item);
             }
@@ -334,5 +334,5 @@ export function inputHistoryForward() {
 }
 export function showInputHistory() {
     showHistoryMenu();
-    ta.focus();
+    ta.focus({ preventScroll: true });
 }

--- a/public/scripts/extensions/quick-reply/src/QuickReply.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReply.js
@@ -721,7 +721,7 @@ export class QuickReply {
                         message.blur();
                         await this.executeFromEditor();
                         if (document.activeElement != message) {
-                            message.focus();
+                            message.focus({ preventScroll: true });
                             message.selectionStart = selectionStart;
                             message.selectionEnd = selectionEnd;
                         }
@@ -899,7 +899,7 @@ export class QuickReply {
                 updateScrollDebounced(evt);
                 if (document.activeElement == message) {
                     message.blur();
-                    message.focus();
+                    message.focus({ preventScroll: true });
                 }
             });
             window.addEventListener('resize', resizeListener);

--- a/public/scripts/extensions/quick-reply/src/QuickReplySet.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplySet.js
@@ -188,7 +188,7 @@ export class QuickReplySet {
         }
 
         ta.value = substituteParams(input);
-        ta.focus();
+        ta.focus({ preventScroll: true });
 
         if (!this.disableSend) {
             // @ts-ignore
@@ -344,7 +344,7 @@ export class QuickReplySet {
                 (dlg.ok ?? dlg.okButton).insertAdjacentElement('afterend', copyBtn);
             }
             const prom = dlg.show();
-            sel.focus();
+            sel.focus({ preventScroll: true });
             await prom;
             if (dlg.result == POPUP_RESULT.AFFIRMATIVE) {
                 const qrs = QuickReplySet.get(sel.value);

--- a/public/scripts/input-md-formatting.js
+++ b/public/scripts/input-md-formatting.js
@@ -88,7 +88,7 @@ export function initInputMarkdown() {
                     end--; // Adjust the end index since we removed the space
                 }
                 // To add the formatting, we need to select the text first
-                textarea.focus();
+                textarea.focus({ preventScroll: true });
                 document.execCommand('insertText', false, charsToAdd + selectedText + charsToAdd + possibleAddedSpace);
             }
         } else {
@@ -119,16 +119,16 @@ export function initInputMarkdown() {
 
                 if (charsToAdd + discoveredWord + charsToAdd === discoveredWordWithPossibleFormatting) {
                     // Replace the expanded selection with the original discovered word
-                    textarea.focus();
+                    textarea.focus({ preventScroll: true });
                     document.execCommand('insertText', false, discoveredWord);
                     // Adjust cursor position
                     cursorShift = -charsToAdd.length;
                 } else { //format did not previously exist, so add it
-                    textarea.focus();
+                    textarea.focus({ preventScroll: true });
                     document.execCommand('insertText', false, charsToAdd + discoveredWord + charsToAdd);
                 }
             } else { //caret is not inside a word, so just add the formatting
-                textarea.focus();
+                textarea.focus({ preventScroll: true });
                 textarea.setSelectionRange(start, end);
                 selectedText = textarea.value.substring(start, end);
                 document.execCommand('insertText', false, charsToAdd + selectedText + charsToAdd);

--- a/public/scripts/macros/engine/MacroBrowser.js
+++ b/public/scripts/macros/engine/MacroBrowser.js
@@ -293,7 +293,7 @@ export class MacroBrowser {
             evt.preventDefault();
             evt.stopPropagation();
             evt.stopImmediatePropagation();
-            this.searchInput?.focus();
+            this.searchInput?.focus({ preventScroll: true });
         }
     }
 }

--- a/public/scripts/mobile-streaming.js
+++ b/public/scripts/mobile-streaming.js
@@ -3,6 +3,12 @@ import { isIOSWebKitPlatform } from './mobile-send-button.js';
 export const IOS_STREAMING_UPDATE_INTERVAL_MS = 250;
 export const IOS_REASONING_RENDER_INTERVAL_MS = 1500;
 
+const ANDROID_REASONING_RENDER_INTERVAL_MS = IOS_REASONING_RENDER_INTERVAL_MS;
+
+function isAndroidPlatform(navigatorRef = globalThis.navigator) {
+    return /Android/i.test(String(navigatorRef?.userAgent || ''));
+}
+
 /**
  * Checks whether Smooth Streaming is effectively active for the current platform.
  * @param {object} [options]
@@ -47,11 +53,27 @@ export function getMobileStreamingBottomPinBehavior({
  * Checks whether live streaming DOM work should be reduced for the current browser.
  * @param {Navigator} [navigatorRef] Navigator-like object
  * @param {object} [options]
- * @param {boolean} [options.enabled] Whether the iOS WebKit reduction is enabled
+ * @param {boolean} [options.enabled] Backwards-compatible iOS WebKit reduction toggle
+ * @param {boolean} [options.iosEnabled] Whether the iOS WebKit reduction is enabled
+ * @param {boolean} [options.androidEnabled] Whether the Android reduction is enabled
  * @returns {boolean}
  */
-export function shouldReduceStreamingDomWork(navigatorRef = globalThis.navigator, { enabled = true } = {}) {
-    return Boolean(enabled) && isIOSWebKitPlatform(navigatorRef);
+export function shouldReduceStreamingDomWork(navigatorRef = globalThis.navigator, { enabled = true, iosEnabled = enabled, androidEnabled = false } = {}) {
+    return (Boolean(iosEnabled) && isIOSWebKitPlatform(navigatorRef))
+        || (Boolean(androidEnabled) && isAndroidPlatform(navigatorRef));
+}
+
+/**
+ * Resolves the minimum live reasoning render interval for reduced streaming platforms.
+ * @param {Navigator} [navigatorRef] Navigator-like object
+ * @returns {number}
+ */
+export function getStreamingReasoningRenderInterval(navigatorRef = globalThis.navigator) {
+    if (isAndroidPlatform(navigatorRef)) {
+        return ANDROID_REASONING_RENDER_INTERVAL_MS;
+    }
+
+    return IOS_REASONING_RENDER_INTERVAL_MS;
 }
 
 /**

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2343,6 +2343,76 @@ function getModelSelectPickerOptionEntries(select) {
     return entries.filter(entry => entry.value);
 }
 
+function clampScrollValue(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function getLayoutViewportScrollAnchor() {
+    const scrollingElement = document.scrollingElement;
+
+    return {
+        left: Math.max(0, Math.round(window.scrollX || scrollingElement?.scrollLeft || 0)),
+        top: Math.max(0, Math.round(window.scrollY || scrollingElement?.scrollTop || 0)),
+    };
+}
+
+function restoreLayoutViewportScroll(anchor) {
+    if (!anchor) {
+        return;
+    }
+
+    const scrollingElement = document.scrollingElement;
+    if (scrollingElement instanceof Element) {
+        scrollingElement.scrollLeft = anchor.left;
+        scrollingElement.scrollTop = anchor.top;
+    }
+
+    if (window.scrollX !== anchor.left || window.scrollY !== anchor.top) {
+        window.scrollTo(anchor.left, anchor.top);
+    }
+}
+
+function scrollElementIntoNearestPanelScroller(element, { block = 'nearest' } = {}) {
+    if (!(element instanceof HTMLElement)) {
+        return;
+    }
+
+    const anchor = getLayoutViewportScrollAnchor();
+    const scroller = element.closest('.sb-model-id-picker-menu, .sb-shell-panel-scroller, .scrollableInner, .scrollableInnerFull');
+
+    if (!(scroller instanceof HTMLElement) || scroller.clientHeight <= 0) {
+        element.scrollIntoView({ block, inline: 'nearest' });
+        restoreLayoutViewportScroll(anchor);
+        requestAnimationFrame(() => restoreLayoutViewportScroll(anchor));
+        return;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const topOverflow = elementRect.top - scrollerRect.top;
+    const bottomOverflow = elementRect.bottom - scrollerRect.bottom;
+    let delta = 0;
+
+    if (block === 'center') {
+        delta = topOverflow - ((scrollerRect.height - elementRect.height) / 2);
+    } else if (block === 'start') {
+        delta = topOverflow;
+    } else if (block === 'end') {
+        delta = bottomOverflow;
+    } else if (topOverflow < 0) {
+        delta = topOverflow;
+    } else if (bottomOverflow > 0) {
+        delta = bottomOverflow;
+    }
+
+    if (Math.abs(delta) > 1) {
+        scroller.scrollTop = clampScrollValue(scroller.scrollTop + delta, 0, Math.max(0, scroller.scrollHeight - scroller.clientHeight));
+    }
+
+    restoreLayoutViewportScroll(anchor);
+    requestAnimationFrame(() => restoreLayoutViewportScroll(anchor));
+}
+
 function openInlineModelSelectPicker(select, { input = null, source = select.id } = {}) {
     const row = input instanceof HTMLInputElement && input.parentElement instanceof HTMLElement ? input.parentElement : null;
     const menuParent = row?.parentElement;
@@ -2406,7 +2476,7 @@ function openInlineModelSelectPicker(select, { input = null, source = select.id 
     menu.hidden = !willOpen;
 
     if (!menu.hidden) {
-        menu.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        scrollElementIntoNearestPanelScroller(menu.querySelector('[aria-selected="true"]'));
     }
 
     return true;
@@ -2529,7 +2599,7 @@ function openInlineSelectPicker(select, { source = select.id, label = select.id,
     menu.hidden = !willOpen;
 
     if (!menu.hidden) {
-        menu.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        scrollElementIntoNearestPanelScroller(menu.querySelector('[aria-selected="true"]'));
     }
 
     return true;
@@ -2604,7 +2674,7 @@ function openModelSelectPicker(select, options = {}) {
         return;
     }
 
-    select.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    scrollElementIntoNearestPanelScroller(select);
 
     if (shouldUseInlineModelSelectPicker() && openInlineModelSelectPicker(select, options)) {
         return;

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -728,7 +728,7 @@ export class Popup {
             // interactable only gets applied when inserted into the DOM
             control.tabIndex = 0;
         } else {
-            control.focus();
+            control.focus({ preventScroll: true });
         }
     }
 
@@ -841,7 +841,7 @@ export class Popup {
                 const id = activeDialog?.getAttribute('data-id');
                 const popup = Popup.util.popups.find(x => x.id == id);
                 if (popup) {
-                    if (popup.lastFocus) popup.lastFocus.focus();
+                    if (popup.lastFocus) popup.lastFocus.focus({ preventScroll: true });
                     else popup.setAutoFocus();
                 }
             }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -314,6 +314,8 @@ export const power_user = {
     ios_webkit_reduce_streaming_work: true,
     ios_webkit_disable_smooth_streaming: true,
     ios_webkit_disable_stream_fade_in: true,
+    android_conservative_streaming: true,
+    android_disable_stream_fade_in: true,
 
     // SillyBunny: aggressive DOM unloading for low-memory devices
     aggressive_dom_unload: false,

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -9,7 +9,7 @@ import { chat_completion_sources, getChatCompletionModel, oai_settings } from '.
 import { Popup } from './popup.js';
 import { performFuzzySearch, power_user } from './power-user.js';
 import { getPresetManager } from './preset-manager.js';
-import { shouldReduceStreamingDomWork, shouldRenderLiveReasoningContent } from './mobile-streaming.js';
+import { getStreamingReasoningRenderInterval, shouldReduceStreamingDomWork, shouldRenderLiveReasoningContent } from './mobile-streaming.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -670,8 +670,10 @@ export class ReasoningHandler {
         setDatasetProperty(this.messageReasoningDetailsDom, 'type', this.type);
 
         const now = Date.now();
-        const shouldReduceReasoningDomWork = shouldReduceStreamingDomWork(globalThis.navigator, {
-            enabled: power_user.ios_webkit_conservative_streaming,
+        const navigatorRef = globalThis.navigator;
+        const shouldReduceReasoningDomWork = shouldReduceStreamingDomWork(navigatorRef, {
+            iosEnabled: power_user.ios_webkit_conservative_streaming,
+            androidEnabled: power_user.android_conservative_streaming,
         });
         const shouldRenderReasoning = shouldRenderLiveReasoningContent({
             isReducedDomWork: shouldReduceReasoningDomWork,
@@ -680,20 +682,22 @@ export class ReasoningHandler {
             hasRenderedContent: Boolean(this.messageReasoningContentDom.childNodes.length),
             lastRenderAt: this.#lastReasoningDomRenderAt,
             now,
+            minIntervalMs: getStreamingReasoningRenderInterval(navigatorRef),
         });
 
-        // SillyBunny: iOS WebKit can force-reload under reasoning-heavy streams if we
+        // SillyBunny: mobile browsers can force-reload under reasoning-heavy streams if we
         // format and morph a growing hidden reasoning block on every live tick.
         if (shouldRenderReasoning) {
-            // SillyBunny: throttle live reasoning DOM work on iOS WebKit so large
+            // SillyBunny: throttle live reasoning DOM work on reduced platforms so large
             // hidden reasoning blocks do not cause aggressive repaint or reload loops.
             const reasoning = trimSpaces(this.reasoningDisplayText ?? this.reasoning);
             const displayReasoning = messageFormatting(reasoning, '', false, false, messageId, {}, true);
 
             if (power_user.stream_fade_in) {
                 applyStreamFadeIn(this.messageReasoningContentDom, displayReasoning, {
-                    bypassFadeIn: shouldReduceStreamingDomWork(globalThis.navigator, {
-                        enabled: power_user.ios_webkit_disable_stream_fade_in,
+                    bypassFadeIn: shouldReduceStreamingDomWork(navigatorRef, {
+                        iosEnabled: power_user.ios_webkit_disable_stream_fade_in,
+                        androidEnabled: power_user.android_disable_stream_fade_in,
                     }),
                 });
             } else {
@@ -1417,7 +1421,7 @@ function setReasoningEventHandlers() {
             resetHeight();
         }
 
-        textarea.focus();
+        textarea.focus({ preventScroll: true });
         textarea.setSelectionRange(textarea.value.length, textarea.value.length);
 
         const textareaRect = textarea.getBoundingClientRect();

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -125,7 +125,7 @@ function focusConversationInput({ skipIOS = false } = {}) {
 
     const input = document.getElementById(CHROME_IDS.input);
     if (input instanceof HTMLTextAreaElement) {
-        input.focus();
+        input.focus({ preventScroll: true });
     }
 }
 

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -161,7 +161,7 @@ export function editConversationMessage(messageId) {
 
     textElement.textContent = '';
     textElement.append(textarea, buttonContainer);
-    textarea.focus();
+    textarea.focus({ preventScroll: true });
 
     saveButton.onclick = () => {
         const value = textarea.value.trim();

--- a/public/scripts/sillybunny-conversation/pickers.js
+++ b/public/scripts/sillybunny-conversation/pickers.js
@@ -354,7 +354,7 @@ export function toggleAddDmPicker() {
     renderList();
 
     if (searchInput instanceof HTMLInputElement) {
-        searchInput.focus();
+        searchInput.focus({ preventScroll: true });
         searchInput.addEventListener('input', () => {
             renderList(searchInput.value.toLowerCase().trim());
         });
@@ -648,7 +648,7 @@ export function toggleConversationGroupPicker({ sourceAvatar = '', sourceGroupId
     renderList();
 
     if (searchInput instanceof HTMLInputElement) {
-        searchInput.focus();
+        searchInput.focus({ preventScroll: true });
         searchInput.addEventListener('input', () => {
             renderList(searchInput.value.toLowerCase().trim());
         });

--- a/public/scripts/sillybunny-conversation/settings-panel.js
+++ b/public/scripts/sillybunny-conversation/settings-panel.js
@@ -408,10 +408,10 @@ export function openScheduleEditorModal(initialAvatar = getCurrentCharAvatar()) 
         const last = focusable[focusable.length - 1];
         if (event.shiftKey && document.activeElement === first) {
             event.preventDefault();
-            last.focus();
+            last.focus({ preventScroll: true });
         } else if (!event.shiftKey && document.activeElement === last) {
             event.preventDefault();
-            first.focus();
+            first.focus({ preventScroll: true });
         }
     });
     setTimeout(() => {

--- a/public/scripts/sillybunny-conversation/timeline-render.js
+++ b/public/scripts/sillybunny-conversation/timeline-render.js
@@ -661,7 +661,7 @@ export function replyToConversationMessage(messageId) {
 
     input.value = newText;
     input.dispatchEvent(new Event('input', { bubbles: true }));
-    input.focus();
+    input.focus({ preventScroll: true });
 
     // Position cursor at the very end
     input.setSelectionRange(input.value.length, input.value.length);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2315,6 +2315,89 @@ function restoreShellFocus(shellKey) {
     }
 }
 
+function getLayoutViewportScrollAnchor() {
+    const scrollingElement = document.scrollingElement;
+
+    return {
+        left: Math.max(0, Math.round(window.scrollX || scrollingElement?.scrollLeft || 0)),
+        top: Math.max(0, Math.round(window.scrollY || scrollingElement?.scrollTop || 0)),
+    };
+}
+
+function restoreLayoutViewportScroll(anchor) {
+    if (!anchor) {
+        return;
+    }
+
+    const scrollingElement = document.scrollingElement;
+    if (scrollingElement instanceof Element) {
+        scrollingElement.scrollLeft = anchor.left;
+        scrollingElement.scrollTop = anchor.top;
+    }
+
+    if (window.scrollX !== anchor.left || window.scrollY !== anchor.top) {
+        window.scrollTo(anchor.left, anchor.top);
+    }
+}
+
+function queueLayoutViewportScrollRestore(anchor) {
+    restoreLayoutViewportScroll(anchor);
+    window.requestAnimationFrame(() => restoreLayoutViewportScroll(anchor));
+    window.setTimeout(() => restoreLayoutViewportScroll(anchor), 120);
+}
+
+function getManagedScrollContainer(target) {
+    if (!(target instanceof HTMLElement)) {
+        return null;
+    }
+
+    return target.closest('.sb-shell-panel-scroller, .scrollableInner, .scrollableInnerFull, .sb-search-results, #chat');
+}
+
+function scrollElementIntoManagedView(target, { block = 'nearest', behavior = 'auto' } = {}) {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    const anchor = getLayoutViewportScrollAnchor();
+    const scroller = getManagedScrollContainer(target);
+
+    if (!(scroller instanceof HTMLElement) || scroller.clientHeight <= 0) {
+        target.scrollIntoView({ block, behavior });
+        queueLayoutViewportScrollRestore(anchor);
+        return false;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const topOverflow = targetRect.top - scrollerRect.top;
+    const bottomOverflow = targetRect.bottom - scrollerRect.bottom;
+    let delta = 0;
+
+    if (block === 'center') {
+        delta = topOverflow - ((scrollerRect.height - targetRect.height) / 2);
+    } else if (block === 'end') {
+        delta = bottomOverflow;
+    } else if (block === 'start') {
+        delta = topOverflow;
+    } else if (topOverflow < 0) {
+        delta = topOverflow;
+    } else if (bottomOverflow > 0) {
+        delta = bottomOverflow;
+    }
+
+    if (Math.abs(delta) > 1) {
+        const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+        scroller.scrollTo({
+            top: clampNumber(scroller.scrollTop + delta, 0, maxScrollTop),
+            behavior,
+        });
+    }
+
+    queueLayoutViewportScrollRestore(anchor);
+    return true;
+}
+
 function scrollShellTabButtonIntoView(nav, button, { smooth = false } = {}) {
     if (!(nav instanceof HTMLElement) || !(button instanceof HTMLElement)) {
         return;
@@ -5253,7 +5336,7 @@ function showBottomChatMassDeleteDialog(files, currentChatId) {
         document.addEventListener('keydown', handleKeydown);
         updateStatus();
         if (!isMobileViewport()) {
-            ageInput.focus();
+            ageInput.focus({ preventScroll: true });
         }
     });
 }
@@ -6223,7 +6306,7 @@ async function applyChatSearchHighlights({ scrollToFirst = false } = {}) {
     setSearchStatusText(getChatSearchStatusText(totalMatches, renderedMatches));
 
     if (scrollToFirst && firstMatch instanceof HTMLElement) {
-        firstMatch.scrollIntoView({
+        scrollElementIntoManagedView(firstMatch, {
             block: 'center',
             behavior: getReducedMotionScrollBehavior(),
         });
@@ -6232,7 +6315,7 @@ async function applyChatSearchHighlights({ scrollToFirst = false } = {}) {
         if (messageElement instanceof HTMLElement) {
             messageElement.classList.add('sb-search-hit');
             window.setTimeout(() => messageElement.classList.remove('sb-search-hit'), 2400);
-            messageElement.scrollIntoView({
+            scrollElementIntoManagedView(messageElement, {
                 block: 'center',
                 behavior: getReducedMotionScrollBehavior(),
             });
@@ -7471,7 +7554,7 @@ function setCharacterEditorFullscreenState(expanded, { focusButton = false } = {
     }
 
     if (isExpanded && !wasExpanded) {
-        document.getElementById('sb_character_editor_subtabs')?.scrollIntoView({ block: 'nearest' });
+        scrollElementIntoManagedView(document.getElementById('sb_character_editor_subtabs'), { block: 'nearest' });
     }
 }
 
@@ -11354,7 +11437,7 @@ async function handleSillyTavernFolderImport() {
     if (!sourcePath) {
         setServerAdminMessage(refs.note, 'Paste the path to your SillyTavern folder or user data folder first.', 'warn');
         toastr.warning('Paste a SillyTavern folder path first.', 'Import SillyTavern');
-        refs.pathInput.focus();
+        refs.pathInput.focus({ preventScroll: true });
         return;
     }
 
@@ -11397,7 +11480,7 @@ async function handleSillyTavernExtensionSync() {
     if (!sourcePath) {
         setServerAdminMessage(refs.note, 'Paste the path to your existing SillyTavern folder before syncing extensions.', 'warn');
         toastr.warning('Paste a SillyTavern folder path first.', 'Sync Extensions');
-        refs.pathInput.focus();
+        refs.pathInput.focus({ preventScroll: true });
         return;
     }
 
@@ -13351,7 +13434,7 @@ function setUniversalSearchActiveIndex(index) {
         button.setAttribute('aria-selected', String(active));
         if (active) {
             input?.setAttribute('aria-activedescendant', button.id);
-            button.scrollIntoView({ block: 'nearest' });
+            scrollElementIntoManagedView(button, { block: 'nearest' });
         }
     }
 
@@ -13455,7 +13538,7 @@ function revealSearchMatch(shellKey, match) {
         if (match.element instanceof HTMLElement) {
             window.setTimeout(() => {
                 expandHiddenAccordions(match.element);
-                match.element.scrollIntoView({
+                scrollElementIntoManagedView(match.element, {
                     block: 'center',
                     behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
                 });
@@ -13471,7 +13554,7 @@ function revealSearchMatch(shellKey, match) {
     window.setTimeout(() => {
         revealSettingsCategoryFor(match.element);
         expandHiddenAccordions(match.element);
-        match.element.scrollIntoView({
+        scrollElementIntoManagedView(match.element, {
             block: 'center',
             behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
         });
@@ -13521,7 +13604,7 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
     shellState.updateNavScrollIndicators?.();
 
     if (focusButton && isActuallyVisible(activeTab.button)) {
-        activeTab.button?.focus();
+        activeTab.button?.focus({ preventScroll: true });
     } else if (isShellOpen(shellKey)) {
         window.requestAnimationFrame(() => focusShellPanel(shellKey, { force: true }));
     }
@@ -15950,7 +16033,7 @@ function openPersonaAppendicesManager() {
         document.getElementById('persona_editor_tab_prompt')?.click();
         const appendicesHeading = document.getElementById('persona_appendices_heading');
         const addButton = document.getElementById('persona_appendix_add');
-        (appendicesHeading ?? addButton)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        scrollElementIntoManagedView(appendicesHeading ?? addButton, { block: 'center', behavior: getReducedMotionScrollBehavior() });
         addButton?.focus({ preventScroll: true });
     }, 160);
 }

--- a/public/scripts/slash-commands/SlashCommandBrowser.js
+++ b/public/scripts/slash-commands/SlashCommandBrowser.js
@@ -141,7 +141,7 @@ export class SlashCommandBrowser {
             evt.preventDefault();
             evt.stopPropagation();
             evt.stopImmediatePropagation();
-            this.search.focus();
+            this.search.focus({ preventScroll: true });
         }
     }
 }

--- a/public/scripts/swipe-picker.js
+++ b/public/scripts/swipe-picker.js
@@ -308,7 +308,7 @@ async function openSwipePicker(messageId) {
         onOpen: function () {
             scrollToSelectedSwipe();
             if (swipeIdInput instanceof HTMLInputElement) {
-                swipeIdInput.focus();
+                swipeIdInput.focus({ preventScroll: true });
                 swipeIdInput.select();
             }
         },
@@ -323,7 +323,7 @@ async function openSwipePicker(messageId) {
             if (!Number.isInteger(targetSwipeNumber) || targetSwipeNumber < 1 || targetSwipeNumber > message.swipes.length) {
                 toastr.warning(t`Enter a swipe ID between 1 and ${message.swipes.length}.`, t`Jump to Swipe`);
                 if (swipeIdInput instanceof HTMLInputElement) {
-                    swipeIdInput.focus();
+                    swipeIdInput.focus({ preventScroll: true });
                     swipeIdInput.select();
                 }
                 return false;

--- a/public/scripts/system-messages.js
+++ b/public/scripts/system-messages.js
@@ -166,7 +166,7 @@ export function sendSystemMessage(type, text, extra = {}) {
         const parent = spinner.parentElement;
         spinner.remove();
         browser.renderInto(parent);
-        browser.search.focus();
+        browser.search.focus({ preventScroll: true });
     }
 
     if (type === system_message_types.MACROS) {
@@ -176,7 +176,7 @@ export function sendSystemMessage(type, text, extra = {}) {
             const parent = spinner.parentElement;
             spinner.remove();
             browser.renderInto(parent);
-            browser.searchInput?.focus();
+            browser.searchInput?.focus({ preventScroll: true });
         }
     }
 }

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1986,7 +1986,16 @@ function onTagCreateClick() {
     printViewTagList($('#tag_view_list .tag_view_list_tags'));
 
     const tagElement = ($('#tag_view_list .tag_view_list_tags')).find(`.tag_view_item[id="${tag.id}"]`);
-    tagElement[0]?.scrollIntoView();
+    const tagElementNode = tagElement[0];
+    const tagList = tagElementNode?.closest?.('.tag_view_list_tags');
+    if (tagElementNode instanceof HTMLElement && tagList instanceof HTMLElement) {
+        const listRect = tagList.getBoundingClientRect();
+        const tagRect = tagElementNode.getBoundingClientRect();
+        const overflow = tagRect.bottom - listRect.bottom;
+        if (overflow > 0) {
+            tagList.scrollTop = Math.min(tagList.scrollTop + overflow, Math.max(0, tagList.scrollHeight - tagList.clientHeight));
+        }
+    }
     flashHighlight(tagElement);
 
     printCharactersDebounced();
@@ -2809,7 +2818,7 @@ export function initTags() {
         // If the new focus would've been inside the now redrawn tag list, we should at least move back the focus to the current name
         // Otherwise tab-navigation gets a bit weird
         if (evt.relatedTarget instanceof HTMLElement && $(evt.relatedTarget).closest('#tag_view_list')) {
-            $(`#tag_view_list .tag_view_item[id="${tagId}"] .tag_view_name`)[0]?.focus();
+            $(`#tag_view_list .tag_view_item[id="${tagId}"] .tag_view_name`)[0]?.focus({ preventScroll: true });
         }
 
         const newOrder = $('#tag_view_list .tag_view_item').map((_, el) => el.id).get();

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -553,7 +553,7 @@ export function copyText(text) {
     const textArea = document.createElement('textarea');
     textArea.value = text;
     parent.appendChild(textArea);
-    textArea.focus();
+    textArea.focus({ preventScroll: true });
     textArea.select();
     document.execCommand('copy');
     parent.removeChild(textArea);

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -1046,7 +1046,13 @@ async function highlightLaunchpadItem(extensionId) {
         return false;
     }
 
-    card.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    const panelRect = welcomePanel.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect();
+    const delta = (cardRect.top - panelRect.top) - ((panelRect.height - cardRect.height) / 2);
+    welcomePanel.scrollTo({
+        top: Math.min(Math.max(welcomePanel.scrollTop + delta, 0), Math.max(0, welcomePanel.scrollHeight - welcomePanel.clientHeight)),
+        behavior: 'smooth',
+    });
     flashHighlight($(card), 1400);
     return true;
 }
@@ -1175,7 +1181,7 @@ function focusSendTextarea(sendTextArea, { skipIOS = false } = {}) {
     }
 
     if (sendTextArea instanceof HTMLTextAreaElement) {
-        sendTextArea.focus();
+        sendTextArea.focus({ preventScroll: true });
     }
 }
 

--- a/tests/mobile-streaming.test.js
+++ b/tests/mobile-streaming.test.js
@@ -1,9 +1,11 @@
 import {
     getMobileStreamingBottomPinBehavior,
+    getStreamingReasoningRenderInterval,
     getStreamingUpdateInterval,
     IOS_REASONING_RENDER_INTERVAL_MS,
     IOS_STREAMING_UPDATE_INTERVAL_MS,
     isSmoothStreamingEffectivelyEnabled,
+    shouldReduceStreamingDomWork,
     shouldRenderLiveReasoningContent,
 } from '../public/scripts/mobile-streaming.js';
 
@@ -34,6 +36,38 @@ describe('mobile streaming helpers', () => {
             navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
             enabled: false,
         })).toBe(33);
+    });
+
+    test('honors platform-specific reduced DOM work toggles', () => {
+        expect(shouldReduceStreamingDomWork({ platform: 'iPhone', maxTouchPoints: 1 }, {
+            iosEnabled: false,
+        })).toBe(false);
+
+        expect(shouldReduceStreamingDomWork({ platform: 'iPhone', maxTouchPoints: 1 }, {
+            iosEnabled: true,
+        })).toBe(true);
+
+        expect(shouldReduceStreamingDomWork({
+            platform: 'Linux armv8l',
+            userAgent: 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36',
+        }, {
+            androidEnabled: true,
+        })).toBe(true);
+
+        expect(shouldReduceStreamingDomWork({
+            platform: 'Linux armv8l',
+            userAgent: 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36',
+        })).toBe(false);
+    });
+
+    test('exports the live reasoning render interval helper', () => {
+        expect(getStreamingReasoningRenderInterval({ platform: 'iPhone', maxTouchPoints: 1 }))
+            .toBe(IOS_REASONING_RENDER_INTERVAL_MS);
+
+        expect(getStreamingReasoningRenderInterval({
+            platform: 'Linux armv8l',
+            userAgent: 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36',
+        })).toBe(IOS_REASONING_RENDER_INTERVAL_MS);
     });
 
     test('reports effective Smooth Streaming after iOS WebKit bypasses', () => {


### PR DESCRIPTION
Will likely need extensive testing to ensure no unintended breaks, but basically I've tried to harden the viewport escapes that keep happening across mobile and PC both. This sets up a viewport anchor so accidental page-level scrolls always snap back to 0. Additionally, it changes the direct scrollIntoView() function with scoped scrolling functions instead.

Finally, all scanned, non-vendored plain .focus() calls are now converted to focus ({preventSCroll: true}) functions. This should HOPEFULLY cause less of these viewport drifts that put the top menu out of reach, and show you black spaces with nothing in it.