### PR TITLE
fix(custom_css): allow importing of custom CSS when uploading themes that have it

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2181,6 +2181,11 @@ function applyTheme(name) {
     }
     applyThemeEffects();
 
+    if (typeof theme.custom_css === 'string') {
+        power_user.custom_css = theme.custom_css;
+        applyCustomCSS();
+    }
+
     console.log('theme applied: ' + name);
 }
 
@@ -3391,13 +3396,8 @@ async function importTheme(file) {
         }
     }
 
-    themes.push(parsed);
     await saveTheme(parsed.name, getNewTheme(parsed));
-    const option = document.createElement('option');
-    option.selected = false;
-    option.value = parsed.name;
-    option.innerText = parsed.name;
-    $('#themes').append(option);
+    applyTheme(parsed.name);
     saveSettingsDebounced();
     toastr.success(parsed.name, 'Theme imported');
 }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -3465,7 +3465,7 @@ async function saveTheme(name = undefined, theme = undefined) {
  * @param {string} name Name of the theme
  */
 export function getThemeObject(name) {
-    const theme = { name, custom_css: power_user.custom_css || '' };
+    const theme = { name };
 
     for (const { key } of THEME_COLOR_PROPERTIES) {
         theme[key] = power_user[key];
@@ -3489,6 +3489,9 @@ function getNewTheme(parsed) {
         if (Object.hasOwn(theme, key)) {
             theme[key] = parsed[key];
         }
+    }
+    if (typeof parsed.custom_css === 'string') {
+        theme.custom_css = parsed.custom_css;
     }
     return theme;
 }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -3396,8 +3396,13 @@ async function importTheme(file) {
         }
     }
 
-    await saveTheme(parsed.name, getNewTheme(parsed));
+    const theme = getNewTheme(parsed);
+    await saveTheme(parsed.name, theme);
     applyTheme(parsed.name);
+    if (typeof theme.custom_css === 'string') {
+        power_user.custom_css = theme.custom_css;
+        applyCustomCSS();
+    }
     saveSettingsDebounced();
     toastr.success(parsed.name, 'Theme imported');
 }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -3460,7 +3460,7 @@ async function saveTheme(name = undefined, theme = undefined) {
  * @param {string} name Name of the theme
  */
 export function getThemeObject(name) {
-    const theme = { name };
+    const theme = { name, custom_css: power_user.custom_css || '' };
 
     for (const { key } of THEME_COLOR_PROPERTIES) {
         theme[key] = power_user[key];

--- a/tests/theme-custom-css-import.test.js
+++ b/tests/theme-custom-css-import.test.js
@@ -25,8 +25,11 @@ describe('theme custom CSS import wiring', () => {
     test('import selects and applies the saved theme instead of only adding it', () => {
         const importThemeSource = getSourceSection('async function importTheme(file)', '/**\n * Saves the current theme to the server.');
 
-        expect(importThemeSource).toContain('await saveTheme(parsed.name, getNewTheme(parsed));');
+        expect(importThemeSource).toContain('const theme = getNewTheme(parsed);');
+        expect(importThemeSource).toContain('await saveTheme(parsed.name, theme);');
         expect(importThemeSource).toContain('applyTheme(parsed.name);');
+        expect(importThemeSource).toContain('power_user.custom_css = theme.custom_css;');
+        expect(importThemeSource).toContain('applyCustomCSS();');
         expect(importThemeSource).toContain('saveSettingsDebounced();');
         expect(importThemeSource).not.toContain('themes.push(parsed);');
     });

--- a/tests/theme-custom-css-import.test.js
+++ b/tests/theme-custom-css-import.test.js
@@ -33,4 +33,14 @@ describe('theme custom CSS import wiring', () => {
         expect(importThemeSource).toContain('saveSettingsDebounced();');
         expect(importThemeSource).not.toContain('themes.push(parsed);');
     });
+
+    test('theme normalization only keeps explicitly bundled custom CSS', () => {
+        const getThemeObjectSource = getSourceSection('export function getThemeObject(name)', '/**\n * Applies imported theme properties');
+        const getNewThemeSource = getSourceSection('function getNewTheme(parsed)', 'async function saveMovingUI');
+
+        expect(getThemeObjectSource).toContain('const theme = { name };');
+        expect(getThemeObjectSource).not.toContain('custom_css: power_user.custom_css');
+        expect(getNewThemeSource).toContain('if (typeof parsed.custom_css === \'string\') {');
+        expect(getNewThemeSource).toContain('theme.custom_css = parsed.custom_css;');
+    });
 });

--- a/tests/theme-custom-css-import.test.js
+++ b/tests/theme-custom-css-import.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const powerUserSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'power-user.js'), 'utf8').replace(/\r\n/g, '\n');
+
+function getSourceSection(startMarker, endMarker) {
+    const startIndex = powerUserSource.indexOf(startMarker);
+    const endIndex = powerUserSource.indexOf(endMarker, startIndex);
+
+    return startIndex === -1 || endIndex === -1 ? '' : powerUserSource.slice(startIndex, endIndex);
+}
+
+describe('theme custom CSS import wiring', () => {
+    test('theme selection applies the theme custom CSS payload', () => {
+        const applyThemeSource = getSourceSection('function applyTheme(name)', 'async function applyMovingUIPreset');
+
+        expect(applyThemeSource).toContain('if (typeof theme.custom_css === \'string\') {');
+        expect(applyThemeSource).toContain('power_user.custom_css = theme.custom_css;');
+        expect(applyThemeSource).toContain('applyCustomCSS();');
+    });
+
+    test('import selects and applies the saved theme instead of only adding it', () => {
+        const importThemeSource = getSourceSection('async function importTheme(file)', '/**\n * Saves the current theme to the server.');
+
+        expect(importThemeSource).toContain('await saveTheme(parsed.name, getNewTheme(parsed));');
+        expect(importThemeSource).toContain('applyTheme(parsed.name);');
+        expect(importThemeSource).toContain('saveSettingsDebounced();');
+        expect(importThemeSource).not.toContain('themes.push(parsed);');
+    });
+});


### PR DESCRIPTION
# Summary

## Issue
A regression that made it so even when you say yes to importing a custom CSS bundled in a theme json, nothing happens.

## What This Fixes
Reverts the regression.