### PR TITLE
fix(ica): render macros in Companion Agents drawer

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-dashboard.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-dashboard.js
@@ -17,6 +17,7 @@ import {
     runCompanionAgentOnMessage,
     runCompanionsOnMessage,
 } from './companion-runner.js';
+import { resolveCompanionContentMacros } from './companion-macros.js';
 import { openCompanionPanel } from './companion-panel.js';
 import {
     MESSAGE_INBOX_EMPTY_OUTPUTS,
@@ -138,7 +139,7 @@ export function collectRecentNoteEntries(limit = RECENT_NOTES_LIMIT) {
                 continue;
             }
 
-            const content = String(result.content ?? '').replace(/\s+/g, ' ').trim();
+            const content = resolveCompanionContentMacros(String(result.content ?? ''), message).replace(/\s+/g, ' ').trim();
             entries.push({
                 messageIndex,
                 agentId,

--- a/public/scripts/extensions/in-chat-agents/companion/companion-macros.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-macros.js
@@ -2,7 +2,7 @@ import { substituteParams } from '../../../../script.js';
 
 export function resolveCompanionContentMacros(content = '', message = null) {
     return substituteParams(content, {
-        name2Override: String(message?.name ?? '').trim(),
+        name2Override: message && !message.is_user ? String(message.name ?? '').trim() || undefined : undefined,
         original: String(message?.mes ?? ''),
     });
 }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-macros.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-macros.js
@@ -1,7 +1,20 @@
 import { substituteParams } from '../../../../script.js';
 
+const ESCAPED_MACRO_OPEN_RE = /\\\{\\\{/g;
+const ESCAPED_MACRO_CLOSE_RE = /\\\}\\\}/g;
+const ENTITY_OPEN_BRACE_RE = /&(?:#123|#x7b|lcub);/gi;
+const ENTITY_CLOSE_BRACE_RE = /&(?:#125|#x7d|rcub);/gi;
+
+function normalizeCompanionMacroSyntax(content = '') {
+    return String(content ?? '')
+        .replace(ESCAPED_MACRO_OPEN_RE, '{{')
+        .replace(ESCAPED_MACRO_CLOSE_RE, '}}')
+        .replace(ENTITY_OPEN_BRACE_RE, '{')
+        .replace(ENTITY_CLOSE_BRACE_RE, '}');
+}
+
 export function resolveCompanionContentMacros(content = '', message = null) {
-    return substituteParams(content, {
+    return substituteParams(normalizeCompanionMacroSyntax(content), {
         name2Override: message && !message.is_user ? String(message.name ?? '').trim() || undefined : undefined,
         original: String(message?.mes ?? ''),
     });

--- a/public/scripts/extensions/in-chat-agents/companion/companion-macros.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-macros.js
@@ -1,0 +1,8 @@
+import { substituteParams } from '../../../../script.js';
+
+export function resolveCompanionContentMacros(content = '', message = null) {
+    return substituteParams(content, {
+        name2Override: String(message?.name ?? '').trim(),
+        original: String(message?.mes ?? ''),
+    });
+}

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -403,10 +403,6 @@ function capResultContent(value = '') {
     return stripMarkdownFence(value).slice(0, MAX_COMPANION_RESULT_CHARS);
 }
 
-function resolveGeneratedCompanionContent(value = '', message = null) {
-    return capResultContent(resolveCompanionContentMacros(value, message));
-}
-
 function getProfileLabel(agent, responseProfileId = '') {
     const profileId = String(responseProfileId || resolveCompanionConnectionProfile(agent?.connectionProfile) || '').trim();
     if (!profileId) {
@@ -1127,7 +1123,7 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
 
         setCompanionResult(message, agent, {
             status: 'done',
-            content: resolveGeneratedCompanionContent(response.output, message),
+            content: capResultContent(response.output),
             error: '',
             profileId: response.profileId,
             profileLabel: getProfileLabel(agent, response.profileId),
@@ -1220,7 +1216,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
 
             setCompanionResult(message, agent, {
                 status: 'done',
-                content: resolveGeneratedCompanionContent(parsed.get(agent.id), message),
+                content: capResultContent(parsed.get(agent.id)),
                 error: '',
                 profileId: response.profileId,
                 profileLabel: getProfileLabel(agent, response.profileId),

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -403,6 +403,10 @@ function capResultContent(value = '') {
     return stripMarkdownFence(value).slice(0, MAX_COMPANION_RESULT_CHARS);
 }
 
+function resolveGeneratedCompanionContent(value = '', message = null) {
+    return capResultContent(resolveCompanionContentMacros(value, message));
+}
+
 function getProfileLabel(agent, responseProfileId = '') {
     const profileId = String(responseProfileId || resolveCompanionConnectionProfile(agent?.connectionProfile) || '').trim();
     if (!profileId) {
@@ -1123,7 +1127,7 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
 
         setCompanionResult(message, agent, {
             status: 'done',
-            content: capResultContent(response.output),
+            content: resolveGeneratedCompanionContent(response.output, message),
             error: '',
             profileId: response.profileId,
             profileLabel: getProfileLabel(agent, response.profileId),
@@ -1216,7 +1220,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
 
             setCompanionResult(message, agent, {
                 status: 'done',
-                content: parsed.get(agent.id),
+                content: resolveGeneratedCompanionContent(parsed.get(agent.id), message),
                 error: '',
                 profileId: response.profileId,
                 profileLabel: getProfileLabel(agent, response.profileId),

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -39,7 +39,9 @@ import {
     PLOT_COMPASS_TEMPLATE_ID,
     getCompanionReferenceIds,
     isAssistantMessage,
+    normalizePlotCompassObjective,
 } from './companion-shared.js';
+import { resolveCompanionContentMacros } from './companion-macros.js';
 
 export const COMPANION_RESULTS_EXTRA_KEY = 'inChatAgentCompanionResults';
 export const COMPANION_RESULTS_UPDATED_EVENT = 'in_chat_agent_companion_results_updated';
@@ -353,7 +355,7 @@ function getDirectorCommentaryVoicePrompt(voice, settings = {}) {
     return DIRECTOR_COMMENTARY_VOICE_PRESETS[normalizedVoice] || DIRECTOR_COMMENTARY_VOICE_PRESETS['conspiratorial-absurdity'];
 }
 
-function getTemplateSettingsPromptBlock(agent = {}) {
+function getTemplateSettingsPromptBlock(agent = {}, message = null) {
     const sourceTemplateId = String(agent?.sourceTemplateId ?? '').trim();
 
     if (sourceTemplateId === CHATROOM_TEMPLATE_ID) {
@@ -384,7 +386,7 @@ function getTemplateSettingsPromptBlock(agent = {}) {
     }
 
     if (sourceTemplateId === PLOT_COMPASS_TEMPLATE_ID) {
-        const objective = String(agent.settings?.plotCompassObjective ?? '').trim();
+        const objective = normalizePlotCompassObjective(resolveCompanionContentMacros(agent.settings?.plotCompassObjective ?? '', message));
         return `[Plot Compass Objective]\n${objective || 'none set'}`;
     }
 
@@ -598,7 +600,11 @@ function getPreviousNotesSection(agent, messageIndex, companion) {
     return collectRecentCompanionResults(agent.id, {
         beforeMessageIndex: messageIndex,
         depth: companion.historyDepth,
-    }).map(result => `Message ${result.messageIndex}:\n${normalizeText(result.content)}`).join('\n\n');
+    }).map(result => `Message ${result.messageIndex}:\n${getResolvedCompanionResultContent(result, result.messageIndex)}`).join('\n\n');
+}
+
+function getResolvedCompanionResultContent(result = {}, messageIndex = -1) {
+    return normalizeText(resolveCompanionContentMacros(result.content ?? '', chat[messageIndex]));
 }
 
 function getSystemPromptSection(companion) {
@@ -718,7 +724,7 @@ function expandCompanionPrompt(agent, messageIndex, generationType = 'normal') {
         dynamicMacros: buildPromptDynamicMacros(messageText, message, agent, generationType),
     }).trim();
 
-    return [prompt, getTemplateSettingsPromptBlock(agent)].filter(Boolean).join('\n\n').trim();
+    return [prompt, getTemplateSettingsPromptBlock(agent, message)].filter(Boolean).join('\n\n').trim();
 }
 
 const COMPANION_REPAIR_INSTRUCTION = 'Repair mode: produce the requested result again in the requested format. Keep scene prose, character dialogue, and narrative continuation outside the result. For choice/menu agents, return the bracketed choice or direction block.';
@@ -857,12 +863,13 @@ function getCurrentCompanionContextContent(agent, messageIndex) {
     }
 
     const result = getCompanionResults(message)[agent.id];
-    return result?.status === 'done' ? normalizeText(result.content) : '';
+    return result?.status === 'done' ? getResolvedCompanionResultContent(result, messageIndex) : '';
 }
 
 function getLatestCompanionContextContent(agent, messageIndex) {
+    const latest = collectRecentCompanionResults(agent.id, { beforeMessageIndex: messageIndex, depth: 1 })[0];
     return getCurrentCompanionContextContent(agent, messageIndex)
-        || normalizeText(collectRecentCompanionResults(agent.id, { beforeMessageIndex: messageIndex, depth: 1 })[0]?.content);
+        || getResolvedCompanionResultContent(latest, latest?.messageIndex);
 }
 
 function getCompanionLinkedContextSections(agent, messageIndex, contextSourceAgents, agentByReferenceId) {
@@ -1440,7 +1447,7 @@ export function injectCompanionFeedbackPrompts(activeAgents = []) {
             continue;
         }
 
-        const body = notes.map(result => normalizeText(result.content)).filter(Boolean).join('\n\n');
+        const body = notes.map(result => getResolvedCompanionResultContent(result, result.messageIndex)).filter(Boolean).join('\n\n');
         if (!body) {
             continue;
         }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
@@ -239,17 +239,18 @@ export function formatCompanionContent(agentId, result = {}, message = null, sty
     }
 
     const content = applyAgentRegexToCompanionContent(agentId, rawContent, message);
+    const resolved = substituteParams(content);
     const sanitizeOptions = { prefix: stylePrefix };
 
     if (result.format === 'html') {
-        return decorateChoiceLines(sanitizeCompanionHtml(content, sanitizeOptions));
+        return decorateChoiceLines(sanitizeCompanionHtml(resolved, sanitizeOptions));
     }
 
     if (result.format === 'text') {
-        return `<pre class="ica--companion-text">${escapeHtml(content)}</pre>`;
+        return `<pre class="ica--companion-text">${escapeHtml(resolved)}</pre>`;
     }
 
-    return decorateChoiceLines(sanitizeCompanionHtml(getMarkdownConverter().makeHtml(content), sanitizeOptions));
+    return decorateChoiceLines(sanitizeCompanionHtml(getMarkdownConverter().makeHtml(resolved), sanitizeOptions));
 }
 
 function getResultStatus(result = {}) {

--- a/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
@@ -14,6 +14,7 @@ import {
     saveAgent,
 } from '../agent-store.js';
 import { AGENT_REGEX_PLACEMENT, applyRegexScriptList } from '../regex-scripts.js';
+import { resolveCompanionContentMacros } from './companion-macros.js';
 import {
     COMPANION_RESULTS_UPDATED_EVENT,
     deleteCompanionResult,
@@ -239,7 +240,7 @@ export function formatCompanionContent(agentId, result = {}, message = null, sty
     }
 
     const content = applyAgentRegexToCompanionContent(agentId, rawContent, message);
-    const resolved = substituteParams(content);
+    const resolved = resolveCompanionContentMacros(content, message);
     const sanitizeOptions = { prefix: stylePrefix };
 
     if (result.format === 'html') {

--- a/tests/in-chat-agents-companion-dashboard.test.js
+++ b/tests/in-chat-agents-companion-dashboard.test.js
@@ -58,6 +58,10 @@ describe('companion dashboard', () => {
 
         await jest.unstable_mockModule('../public/script.js', () => ({
             chat,
+            substituteParams: jest.fn((value, options = {}) => String(value ?? '')
+                .replaceAll('{{user}}', 'Traveler')
+                .replaceAll('{{char}}', options.name2Override || 'Assistant')
+                .replaceAll('{{original}}', options.original ?? '')),
         }));
 
         await jest.unstable_mockModule('../public/scripts/events.js', () => ({
@@ -206,6 +210,21 @@ describe('companion dashboard', () => {
         expect(entries[1].snippet.length).toBeLessThanOrEqual(121);
         expect(entries.some(entry => entry.agentName === 'Pending')).toBe(false);
         expect(entries.some(entry => entry.agentName === 'Message Inbox')).toBe(false);
+    });
+
+    test('resolves macros in recent note snippets with the source message context', async () => {
+        const dashboard = await importDashboard();
+        const message = { name: 'Mona', is_user: false, is_system: false, mes: 'the stars are bright' };
+        chat.push(message);
+
+        companionResultsByMessage.set(message, {
+            'agent-a': { status: 'done', agentName: 'Notes', content: '{{user}} saw {{char}} write: {{original}}' },
+        });
+
+        const entries = dashboard.collectRecentNoteEntries();
+
+        expect(entries).toHaveLength(1);
+        expect(entries[0].snippet).toBe('Traveler saw Mona write: the stars are bright');
     });
 
     test('appends the wand menu item once and wires its click handler', async () => {

--- a/tests/in-chat-agents-companion.test.js
+++ b/tests/in-chat-agents-companion.test.js
@@ -257,6 +257,17 @@ describe('companion card ui', () => {
         expect(html).toBe('<md>Traveler noticed Aria said the door is open</md>');
     });
 
+    test('keeps the active character macro when the source message is from the user', async () => {
+        const { formatCompanionContent } = await importCompanionUi();
+
+        const html = formatCompanionContent('companion-tracker', {
+            content: '{{user}} asked {{char}} about {{original}}',
+            format: 'markdown',
+        }, { name: 'Traveler', is_user: true, mes: 'the hidden door' });
+
+        expect(html).toBe('<md>Traveler asked Assistant about the hidden door</md>');
+    });
+
     test('preserves style tags emitted by regex scripts in card bodies', async () => {
         agents[0].regexScripts = [{
             id: 'styled-card',

--- a/tests/in-chat-agents-companion.test.js
+++ b/tests/in-chat-agents-companion.test.js
@@ -66,7 +66,10 @@ describe('companion card ui', () => {
         await jest.unstable_mockModule('../public/script.js', () => ({
             chat,
             saveChatDebounced: jest.fn(),
-            substituteParams: jest.fn(value => String(value ?? '')),
+            substituteParams: jest.fn((value, options = {}) => String(value ?? '')
+                .replaceAll('{{user}}', 'Traveler')
+                .replaceAll('{{char}}', options.name2Override || 'Assistant')
+                .replaceAll('{{original}}', options.original ?? '')),
             substituteParamsExtended: jest.fn(value => String(value ?? '')),
         }));
 
@@ -243,6 +246,17 @@ describe('companion card ui', () => {
         expect(sanitize).toHaveBeenCalledWith('<div class="status">calm</div>', expect.anything());
     });
 
+    test('resolves companion output macros with the source message context', async () => {
+        const { formatCompanionContent } = await importCompanionUi();
+
+        const html = formatCompanionContent('companion-tracker', {
+            content: '{{user}} noticed {{char}} said {{original}}',
+            format: 'markdown',
+        }, { name: 'Aria', mes: 'the door is open' });
+
+        expect(html).toBe('<md>Traveler noticed Aria said the door is open</md>');
+    });
+
     test('preserves style tags emitted by regex scripts in card bodies', async () => {
         agents[0].regexScripts = [{
             id: 'styled-card',
@@ -305,14 +319,14 @@ describe('companion card ui', () => {
         const { formatCompanionContent } = await importCompanionUi();
 
         const html = formatCompanionContent('chatroom', {
-            content: "mixed|mixed @Rover_Stan/user/18/omg she's so precious/so sweet @Rinascita_Historian/user/42/The contrast is wild/analytical @CatEarEnthusiast/user/92/Kris is a real one/hype",
+            content: 'mixed|mixed @Rover_Stan/user/18/omg she\'s so precious/so sweet @Rinascita_Historian/user/42/The contrast is wild/analytical @CatEarEnthusiast/user/92/Kris is a real one/hype',
             format: 'html',
         }, { name: 'Assistant' });
 
         expect(html).toContain('Chatroom');
         expect(html).toContain('STYLE: mixed');
         expect(html).toContain('Rover_Stan');
-        expect(html).toContain("omg she's so precious");
+        expect(html).toContain('omg she\'s so precious');
         expect(html).toContain('Rinascita_Historian');
         expect(html).toContain('The contrast is wild');
         expect(html).toContain('CatEarEnthusiast');
@@ -334,7 +348,7 @@ describe('companion card ui', () => {
         const html = formatCompanionContent('chatroom', {
             content: [
                 'chatroom-style|reddit',
-                "chatroom|Laurus_Fan_99|meta|18|top comment|181|He's so pure!",
+                'chatroom|Laurus_Fan_99|meta|18|top comment|181|He\'s so pure!',
                 'chatroom|Gale_Watcher|meta|42|reply|42|She looks exhausted.',
                 'chatroom-end',
             ].join('\n'),
@@ -345,9 +359,9 @@ describe('companion card ui', () => {
         expect(html).toContain('Gale_Watcher');
         expect(html).toContain('top comment');
         expect(html).toContain('reply');
-        expect(html).toContain("He's so pure!");
+        expect(html).toContain('He\'s so pure!');
         expect(html).toContain('She looks exhausted.');
-        expect(html).not.toContain("top comment|181|He's so pure!");
+        expect(html).not.toContain('top comment|181|He\'s so pure!');
         expect(html).not.toContain('reply|42|She looks exhausted.');
     });
 

--- a/tests/in-chat-agents-companion.test.js
+++ b/tests/in-chat-agents-companion.test.js
@@ -257,6 +257,17 @@ describe('companion card ui', () => {
         expect(html).toBe('<md>Traveler noticed Aria said the door is open</md>');
     });
 
+    test('resolves escaped companion output macro delimiters before rendering', async () => {
+        const { formatCompanionContent } = await importCompanionUi();
+
+        const html = formatCompanionContent('companion-tracker', {
+            content: 'Objective: \\{\\{user\\}\\} ends up with &#123;&#123;char&#125;&#125;',
+            format: 'markdown',
+        }, { name: 'Aria', mes: 'the door is open' });
+
+        expect(html).toBe('<md>Objective: Traveler ends up with Aria</md>');
+    });
+
     test('keeps the active character macro when the source message is from the user', async () => {
         const { formatCompanionContent } = await importCompanionUi();
 

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -204,7 +204,10 @@ describe('in-chat agent post-processing runner', () => {
             setExtensionPrompt: jest.fn((key, value) => {
                 extensionPrompts[key] = { value };
             }),
-            substituteParams: jest.fn(value => String(value ?? '')),
+            substituteParams: jest.fn((value, options = {}) => String(value ?? '')
+                .replaceAll('{{user}}', 'Traveler')
+                .replaceAll('{{char}}', options.name2Override || 'Assistant')
+                .replaceAll('{{original}}', options.original ?? '')),
             generateQuietPrompt,
             getCurrentChatId: jest.fn(() => currentChatId),
             normalizeContentText: jest.fn(value => String(value ?? '')),
@@ -1235,7 +1238,7 @@ describe('in-chat agent post-processing runner', () => {
         const plotCompass = createCompanionAgent({
             id: 'plot-compass-companion',
             sourceTemplateId: 'tpl-plot-compass-companion',
-            settings: { plotCompassObjective: 'Reach the tower' },
+            settings: { plotCompassObjective: '{{user}} helps {{char}} after {{original}}' },
             companion: { rawPrompt: true },
             prompt: 'Plan from the objective.',
         });
@@ -1243,12 +1246,29 @@ describe('in-chat agent post-processing runner', () => {
 
         chat.push(
             { mes: 'Hello there.', name: 'User', is_user: true, is_system: false, extra: {} },
-            { mes: 'Assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} },
+            { mes: 'Assistant reply', name: 'Mira', is_user: false, is_system: false, extra: {} },
         );
 
         const messages = await companionRunner.buildCompanionPromptMessages(plotCompass, 1);
 
-        expect(messages[0].content).toContain('[Plot Compass Objective]\nReach the tower');
+        expect(messages[0].content).toContain('[Plot Compass Objective]\nTraveler helps Mira after Assistant reply');
+    });
+
+    test('uses the active character for Plot Compass objective macros on user-sourced runs', async () => {
+        const plotCompass = createCompanionAgent({
+            id: 'plot-compass-companion',
+            sourceTemplateId: 'tpl-plot-compass-companion',
+            settings: { plotCompassObjective: 'Guide {{char}} after {{original}}' },
+            companion: { rawPrompt: true },
+            prompt: 'Plan from the objective.',
+        });
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push({ mes: 'I step through the gate.', name: 'Traveler', is_user: true, is_system: false, extra: {} });
+
+        const messages = await companionRunner.buildCompanionPromptMessages(plotCompass, 0);
+
+        expect(messages[0].content).toContain('[Plot Compass Objective]\nGuide Assistant after I step through the gate.');
     });
 
     test('includes the system prompt and authors note sections when toggled on', async () => {
@@ -1300,6 +1320,28 @@ describe('in-chat agent post-processing runner', () => {
         chat.push({ mes: 'And then?', name: 'User', is_user: true, is_system: false, extra: {} });
         companionRunner.injectCompanionFeedbackPrompts([feedbackCompanion]);
         expect(extensionPrompts['inchat_agent_companion_feedback-companion'].value).toContain('Stale swipe state');
+    });
+
+    test('resolves companion macros before injecting feedback prompts', async () => {
+        const feedbackCompanion = createCompanionAgent({
+            id: 'feedback-companion',
+            companion: { feedback: { enabled: true, depth: 1 } },
+        });
+        enabledAgents = [feedbackCompanion];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        const reply = { mes: 'The door opened.', name: 'Mira', is_user: false, is_system: false, extra: {} };
+        chat.push(reply, { mes: 'Continue.', name: 'Traveler', is_user: true, is_system: false, extra: {} });
+        companionRunner.setCompanionResult(reply, feedbackCompanion, {
+            status: 'done',
+            content: '{{user}} saw {{char}} write: {{original}}',
+        });
+
+        companionRunner.injectCompanionFeedbackPrompts([feedbackCompanion]);
+        const injected = extensionPrompts['inchat_agent_companion_feedback-companion'].value;
+
+        expect(injected).toContain('Traveler saw Mira write: The door opened.');
+        expect(injected).not.toContain('{{user}}');
     });
 
     test('prepends an anti-echo guard when feedback body contains tracker-format blocks', async () => {
@@ -1458,12 +1500,13 @@ describe('in-chat agent post-processing runner', () => {
             { mes: 'Keep going.', name: 'User', is_user: true, is_system: false, extra: {} },
             { mes: 'Reply two', name: 'Assistant', is_user: false, is_system: false, extra: {} },
         );
-        companionRunner.setCompanionResult(chat[0], historyCompanion, { status: 'done', content: 'State after reply one' });
+        companionRunner.setCompanionResult(chat[0], historyCompanion, { status: 'done', content: '{{user}} saw {{char}} write: {{original}}' });
 
         const messages = await companionRunner.buildCompanionPromptMessages(historyCompanion, 2);
 
         expect(messages[1].content).toContain('[Your previous notes]');
-        expect(messages[1].content).toContain('State after reply one');
+        expect(messages[1].content).toContain('Traveler saw Assistant write: Reply one');
+        expect(messages[1].content).not.toContain('{{user}}');
 
         const noHistoryCompanion = createCompanionAgent({ id: 'no-history-companion', companion: { includeHistory: false } });
         const plainMessages = await companionRunner.buildCompanionPromptMessages(noHistoryCompanion, 2);

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1987,14 +1987,14 @@ describe('in-chat agent post-processing runner', () => {
         expect(chat[0].extra.inChatAgentCompanionResults['single-user-companion'].content).toBe('Single user note');
     });
 
-    test('stores generated companion notes with macros resolved from the source message', async () => {
+    test('stores generated companion notes raw and resolves them once when reused', async () => {
         generateQuietPrompt.mockResolvedValue('Objective: {{user}} ends up living with {{char}} after {{original}}');
 
         const companionAgent = createCompanionAgent({
             id: 'plot-compass',
             name: 'Plot Compass',
             sourceTemplateId: 'tpl-plot-compass-companion',
-            companion: { trigger: 'manual', displayMode: 'panel' },
+            companion: { trigger: 'manual', displayMode: 'panel', feedback: { enabled: true, depth: 1 } },
         });
         enabledAgents = [companionAgent];
 
@@ -2002,15 +2002,19 @@ describe('in-chat agent post-processing runner', () => {
 
         chat.push(
             { mes: 'User message', name: 'Traveler', is_user: true, is_system: false, extra: {} },
-            { mes: 'Mira opens the window.', name: 'Mira', is_user: false, is_system: false, extra: {} },
+            { mes: 'Mira sees literal {{char}} text.', name: 'Mira', is_user: false, is_system: false, extra: {} },
         );
 
         const result = await companionRunner.runCompanionAgentOnMessage('plot-compass', 1);
 
-        expect(result?.content).toBe('Objective: Traveler ends up living with Mira after Mira opens the window.');
-        expect(chat[1].extra.inChatAgentCompanionResults['plot-compass'].content).toBe('Objective: Traveler ends up living with Mira after Mira opens the window.');
-        expect(result?.content).not.toContain('{{user}}');
-        expect(result?.content).not.toContain('{{char}}');
+        expect(result?.content).toBe('Objective: {{user}} ends up living with {{char}} after {{original}}');
+        expect(chat[1].extra.inChatAgentCompanionResults['plot-compass'].content).toBe('Objective: {{user}} ends up living with {{char}} after {{original}}');
+
+        chat.push({ mes: 'Continue.', name: 'Traveler', is_user: true, is_system: false, extra: {} });
+        companionRunner.injectCompanionFeedbackPrompts([companionAgent]);
+        const injected = extensionPrompts['inchat_agent_companion_plot-compass'].value;
+        expect(injected).toContain('Objective: Traveler ends up living with Mira after Mira sees literal {{char}} text.');
+        expect(injected).not.toContain('{{user}}');
     });
 
     test('runs connected companions from wrench/fix flow', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1987,6 +1987,32 @@ describe('in-chat agent post-processing runner', () => {
         expect(chat[0].extra.inChatAgentCompanionResults['single-user-companion'].content).toBe('Single user note');
     });
 
+    test('stores generated companion notes with macros resolved from the source message', async () => {
+        generateQuietPrompt.mockResolvedValue('Objective: {{user}} ends up living with {{char}} after {{original}}');
+
+        const companionAgent = createCompanionAgent({
+            id: 'plot-compass',
+            name: 'Plot Compass',
+            sourceTemplateId: 'tpl-plot-compass-companion',
+            companion: { trigger: 'manual', displayMode: 'panel' },
+        });
+        enabledAgents = [companionAgent];
+
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push(
+            { mes: 'User message', name: 'Traveler', is_user: true, is_system: false, extra: {} },
+            { mes: 'Mira opens the window.', name: 'Mira', is_user: false, is_system: false, extra: {} },
+        );
+
+        const result = await companionRunner.runCompanionAgentOnMessage('plot-compass', 1);
+
+        expect(result?.content).toBe('Objective: Traveler ends up living with Mira after Mira opens the window.');
+        expect(chat[1].extra.inChatAgentCompanionResults['plot-compass'].content).toBe('Objective: Traveler ends up living with Mira after Mira opens the window.');
+        expect(result?.content).not.toContain('{{user}}');
+        expect(result?.content).not.toContain('{{char}}');
+    });
+
     test('runs connected companions from wrench/fix flow', async () => {
         globalSettings.companionExecutionMode = 'sequential';
         generateQuietPrompt


### PR DESCRIPTION
# Summary

## Issue
In the draggable Companion Agents drawer, macros such as {{user}}, {{char}}, etc are rendered as plaintext rather than converted through the DOM.