### PR TITLE
fix: agent prompt editor blow-up being shapeless/formless with text spilling off-screen

### DIFF
--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1079,16 +1079,30 @@ button.ica--card-pill--version-update {
     overflow: hidden;
 }
 
-.ica--textarea-fullscreen-backdrop {
+dialog.ica--textarea-fullscreen-backdrop {
     position: fixed;
     inset: 0;
     z-index: 10060;
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
     background: color-mix(in srgb, var(--SmartThemeShadowColor, #000) 42%, transparent);
     -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
 }
 
-.ica--textarea-fullscreen-wrapper textarea.ica--textarea-fullscreen-field {
+dialog.ica--textarea-fullscreen-backdrop::backdrop {
+    background: transparent;
+}
+
+/* While fullscreen, the field and toggle are hosted inside the body-level backdrop so
+   transformed/filtered dialog ancestors cannot become their containing block and
+   shrink or misplace the viewport-sized editor. */
+.ica--textarea-fullscreen-backdrop textarea.ica--textarea-fullscreen-field {
     --ica-textarea-fullscreen-top: max(10px, env(safe-area-inset-top, 0px));
     --ica-textarea-fullscreen-right: max(10px, env(safe-area-inset-right, 0px));
     --ica-textarea-fullscreen-bottom: max(10px, env(safe-area-inset-bottom, 0px));
@@ -1110,9 +1124,12 @@ button.ica--card-pill--version-update {
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 96%, var(--SmartThemeChatTintColor, #222) 4%);
     box-shadow: 0 24px 80px color-mix(in srgb, var(--SmartThemeShadowColor) 42%, transparent);
     line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    overflow-y: auto;
 }
 
-.ica--textarea-fullscreen-wrapper.is-fullscreen .ica--textarea-fullscreen-toggle {
+.ica--textarea-fullscreen-backdrop .ica--textarea-fullscreen-toggle {
     position: fixed;
     top: calc(max(10px, env(safe-area-inset-top, 0px)) + 10px);
     right: calc(max(10px, env(safe-area-inset-right, 0px)) + 10px);
@@ -1121,7 +1138,7 @@ button.ica--card-pill--version-update {
 }
 
 @media (max-width: 600px) {
-    .ica--textarea-fullscreen-wrapper textarea.ica--textarea-fullscreen-field {
+    .ica--textarea-fullscreen-backdrop textarea.ica--textarea-fullscreen-field {
         --ica-textarea-fullscreen-top: max(6px, env(safe-area-inset-top, 0px));
         --ica-textarea-fullscreen-right: max(6px, env(safe-area-inset-right, 0px));
         --ica-textarea-fullscreen-bottom: max(6px, env(safe-area-inset-bottom, 0px));
@@ -1131,7 +1148,7 @@ button.ica--card-pill--version-update {
         font-size: 16px;
     }
 
-    .ica--textarea-fullscreen-wrapper.is-fullscreen .ica--textarea-fullscreen-toggle {
+    .ica--textarea-fullscreen-backdrop .ica--textarea-fullscreen-toggle {
         top: calc(max(6px, env(safe-area-inset-top, 0px)) + 8px);
         right: calc(max(6px, env(safe-area-inset-right, 0px)) + 8px);
     }

--- a/public/scripts/extensions/in-chat-agents/textarea-fullscreen.js
+++ b/public/scripts/extensions/in-chat-agents/textarea-fullscreen.js
@@ -110,10 +110,29 @@ function enhanceTextarea(textarea) {
         textarea.classList.add(FIELD_ACTIVE_CLASS);
         document.body.classList.add(BODY_ACTIVE_CLASS);
 
-        backdrop = document.createElement('div');
+        // Popup dialogs have backdrop-filter, which makes them the containing block for
+        // position: fixed and shrinks/misplaces the fullscreen field, and they are shown
+        // with showModal(), which makes everything outside their top layer inert. Hosting
+        // the field in a modal <dialog> backdrop of its own solves both: it stacks above
+        // the popup in the top layer and stays viewport-sized regardless of ancestors.
+        backdrop = document.createElement('dialog');
         backdrop.className = BACKDROP_CLASS;
-        backdrop.addEventListener('click', close);
+        backdrop.addEventListener('click', event => {
+            if (event.target === backdrop) {
+                close();
+            }
+        });
+        backdrop.addEventListener('cancel', event => {
+            event.preventDefault();
+            close();
+        });
+        backdrop.append(textarea, toggle);
         document.body.append(backdrop);
+        try {
+            backdrop.showModal();
+        } catch {
+            backdrop.setAttribute('open', '');
+        }
         document.addEventListener('keydown', onKeyDown, true);
         updateToggleState(true);
         textarea.focus({ preventScroll: true });
@@ -130,6 +149,12 @@ function enhanceTextarea(textarea) {
         textarea.classList.remove(FIELD_ACTIVE_CLASS);
         document.body.classList.remove(BODY_ACTIVE_CLASS);
         document.removeEventListener('keydown', onKeyDown, true);
+        wrapper.append(textarea, toggle);
+        try {
+            backdrop?.close();
+        } catch {
+            // Already closed or never shown modally.
+        }
         backdrop?.remove();
         backdrop = null;
         updateToggleState(false);


### PR DESCRIPTION
What was happening earlier: Text when made `fullscreen` in agent prompt editor had no shape to the box that popped out, and the text wasn't wrapped around the current viewport correctly. This rectifies that.

In Claude's terms for reference:
- **Bug:** The per-textarea fullscreen editor (companion prompt and any other textarea with the expand toggle) rendered as a misshapen, off-screen box with seemingly unwrapped text when opened from inside a popup. Cause: the field uses `position: fixed` sized to the viewport, but `.popup` has `backdrop-filter`, which makes the dialog the containing block for fixed descendants — the "fullscreen" field anchored to the dialog's box instead of the viewport.
- **Fix:** While expanded, the textarea and its exit toggle move into a backdrop that is itself a modal `<dialog>` (`showModal()`), placing it in the top layer above the popup — viewport-anchored regardless of ancestor transforms/filters, and fully interactive (a plain body-level overlay would be inert under the popup's modal top layer). Everything is restored to its original DOM position on close (Esc, backdrop click, or the compress button), so form saves read the edited value normally. Input listeners are direct bindings, so they survive the temporary move. Also added explicit `white-space: pre-wrap`/`overflow-wrap: break-word` on the fullscreen field and updated the CSS selectors for the new structure, with a transparent `::backdrop` to keep the existing blur styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
