### PR TITLE
feat(ica): add a hide/unhide button for every agent in the Companion Agents drawer

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -169,11 +169,12 @@ let globalSettings = {
     companionExecutionMode: 'parallel',
     companionConcurrentWithPostGen: false,
     helperPrefillMessages: '',
+    hiddenCompanionAgentIds: [],
 };
 
 /**
  * Returns the global settings.
- * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, postMainInterceptShowMessageFirst: boolean, appendAgentsExecutionMode: 'parallel'|'sequential', helperPrefillMessages: string }}
+ * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, postMainInterceptShowMessageFirst: boolean, appendAgentsExecutionMode: 'parallel'|'sequential', helperPrefillMessages: string, hiddenCompanionAgentIds: string[] }}
  */
 export function getGlobalSettings() {
     return globalSettings;
@@ -195,6 +196,7 @@ export function setGlobalSettings(update) {
     globalSettings.helperPrefillMessages = typeof globalSettings.helperPrefillMessages === 'string'
         ? globalSettings.helperPrefillMessages
         : '';
+    globalSettings.hiddenCompanionAgentIds = normalizeAgentIdCollection(globalSettings.hiddenCompanionAgentIds);
 
     if (!globalSettings.scopedEnabledAgentIdsInitialized) {
         const scopedSetting = update.enabledAgentIdsByChatType;
@@ -204,6 +206,14 @@ export function setGlobalSettings(update) {
             AGENT_CHAT_SCOPE_KEYS.some(scope => Object.hasOwn(scopedSetting, scope)),
         );
     }
+}
+
+function normalizeAgentIdCollection(value = []) {
+    if (!value || typeof value[Symbol.iterator] !== 'function') {
+        return [];
+    }
+
+    return normalizeAgentIdList([...value]).sort();
 }
 
 function normalizeAgentIdList(value) {
@@ -216,6 +226,26 @@ function normalizeAgentIdList(value) {
             .map(id => String(id ?? '').trim())
             .filter(Boolean),
     ));
+}
+
+export function getHiddenAgentIds() {
+    return new Set(globalSettings.hiddenCompanionAgentIds);
+}
+
+export function setHiddenAgentIds(ids) {
+    const nextHiddenIds = normalizeAgentIdCollection(ids);
+    const previous = JSON.stringify(globalSettings.hiddenCompanionAgentIds);
+    const next = JSON.stringify(nextHiddenIds);
+
+    globalSettings.hiddenCompanionAgentIds = nextHiddenIds;
+    if (previous !== next) {
+        persistAgentGlobalSettings();
+    }
+}
+
+export function isAgentHidden(agentId) {
+    const normalizedAgentId = String(agentId ?? '').trim();
+    return Boolean(normalizedAgentId && getHiddenAgentIds().has(normalizedAgentId));
 }
 
 function normalizeAgentChatScope(scope = AGENT_CHAT_SCOPES.INDIVIDUAL) {

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -31,7 +31,9 @@ import {
     MEMORY_SHARD_TEMPLATE_ID,
     PLOT_COMPASS_OBJECTIVE_MAX_CHARS,
     appendChatOnlyUserMessage,
+    getHiddenAgentIds,
     isAssistantMessage,
+    isAgentHidden,
     isChatOnlyAgent,
     isChatroomAgent,
     isPlotCompassAgent,
@@ -39,6 +41,7 @@ import {
     normalizeChatOnlyInput,
     normalizeChatroomReply,
     normalizePlotCompassObjective,
+    setHiddenAgentIds,
 } from './companion-shared.js';
 
 const PANEL_HISTORY_LIMIT = 5;
@@ -528,6 +531,7 @@ function buildPanelAgentSection(state) {
     const latest = state.latest;
     const name = getStateDisplayName(state);
     const icon = getStateIcon(state);
+    const isHidden = isAgentHidden(agentId);
 
     const settingsButton = state.agent
         ? '<button type="button" class="ica--cdash-action" data-action="panel-edit" title="Open this companion\'s agent settings" aria-label="Agent settings"><i class="fa-solid fa-gear"></i></button>'
@@ -535,13 +539,17 @@ function buildPanelAgentSection(state) {
     const runLatestButton = state.agent
         ? '<button type="button" class="ica--cdash-action" data-action="panel-run-latest" title="Run this companion on the latest assistant reply" aria-label="Run companion"><i class="fa-solid fa-play"></i></button>'
         : '';
+    const hiddenTitle = isHidden ? 'Unhide this companion' : 'Hide this companion (skipped on auto-trigger)';
+    const hiddenLabel = isHidden ? 'Unhide companion' : 'Hide companion';
+    const hiddenIcon = isHidden ? 'fa-eye-slash' : 'fa-eye';
+    const hiddenButton = `<button type="button" class="ica--cdash-action" data-action="panel-hide" title="${hiddenTitle}" aria-label="${hiddenLabel}"><i class="fa-solid ${hiddenIcon}"></i></button>`;
 
     if (!latest) {
         return `
-            <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}">
+            <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}" data-hidden="${isHidden}">
                 <div class="ica--tpanel-agent-head">
                     <span class="ica--tpanel-agent-name"><i class="fa-solid ${escapeHtml(icon)}"></i><span>${escapeHtml(name)}</span></span>
-                    <span class="ica--tpanel-agent-actions">${runLatestButton}${settingsButton}</span>
+                    <span class="ica--tpanel-agent-actions">${hiddenButton}${runLatestButton}${settingsButton}</span>
                 </div>
                 <div class="ica--cdash-empty">No state yet. It will appear after the next reply${getCompanionConfig(state.agent).trigger === 'manual' ? ' you run it on' : ''}.</div>
                 ${buildPanelEntryControls(state)}
@@ -567,11 +575,12 @@ function buildPanelAgentSection(state) {
         : '';
 
     return `
-        <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}" data-message-index="${latest.messageIndex}">
+        <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}" data-message-index="${latest.messageIndex}" data-hidden="${isHidden}">
             <div class="ica--tpanel-agent-head">
                 <span class="ica--tpanel-agent-name"><i class="fa-solid ${escapeHtml(icon)}"></i><span>${escapeHtml(name)}</span></span>
                 <span class="ica--tpanel-agent-when">#${latest.messageIndex}</span>
                 <span class="ica--tpanel-agent-actions">
+                    ${hiddenButton}
                     ${runLatestButton}
                     <button type="button" class="ica--cdash-action" data-action="panel-regenerate" title="Regenerate this state" aria-label="Regenerate state"><i class="fa-solid fa-rotate-right"></i></button>
                     <button type="button" class="ica--cdash-action" data-action="panel-fix" title="Fix: re-run with strict output enforcement (use when the model wrote roleplay instead)" aria-label="Fix state"><i class="fa-solid fa-wrench"></i></button>
@@ -708,6 +717,27 @@ async function handlePanelAction(event) {
 
     const section = button.closest('.ica--tpanel-agent');
     const agentId = section.attr('data-agent-id') || '';
+
+    if (action === 'panel-hide') {
+        if (!agentId) {
+            toastr.warning('No companion selected.');
+            return;
+        }
+
+        const hiddenAgentIds = getHiddenAgentIds();
+        if (hiddenAgentIds.has(agentId)) {
+            hiddenAgentIds.delete(agentId);
+        } else {
+            hiddenAgentIds.add(agentId);
+        }
+        setHiddenAgentIds(hiddenAgentIds);
+
+        if (panelOpen) {
+            renderPanel();
+        }
+        return;
+    }
+
     const messageIndex = Number(button.closest('[data-message-index]').attr('data-message-index'));
 
     if (action === 'panel-run-latest') {

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -7,9 +7,12 @@ import {
     areAgentsGloballyEnabled,
     getAgents,
     getCompanionConfig,
+    getHiddenAgentIds,
     isAgentEnabledForCurrentScope,
+    isAgentHidden,
     isCompanionAgent,
     saveAgent,
+    setHiddenAgentIds,
 } from '../agent-store.js';
 import {
     COMPANION_RESULTS_UPDATED_EVENT,
@@ -31,9 +34,7 @@ import {
     MEMORY_SHARD_TEMPLATE_ID,
     PLOT_COMPASS_OBJECTIVE_MAX_CHARS,
     appendChatOnlyUserMessage,
-    getHiddenAgentIds,
     isAssistantMessage,
-    isAgentHidden,
     isChatOnlyAgent,
     isChatroomAgent,
     isPlotCompassAgent,
@@ -41,7 +42,6 @@ import {
     normalizeChatOnlyInput,
     normalizeChatroomReply,
     normalizePlotCompassObjective,
-    setHiddenAgentIds,
 } from './companion-shared.js';
 
 const PANEL_HISTORY_LIMIT = 5;

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -1456,13 +1456,13 @@ async function runCompanionAgentsWithDependencyDelay(agents, messageIndex, gener
 
     const changedAgentIds = results.filter(r => r?.changed).map(r => r.agentId);
     if (changedAgentIds.length > 0) {
-        await runCompanionDependencyCascade(messageIndex, changedAgentIds, generationType, cancelRevision, visited);
+        await runCompanionDependencyCascade(messageIndex, changedAgentIds, generationType, cancelRevision, visited, { contextSourceAgents });
     }
 
     return results;
 }
 
-async function runCompanionDependencyCascade(messageIndex, changedAgentIds, generationType, cancelRevision, visited = new Set()) {
+async function runCompanionDependencyCascade(messageIndex, changedAgentIds, generationType, cancelRevision, visited = new Set(), { contextSourceAgents = null } = {}) {
     if (!changedAgentIds?.length) {
         return [];
     }
@@ -1473,7 +1473,9 @@ async function runCompanionDependencyCascade(messageIndex, changedAgentIds, gene
     }
 
     const allEnabled = getEnabledAgents();
-    const runnable = getRunnableCompanionAgents(allEnabled, { manual: true, messageIndex });
+    const runnable = Array.isArray(contextSourceAgents)
+        ? contextSourceAgents
+        : getRunnableCompanionAgents(allEnabled, { manual: true, messageIndex });
     const agentByReferenceId = buildCompanionReferenceMap(runnable);
     const dependents = [];
 
@@ -1495,7 +1497,7 @@ async function runCompanionDependencyCascade(messageIndex, changedAgentIds, gene
     const nextChangedIds = results.filter(r => r?.changed).map(r => r.agentId);
 
     if (nextChangedIds.length > 0) {
-        await runCompanionDependencyCascade(messageIndex, nextChangedIds, generationType, cancelRevision, visited);
+        await runCompanionDependencyCascade(messageIndex, nextChangedIds, generationType, cancelRevision, visited, { contextSourceAgents: runnable });
     }
 
     return results;

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -19,6 +19,7 @@ import {
     getEnabledAgents,
     getGlobalSettings,
     MAX_AGENT_MAX_TOKENS,
+    isAgentHidden,
     isCompanionAgent,
     resolveCompanionConnectionProfile,
 } from '../agent-store.js';
@@ -39,7 +40,6 @@ import {
     PLOT_COMPASS_TEMPLATE_ID,
     getCompanionReferenceIds,
     isAssistantMessage,
-    isAgentHidden,
 } from './companion-shared.js';
 
 export const COMPANION_RESULTS_EXTRA_KEY = 'inChatAgentCompanionResults';
@@ -1287,14 +1287,14 @@ export function meetsCompanionContextThreshold(agent, messageIndex = chat.length
     return !minContextTokens || getChatTokenEstimate(messageIndex + 1) >= minContextTokens;
 }
 
-function getRunnableCompanionAgents(activeAgents = [], { manual = false, messageIndex = chat.length - 1 } = {}) {
+function getRunnableCompanionAgents(activeAgents = [], { manual = false, messageIndex = chat.length - 1, includeHidden = manual } = {}) {
     return activeAgents.filter(agent => {
         const companion = getCompanionConfig(agent);
         if (!isCompanionAgent(agent) || !String(agent.prompt ?? '').trim()) {
             return false;
         }
 
-        if (!manual && isAgentHidden(agent.id)) {
+        if (!includeHidden && isAgentHidden(agent.id)) {
             return false;
         }
 
@@ -1416,7 +1416,7 @@ export async function runCompanionStage({ messageIndex, message, generationType 
     }
 
     const cancelRevision = getAgentGenerationCancelRevision();
-    const contextSourceAgents = getRunnableCompanionAgents(getEnabledAgents(), { manual: true, messageIndex });
+    const contextSourceAgents = getRunnableCompanionAgents(getEnabledAgents(), { manual: true, messageIndex, includeHidden: false });
     await runCompanionAgentsWithDependencyDelay(agents, messageIndex, generationType, cancelRevision, { contextSourceAgents });
 
     saveChatDebounced({ deferBackup: false });
@@ -1431,6 +1431,9 @@ export function injectCompanionFeedbackPrompts(activeAgents = []) {
 
     for (const agent of activeAgents) {
         if (!isCompanionAgent(agent)) {
+            continue;
+        }
+        if (isAgentHidden(agent.id)) {
             continue;
         }
 

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -39,6 +39,7 @@ import {
     PLOT_COMPASS_TEMPLATE_ID,
     getCompanionReferenceIds,
     isAssistantMessage,
+    isAgentHidden,
 } from './companion-shared.js';
 
 export const COMPANION_RESULTS_EXTRA_KEY = 'inChatAgentCompanionResults';
@@ -1289,9 +1290,15 @@ export function meetsCompanionContextThreshold(agent, messageIndex = chat.length
 function getRunnableCompanionAgents(activeAgents = [], { manual = false, messageIndex = chat.length - 1 } = {}) {
     return activeAgents.filter(agent => {
         const companion = getCompanionConfig(agent);
-        return isCompanionAgent(agent) &&
-            String(agent.prompt ?? '').trim() &&
-            (manual || (companion.trigger === 'auto' && meetsCompanionContextThreshold(agent, messageIndex)));
+        if (!isCompanionAgent(agent) || !String(agent.prompt ?? '').trim()) {
+            return false;
+        }
+
+        if (!manual && isAgentHidden(agent.id)) {
+            return false;
+        }
+
+        return manual || (companion.trigger === 'auto' && meetsCompanionContextThreshold(agent, messageIndex));
     });
 }
 
@@ -1377,7 +1384,7 @@ async function runCompanionDependencyCascade(messageIndex, changedAgentIds, gene
     for (const changedId of changedAgentIds) {
         const changedAgent = agentByReferenceId.get(changedId) ?? { id: changedId };
         for (const dependent of findCompanionDependents(changedAgent, runnable)) {
-            if (!visited.has(dependent.id)) {
+            if (!visited.has(dependent.id) && !isAgentHidden(dependent.id)) {
                 dependents.push(dependent);
                 visited.add(dependent.id);
             }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
@@ -38,60 +38,6 @@ export const CHAT_ONLY_INPUT_MAX_CHARS = 2000;
 export const CHAT_ONLY_TRANSCRIPT_MAX_CHARS = 12000;
 export const PLOT_COMPASS_OBJECTIVE_MAX_CHARS = 2000;
 
-const HIDDEN_AGENT_IDS_STORAGE_KEY = 'ica--tracker-panel-hidden-agents';
-
-let hiddenAgentIdsFallback = new Set();
-
-function normalizeHiddenAgentIds(ids = []) {
-    return new Set([...ids]
-        .map(id => String(id ?? '').trim())
-        .filter(Boolean)
-        .sort());
-}
-
-export function getHiddenAgentIds() {
-    let rawValue = null;
-
-    try {
-        rawValue = globalThis.localStorage?.getItem?.(HIDDEN_AGENT_IDS_STORAGE_KEY) ?? null;
-    } catch {
-        return new Set(hiddenAgentIdsFallback);
-    }
-
-    if (!rawValue) {
-        return new Set(hiddenAgentIdsFallback);
-    }
-
-    try {
-        const parsed = JSON.parse(rawValue);
-        if (!Array.isArray(parsed)) {
-            return new Set();
-        }
-
-        const ids = normalizeHiddenAgentIds(parsed);
-        hiddenAgentIdsFallback = new Set(ids);
-        return ids;
-    } catch {
-        return new Set();
-    }
-}
-
-export function setHiddenAgentIds(ids) {
-    const normalizedIds = normalizeHiddenAgentIds(ids);
-    hiddenAgentIdsFallback = new Set(normalizedIds);
-
-    try {
-        globalThis.localStorage?.setItem?.(HIDDEN_AGENT_IDS_STORAGE_KEY, JSON.stringify([...normalizedIds]));
-    } catch {
-        // Private browsing or storage quota: the hidden state still applies for this session.
-    }
-}
-
-export function isAgentHidden(agentId) {
-    const normalizedId = String(agentId ?? '').trim();
-    return Boolean(normalizedId && getHiddenAgentIds().has(normalizedId));
-}
-
 /**
  * The template an agent was created from, falling back to its own id.
  * @param {object} [agent]

--- a/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
@@ -1,8 +1,8 @@
 /**
- * Shared companion constants and pure helpers.
+ * Shared companion constants and helpers.
  *
- * This module has ZERO imports and no side effects on purpose: it is the single
- * source of truth for the template IDs, value sets and small normalizers that
+ * This module has ZERO imports and no side effects on import: it is the single
+ * source of truth for the template IDs, value sets and small helpers that
  * the companion runner, UI, panel and dashboard all need. Keeping it dependency
  * free means every consumer (and every test) can import it as the real module
  * without dragging in script.js or other heavy runtime singletons.
@@ -37,6 +37,60 @@ export const MESSAGE_INBOX_EMPTY_OUTPUTS = new Set(['phone-none', 'PHONE_NONE'])
 export const CHAT_ONLY_INPUT_MAX_CHARS = 2000;
 export const CHAT_ONLY_TRANSCRIPT_MAX_CHARS = 12000;
 export const PLOT_COMPASS_OBJECTIVE_MAX_CHARS = 2000;
+
+const HIDDEN_AGENT_IDS_STORAGE_KEY = 'ica--tracker-panel-hidden-agents';
+
+let hiddenAgentIdsFallback = new Set();
+
+function normalizeHiddenAgentIds(ids = []) {
+    return new Set([...ids]
+        .map(id => String(id ?? '').trim())
+        .filter(Boolean)
+        .sort());
+}
+
+export function getHiddenAgentIds() {
+    let rawValue = null;
+
+    try {
+        rawValue = globalThis.localStorage?.getItem?.(HIDDEN_AGENT_IDS_STORAGE_KEY) ?? null;
+    } catch {
+        return new Set(hiddenAgentIdsFallback);
+    }
+
+    if (!rawValue) {
+        return new Set(hiddenAgentIdsFallback);
+    }
+
+    try {
+        const parsed = JSON.parse(rawValue);
+        if (!Array.isArray(parsed)) {
+            return new Set();
+        }
+
+        const ids = normalizeHiddenAgentIds(parsed);
+        hiddenAgentIdsFallback = new Set(ids);
+        return ids;
+    } catch {
+        return new Set();
+    }
+}
+
+export function setHiddenAgentIds(ids) {
+    const normalizedIds = normalizeHiddenAgentIds(ids);
+    hiddenAgentIdsFallback = new Set(normalizedIds);
+
+    try {
+        globalThis.localStorage?.setItem?.(HIDDEN_AGENT_IDS_STORAGE_KEY, JSON.stringify([...normalizedIds]));
+    } catch {
+        // Private browsing or storage quota: the hidden state still applies for this session.
+    }
+}
+
+export function isAgentHidden(agentId) {
+    const normalizedId = String(agentId ?? '').trim();
+    return Boolean(normalizedId && getHiddenAgentIds().has(normalizedId));
+}
 
 /**
  * The template an agent was created from, falling back to its own id.

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1961,6 +1961,23 @@ button.ica--card-pill--version-update {
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 36%, transparent);
 }
 
+.ica--tpanel-agent[data-hidden="true"] {
+    opacity: 0.55;
+}
+
+.ica--tpanel-agent[data-hidden="true"] .ica--tpanel-agent-name span {
+    text-decoration: line-through;
+}
+
+.ica--tpanel-agent[data-hidden="true"] .ica--tpanel-agent-body,
+.ica--tpanel-agent[data-hidden="true"] .ica--tpanel-history,
+.ica--tpanel-agent[data-hidden="true"] .ica--chatonly-composer,
+.ica--tpanel-agent[data-hidden="true"] .ica--plot-objective-composer,
+.ica--tpanel-agent[data-hidden="true"] .ica--tpanel-compact,
+.ica--tpanel-agent[data-hidden="true"] .ica--cdash-empty {
+    display: none;
+}
+
 .ica--tpanel-agent-head {
     display: flex;
     align-items: center;

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -9,6 +9,7 @@ describe('companion tracker panel', () => {
     let globallyEnabled;
     let chatTokenEstimate;
     let localStorageValues;
+    let hiddenAgentIds;
 
     function createEventSource() {
         const handlers = new Map();
@@ -74,9 +75,14 @@ describe('companion tracker panel', () => {
                 trigger: agent?.companion?.trigger === 'manual' ? 'manual' : 'auto',
                 displayMode: agent?.companion?.displayMode ?? 'panel',
             })),
+            getHiddenAgentIds: jest.fn(() => new Set(hiddenAgentIds)),
             isAgentEnabledForCurrentScope: jest.fn(agent => Boolean(agent?.enabled)),
+            isAgentHidden: jest.fn(agentId => hiddenAgentIds.has(String(agentId ?? '').trim())),
             isCompanionAgent: jest.fn(agent => agent?.execution === 'companion' || agent?.category === 'companion'),
             saveAgent: jest.fn(async () => {}),
+            setHiddenAgentIds: jest.fn(ids => {
+                hiddenAgentIds = new Set([...ids].map(id => String(id ?? '').trim()).filter(Boolean));
+            }),
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js', () => ({
@@ -112,6 +118,7 @@ describe('companion tracker panel', () => {
         globallyEnabled = true;
         chatTokenEstimate = 0;
         localStorageValues = new Map();
+        hiddenAgentIds = new Set();
         globalThis.localStorage = {
             getItem: jest.fn(key => localStorageValues.get(key) ?? null),
             setItem: jest.fn((key, value) => localStorageValues.set(key, String(value))),
@@ -295,9 +302,27 @@ describe('companion tracker panel', () => {
         // SillyBunny: the per-companion Play button must remain visible after a companion has
         // already produced state, otherwise manual companions can only regenerate the first run
         // and never pick up a newer assistant reply from the draggable panel.
-        const trackerSection = html.match(/<section class="ica--tpanel-agent"[\s\S]*?data-message-index="0"[\s\S]*?<\/section>/)?.[0] ?? '';
-        const playButtonMatches = trackerSection.match(/data-action="panel-run-latest"/g) ?? [];
-        expect(playButtonMatches).toHaveLength(1);
+        expect(html).toMatch(/<section class="ica--tpanel-agent"[\s\S]*?data-message-index="0"[\s\S]*?data-action="panel-run-latest"[\s\S]*?<\/section>/);
+    });
+
+    test('keeps hidden companions unhideable from the collapsed panel row', async () => {
+        const tracker = { id: 'tracker-1', name: 'Scene Tracker', execution: 'companion', enabled: true, companion: { displayMode: 'panel' } };
+        agents = [tracker];
+        hiddenAgentIds = new Set(['tracker-1']);
+        const panel = await importPanel();
+
+        const message = { is_user: false, is_system: false, mes: 'reply' };
+        chat.push(message);
+        companionResultsByMessage.set(message, {
+            'tracker-1': { status: 'done', content: 'Hidden state', agentName: 'Scene Tracker' },
+        });
+
+        const html = panel.buildPanelHtml();
+
+        expect(html).toContain('data-agent-id="tracker-1" data-message-index="0" data-hidden="true"');
+        expect(html).toContain('data-action="panel-hide"');
+        expect(html).toContain('aria-label="Unhide companion"');
+        expect(html).toContain('data-action="panel-run-latest"');
     });
 
     test('renders edit buttons with per-entry message indices on history entries', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -363,7 +363,9 @@ describe('in-chat agent post-processing runner', () => {
             getEnabledAgents: jest.fn(() => [...enabledAgents]),
             getEnabledToolAgents: jest.fn(() => []),
             getGlobalSettings: jest.fn(() => globalSettings),
+            getHiddenAgentIds: jest.fn(() => new Set(globalSettings.hiddenCompanionAgentIds ?? [])),
             getPromptTransformMode: jest.fn(agent => agent?.postProcess?.promptTransformMode === 'append' ? 'append' : 'rewrite'),
+            isAgentHidden: jest.fn(agentId => new Set(globalSettings.hiddenCompanionAgentIds ?? []).has(String(agentId ?? '').trim())),
             isTrackerFixAgent: jest.fn(agent => {
                 if (agent?.category !== 'tracker') return false;
                 if (agent.phase === 'post' || agent.phase === 'both') return true;
@@ -1302,6 +1304,36 @@ describe('in-chat agent post-processing runner', () => {
         expect(extensionPrompts['inchat_agent_companion_feedback-companion'].value).toContain('Stale swipe state');
     });
 
+    test('skips hidden companions when injecting feedback prompts', async () => {
+        const hiddenCompanion = createCompanionAgent({
+            id: 'hidden-feedback-companion',
+            companion: { feedback: { enabled: true, depth: 2 } },
+        });
+        const visibleCompanion = createCompanionAgent({
+            id: 'visible-feedback-companion',
+            companion: { feedback: { enabled: true, depth: 2 } },
+        });
+        enabledAgents = [hiddenCompanion, visibleCompanion];
+        globalSettings.hiddenCompanionAgentIds = ['hidden-feedback-companion'];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        const reply = { mes: 'Reply', name: 'Assistant', is_user: false, is_system: false, extra: {} };
+        chat.push(reply, { mes: 'Continue.', name: 'User', is_user: true, is_system: false, extra: {} });
+        companionRunner.setCompanionResult(reply, hiddenCompanion, {
+            status: 'done',
+            content: 'Hidden note that should not feed the next message.',
+        });
+        companionRunner.setCompanionResult(reply, visibleCompanion, {
+            status: 'done',
+            content: 'Visible note that should feed back.',
+        });
+
+        companionRunner.injectCompanionFeedbackPrompts([hiddenCompanion, visibleCompanion]);
+
+        expect(extensionPrompts['inchat_agent_companion_hidden-feedback-companion']).toBeUndefined();
+        expect(extensionPrompts['inchat_agent_companion_visible-feedback-companion'].value).toContain('Visible note that should feed back.');
+    });
+
     test('prepends an anti-echo guard when feedback body contains tracker-format blocks', async () => {
         const trackerCompanion = createCompanionAgent({
             id: 'tracker-companion',
@@ -1785,6 +1817,51 @@ describe('in-chat agent post-processing runner', () => {
         expect(statsPrompt).toContain('[LEVEL_UP]\nLevel: 2\n[/LEVEL_UP]');
         expect(chat[3].extra.inChatAgentCompanionResults['saved-level-up-companion'].content).toBe('[LEVEL_UP]\nLevel: 2\n[/LEVEL_UP]');
         expect(chat[3].extra.inChatAgentCompanionResults['saved-user-stats-generator'].content).toBe('[USER_STATS]\nLevel: 2\n[/USER_STATS]');
+    });
+
+    test('excludes hidden companions from automatic linked context', async () => {
+        generateQuietPrompt.mockResolvedValue('Visible companion note');
+        globalSettings.hiddenCompanionAgentIds = ['source-companion'];
+
+        const sourceCompanion = createCompanionAgent({
+            id: 'source-companion',
+            name: 'Source Companion',
+            companion: {
+                trigger: 'manual',
+                sendContextToCompanions: true,
+                contextRecipientAgentIds: ['visible-companion'],
+            },
+        });
+        const visibleCompanion = createCompanionAgent({
+            id: 'visible-companion',
+            name: 'Visible Companion',
+            prompt: 'Write the visible companion note.',
+            companion: { trigger: 'auto' },
+        });
+        enabledAgents = [sourceCompanion, visibleCompanion];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push(
+            { mes: 'Previous assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} },
+            { mes: 'Please continue.', name: 'User', is_user: true, is_system: false, extra: {} },
+            { mes: 'Current assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} },
+        );
+        companionRunner.setCompanionResult(chat[0], sourceCompanion, {
+            status: 'done',
+            content: 'Hidden source note that should not be linked.',
+        });
+
+        await companionRunner.runCompanionStage({
+            messageIndex: 2,
+            message: chat[2],
+            activeAgents: [sourceCompanion, visibleCompanion],
+        });
+
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(1);
+        const visiblePrompt = generateQuietPrompt.mock.calls[0][0].quietPrompt;
+        expect(visiblePrompt).toContain('Write the visible companion note.');
+        expect(visiblePrompt).not.toContain('Source Companion');
+        expect(visiblePrompt).not.toContain('Hidden source note that should not be linked.');
     });
 
     test('does not cascade to dependents when parent output is unchanged', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1915,6 +1915,63 @@ describe('in-chat agent post-processing runner', () => {
         expect(visiblePrompt).not.toContain('Hidden source note that should not be linked.');
     });
 
+    test('excludes hidden companions from automatic cascade linked context', async () => {
+        generateQuietPrompt
+            .mockResolvedValueOnce('Updated parent note')
+            .mockResolvedValueOnce('Dependent note');
+        globalSettings.hiddenCompanionAgentIds = ['hidden-source'];
+
+        const hiddenSource = createCompanionAgent({
+            id: 'hidden-source',
+            name: 'Hidden Source',
+            companion: {
+                trigger: 'manual',
+                sendContextToCompanions: true,
+                contextRecipientAgentIds: ['dependent-companion'],
+            },
+        });
+        const parentCompanion = createCompanionAgent({
+            id: 'parent-companion',
+            name: 'Parent Companion',
+            prompt: 'Write the parent note.',
+            companion: { trigger: 'auto' },
+        });
+        const dependentCompanion = createCompanionAgent({
+            id: 'dependent-companion',
+            name: 'Dependent Companion',
+            prompt: 'Write the dependent note.',
+            companion: {
+                trigger: 'manual',
+                dependencies: ['parent-companion'],
+            },
+        });
+        enabledAgents = [hiddenSource, parentCompanion, dependentCompanion];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push(
+            { mes: 'Previous assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} },
+            { mes: 'Please continue.', name: 'User', is_user: true, is_system: false, extra: {} },
+            { mes: 'Current assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} },
+        );
+        companionRunner.setCompanionResult(chat[0], hiddenSource, {
+            status: 'done',
+            content: 'Hidden cascade source note that should not be linked.',
+        });
+
+        await companionRunner.runCompanionStage({
+            messageIndex: 2,
+            message: chat[2],
+            activeAgents: [hiddenSource, parentCompanion, dependentCompanion],
+        });
+
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(2);
+        const dependentPrompt = generateQuietPrompt.mock.calls[1][0].quietPrompt;
+        expect(dependentPrompt).toContain('Write the dependent note.');
+        expect(dependentPrompt).toContain('Updated parent note');
+        expect(dependentPrompt).not.toContain('Hidden Source');
+        expect(dependentPrompt).not.toContain('Hidden cascade source note that should not be linked.');
+    });
+
     test('does not cascade to dependents when parent output is unchanged', async () => {
         globalSettings.companionExecutionMode = 'sequential';
         generateQuietPrompt.mockResolvedValue('Same note');

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -100,6 +100,25 @@ describe('in-chat agent scoped enabled state', () => {
         expect(store.getGlobalSettings().helperPrefillMessages).toBe('');
     });
 
+    test('stores hidden companion IDs in global settings', async () => {
+        const store = await importStore();
+
+        expect([...store.getHiddenAgentIds()]).toEqual([]);
+
+        store.setGlobalSettings({
+            hiddenCompanionAgentIds: ['companion-b', '', ' companion-a ', 'companion-b'],
+        });
+
+        expect(store.getGlobalSettings().hiddenCompanionAgentIds).toEqual(['companion-a', 'companion-b']);
+        expect(store.isAgentHidden('companion-a')).toBe(true);
+        expect(store.isAgentHidden('missing-companion')).toBe(false);
+
+        store.setHiddenAgentIds(new Set(['companion-c', 'companion-a']));
+
+        expect(store.getGlobalSettings().hiddenCompanionAgentIds).toEqual(['companion-a', 'companion-c']);
+        expect(saveSettingsDebounced).toHaveBeenCalledTimes(1);
+    });
+
     test('resolves compact regex snapshots from runtime cache', async () => {
         const store = await importStore();
         const snapshotStore = await import('../public/scripts/extensions/in-chat-agents/regex-snapshot-store.js');


### PR DESCRIPTION
# Summary

## Reasoning
Sometimes you wanna hide an agent for the next message or something for whatever reason.

## What This Adds
- Persistent hide/unhide state via localStorage.
- Eye toggle per companion in the slide-out panel.
- Hidden companions dim/collapse in the panel.
- Hidden companions are skipped for auto-trigger runs such as delay/dependence/context stuff.
- Manual run actions remain available.