### PR TITLE
fix(mobile_webkit_safari): steady the input textbox viewport

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -1,5 +1,6 @@
 import { getParsedUA, isMobile } from './RossAscends-mods.js';
 import { shouldBlockMobileDocumentPan } from './mobile-shell-lifecycle/index.js';
+import { isIOSWebKitPlatform } from './mobile-send-button.js';
 
 const isFirefox = () => /firefox/i.test(navigator.userAgent);
 
@@ -109,10 +110,16 @@ function isEditableFocusTarget(element) {
         || (element instanceof HTMLElement && element.isContentEditable);
 }
 
-function addDocumentViewportAnchorPatch() {
+function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {
     let resetScheduled = false;
 
+    const shouldSuspendDocumentScrollReset = () => suspendWhileEditing && isEditableFocusTarget(document.activeElement);
+
     const resetDocumentScroll = () => {
+        if (shouldSuspendDocumentScrollReset()) {
+            return;
+        }
+
         const scrollingElement = document.scrollingElement;
         const scrollLeft = Math.max(window.scrollX || 0, scrollingElement?.scrollLeft || 0);
         const scrollTop = Math.max(window.scrollY || 0, scrollingElement?.scrollTop || 0);
@@ -130,7 +137,7 @@ function addDocumentViewportAnchorPatch() {
     };
 
     const scheduleDocumentScrollReset = () => {
-        if (resetScheduled) {
+        if (resetScheduled || shouldSuspendDocumentScrollReset()) {
             return;
         }
 
@@ -143,6 +150,10 @@ function addDocumentViewportAnchorPatch() {
 
     resetDocumentScroll();
     window.addEventListener('scroll', scheduleDocumentScrollReset, { passive: true });
+
+    if (suspendWhileEditing) {
+        document.addEventListener('focusout', scheduleDocumentScrollReset, true);
+    }
 }
 
 function applyBrowserFixes() {
@@ -150,11 +161,13 @@ function applyBrowserFixes() {
         sanitizeInlineQuotationOnCopy();
     }
 
-    addDocumentViewportAnchorPatch();
+    const isMobileViewport = isMobile();
+    const isIOSWebKit = isIOSWebKitPlatform();
 
-    if (isMobile()) {
+    addDocumentViewportAnchorPatch({ suspendWhileEditing: isMobileViewport && isIOSWebKit });
+
+    if (isMobileViewport) {
         const viewport = window.visualViewport;
-        const isIOSWebKit = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
         const viewportResetSettleMs = 360;
         let viewportFixScheduled = false;
         let viewportResetScheduled = false;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2499,11 +2499,7 @@ function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
     }
 
     const activeElement = document.activeElement;
-    if (isChatComposerEditableElement(activeElement)) {
-        return false;
-    }
-
-    return isMobileShellPanelEditableElement(activeElement) || hasOpenMobileShellDrawer();
+    return isMobileShellPanelEditableElement(activeElement) || isChatComposerEditableElement(activeElement) || hasOpenMobileShellDrawer();
 }
 
 function isVisualViewportKeyboardOpen(layoutViewport = getLayoutViewportSize(), visualViewportSize = getVisualViewportSize(layoutViewport)) {
@@ -2534,9 +2530,9 @@ function getShellViewportSize() {
     const layoutViewport = getLayoutViewportSize();
     const visualViewportSize = getVisualViewportSize(layoutViewport);
 
-    // SillyBunny: iOS keyboard edits inside shell panels should not resize or
-    // raise the Customize/Workspace windows. Keep shell geometry on the stable
-    // layout viewport while focused-input scrolling still uses visualViewport.
+    // SillyBunny: iOS keyboard edits inside shell panels or the chat composer
+    // should not feed Safari visualViewport jitter back into shell geometry.
+    // Keep layout stable while focused panel scrolling still uses visualViewport.
     if (shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize)) {
         return layoutViewport;
     }
@@ -2561,9 +2557,8 @@ function syncShellViewportBounds() {
     setRootViewportProperty('--sb-shell-viewport-height', `${viewportSize.height}px`);
     setRootViewportProperty('--sb-shell-measured-top-offset', `${topOffset}px`);
     setRootViewportProperty('--sb-shell-available-height', `${Math.max(0, viewportSize.height - topOffset)}px`);
-    // SillyBunny: iOS Safari shifts the visual viewport (visualViewport.offsetTop > 0)
-    // when the keyboard opens; composer-focused edits use that offset, while
-    // panel-focused edits keep the stable layout top so windows are not raised.
+    // SillyBunny: iOS Safari shifts the visual viewport while the keyboard opens;
+    // keyboard edit paths intentionally keep the stable layout top.
     setRootViewportProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
 }
 
@@ -2571,9 +2566,9 @@ function syncShellViewportBounds() {
  * SillyBunny: on mobile the body is fixed/clip, so the browser cannot scroll a
  * focused input above the virtual keyboard the way a normal page would. When
  * focus enters an input inside a shell panel or drawer scroller, manually scroll
- * that scroller so the input sits above the keyboard. The chat composer itself
- * stays on visual-viewport shell sizing when it has focus; this covers the
- * remaining settings/drawer inputs (e.g. "Enter a Model ID").
+ * that scroller so the input sits above the keyboard. The chat composer and
+ * stable iOS shell sizing are handled separately; this covers the remaining
+ * settings/drawer inputs (e.g. "Enter a Model ID").
  */
 function scrollMobileFocusedInputIntoView(event) {
     if (!isMobileViewport()) {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -241,6 +241,15 @@ describe('mobile shell lifecycle wiring', () => {
     });
 
     test('settles mobile viewport reset without reapplying the fixed-position workaround', () => {
+        expect(browserFixesSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
+        expect(browserFixesSource).toContain('function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {');
+        expect(browserFixesSource).toContain('const shouldSuspendDocumentScrollReset = () => suspendWhileEditing && isEditableFocusTarget(document.activeElement);');
+        expect(browserFixesSource).toContain('if (shouldSuspendDocumentScrollReset()) {');
+        expect(browserFixesSource).toContain('if (resetScheduled || shouldSuspendDocumentScrollReset()) {');
+        expect(browserFixesSource).toContain('document.addEventListener(\'focusout\', scheduleDocumentScrollReset, true);');
+        expect(browserFixesSource).toContain('const isMobileViewport = isMobile();');
+        expect(browserFixesSource).toContain('const isIOSWebKit = isIOSWebKitPlatform();');
+        expect(browserFixesSource).toContain('addDocumentViewportAnchorPatch({ suspendWhileEditing: isMobileViewport && isIOSWebKit });');
         expect(browserFixesSource).toContain('const viewportResetSettleMs = 360;');
         expect(browserFixesSource).toContain('const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {');
         expect(browserFixesSource).toContain('const scheduleViewportReset = ({ restoreScroll = false } = {}) => {');

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -298,7 +298,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(getInlineDrawerStorageKeySource).not.toContain('`${SB_STORAGE_KEYS.settingsDrawerStatePrefix}:${contextSegments.join(\'/\')}:drawer:${drawerLabel}:${drawerIndex}`');
     });
 
-    test('clamps shell panels while keeping iOS keyboard edits on stable panel bounds', () => {
+    test('clamps shell panels and iOS composer edits on stable viewport bounds', () => {
         const getResolvedShellTopbarOffsetSource = getFunctionSource('getResolvedShellTopbarOffset');
         const getDesktopShellResizeBoundsSource = getFunctionSource('getDesktopShellResizeBounds');
         const setShellSizeOverrideSource = getFunctionSource('setShellSizeOverride');
@@ -313,7 +313,8 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsSource).toContain('function isChatComposerEditableElement(');
         expect(tabsSource).toContain('function hasOpenMobileShellDrawer(');
         expect(tabsSource).toContain('!isMobileViewport() || !isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)');
-        expect(tabsSource).toContain('return isMobileShellPanelEditableElement(activeElement) || hasOpenMobileShellDrawer();');
+        expect(tabsSource).toContain('return isMobileShellPanelEditableElement(activeElement) || isChatComposerEditableElement(activeElement) || hasOpenMobileShellDrawer();');
+        expect(tabsSource).not.toContain('if (isChatComposerEditableElement(activeElement)) {');
         expect(tabsSource).toContain('return layoutViewport;');
         expect(tabsSource).toContain('function syncShellViewportBounds(');
         expect(tabsSource).toContain('function syncMobileShellDrawerBounds(');


### PR DESCRIPTION
# Summary

## Issue
Specifically on *Safari*, and it doesn't happen on Firefox iOS, when I try to type on an input box, it steadies the screen and doesn't move to the input box, causing it to go down whenever I type a letter, then up, then down again, etc.

## What This Fixes
Stabilises input box viewport
