### PR TITLE
feat(tts) - add stop button for TTS playback

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -51,6 +51,7 @@ let lastMessageHash = null;
 let periodicMessageGenerationTimer = null;
 let lastPositionOfParagraphEnd = -1;
 let currentInitVoiceMapPromise = null;
+let activeNarrateButton = null;
 
 const DEFAULT_VOICE_MARKER = '[Default Voice]';
 const DISABLED_VOICE_MARKER = 'disabled';
@@ -170,6 +171,12 @@ let ttsProviderName;
 
 
 async function onNarrateOneMessage() {
+    if (isTtsProcessing()) {
+        resetTtsPlayback();
+        resetNarrateButtonIcon();
+        return;
+    }
+
     audioElement.src = '/sounds/silence.mp3';
     const context = getContext();
     const id = $(this).closest('.mes').attr('mesid');
@@ -182,6 +189,9 @@ async function onNarrateOneMessage() {
     resetTtsPlayback();
     processAndQueueTtsMessage(message, Number(id), { manual: true });
     moduleWorker();
+
+    activeNarrateButton = $(this);
+    activeNarrateButton.removeClass('fa-bullhorn').addClass('fa-stop');
 }
 
 async function onNarrateText(args, text) {
@@ -250,6 +260,14 @@ function resetTtsPlayback() {
 
     // Set audio ready to process again
     audioQueueProcessorReady = true;
+    resetNarrateButtonIcon();
+}
+
+function resetNarrateButtonIcon() {
+    if (activeNarrateButton) {
+        activeNarrateButton.removeClass('fa-stop').addClass('fa-bullhorn');
+        activeNarrateButton = null;
+    }
 }
 
 function isTtsProcessing() {
@@ -460,6 +478,9 @@ function addAudioControl() {
 function completeCurrentAudioJob() {
     audioQueueProcessorReady = true;
     currentAudioJob = null;
+    if (!isTtsProcessing()) {
+        resetNarrateButtonIcon();
+    }
     // updateUiPlayState();
     wrapper.update();
 }


### PR DESCRIPTION
<!---
Thank you for contributing to SillyBunny!

Please [read the Contributor's Guide](https://github.com/platberlitz/SillyBunny/blob/main/CONTRIBUTING.md) before submitting a pull request.

In this project we follow [Conventional Commits][2] as prefixes to describe features and fixes.

- `fix` - a direct bug fix.
- `chore` - a simple maintenance change.
- `feat` - a new feature implementation.
- `sync` - synchronizing with upstream.
- `docs` - new documentation or modifications to documentation.

More information here:

[1]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[2]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Small PR to add a stop button to TTS playback
What it does -
- When playback starts, the narrate icon is replaced by a stop icon
 - if playback ends normally the icon returns to the normal narrate icon automatically
 - playback can be stopped before it ends by clicking the stop icon. This should stop TTS playback immediately and return the icon back to it's original state.
 
 Without this there's no way to stop TTS playback once it has started.
 
 (Disclaimer - code is AI assisted but this overview is not)