### PR TITLE
fix(ica): minimum context overrides number of messages in Companion Agents

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -40,6 +40,7 @@ import {
     PLOT_COMPASS_TEMPLATE_ID,
     getCompanionReferenceIds,
     isAssistantMessage,
+    isValidCompanionMessage,
     normalizePlotCompassObjective,
 } from './companion-shared.js';
 import { resolveCompanionContentMacros } from './companion-macros.js';
@@ -555,9 +556,34 @@ function getMessageLine(message) {
     return `${label}: ${normalizeText(message?.mes ?? '')}`;
 }
 
+function getMessageTokenEstimate(message) {
+    const counted = Number(message?.extra?.token_count);
+    return Number.isFinite(counted) && counted > 0
+        ? counted
+        : Math.ceil(String(message?.mes ?? '').length / 4);
+}
+
 function getRecentConversationSection(messageIndex, companion) {
-    const start = Math.max(0, messageIndex + 1 - companion.contextMessages);
-    const lines = chat.slice(start, messageIndex + 1)
+    const minMessages = Math.max(1, Number(companion.contextMessages) || 1);
+    const minContextTokens = Math.max(0, Number(companion.minContextTokens) || 0);
+    const selected = [];
+    let tokenTotal = 0;
+
+    for (let index = Math.min(messageIndex, chat.length - 1); index >= 0; index--) {
+        const message = chat[index];
+        if (!isValidCompanionMessage(message)) {
+            continue;
+        }
+
+        selected.push(message);
+        tokenTotal += getMessageTokenEstimate(message);
+
+        if (selected.length >= minMessages && (!minContextTokens || tokenTotal >= minContextTokens)) {
+            break;
+        }
+    }
+
+    const lines = selected.reverse()
         .map(getMessageLine)
         .filter(line => line.trim());
     return lines.length ? lines.join('\n') : '';
@@ -609,6 +635,7 @@ async function getWorldInfoSection(messageIndex, companion) {
 
     try {
         const scanLines = chat.slice(0, messageIndex + 1)
+            .filter(isValidCompanionMessage)
             .map(message => normalizeText(message?.mes ?? ''))
             .filter(Boolean)
             .reverse();
@@ -812,6 +839,7 @@ function getBatchKey(agent, messageIndex) {
         profile: resolveCompanionConnectionProfile(agent.connectionProfile),
         model: String(agent.modelOverride ?? '').trim(),
         contextMessages: companion.contextMessages,
+        minContextTokens: companion.minContextTokens,
         includeCharacterCard: companion.includeCharacterCard,
         includePersona: companion.includePersona,
         includeWorldInfo: companion.includeWorldInfo,
@@ -1367,10 +1395,7 @@ export function getChatTokenEstimate(beforeMessageIndex = chat.length) {
         if (message?.is_system) {
             continue;
         }
-        const counted = Number(message?.extra?.token_count);
-        total += Number.isFinite(counted) && counted > 0
-            ? counted
-            : Math.ceil(String(message?.mes ?? '').length / 4);
+        total += getMessageTokenEstimate(message);
     }
 
     return total;

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -54,6 +54,7 @@ describe('in-chat agent post-processing runner', () => {
     let contextCharacterId;
     let contextGroups;
     let contextGroupId;
+    let getWorldInfoPrompt;
 
     beforeEach(async () => {
         jest.resetModules();
@@ -138,6 +139,7 @@ describe('in-chat agent post-processing runner', () => {
         contextCharacterId = undefined;
         contextGroups = [];
         contextGroupId = null;
+        getWorldInfoPrompt = jest.fn(async () => ({ worldInfoString: '' }));
 
         const addListener = (listeners, event, handler) => {
             const eventListeners = listeners.get(event) ?? [];
@@ -280,7 +282,7 @@ describe('in-chat agent post-processing runner', () => {
         }));
 
         await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
-            getWorldInfoPrompt: jest.fn(async () => ({ worldInfoString: '' })),
+            getWorldInfoPrompt,
         }));
 
         await jest.unstable_mockModule('../public/scripts/power-user.js', () => ({
@@ -1499,6 +1501,54 @@ describe('in-chat agent post-processing runner', () => {
         // so the threshold is unmet again until fresh context accrues.
         expect(companionRunner.getChatTokenEstimate()).toBe(15000);
         expect(companionRunner.meetsCompanionContextThreshold(shard, 2)).toBe(false);
+    });
+
+    test('expands companion context to the minimum token window and skips hidden messages', async () => {
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        const shard = createCompanionAgent({
+            id: 'memory-shard',
+            companion: { contextMessages: 2, minContextTokens: 30 },
+        });
+
+        chat.push(
+            { mes: 'Visible beginning context.', name: 'Assistant', is_user: false, is_system: false, extra: { token_count: 10 } },
+            { mes: 'Hidden absorbed context.', name: 'System', is_user: false, is_system: true, extra: { token_count: 1000 } },
+            { mes: 'Visible recent setup.', name: 'User', is_user: true, is_system: false, extra: { token_count: 10 } },
+            { mes: 'Visible latest reply.', name: 'Assistant', is_user: false, is_system: false, extra: { token_count: 10 } },
+        );
+
+        const messages = await companionRunner.buildCompanionPromptMessages(shard, 3);
+        const prompt = messages[1].content;
+
+        expect(prompt).toContain('[Recent conversation]');
+        expect(prompt).toContain('Assistant: Visible beginning context.');
+        expect(prompt).toContain('User: Visible recent setup.');
+        expect(prompt).toContain('Assistant: Visible latest reply.');
+        expect(prompt).not.toContain('Hidden absorbed context.');
+        expect(prompt.indexOf('Assistant: Visible beginning context.')).toBeLessThan(prompt.indexOf('User: Visible recent setup.'));
+        expect(prompt.indexOf('User: Visible recent setup.')).toBeLessThan(prompt.indexOf('Assistant: Visible latest reply.'));
+    });
+
+    test('excludes hidden messages from companion world info scans', async () => {
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        const worldInfoCompanion = createCompanionAgent({
+            id: 'world-info-companion',
+            companion: { includeWorldInfo: true },
+        });
+
+        chat.push(
+            { mes: 'Visible lore trigger.', name: 'Assistant', is_user: false, is_system: false, extra: {} },
+            { mes: 'Hidden lore trigger.', name: 'System', is_user: false, is_system: true, extra: {} },
+            { mes: 'Visible current turn.', name: 'User', is_user: true, is_system: false, extra: {} },
+        );
+
+        await companionRunner.buildCompanionPromptMessages(worldInfoCompanion, 2);
+
+        expect(getWorldInfoPrompt).toHaveBeenCalledTimes(1);
+        expect(getWorldInfoPrompt.mock.calls[0][0]).toEqual([
+            'Visible current turn.',
+            'Visible lore trigger.',
+        ]);
     });
 
     test('appends the repair instruction on fix runs', async () => {


### PR DESCRIPTION
# Summary
## Issue
Seen most easily in the Memory Shard agent: instead of adhering to the minimum context before it runs, it runs based on that *but* only bases the summary on the number of messages it's set to (by default, 30 messages), making it miss additional context from beginning to end, especially if there are more than 30 messages before it hits 30k context.
Additionally, it considers hidden messages in summarising and context as well when it shouldn't.