### PR TITLE
fix(sampling_profile): automatic sampling profile switch

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -15,7 +15,7 @@ import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
 import { cancelDebounce, collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
 import { getSecretLabelById } from '../../secrets.js';
-import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset, syncCustomEndpointPresetSelectionBySecretId } from '../../openai.js';
+import { chat_completion_sources, maybeApplyModelSamplingProfile, oai_settings, selected_custom_endpoint_preset, syncCustomEndpointPresetSelectionBySecretId } from '../../openai.js';
 import { performFuzzySearch } from '/scripts/power-user.js';
 import { StreamingDisplay } from '/scripts/streaming-display.js';
 import { ConnectionManagerRequestService } from '../shared.js';
@@ -1017,6 +1017,11 @@ async function applyConnectionProfile(profile) {
             if (spinner.isAborted()) {
                 throw new Error(PROFILE_APPLICATION_ABORTED);
             }
+        }
+
+        if (mode === 'cc') {
+            maybeApplyModelSamplingProfile();
+            cancelDebounce(saveSettingsDebounced);
         }
     } finally {
         spinner.stop();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -10229,6 +10229,7 @@ export function initOpenAI() {
         syncProxyPresetToBoundSource(oai_settings.chat_completion_source);
         // SillyBunny: source switches should not reset the selected settings preset.
         restoreOpenAIPresetSelection(presetName);
+        maybeApplyModelSamplingProfile();
         saveSettingsDebounced();
         reconnectOpenAi();
         forceCharacterEditorTokenize();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6893,7 +6893,7 @@ function clearSamplingProfileForCurrentModel() {
     }
 }
 
-function maybeApplyModelSamplingProfile() {
+export function maybeApplyModelSamplingProfile() {
     if (!oai_settings.model_sampling_profiles_enabled) {
         return;
     }

--- a/tests/connection-manager-profile-save.test.js
+++ b/tests/connection-manager-profile-save.test.js
@@ -63,7 +63,10 @@ describe('connection manager profile save wiring', () => {
         const helperSource = getFunctionSource('getCustomEndpointProfileSecretId');
         const readSource = getFunctionSource('readProfileFromCommands');
 
-        expect(connectionManagerSource).toContain('import { chat_completion_sources, oai_settings, selected_custom_endpoint_preset, syncCustomEndpointPresetSelectionBySecretId } from \'../../openai.js\';');
+        expect(connectionManagerSource).toContain('chat_completion_sources');
+        expect(connectionManagerSource).toContain('oai_settings');
+        expect(connectionManagerSource).toContain('selected_custom_endpoint_preset');
+        expect(connectionManagerSource).toContain('syncCustomEndpointPresetSelectionBySecretId');
         expect(helperSource).toContain('mode !== \'cc\'');
         expect(helperSource).toContain('oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM');
         expect(helperSource).toContain('selected_custom_endpoint_preset?.name === \'None\'');

--- a/tests/openai-sampling-profiles-wiring.test.js
+++ b/tests/openai-sampling-profiles-wiring.test.js
@@ -62,4 +62,26 @@ describe('OpenAI sampling profile wiring', () => {
         expect(indexHtml).not.toContain('id="model_sampling_profile_save" class="menu_button menu_button_icon"');
         expect(indexHtml).not.toContain('id="model_sampling_profile_clear" class="menu_button menu_button_icon"');
     });
+
+    test('applies the selected model sampling profile when the chat completion source changes', () => {
+        const initOpenAISource = getFunctionSource('initOpenAI');
+        const sourceChangeStart = initOpenAISource.indexOf('$(\'#chat_completion_source\').on(\'change\', function () {');
+        const nextHandlerStart = initOpenAISource.indexOf('$(\'#oai_max_context_unlocked\')', sourceChangeStart);
+
+        expect(sourceChangeStart).toBeGreaterThanOrEqual(0);
+        expect(nextHandlerStart).toBeGreaterThan(sourceChangeStart);
+
+        const sourceChangeHandler = initOpenAISource.slice(sourceChangeStart, nextHandlerStart);
+        const toggleFormsIndex = sourceChangeHandler.indexOf('toggleChatCompletionForms();');
+        const restorePresetIndex = sourceChangeHandler.indexOf('restoreOpenAIPresetSelection(presetName);');
+        const applyProfileIndex = sourceChangeHandler.indexOf('maybeApplyModelSamplingProfile();');
+        const saveSettingsIndex = sourceChangeHandler.indexOf('saveSettingsDebounced();');
+        const reconnectIndex = sourceChangeHandler.indexOf('reconnectOpenAi();');
+
+        expect(toggleFormsIndex).toBeGreaterThanOrEqual(0);
+        expect(restorePresetIndex).toBeGreaterThan(toggleFormsIndex);
+        expect(applyProfileIndex).toBeGreaterThan(restorePresetIndex);
+        expect(saveSettingsIndex).toBeGreaterThan(applyProfileIndex);
+        expect(reconnectIndex).toBeGreaterThan(applyProfileIndex);
+    });
 });

--- a/tests/openai-sampling-profiles-wiring.test.js
+++ b/tests/openai-sampling-profiles-wiring.test.js
@@ -5,31 +5,36 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+const connectionManagerSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'connection-manager', 'index.js'), 'utf8');
 const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
 const toggleDependentCss = readFileSync(path.join(repoRoot, 'public', 'css', 'toggle-dependent.css'), 'utf8');
 
-function getFunctionSource(name) {
+function getFunctionSourceFrom(source, name) {
     const marker = `function ${name}(`;
-    const start = openAiSource.indexOf(marker);
+    const start = source.indexOf(marker);
 
     expect(start).toBeGreaterThanOrEqual(0);
 
-    const bodyStart = openAiSource.indexOf(') {', start) + 2;
+    const bodyStart = source.indexOf(') {', start) + 2;
     let depth = 0;
 
-    for (let index = bodyStart; index < openAiSource.length; index++) {
-        const char = openAiSource[index];
+    for (let index = bodyStart; index < source.length; index++) {
+        const char = source[index];
         if (char === '{') {
             depth++;
         } else if (char === '}') {
             depth--;
             if (depth === 0) {
-                return openAiSource.slice(start, index + 1);
+                return source.slice(start, index + 1);
             }
         }
     }
 
     throw new Error(`Unable to find function source for ${name}`);
+}
+
+function getFunctionSource(name) {
+    return getFunctionSourceFrom(openAiSource, name);
 }
 
 describe('OpenAI sampling profile wiring', () => {
@@ -83,5 +88,20 @@ describe('OpenAI sampling profile wiring', () => {
         expect(applyProfileIndex).toBeGreaterThan(restorePresetIndex);
         expect(saveSettingsIndex).toBeGreaterThan(applyProfileIndex);
         expect(reconnectIndex).toBeGreaterThan(applyProfileIndex);
+    });
+
+    test('re-applies the final model sampling profile after connection profile backend switches', () => {
+        const applyConnectionProfileSource = getFunctionSourceFrom(connectionManagerSource, 'applyConnectionProfile');
+        const commandLoopIndex = applyConnectionProfileSource.indexOf('for (const command of commands) {');
+        const applyProfileIndex = applyConnectionProfileSource.indexOf('maybeApplyModelSamplingProfile();');
+        const cancelSaveIndex = applyConnectionProfileSource.indexOf('cancelDebounce(saveSettingsDebounced);', applyProfileIndex);
+        const stopSpinnerIndex = applyConnectionProfileSource.indexOf('spinner.stop();');
+
+        expect(openAiSource).toContain('export function maybeApplyModelSamplingProfile()');
+        expect(connectionManagerSource).toContain('maybeApplyModelSamplingProfile');
+        expect(commandLoopIndex).toBeGreaterThanOrEqual(0);
+        expect(applyProfileIndex).toBeGreaterThan(commandLoopIndex);
+        expect(cancelSaveIndex).toBeGreaterThan(applyProfileIndex);
+        expect(stopSpinnerIndex).toBeGreaterThan(applyProfileIndex);
     });
 });


### PR DESCRIPTION
# Summary

## Issue
When you switch to a different model using the backend dropdown (e.g. going from ZAI to MoonshotAI), it doesn't automatically load the sampling profile associated with the model. You have to switch to a different model, then back to the model you want to use to load the sampling profile.

## What This Changes
It should instantly switch to the sampling profile without having to switch models and load it manually.