### PR TITLE
fix: Endpoint Profiles Not Loading Correctly in Clientside UI

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -9404,8 +9404,13 @@ export async function loadCustomEndpointPresets(settings) {
     }
 
     const savedSelectedPreset = settings.selected_custom_endpoint_preset;
-    selected_custom_endpoint_preset = savedSelectedPreset ? normalizeCustomEndpointPreset(savedSelectedPreset) : null;
-    if (selected_custom_endpoint_preset && !custom_endpoint_presets.some(preset => preset.name === selected_custom_endpoint_preset.name)) {
+    // SillyBunny: re-resolve the saved selection against the presets array so both point at the same object.
+    const savedSelectedName = savedSelectedPreset ? normalizeCustomEndpointPreset(savedSelectedPreset).name : null;
+    selected_custom_endpoint_preset = savedSelectedName
+        ? custom_endpoint_presets.find(preset => preset.name === savedSelectedName) ?? null
+        : null;
+    if (savedSelectedName && !selected_custom_endpoint_preset) {
+        selected_custom_endpoint_preset = normalizeCustomEndpointPreset(savedSelectedPreset);
         custom_endpoint_presets.push(selected_custom_endpoint_preset);
     }
 
@@ -9418,15 +9423,16 @@ export async function loadCustomEndpointPresets(settings) {
     $('#custom_endpoint_preset').val(selected_custom_endpoint_preset?.name || 'None');
 
     if (selected_custom_endpoint_preset) {
+        // SillyBunny: load-time apply must not rotate or write secrets; requests send secret_id explicitly.
         await setCustomEndpointPreset(
             selected_custom_endpoint_preset.name,
             selected_custom_endpoint_preset.url,
             selected_custom_endpoint_preset.key,
             selected_custom_endpoint_preset.model,
-            { secretId: selected_custom_endpoint_preset.secretId, reconnect: false },
+            { secretId: selected_custom_endpoint_preset.secretId, writeKey: false, reconnect: false },
         );
     } else {
-        $('#custom_endpoint_preset_name').val('None');
+        $('#custom_endpoint_preset_name').val('');
     }
 }
 
@@ -9523,7 +9529,7 @@ async function setCustomEndpointPreset(name, url, key, model, { secretId = '', w
         appendCustomEndpointPresetOption(newPreset);
     }
 
-    $('#custom_endpoint_preset_name').val(normalizedPreset.name);
+    $('#custom_endpoint_preset_name').val(normalizedPreset.name === 'None' ? '' : normalizedPreset.name);
     oai_settings.custom_url = normalizedPreset.url;
     $('#custom_api_url_text').val(oai_settings.custom_url);
     oai_settings.custom_model = normalizedPreset.model;
@@ -9554,9 +9560,15 @@ async function onCustomEndpointPresetChange() {
 }
 
 $('#save_custom_endpoint').on('click', async function () {
-    const presetName = $('#custom_endpoint_preset_name').val();
+    const presetName = String($('#custom_endpoint_preset_name').val()).trim();
     const keyInputValue = String($('#api_key_custom').val()).trim();
-    const existingPreset = custom_endpoint_presets.find(preset => preset.name === String(presetName));
+
+    if (!presetName || presetName === 'None') {
+        toastr.error(t`Please enter a name for the endpoint profile.`);
+        return;
+    }
+
+    const existingPreset = custom_endpoint_presets.find(preset => preset.name === presetName);
     const preset = buildCustomEndpointPresetForSave({
         name: presetName,
         url: $('#custom_api_url_text').val(),
@@ -9565,26 +9577,16 @@ $('#save_custom_endpoint').on('click', async function () {
         secretId: existingPreset?.secretId,
     });
 
-    // Check if there's an active secret for CUSTOM key
+    // Bind the active CUSTOM secret when saving without typing a new key (e.g. picked via the secrets manager)
     const activeSecret = secret_state[SECRET_KEYS.CUSTOM]?.find(s => s.active);
-    const hasActiveSecret = !!activeSecret;
-
-    // Validate: need at least one of: new key input, existing secretId, or active secret
-    if (!keyInputValue && !preset.secretId && !hasActiveSecret) {
-        toastr.error(t`API key cannot be empty. Please enter an API key or select an existing secret.`);
-        return;
-    }
-
-    // If no new key but has active secret, bind it to the profile
-    if (!keyInputValue && hasActiveSecret && !preset.secretId) {
+    if (!keyInputValue && !preset.secretId && activeSecret) {
         preset.secretId = activeSecret.id;
     }
 
-    // Only write secret if user provided a new key
-    if (keyInputValue) {
+    // Write a secret when a key was typed, or mint a stable empty secret for keyless endpoints
+    if (keyInputValue || !preset.secretId) {
         await activateCustomEndpointPresetSecret(preset, { forceWrite: true });
     }
-    // If no new key but has secretId, keep existing secret (no action needed)
 
     await setCustomEndpointPreset(preset.name, preset.url, preset.key, preset.model, { secretId: preset.secretId, writeKey: false });
     saveSettingsDebounced();

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -153,11 +153,20 @@ describe('OpenAI proxy preset wiring', () => {
     test('saves Custom endpoint profiles with URL, key, and model fields', () => {
         expect(openAiSource).toContain('buildCustomEndpointPresetForSave({');
         expect(openAiSource).toContain('url: $(\'#custom_api_url_text\').val()');
-        expect(openAiSource).toContain('key: $(\'#api_key_custom\').val()');
+        expect(openAiSource).toContain('key: keyInputValue');
         expect(openAiSource).toContain('model: $(\'#custom_model_id\').val()');
         expect(openAiSource).toContain('secretId: existingPreset?.secretId');
         expect(openAiSource).toContain('await activateCustomEndpointPresetSecret(preset, { forceWrite: true });');
         expect(openAiSource).toContain('writeKey: false');
+    });
+
+    test('requires a profile name before saving a Custom endpoint profile', () => {
+        expect(openAiSource).toContain('if (!presetName || presetName === \'None\') {');
+    });
+
+    test('allows saving keyless Custom endpoint profiles with a stable empty secret', () => {
+        expect(openAiSource).toContain('if (keyInputValue || !preset.secretId) {');
+        expect(openAiSource).not.toContain('API key cannot be empty');
     });
 
     test('applies Custom endpoint profile values before reconnecting', () => {
@@ -246,16 +255,31 @@ describe('OpenAI proxy preset wiring', () => {
 
     test('preserves legacy Custom endpoint settings until a profile is selected', () => {
         const loadCustomEndpointSource = getFunctionSource('loadCustomEndpointPresets');
-        const selectedAssignmentIndex = loadCustomEndpointSource.indexOf('selected_custom_endpoint_preset = savedSelectedPreset ? normalizeCustomEndpointPreset(savedSelectedPreset) : null;');
+        const selectedAssignmentIndex = loadCustomEndpointSource.indexOf('selected_custom_endpoint_preset = savedSelectedName');
         const applyBranchIndex = loadCustomEndpointSource.indexOf('if (selected_custom_endpoint_preset) {');
         const applyPresetIndex = loadCustomEndpointSource.indexOf('await setCustomEndpointPreset(', applyBranchIndex);
-        const fallbackNameIndex = loadCustomEndpointSource.indexOf('$(\'#custom_endpoint_preset_name\').val(\'None\');');
+        const fallbackNameIndex = loadCustomEndpointSource.indexOf('$(\'#custom_endpoint_preset_name\').val(\'\');');
 
         expect(selectedAssignmentIndex).toBeGreaterThanOrEqual(0);
         expect(applyBranchIndex).toBeGreaterThan(selectedAssignmentIndex);
         expect(applyPresetIndex).toBeGreaterThan(applyBranchIndex);
         expect(fallbackNameIndex).toBeGreaterThan(applyPresetIndex);
         expect(loadCustomEndpointSource).not.toContain('savedSelectedPreset ||');
+    });
+
+    test('applies the saved profile on load without rotating or writing secrets', () => {
+        const loadCustomEndpointSource = getFunctionSource('loadCustomEndpointPresets');
+        const applyPresetIndex = loadCustomEndpointSource.indexOf('await setCustomEndpointPreset(');
+        const optionsIndex = loadCustomEndpointSource.indexOf('{ secretId: selected_custom_endpoint_preset.secretId, writeKey: false, reconnect: false }', applyPresetIndex);
+
+        expect(applyPresetIndex).toBeGreaterThanOrEqual(0);
+        expect(optionsIndex).toBeGreaterThan(applyPresetIndex);
+    });
+
+    test('resolves the saved selection to the same object as the presets array entry', () => {
+        const loadCustomEndpointSource = getFunctionSource('loadCustomEndpointPresets');
+
+        expect(loadCustomEndpointSource).toContain('custom_endpoint_presets.find(preset => preset.name === savedSelectedName) ?? null');
     });
 
     test('wires Custom endpoint profile selection from initOpenAI', () => {


### PR DESCRIPTION
State before and after:

1) Load-time secret rotation chaos
loadCustomEndpointPresets() applied the saved profile with writeKey: true, which on every app load rotated the CUSTOM secret - and rotateSecret() fires $('#main_api').trigger('change'), forcing a reconnect mid-startup. Worse, a legacy profile without a secretId minted a new duplicate secret on every single load.

Now loads with writeKey: false, reconnect: false.

2) Selection identity bug: the saved selection was normalized into a detached copy instead of being resolved to the object inside custom_endpoint_presets, so edits/saves against the array didn't reflect into the active selection (a likely cause of "it never sticks").

Now re-resolved by name to the same object.

3) Keyless endpoints were un-savable: save hard-failed with "API key cannot be empty" - but the Custom API key is explicitly optional (local llama.cpp/LM Studio/etc.).

Now a keyless save mints a stable empty per-profile secret (the mechanism #621 already built but the validation blocked).

4) "None" pollution: with no profile selected, the Profile Name input was filled with the literal string "None", and clicking Save could clobber the "None" sentinel row with empty URL/model.

Name field now blanks for "None" and saving requires a real name.

Verified: lint clean, full unit suite 1448/1448 passing (updated + added wiring tests).

Note for later (should track probably in current issues/bugs but deviates from upstream): Profile API keys are still stored in plaintext in settings.json (preset.key) in addition to the secret store - pre-existing behavior, left untouched to keep the diff scoped.
