### PR TITLE
fix: Gemini thought signatures getting mangled/corrupted

### DIFF
--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -584,10 +584,15 @@ export function convertGooglePrompt(messages, model, useSysPrompt, names) {
         // Inject stored thought signatures, or fall back to bypass magic for Gemini 3
         if (/gemini-3/.test(model) || /gemini-2\.5/.test(model)) {
             const skipSignatureMagic = 'skip_thought_signature_validator';
-            const textSignature = message.signature;
+            // Signatures are only valid on model turns; stamping one on a user-role part
+            // gets the request rejected with a 400 "Corrupted thought signature".
+            const textSignature = message.role === 'model' ? message.signature : null;
+            // A stored signature covers one generated part. Duplicating it across every
+            // text part of the message also trips the corruption validator.
+            const lastTextPart = parts.findLast((part) => typeof part.text === 'string');
 
             parts.forEach((part) => {
-                if (isThoughtSignaturesEnabled() && textSignature && typeof part.text === 'string') {
+                if (isThoughtSignaturesEnabled() && textSignature && part === lastTextPart) {
                     part.thoughtSignature = textSignature;
                 } else if (/gemini-3/.test(model)) {
                     // Gemini 3: Fall back to bypass magic for function calls (mandatory) and images
@@ -606,17 +611,22 @@ export function convertGooglePrompt(messages, model, useSysPrompt, names) {
 
         // merge consecutive messages with the same role
         if (index > 0 && message.role === contents[contents.length - 1].role) {
+            const previousParts = contents[contents.length - 1].parts;
             parts.forEach((part) => {
-                if (part.text) {
-                    const textPart = contents[contents.length - 1].parts.find(p => typeof p.text === 'string');
+                const isPlainText = typeof part.text === 'string'
+                    && !part.inlineData && !part.functionCall && !part.functionResponse
+                    && !part.thoughtSignature && !part.mediaResolution;
+                if (isPlainText) {
+                    // Signed parts must stay byte-identical to what the model produced,
+                    // so plain text never folds into them and they never fold into text.
+                    const textPart = previousParts.find(p => typeof p.text === 'string' && !p.thoughtSignature);
                     if (textPart) {
                         textPart.text += '\n\n' + part.text;
                     } else {
-                        contents[contents.length - 1].parts.push(part);
+                        previousParts.push(part);
                     }
-                }
-                if (part.inlineData || part.functionCall || part.functionResponse || part.thoughtSignature || part.mediaResolution) {
-                    contents[contents.length - 1].parts.push(part);
+                } else {
+                    previousParts.push(part);
                 }
             });
         } else {


### PR DESCRIPTION
What was happening earlier: Gemini thought signatures were getting corrupted for unknown reasons on both API as well as reverse proxy modes. This is now fixed with some targeted changes.

In Claude's terms for reference:

- **Bug:** Gemini 2.5/3 models (e.g. 3.1 Pro Preview) intermittently rejected requests with `400: Corrupted thought signature`, both direct and through reverse proxies (the payload SillyBunny builds is the problem; proxies just relay it). 
Three defects in `convertGooglePrompt`:
  1. The stored text signature was stamped onto **every** text part of a message, and onto **user-role** messages that carried a stray signature — signatures are only valid once, on model turns.
  2. The consecutive-same-role merge double-handled signed text parts: the text was concatenated into the previous part **and** the part was pushed again — duplicated content with misplaced signatures. Triggers in group chats and whenever assistant-role prompt injections sit next to a signed chat message.
  3. Plain text could be folded into a signed part (and signed text into plain parts), mutating content the signature was bound to.
- **Fix:** The signature is attached only to the last text part of model-role messages; the merge keeps signed parts byte-identical as standalone parts and only concatenates unsigned plain text. Gemini 3 `skip_thought_signature_validator` fallbacks for function calls and image models are unchanged.
- **Verification:** A scenario harness against the old code reproduced all three defects; the fixed code passes all 11 checks, and the existing 152 prompt-converter tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
