### PR TITLE
feat(ica): include the number of tokens used by agents in the UI

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -39,6 +39,8 @@ function debouncePromise(func, delay) {
 const DEFAULT_DEPTH = 4;
 const DEFAULT_ORDER = 100;
 const PROMPT_MANAGER_DESKTOP_SPLIT_QUERY = '(min-width: 961px)';
+// SillyBunny In-Chat Agents reserve this extension prompt key prefix.
+const IN_CHAT_AGENT_PROMPT_KEY_PREFIX = 'inchat_agent_';
 
 /**
  * @enum {number}
@@ -2084,6 +2086,17 @@ class PromptManager {
         return this.hasRuntimePromptTokenCounts() ? this.tokenUsage : this.sourcePromptTokenUsage;
     }
 
+    getInChatAgentTokenUsage() {
+        return Object.entries(this.getActivePromptTokenCounts() ?? {}).reduce((total, [identifier, tokens]) => {
+            if (!identifier.startsWith(IN_CHAT_AGENT_PROMPT_KEY_PREFIX)) {
+                return total;
+            }
+
+            const tokenCount = Number(tokens);
+            return total + (Number.isFinite(tokenCount) ? tokenCount : 0);
+        }, 0);
+    }
+
     async populateSourcePromptTokenCounts() {
         if (this.hasRuntimePromptTokenCounts() || !this.activeCharacter || !this.tokenHandler) {
             this.sourcePromptTokenCounts = {};
@@ -2126,8 +2139,9 @@ class PromptManager {
         ` : '';
 
         const totalActiveTokens = this.getDisplayTokenUsage();
+        const totalAgentTokens = this.getInChatAgentTokenUsage();
 
-        const headerHtml = await renderTemplateAsync('promptManagerHeader', { error: this.error, errorDiv, prefix: this.configuration.prefix, totalActiveTokens, dragLocked: power_user.prompt_manager_drag_locked });
+        const headerHtml = await renderTemplateAsync('promptManagerHeader', { error: this.error, errorDiv, prefix: this.configuration.prefix, totalActiveTokens, totalAgentTokens, dragLocked: power_user.prompt_manager_drag_locked });
         if (!this.#isRenderCurrent(renderRequestId)) {
             return false;
         }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-dashboard.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-dashboard.js
@@ -91,16 +91,53 @@ function partitionDashboardAgents(agents = []) {
     return { companions, convertible };
 }
 
+function normalizeTokenCount(value) {
+    const tokenCount = Number(value);
+    return Number.isFinite(tokenCount) && tokenCount > 0 ? Math.round(tokenCount) : 0;
+}
+
+function formatTokenCount(value) {
+    return normalizeTokenCount(value).toLocaleString();
+}
+
+function buildCompanionTokenUsagePillsHtml(result = {}) {
+    const inputTokens = normalizeTokenCount(result?.tokenUsage?.inputTokens);
+    const outputTokens = normalizeTokenCount(result?.tokenUsage?.outputTokens);
+
+    return [
+        inputTokens ? `<span class="ica--card-pill ica--card-pill--tokens" title="Estimated input tokens" aria-label="Input tokens ${escapeHtml(formatTokenCount(inputTokens))}"><span>Input</span><strong>${escapeHtml(formatTokenCount(inputTokens))}</strong></span>` : '',
+        outputTokens ? `<span class="ica--card-pill ica--card-pill--tokens" title="Estimated output tokens" aria-label="Output tokens ${escapeHtml(formatTokenCount(outputTokens))}"><span>Output</span><strong>${escapeHtml(formatTokenCount(outputTokens))}</strong></span>` : '',
+    ].filter(Boolean).join('');
+}
+
+function getLatestDashboardResult(agentId) {
+    for (let messageIndex = chat.length - 1; messageIndex >= 0; messageIndex--) {
+        const message = chat[messageIndex];
+        if (!isValidCompanionMessage(message)) {
+            continue;
+        }
+
+        const result = getCompanionResults(message)[agentId];
+        if (result && typeof result === 'object' && !isSuppressedDashboardResult(agentId, result)) {
+            return result;
+        }
+    }
+
+    return null;
+}
+
 export function buildCompanionAgentRowHtml(agent) {
     const companion = getCompanionConfig(agent);
     const enabled = isAgentEnabledForCurrentScope(agent);
-    const pills = [
+    const configPills = [
         companion.trigger === 'manual' ? 'manual' : 'auto',
         ['panel', 'hidden'].includes(companion.displayMode) ? companion.displayMode : 'card',
         companion.format,
         companion.batch ? 'batch' : '',
         companion.feedback.enabled ? `feedback ×${companion.feedback.depth}` : '',
     ].filter(Boolean).map(label => `<span class="ica--card-pill">${escapeHtml(label)}</span>`).join('');
+    const tokenPills = buildCompanionTokenUsagePillsHtml(getLatestDashboardResult(agent.id));
+    const pills = `${configPills}${tokenPills}`;
 
     return `
         <div class="ica--cdash-row${enabled ? ' is-enabled' : ''}" data-agent-id="${escapeHtml(agent.id)}">

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -465,6 +465,27 @@ function getStateIcon(state) {
     return icon || 'fa-user-astronaut';
 }
 
+function normalizeTokenCount(value) {
+    const tokenCount = Number(value);
+    return Number.isFinite(tokenCount) && tokenCount > 0 ? Math.round(tokenCount) : 0;
+}
+
+function formatTokenCount(value) {
+    return normalizeTokenCount(value).toLocaleString();
+}
+
+function buildCompanionTokenUsagePillsHtml(result = {}) {
+    const inputTokens = normalizeTokenCount(result?.tokenUsage?.inputTokens);
+    const outputTokens = normalizeTokenCount(result?.tokenUsage?.outputTokens);
+
+    const pills = [
+        inputTokens ? `<span class="ica--card-pill ica--card-pill--tokens" title="Estimated input tokens" aria-label="Input tokens ${escapeHtml(formatTokenCount(inputTokens))}"><span>Input</span><strong>${escapeHtml(formatTokenCount(inputTokens))}</strong></span>` : '',
+        outputTokens ? `<span class="ica--card-pill ica--card-pill--tokens" title="Estimated output tokens" aria-label="Output tokens ${escapeHtml(formatTokenCount(outputTokens))}"><span>Output</span><strong>${escapeHtml(formatTokenCount(outputTokens))}</strong></span>` : '',
+    ].filter(Boolean).join('');
+
+    return pills ? `<span class="ica--tpanel-agent-token-pills">${pills}</span>` : '';
+}
+
 function buildPanelEntryBody(agentId, entry) {
     const status = String(entry.result.status ?? 'done');
     if (status === 'pending') {
@@ -575,6 +596,7 @@ function buildPanelAgentSection(state) {
                     <div class="ica--tpanel-history-entry" data-message-index="${entry.messageIndex}">
                         <div class="ica--tpanel-history-head">
                             <span>Message #${entry.messageIndex}</span>
+                            ${buildCompanionTokenUsagePillsHtml(entry.result)}
                             <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text" aria-label="Edit history entry"><i class="fa-solid fa-pen-to-square"></i></button>
                         </div>
                         <div class="ica--tpanel-agent-body">${buildPanelEntryBody(agentId, entry)}</div>
@@ -589,6 +611,7 @@ function buildPanelAgentSection(state) {
             <div class="ica--tpanel-agent-head">
                 <span class="ica--tpanel-agent-name"><i class="fa-solid ${escapeHtml(icon)}"></i><span>${escapeHtml(name)}</span></span>
                 <span class="ica--tpanel-agent-when">#${latest.messageIndex}</span>
+                ${buildCompanionTokenUsagePillsHtml(latest.result)}
                 <span class="ica--tpanel-agent-actions">
                     ${runLatestButton}
                     <button type="button" class="ica--cdash-action" data-action="panel-regenerate" title="Regenerate this state" aria-label="Regenerate state"><i class="fa-solid fa-rotate-right"></i></button>

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -1191,24 +1191,49 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
     return { agentId: agent.id, changed, result };
 }
 
-async function buildBatchPromptMessages(agents, messageIndex, generationType, { extraContextSections = [] } = {}) {
-    const contextSections = await buildCompanionContextSections(agents[0], messageIndex, { extraContextSections });
-    const tasks = agents.map(agent => {
-        const companion = getCompanionConfig(agent);
-        const formatLines = companion.rawPrompt ? [] : ['Output format:', getFormatInstruction(companion.format)];
-        return [
-            `<<<companion:${agent.id}>>>`,
-            `Agent: ${String(agent.name ?? '').trim() || agent.id}`,
-            COMPANION_GUARD_INSTRUCTION,
-            'Instruction:',
-            expandCompanionPrompt(agent, messageIndex, generationType),
-            ...formatLines,
-            COMPANION_FINAL_BOUNDARY,
-            `<<<end:${agent.id}>>>`,
-        ].join('\n');
-    }).join('\n\n');
-
+function buildBatchAgentTask(agent, messageIndex, generationType) {
+    const companion = getCompanionConfig(agent);
+    const formatLines = companion.rawPrompt ? [] : ['Output format:', getFormatInstruction(companion.format)];
     return [
+        `<<<companion:${agent.id}>>>`,
+        `Agent: ${String(agent.name ?? '').trim() || agent.id}`,
+        COMPANION_GUARD_INSTRUCTION,
+        'Instruction:',
+        expandCompanionPrompt(agent, messageIndex, generationType),
+        ...formatLines,
+        COMPANION_FINAL_BOUNDARY,
+        `<<<end:${agent.id}>>>`,
+    ].join('\n');
+}
+
+async function buildBatchInputTokenUsage(promptMessages, taskPayloads) {
+    const batchInputTokens = await countCompanionTokens(promptMessages);
+    if (!taskPayloads.length) {
+        return new Map();
+    }
+
+    const taskTokenPairs = await Promise.all(taskPayloads.map(async payload => [
+        payload.agentId,
+        await countCompanionTokens(payload.content),
+    ]));
+    const totalTaskTokens = taskTokenPairs.reduce((total, [, tokens]) => total + tokens, 0);
+    const sharedTokens = Math.max(0, batchInputTokens - totalTaskTokens);
+    const sharedTokensPerAgent = sharedTokens / taskTokenPairs.length;
+
+    return new Map(taskTokenPairs.map(([agentId, tokens]) => [
+        agentId,
+        normalizeCompanionTokenCount(tokens + sharedTokensPerAgent),
+    ]));
+}
+
+async function buildBatchPromptPayload(agents, messageIndex, generationType, { extraContextSections = [] } = {}) {
+    const contextSections = await buildCompanionContextSections(agents[0], messageIndex, { extraContextSections });
+    const taskPayloads = agents.map(agent => ({
+        agentId: agent.id,
+        content: buildBatchAgentTask(agent, messageIndex, generationType),
+    }));
+    const tasks = taskPayloads.map(payload => payload.content).join('\n\n');
+    const promptMessages = [
         {
             role: 'system',
             content: 'Run each side-channel task independently. These are not chat replies or scene continuations. Put every result inside its matching <<<companion:agentId>>> and <<<end:agentId>>> markers. Text outside markers is ignored.',
@@ -1218,6 +1243,8 @@ async function buildBatchPromptMessages(agents, messageIndex, generationType, { 
             content: `${contextSections || '[Recent conversation]\nConversation context is empty.'}\n\n[Tasks]\n${tasks}\n\nPlace every result inside its markers now.\n${COMPANION_BATCH_FINAL_BOUNDARY}`,
         },
     ];
+
+    return { promptMessages, taskPayloads };
 }
 
 async function runBatchCompanionAgents(agents, messageIndex, generationType, cancelRevision, { allowUserMessage = false, previousContents = null, extraContextSectionsByAgentId = null } = {}) {
@@ -1230,7 +1257,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
 
     try {
         const extraContextSections = getUnitExtraContextSections(agents, extraContextSectionsByAgentId);
-        const promptMessages = await buildBatchPromptMessages(agents, messageIndex, generationType, { extraContextSections });
+        const { promptMessages, taskPayloads } = await buildBatchPromptPayload(agents, messageIndex, generationType, { extraContextSections });
         const maxTokens = Math.min(MAX_AGENT_MAX_TOKENS, agents.reduce((sum, agent) => sum + getCompanionConfig(agent).maxTokens, 0));
         const response = await requestPromptTransform(agents[0], promptMessages, maxTokens);
 
@@ -1254,7 +1281,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
             });
         }
 
-        const batchInputTokens = await countCompanionTokens(promptMessages);
+        const inputTokensByAgentId = await buildBatchInputTokenUsage(promptMessages, taskPayloads);
         const parsed = parseBatchResponse(response.output);
         const missingAgents = [];
         for (const agent of agents) {
@@ -1269,7 +1296,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
                 content,
                 error: '',
                 tokenUsage: {
-                    inputTokens: batchInputTokens,
+                    inputTokens: inputTokensByAgentId.get(agent.id) ?? 0,
                     outputTokens: await countCompanionTokens({ role: 'assistant', content }),
                 },
                 profileId: response.profileId,

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -87,6 +87,55 @@ function normalizeText(value = '') {
     return normalizeContentText(String(value ?? '')).trim();
 }
 
+function normalizeCompanionTokenCount(value) {
+    const tokenCount = Number(value);
+    return Number.isFinite(tokenCount) && tokenCount > 0 ? Math.round(tokenCount) : 0;
+}
+
+function stringifyCompanionTokenPayload(value) {
+    if (Array.isArray(value)) {
+        return value.map(message => stringifyCompanionTokenPayload(message)).filter(Boolean).join('\n\n');
+    }
+
+    if (value && typeof value === 'object') {
+        const role = String(value.role ?? 'user').trim().toUpperCase() || 'USER';
+        const content = normalizeText(value.content ?? '');
+        return content ? `${role}:\n${content}` : '';
+    }
+
+    return normalizeText(value);
+}
+
+async function countCompanionTokens(value) {
+    const fallbackText = stringifyCompanionTokenPayload(value);
+    if (!fallbackText) {
+        return 0;
+    }
+
+    try {
+        const tokenHandler = getContext()?.promptManager?.tokenHandler;
+        if (typeof tokenHandler?.countUntrackedAsync === 'function') {
+            const tokenCount = normalizeCompanionTokenCount(await tokenHandler.countUntrackedAsync(value));
+            if (tokenCount > 0) {
+                return tokenCount;
+            }
+        }
+    } catch {
+        // Fall back to the same rough chars/4 estimate used elsewhere in companion sizing.
+    }
+
+    return Math.ceil(fallbackText.length / 4);
+}
+
+async function buildCompanionTokenUsage(inputPayload, outputText = '') {
+    const [inputTokens, outputTokens] = await Promise.all([
+        countCompanionTokens(inputPayload),
+        countCompanionTokens({ role: 'assistant', content: outputText }),
+    ]);
+
+    return { inputTokens, outputTokens };
+}
+
 function normalizeChatroomStyle(value = '') {
     const normalized = String(value ?? '').trim().toLowerCase();
     return CHATROOM_STYLE_VALUES.has(normalized) ? normalized : 'mixed';
@@ -1104,6 +1153,7 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
                 status: 'cancelled',
                 content: '',
                 error: 'Cancelled.',
+                tokenUsage: null,
                 profileId: response.profileId,
                 profileLabel: getProfileLabel(agent, response.profileId),
                 modelLabel: getModelLabel(agent),
@@ -1114,10 +1164,13 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
             return { agentId: agent.id, changed, result };
         }
 
+        const content = capResultContent(response.output);
+        const tokenUsage = await buildCompanionTokenUsage(promptMessages, content);
         setCompanionResult(message, agent, {
             status: 'done',
-            content: capResultContent(response.output),
+            content,
             error: '',
+            tokenUsage,
             profileId: response.profileId,
             profileLabel: getProfileLabel(agent, response.profileId),
             modelLabel: getModelLabel(agent),
@@ -1128,6 +1181,7 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
             status: cancelled ? 'cancelled' : 'error',
             content: '',
             error: cancelled ? 'Cancelled.' : (error instanceof Error ? error.message : String(error)),
+            tokenUsage: null,
         });
     }
 
@@ -1186,6 +1240,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
                     status: 'cancelled',
                     content: '',
                     error: 'Cancelled.',
+                    tokenUsage: null,
                     profileId: response.profileId,
                     profileLabel: getProfileLabel(agent, response.profileId),
                     modelLabel: getModelLabel(agent),
@@ -1199,6 +1254,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
             });
         }
 
+        const batchInputTokens = await countCompanionTokens(promptMessages);
         const parsed = parseBatchResponse(response.output);
         const missingAgents = [];
         for (const agent of agents) {
@@ -1207,10 +1263,15 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
                 continue;
             }
 
+            const content = parsed.get(agent.id);
             setCompanionResult(message, agent, {
                 status: 'done',
-                content: parsed.get(agent.id),
+                content,
                 error: '',
+                tokenUsage: {
+                    inputTokens: batchInputTokens,
+                    outputTokens: await countCompanionTokens({ role: 'assistant', content }),
+                },
                 profileId: response.profileId,
                 profileLabel: getProfileLabel(agent, response.profileId),
                 modelLabel: getModelLabel(agent),
@@ -1328,6 +1389,7 @@ async function runCompanionAgentSet(agents, messageIndex, generationType, cancel
             status: 'pending',
             content: '',
             error: '',
+            tokenUsage: null,
         });
         await emitCompanionResultsUpdated(messageIndex, agent.id);
     }
@@ -1480,6 +1542,7 @@ export async function runCompanionAgentOnMessage(agentId, messageIndex, { cancel
         status: 'pending',
         content: capResultContent(pendingContent),
         error: '',
+        tokenUsage: null,
     });
     await emitCompanionResultsUpdated(messageIndex, agent.id);
     const { changed, result } = await runSingleCompanionAgent(agent, messageIndex, 'normal', cancelRevision, {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -5,6 +5,7 @@ import { download, escapeHtml, escapeRegex, getSortableDelay, uuidv4 } from '../
 import { activateSendButtons, CLIENT_VERSION, chat, deactivateSendButtons, getRequestHeaders, generateQuietPrompt, is_send_press, normalizeContentText, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { eventSource, event_types } from '../../events.js';
 import { is_group_generating } from '../../group-chats.js';
+import { promptManager } from '../../openai.js';
 import {
     areAgentsGloballyEnabled,
     getAgents,
@@ -2119,11 +2120,29 @@ function syncAgentTabStrip(activeTab) {
 /**
  * Re-renders the agent list panel.
  */
+function getInChatAgentTokenUsage() {
+    const tokenCount = Number(promptManager?.getInChatAgentTokenUsage?.() ?? 0);
+    return Number.isFinite(tokenCount) ? tokenCount : 0;
+}
+
+function updateAgentTokenCounter() {
+    const tokenCounter = document.getElementById('ica--agent-token-counter');
+    const tokenValue = document.getElementById('ica--total-tokens-val');
+    if (!(tokenCounter instanceof HTMLElement) || !(tokenValue instanceof HTMLElement)) {
+        return;
+    }
+
+    const tokenCount = getInChatAgentTokenUsage();
+    tokenValue.textContent = String(tokenCount);
+    tokenCounter.classList.toggle('is-empty', tokenCount <= 0);
+}
+
 function renderAgentList() {
     const container = $('#ica--agentList');
     const scrollState = captureAgentListScrollState(container[0]);
     container.empty();
     updateCancelGenerationButton();
+    updateAgentTokenCounter();
     const profileNames = buildConnectionProfileNameMap();
     const allAgents = sortAgentsByOrder(getVisibleInChatAgents());
     const activeTab = getActiveAgentListTab();
@@ -5864,6 +5883,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     document.addEventListener('sb:shell-tab-activated', (event) => {
         if (event.detail?.tabId === 'agents') {
             syncToolAgentRegistrations();
+            updateAgentTokenCounter();
         }
     });
 
@@ -5891,12 +5911,15 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         event_types.CHAT_CHANGED,
         event_types.USER_MESSAGE_RENDERED,
         event_types.CHARACTER_MESSAGE_RENDERED,
+        event_types.CHAT_COMPLETION_PROMPT_READY,
     ].filter(Boolean)) {
         eventSource.on(eventName, () => {
             updateFixTrackersButtonVisibility();
             updateCompanionButtonVisibility();
+            updateAgentTokenCounter();
         });
     }
     updateFixTrackersButtonVisibility();
     updateCompanionButtonVisibility();
+    updateAgentTokenCounter();
 })();

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -5,7 +5,6 @@ import { download, escapeHtml, escapeRegex, getSortableDelay, uuidv4 } from '../
 import { activateSendButtons, CLIENT_VERSION, chat, deactivateSendButtons, getRequestHeaders, generateQuietPrompt, is_send_press, normalizeContentText, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { eventSource, event_types } from '../../events.js';
 import { is_group_generating } from '../../group-chats.js';
-import { promptManager } from '../../openai.js';
 import {
     areAgentsGloballyEnabled,
     getAgents,
@@ -2121,7 +2120,13 @@ function syncAgentTabStrip(activeTab) {
  * Re-renders the agent list panel.
  */
 function getInChatAgentTokenUsage() {
-    const tokenCount = Number(promptManager?.getInChatAgentTokenUsage?.() ?? 0);
+    let tokenCount = 0;
+    try {
+        tokenCount = Number(getContext()?.promptManager?.getInChatAgentTokenUsage?.() ?? 0);
+    } catch {
+        tokenCount = 0;
+    }
+
     return Number.isFinite(tokenCount) ? tokenCount : 0;
 }
 

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -123,6 +123,11 @@
             </select>
         </div>
 
+        <div id="ica--agent-token-counter" class="ica--token-counter" aria-live="polite">
+            <span class="ica--token-counter-label"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i> Agent Tokens</span>
+            <strong id="ica--total-tokens-val">0</strong>
+        </div>
+
         <div id="ica--agentList" class="ica--agentList"></div>
 
         <div class="ica--footer">

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -625,6 +625,16 @@ button.ica--card-pill--version-update {
     animation: ica--version-pulse 0.85s ease-in-out;
 }
 
+.ica--card-pill--tokens {
+    font-variant-numeric: tabular-nums;
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 13%, var(--SmartThemeBorderColor, #555) 18%, transparent);
+    opacity: 0.86;
+}
+
+.ica--card-pill--tokens strong {
+    font-weight: 700;
+}
+
 @keyframes ica--version-pulse {
     0%, 100% {
         box-shadow: 0 0 0 0 color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 0%, transparent);
@@ -1990,6 +2000,7 @@ button.ica--card-pill--version-update {
 .ica--tpanel-agent-head {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
 }
 
@@ -2019,6 +2030,14 @@ button.ica--card-pill--version-update {
     align-items: center;
     gap: 4px;
     flex: 0 0 auto;
+}
+
+.ica--tpanel-agent-token-pills {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    min-width: 0;
 }
 
 .ica--tpanel-agent-body {

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -124,6 +124,32 @@
     flex-shrink: 0;
 }
 
+.ica--token-counter {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 35%, transparent);
+    border-radius: var(--sb-radius-md, 10px);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 8%, transparent);
+}
+
+.ica--token-counter.is-empty {
+    opacity: 0.75;
+}
+
+.ica--token-counter-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+}
+
+#ica--total-tokens-val {
+    font-variant-numeric: tabular-nums;
+}
+
 /* ── Agent List ─────────────────────────────────────── */
 
 .ica--agentList {

--- a/public/scripts/templates/promptManagerHeader.html
+++ b/public/scripts/templates/promptManagerHeader.html
@@ -6,7 +6,7 @@
         <div class="inline-drawer-toggle inline-drawer-header">
             <div class="flex-container flexFlowColumn">
                 <b data-i18n="Prompts">Prompts</b>
-                <small class="sb-group-meta"><span data-i18n="Inspect, reorder, toggle, and edit injected prompts">Inspect, reorder, toggle, and edit injected prompts</span> &middot; <span data-i18n="Total Tokens:">Total Tokens:</span> {{totalActiveTokens}}</small>
+                <small class="sb-group-meta"><span data-i18n="Inspect, reorder, toggle, and edit injected prompts">Inspect, reorder, toggle, and edit injected prompts</span> &middot; <span data-i18n="Total Tokens:">Total Tokens:</span> {{totalActiveTokens}}{{#if totalAgentTokens}} &middot; <span data-i18n="Agent Tokens:">Agent Tokens:</span> {{totalAgentTokens}}{{/if}}</small>
             </div>
             <div class="prompt_manager_header_controls {{prefix}}prompt_manager_header_controls">
                 <button type="button" id="{{prefix}}prompt_manager_drag_lock" class="menu_button menu_button_icon toggleable prompt_manager_drag_lock_button {{#if dragLocked}}toggled{{/if}}" title="Lock/unlock prompt reordering" aria-label="Lock/unlock prompt reordering" aria-pressed="{{#if dragLocked}}true{{else}}false{{/if}}" data-i18n="[title]Lock/unlock prompt reordering;[aria-label]Lock/unlock prompt reordering">

--- a/tests/group-chat-greetings-qol.test.js
+++ b/tests/group-chat-greetings-qol.test.js
@@ -48,9 +48,9 @@ describe('group chat greetings QoL', () => {
         expect(groupChatSource).toContain('container.on(\'click\', \'#group_add_greeting\', addSelectedGroupGreeting);');
         expect(styleSource).toContain('grid-template-areas: "typing typing typing" "avatars greeting speak";');
         expect(styleSource).toContain('#group_add_greeting span,');
-        expect(styleSource).toContain('#group_add_greeting {\n        grid-area: greeting;\n    }');
+        expect(styleSource).toMatch(/#group_add_greeting\s*\{[\s\S]*?grid-area:\s*greeting;\s*}/);
         expect(mobileStyleSource).toContain('grid-template-areas: "avatars greeting speak" !important;');
         expect(mobileStyleSource).toContain('#group_add_greeting span,');
-        expect(mobileStyleSource).toContain('#group_add_greeting {\n        grid-area: greeting !important;\n    }');
+        expect(mobileStyleSource).toMatch(/#group_add_greeting\s*\{[\s\S]*?grid-area:\s*greeting\s*!important;\s*}/);
     });
 });

--- a/tests/in-chat-agents-companion-dashboard.test.js
+++ b/tests/in-chat-agents-companion-dashboard.test.js
@@ -159,6 +159,31 @@ describe('companion dashboard', () => {
         expect(html).not.toContain('Tool Agent');
     });
 
+    test('shows latest companion input and output token estimates in rows', async () => {
+        agents = [{ id: 'companion-1', name: 'Scene Notes', execution: 'companion', enabled: true }];
+        const message = { is_user: false, is_system: false, mes: 'reply' };
+        chat.push(message);
+        companionResultsByMessage.set(message, {
+            'companion-1': {
+                status: 'done',
+                content: 'note',
+                tokenUsage: { inputTokens: 1234, outputTokens: 56 },
+            },
+        });
+        const dashboard = await importDashboard();
+        dashboard.configureCompanionDashboard({
+            getVisibleAgents: () => agents,
+            getLastAssistantMessageIndex: () => 0,
+        });
+
+        const html = dashboard.buildDashboardHtml();
+
+        expect(html).toContain('Input');
+        expect(html).toContain('1,234');
+        expect(html).toContain('Output');
+        expect(html).toContain('56');
+    });
+
     test('shows the disabled notice and empty states when nothing is configured', async () => {
         const dashboard = await importDashboard();
         const store = await import('../public/scripts/extensions/in-chat-agents/agent-store.js');

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -273,7 +273,12 @@ describe('companion tracker panel', () => {
         const message = { is_user: false, is_system: false, mes: 'reply' };
         chat.push(message);
         companionResultsByMessage.set(message, {
-            'tracker-1': { status: 'done', content: 'Sumeru City Market', agentName: 'Scene Tracker' },
+            'tracker-1': {
+                status: 'done',
+                content: 'Sumeru City Market',
+                agentName: 'Scene Tracker',
+                tokenUsage: { inputTokens: 321, outputTokens: 45 },
+            },
         });
 
         const html = panel.buildPanelHtml();
@@ -290,6 +295,10 @@ describe('companion tracker panel', () => {
         expect(html).toContain('data-action="panel-run-latest"');
         expect(html).toContain('data-action="panel-regenerate-all"');
         expect(html).toContain('data-message-index="0"');
+        expect(html).toContain('Input');
+        expect(html).toContain('321');
+        expect(html).toContain('Output');
+        expect(html).toContain('45');
         expect(html).toContain('No state yet');
 
         // SillyBunny: the per-companion Play button must remain visible after a companion has

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1944,6 +1944,32 @@ describe('in-chat agent post-processing runner', () => {
         expect(chat[0].extra.inChatAgentCompanionResults['single-user-companion'].content).toBe('Single user note');
     });
 
+    test('stores estimated input and output token usage on companion results', async () => {
+        generateQuietPrompt.mockResolvedValue('Token note');
+
+        const companionAgent = createCompanionAgent({
+            id: 'token-companion',
+            name: 'Token Companion',
+        });
+        enabledAgents = [companionAgent];
+
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push(
+            { mes: 'User message', name: 'User', is_user: true, is_system: false, extra: {} },
+        );
+
+        const result = await companionRunner.runCompanionAgentOnMessage('token-companion', 0);
+
+        expect(result?.tokenUsage).toEqual(expect.objectContaining({
+            inputTokens: expect.any(Number),
+            outputTokens: expect.any(Number),
+        }));
+        expect(result.tokenUsage.inputTokens).toBeGreaterThan(0);
+        expect(result.tokenUsage.outputTokens).toBeGreaterThan(0);
+        expect(chat[0].extra.inChatAgentCompanionResults['token-companion'].tokenUsage).toEqual(result.tokenUsage);
+    });
+
     test('runs connected companions from wrench/fix flow', async () => {
         globalSettings.companionExecutionMode = 'sequential';
         generateQuietPrompt

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1509,6 +1509,7 @@ describe('in-chat agent post-processing runner', () => {
         const companionB = createCompanionAgent({
             id: 'companion-b',
             name: 'Companion B',
+            prompt: 'Write the Companion B note with a little more detail than the first companion.',
             companion: { batch: false, batchAgentIds: [] },
         });
         const companionC = createCompanionAgent({
@@ -1547,6 +1548,13 @@ describe('in-chat agent post-processing runner', () => {
         expect(chat[1].extra.inChatAgentCompanionResults['companion-a'].content).toBe('A note');
         expect(chat[1].extra.inChatAgentCompanionResults['companion-b'].content).toBe('B note');
         expect(chat[1].extra.inChatAgentCompanionResults['companion-c'].content).toBe('C note');
+        const batchInputTokens = Math.ceil(batchPrompt.length / 4);
+        const companionAInputTokens = chat[1].extra.inChatAgentCompanionResults['companion-a'].tokenUsage.inputTokens;
+        const companionBInputTokens = chat[1].extra.inChatAgentCompanionResults['companion-b'].tokenUsage.inputTokens;
+        expect(companionAInputTokens).toBeGreaterThan(0);
+        expect(companionBInputTokens).toBeGreaterThan(companionAInputTokens);
+        expect(companionAInputTokens).toBeLessThan(batchInputTokens);
+        expect(companionBInputTokens).toBeLessThan(batchInputTokens);
     });
 
     test('does not batch companions with different linked context', async () => {

--- a/tests/openai-custom-favorites.test.js
+++ b/tests/openai-custom-favorites.test.js
@@ -74,6 +74,6 @@ describe('OpenAI custom favorites wiring', () => {
 
     test('refreshes Custom model ID favorites when manually changing the endpoint URL', () => {
         expect(openAiSource).toContain('$(\'#custom_api_url_text\').on(\'change\', function () {');
-        expect(openAiSource).toContain('if (oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {\n            refreshModelIdSearchControlsForSource(chat_completion_sources.CUSTOM);\n        }');
+        expect(openAiSource).toMatch(/\$\('#custom_api_url_text'\)\.on\('change', function \(\) \{[\s\S]*if \(oai_settings\.chat_completion_source === chat_completion_sources\.CUSTOM\) \{[\s\S]*refreshModelIdSearchControlsForSource\(chat_completion_sources\.CUSTOM\);[\s\S]*\}\);/);
     });
 });


### PR DESCRIPTION
# Summary

## Issue
While you can see token counts of separate agents by clicking the Main prompt, there isn't really a proper, easy UI to see how much tokens agents use in total.

## What This Adds
Multiple ways to access In-Chat Agents token counts.
- In Prompt Manager
- In agents page

## For Companion Agents?
Adds Input: xx Output: xx token counts on the side drawer.