### PR TITLE
fix: requests made under a connection profile no longer inherit the currently active proxy

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -989,8 +989,14 @@ async function applyConnectionProfile(profile) {
                 throw new Error(PROFILE_APPLICATION_ABORTED);
             }
 
-            const argument = profile[command];
+            let argument = profile[command];
             const allowEmpty = ALLOW_EMPTY.includes(command);
+            // SillyBunny: a profile without a proxy value means "no proxy". Reset the
+            // proxy preset instead of skipping, otherwise the previous profile's proxy
+            // stays active and leaks into requests made under this profile.
+            if (command === 'proxy' && !argument && !profile.exclude?.includes(command)) {
+                argument = 'None';
+            }
             if (!argument && !(allowEmpty && argument === '')) {
                 continue;
             }

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -50,10 +50,18 @@ function getReverseProxyRequestFields(proxyPreset) {
 }
 
 export function getChatCompletionProfileReverseProxy(profile, chatCompletionSource) {
-    const profileProxy = proxies.find((preset) => preset.name === profile?.proxy);
+    const profileProxyName = profile?.proxy;
+    const profileProxy = proxies.find((preset) => preset.name === profileProxyName);
     const profileProxyFields = getReverseProxyRequestFields(profileProxy);
     if (profileProxyFields.reverse_proxy) {
         return profileProxyFields;
+    }
+
+    // SillyBunny: a profile that explicitly stores a proxy selection ('None' included)
+    // must be honored as-is. Falling through here would leak the currently active
+    // profile's proxy state into requests made under this profile (e.g. Agents).
+    if (profileProxyName) {
+        return {};
     }
 
     const sourceProxy = proxies.find((preset) => preset.name !== 'None' && preset.source === chatCompletionSource && preset.url);

--- a/tests/connection-profile-request-fields.test.js
+++ b/tests/connection-profile-request-fields.test.js
@@ -187,36 +187,46 @@ describe('Connection Profile reverse proxy request mapping', () => {
         });
     });
 
-    test('falls back to a backend-bound proxy preset when the profile preset has no URL', () => {
+    test('honors an explicit profile proxy selection of None without fallbacks', () => {
+        mockOpenAiSettings.reverse_proxy = 'https://active.example/v1';
+        mockOpenAiSettings.proxy_password = 'active-secret';
         mockProxies.push(
             { name: 'None', url: '', password: '', source: '' },
             { name: 'Gemini proxy', url: 'https://proxy.example/google', password: '', source: 'makersuite' },
         );
 
-        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'makersuite')).toEqual({
-            reverse_proxy: 'https://proxy.example/google',
-            proxy_password: '',
-        });
-        expect(getChatCompletionProfileReverseProxy({ proxy: 'Deleted proxy' }, 'makersuite')).toEqual({
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'makersuite')).toEqual({});
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'Deleted proxy' }, 'makersuite')).toEqual({});
+    });
+
+    test('falls back to a backend-bound proxy preset when the profile has no proxy key', () => {
+        mockProxies.push(
+            { name: 'None', url: '', password: '', source: '' },
+            { name: 'Gemini proxy', url: 'https://proxy.example/google', password: '', source: 'makersuite' },
+        );
+
+        expect(getChatCompletionProfileReverseProxy({}, 'makersuite')).toEqual({
             reverse_proxy: 'https://proxy.example/google',
             proxy_password: '',
         });
     });
 
-    test('falls back to the active reverse proxy for unsaved manual proxy URLs', () => {
+    test('falls back to the active reverse proxy only when the profile has no proxy key', () => {
         mockOpenAiSettings.reverse_proxy = 'https://manual.example/v1';
         mockOpenAiSettings.proxy_password = 'manual-secret';
         mockProxies.push({ name: 'None', url: '', password: '', source: '' });
 
-        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'openai')).toEqual({
+        expect(getChatCompletionProfileReverseProxy({}, 'openai')).toEqual({
             reverse_proxy: 'https://manual.example/v1',
             proxy_password: 'manual-secret',
         });
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'openai')).toEqual({});
     });
 
     test('omits reverse proxy fields when no usable proxy is available', () => {
         mockProxies.push({ name: 'None', url: '', password: '', source: '' });
 
         expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'openai')).toEqual({});
+        expect(getChatCompletionProfileReverseProxy({}, 'openai')).toEqual({});
     });
 });


### PR DESCRIPTION
What was happening earlier:

The proxy preset of the current connection profiles doesn't become blank when a profile without a proxy preset is used, causing Agents to not work, among other functions.

Sample:
Proxy preset 1 > Prose Polisher on DeepSeek > Deepseek doesn't work on said agent
Proxy preset 1 > Prose Polisher on DeepSeek > Switch to Deepseek profile > Run same agent > Agent works

In Claude's terms for reference:

- **Bug:** Requests made under a connection profile (Agents via `ConnectionManagerRequestService`) inherited the *currently active* proxy. `getChatCompletionProfileReverseProxy` resolved the profile's own proxy preset, but when that was 'None' it fell through to `oai_settings.reverse_proxy` — the proxy of whatever profile is active in the UI. 
Repro: LAPI profile active → run an agent on a DeepSeek profile → the DeepSeek request is routed through the LAPI proxy and fails; switching the UI to the DeepSeek profile first "fixes" it.
- **Fix:** An explicit proxy selection stored in a profile (including 'None') is now honored strictly — no fallbacks. The legacy fallbacks (source-bound preset, then active manual proxy) only apply to old profiles that have no proxy key at all. 
Additionally, applying a profile with no proxy value now runs `/proxy None` instead of silently keeping the previous profile's proxy (skipped if Proxy Preset is excluded from the profile).
- **Tests:** Updated the reverse-proxy mapping tests to pin the new semantics and added coverage for the legacy no-proxy-key fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
