### PR TITLE
fix(ipad_webkit_viewport): steady text box input viewport on iPadOS

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -897,6 +897,20 @@
     }
 }
 
+/* SillyBunny: mirror the <=768px drawer keyboard inset on wide iOS viewports
+   (iPadOS desktop-mode Safari reports a desktop UA and exceeds 768px).
+   .sb-ios-keyboard-inset-active is only toggled while the iOS software
+   keyboard is open, so non-iOS and keyboard-closed layouts never match. */
+html.sb-ios-keyboard-inset-active #left-nav-panel.openDrawer .sb-shell-panel-scroller,
+html.sb-ios-keyboard-inset-active #user-settings-block.openDrawer .sb-shell-panel-scroller,
+html.sb-ios-keyboard-inset-active .sb-shell-root.openDrawer .sb-shell-panel-scroller,
+html.sb-ios-keyboard-inset-active .sb-shell-root.fillLeft.openDrawer .sb-shell-panel-scroller,
+html.sb-ios-keyboard-inset-active .sb-shell-root.fillRight.openDrawer .sb-shell-panel-scroller,
+html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner,
+html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInnerFull {
+    padding-bottom: max(24px, calc(var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) + var(--sb-ios-keyboard-bottom-inset, 0px)));
+}
+
 /* =========================================================================
    Mobile fixes for the new character editor (PR #153)
    ========================================================================= */

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -164,7 +164,7 @@ function applyBrowserFixes() {
     const isMobileViewport = isMobile();
     const isIOSWebKit = isIOSWebKitPlatform();
 
-    addDocumentViewportAnchorPatch({ suspendWhileEditing: isMobileViewport && isIOSWebKit });
+    addDocumentViewportAnchorPatch({ suspendWhileEditing: isIOSWebKit });
 
     if (isMobileViewport) {
         const viewport = window.visualViewport;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2494,7 +2494,7 @@ function hasOpenMobileShellDrawer() {
 }
 
 function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
-    if (!isMobileViewport() || !isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
+    if (!isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
         return false;
     }
 
@@ -2511,7 +2511,7 @@ function syncIOSKeyboardBottomInset() {
     const root = document.documentElement;
     let bottomInset = 0;
 
-    if (isMobileViewport() && isIOSWebKitPlatform()) {
+    if (isIOSWebKitPlatform()) {
         const layoutViewport = getLayoutViewportSize();
         const visualViewportSize = getVisualViewportSize(layoutViewport);
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2524,6 +2524,11 @@ function syncIOSKeyboardBottomInset() {
     if (root.style.getPropertyValue('--sb-ios-keyboard-bottom-inset') !== value) {
         root.style.setProperty('--sb-ios-keyboard-bottom-inset', value);
     }
+
+    // SillyBunny: the <=768px shell CSS consumes the inset var directly; wide
+    // viewports (iPadOS desktop-mode Safari) gate the padding on this class so
+    // desktop layouts only pick it up while the software keyboard is open.
+    root.classList.toggle('sb-ios-keyboard-inset-active', bottomInset > 0);
 }
 
 function getShellViewportSize() {

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -19,6 +19,8 @@ describe('mobile keyboard focused-input scroll wiring', () => {
 
     test('adds iOS keyboard bottom inset without locking document scroll', () => {
         expect(tabsSource).toContain('function syncIOSKeyboardBottomInset(');
+        expect(tabsSource).toContain('if (isIOSWebKitPlatform()) {');
+        expect(tabsSource).not.toContain('if (isMobileViewport() && isIOSWebKitPlatform()) {');
         expect(tabsSource).toContain('--sb-ios-keyboard-bottom-inset');
         expect(tabsSource).toMatch(/layoutViewport\.height - visualViewportSize\.top - visualViewportSize\.height/);
         expect(tabsSource).not.toContain('sb-ios-keyboard-locked');

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -23,6 +23,7 @@ describe('mobile keyboard focused-input scroll wiring', () => {
         expect(tabsSource).not.toContain('if (isMobileViewport() && isIOSWebKitPlatform()) {');
         expect(tabsSource).toContain('--sb-ios-keyboard-bottom-inset');
         expect(tabsSource).toMatch(/layoutViewport\.height - visualViewportSize\.top - visualViewportSize\.height/);
+        expect(tabsSource).toContain('root.classList.toggle(\'sb-ios-keyboard-inset-active\', bottomInset > 0);');
         expect(tabsSource).not.toContain('sb-ios-keyboard-locked');
         expect(tabsSource).not.toContain('window.scrollTo(0, 0)');
         expect(tabsSource).not.toMatch(/window\.addEventListener\('scroll', syncIOSKeyboardBottomInset/);
@@ -32,6 +33,8 @@ describe('mobile keyboard focused-input scroll wiring', () => {
         const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
 
         expect(mobileShellCss).toContain('var(--sb-ios-keyboard-bottom-inset, 0px)');
+        expect(mobileShellCss).toContain('html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner,');
+        expect(mobileShellCss).toContain('html.sb-ios-keyboard-inset-active .sb-shell-root.openDrawer .sb-shell-panel-scroller,');
         expect(mobileShellCss).not.toContain('body.sb-ios-keyboard-locked');
     });
 

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -249,7 +249,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(browserFixesSource).toContain('document.addEventListener(\'focusout\', scheduleDocumentScrollReset, true);');
         expect(browserFixesSource).toContain('const isMobileViewport = isMobile();');
         expect(browserFixesSource).toContain('const isIOSWebKit = isIOSWebKitPlatform();');
-        expect(browserFixesSource).toContain('addDocumentViewportAnchorPatch({ suspendWhileEditing: isMobileViewport && isIOSWebKit });');
+        expect(browserFixesSource).toContain('addDocumentViewportAnchorPatch({ suspendWhileEditing: isIOSWebKit });');
         expect(browserFixesSource).toContain('const viewportResetSettleMs = 360;');
         expect(browserFixesSource).toContain('const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {');
         expect(browserFixesSource).toContain('const scheduleViewportReset = ({ restoreScroll = false } = {}) => {');
@@ -321,7 +321,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
         expect(tabsSource).toContain('function isChatComposerEditableElement(');
         expect(tabsSource).toContain('function hasOpenMobileShellDrawer(');
-        expect(tabsSource).toContain('!isMobileViewport() || !isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)');
+        expect(tabsSource).toContain('!isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)');
         expect(tabsSource).toContain('return isMobileShellPanelEditableElement(activeElement) || isChatComposerEditableElement(activeElement) || hasOpenMobileShellDrawer();');
         expect(tabsSource).not.toContain('if (isChatComposerEditableElement(activeElement)) {');
         expect(tabsSource).toContain('return layoutViewport;');

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -153,7 +153,8 @@ describe('OpenAI proxy preset wiring', () => {
     test('saves Custom endpoint profiles with URL, key, and model fields', () => {
         expect(openAiSource).toContain('buildCustomEndpointPresetForSave({');
         expect(openAiSource).toContain('url: $(\'#custom_api_url_text\').val()');
-        expect(openAiSource).toContain('key: $(\'#api_key_custom\').val()');
+        expect(openAiSource).toContain('const keyInputValue = String($(\'#api_key_custom\').val()).trim();');
+        expect(openAiSource).toContain('key: keyInputValue');
         expect(openAiSource).toContain('model: $(\'#custom_model_id\').val()');
         expect(openAiSource).toContain('secretId: existingPreset?.secretId');
         expect(openAiSource).toContain('await activateCustomEndpointPresetSecret(preset, { forceWrite: true });');


### PR DESCRIPTION
# Summary
## Issue
Previously, the PR https://github.com/platberlitz/SillyBunny/pull/636 was able to fix the viewport constantly jittering up whenever the keyboard appears and hides the input textbox. However, it seems this doesn't work on iPadOS, only on iOS.

## Fix
Applies the same fix to iPadOS.