### PR TITLE
feat: add LinkAPI chat completion provider integration with auto-routing

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -5,6 +5,12 @@
 <img src="screenshots/banner.jpg" width="100%">
 </div>
 
+<div align="center">
+
+English | [Deutsch](.github/readme-de_de.md) | [中文](.github/readme-zh_cn.md) | [繁體中文](.github/readme-zh_tw.md) | [日本語](.github/readme-ja_jp.md) | [Русский](.github/readme-ru_ru.md) | [한국어](.github/readme-ko_kr.md)
+
+</div>
+
 ---
 
 An elegant fork of [SillyTavern](https://github.com/SillyTavern/SillyTavern), designed with a cleaner, graphical shell UI; Bun-based backend; built-in tutorials, presets, extensions, and a quick-start dashboard; and a lightweight agentic system to facilitate modern agent functionality.

--- a/public/index.html
+++ b/public/index.html
@@ -342,7 +342,7 @@
                             -->
                             <div id="range_block_novel">
                                 <div class="flex-container gap10h5v justifyCenter">
-                                    <div data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai" data-tg-samplers="temp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,linkapi" data-tg-samplers="temp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Temperature">Temperature</span>
                                         </small>
@@ -591,7 +591,7 @@
                                     </div>
                                 </div>
                                 <div class="flex-container gap10h5v justifyCenter">
-                                    <div data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai" data-tg-samplers="temp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,linkapi" data-tg-samplers="temp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Temperature">Temperature</span>
                                             <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Temperature controls the randomness in token selection" title="Temperature controls the randomness in token selection:&#13;- low temperature (<1.0) leads to more predictable text, favoring higher probability tokens.&#13;- high temperature (>1.0) increases creativity and diversity in the output by giving lower probability tokens a better chance.&#13;Set to 1.0 for the original probabilities."></div>
@@ -599,21 +599,21 @@
                                         <input class="neo-range-slider" type="range" id="temp_openai" name="volume" min="0" max="2.0" step="0.01">
                                         <input class="neo-range-input" type="number" min="0" max="2.0" step="0.01" data-for="temp_openai" id="temp_counter_openai">
                                     </div>
-                                    <div data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai" data-tg-samplers="freq_pen" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai,linkapi" data-tg-samplers="freq_pen" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Frequency Penalty">Frequency Penalty</span>
                                         </small>
                                         <input class="neo-range-slider" type="range" id="freq_pen_openai" name="volume" min="-2" max="2" step="0.01">
                                         <input class="neo-range-input" type="number" min="-2" max="2" step="0.01" data-for="freq_pen_openai" id="freq_pen_counter_openai">
                                     </div>
-                                    <div data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai" data-tg-samplers="presence_pen" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai,linkapi" data-tg-samplers="presence_pen" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Presence Penalty">Presence Penalty</span>
                                         </small>
                                         <input class="neo-range-slider" type="range" id="pres_pen_openai" name="volume" min="-2" max="2" step="0.01">
                                         <input class="neo-range-input" type="number" min="-2" max="2" step="0.01" data-for="pres_pen_openai" id="pres_pen_counter_openai">
                                     </div>
-                                    <div data-source="claude,aimlapi,openrouter,makersuite,vertexai,cohere,perplexity,electronhub,chutes,nanogpt,workers_ai" data-tg-samplers="top_k" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-source="claude,aimlapi,openrouter,makersuite,vertexai,cohere,perplexity,electronhub,chutes,nanogpt,workers_ai,linkapi" data-tg-samplers="top_k" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Top K">Top K</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="Top K sets a maximum amount of top tokens that can be chosen from.&#13;E.g Top K is 20, this means only the 20 highest ranking tokens will be kept (regardless of their probabilities being diverse or limited).&#13;Set to 0 (or -1, depending on your backend) to disable." data-i18n="[title]Top_K_desc"></div>
@@ -621,7 +621,7 @@
                                         <input class="neo-range-slider" type="range" id="top_k_openai" name="volume" min="0" max="500" step="1">
                                         <input class="neo-range-input" type="number" min="0" max="500" step="1" data-for="top_k_openai" id="top_k_counter_openai">
                                     </div>
-                                    <div data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai" data-tg-samplers="top_p" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,linkapi" data-tg-samplers="top_p" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Top P">Top P</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="Top P (a.k.a. nucleus sampling) adds up all the top tokens required to add up to the target percentage.&#13;E.g If the Top 2 tokens are both 25%, and Top P is 0.50, only the Top 2 tokens are considered.&#13;Set to 1.0 to disable." data-i18n="[title]Top_P_desc"></div>
@@ -838,7 +838,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,openrouter,mistralai,custom,cohere,groq,electronhub,chutes,nanogpt,xai,pollinations,aimlapi,makersuite,vertexai,azure_openai,workers_ai">
+                                <div class="range-block" data-source="openai,openrouter,mistralai,custom,cohere,groq,electronhub,chutes,nanogpt,xai,pollinations,aimlapi,makersuite,vertexai,azure_openai,workers_ai,linkapi">
                                     <div class="range-block-title justifyLeft" data-i18n="Seed">
                                         Seed
                                     </div>
@@ -1851,7 +1851,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="claude,makersuite,vertexai">
+                                    <div class="range-block" data-source="claude,makersuite,vertexai,linkapi">
                                         <label for="use_sysprompt" class="checkbox_label widthFreeExpand">
                                             <input id="use_sysprompt" type="checkbox" />
                                             <span>
@@ -1864,7 +1864,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="makersuite,vertexai,aimlapi,openrouter,claude,electronhub,chutes,nanogpt">
+                                    <div class="range-block" data-source="makersuite,vertexai,aimlapi,openrouter,claude,electronhub,chutes,nanogpt,linkapi">
                                         <label for="openai_enable_web_search" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_enable_web_search" type="checkbox" />
                                             <span data-i18n="Enable web search">Enable web search</span>
@@ -1878,7 +1878,7 @@
                                             </b>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="openai,cohere,mistralai,custom,claude,aimlapi,openrouter,groq,siliconflow,minimax,deepseek,makersuite,vertexai,ai21,xai,pollinations,moonshot,fireworks,cometapi,electronhub,chutes,azure_openai,zai,nanogpt,workers_ai">
+                                    <div class="range-block" data-source="openai,cohere,mistralai,custom,claude,aimlapi,openrouter,groq,siliconflow,minimax,deepseek,makersuite,vertexai,ai21,xai,pollinations,moonshot,fireworks,cometapi,electronhub,chutes,azure_openai,zai,nanogpt,workers_ai,linkapi">
                                         <label for="openai_function_calling" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_function_calling" type="checkbox" />
                                             <span data-i18n="Enable function calling">Enable function calling</span>
@@ -1931,7 +1931,7 @@
                                             </em>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="openai,aimlapi,openrouter,mistralai,makersuite,vertexai,claude,custom,xai,pollinations,moonshot,cohere,cometapi,nanogpt,electronhub,azure_openai,zai,siliconflow,chutes,workers_ai">
+                                    <div class="range-block" data-source="openai,aimlapi,openrouter,mistralai,makersuite,vertexai,claude,custom,xai,pollinations,moonshot,cohere,cometapi,nanogpt,electronhub,azure_openai,zai,siliconflow,chutes,workers_ai,linkapi">
                                         <label for="openai_media_inlining" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_media_inlining" type="checkbox" />
                                             <span data-i18n="Send inline media">Send inline media</span>
@@ -1955,7 +1955,7 @@
                                             <strong data-source="makersuite,vertexai" data-i18n="video_inlining_hint_4">Videos must be less than 20 MB and under 1 minute long.</strong>
                                             <strong data-source="makersuite,vertexai" data-i18n="audio_inlining_hint_2">Audio must be less than 20 MB.</strong>
                                         </div>
-                                        <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,xai,pollinations,cohere,cometapi,nanogpt,moonshot,aimlapi,openrouter,mistralai,electronhub,azure_openai,zai,siliconflow,chutes,makersuite,vertexai,workers_ai">
+                                        <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,xai,pollinations,cohere,cometapi,nanogpt,moonshot,aimlapi,openrouter,mistralai,electronhub,azure_openai,zai,siliconflow,chutes,makersuite,vertexai,workers_ai,linkapi">
                                             <div class="flex-container oneline-dropdown">
                                                 <label for="openai_inline_image_quality" data-i18n="Inline Image Quality">
                                                     Inline Image Quality
@@ -2016,7 +2016,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="deepseek,aimlapi,openrouter,custom,claude,xai,makersuite,vertexai,pollinations,moonshot,mistralai,fireworks,cometapi,electronhub,chutes,azure_openai,nanogpt,zai">
+                                    <div class="range-block" data-source="deepseek,aimlapi,openrouter,custom,claude,xai,makersuite,vertexai,pollinations,moonshot,mistralai,fireworks,cometapi,electronhub,chutes,azure_openai,nanogpt,zai,linkapi">
                                         <label for="openai_show_thoughts" class="checkbox_label widthFreeExpand">
                                             <input id="openai_show_thoughts" type="checkbox" />
                                             <span data-i18n="Request model reasoning">Request model reasoning</span>
@@ -2056,7 +2056,7 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,linkapi">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>
@@ -2091,7 +2091,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,openrouter,claude">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,openrouter,claude,linkapi">
                                         <div class="flex-container oneline-dropdown sb-setting-inline-help sb-setting-inline-center">
                                             <div class="sb-setting-inline-copy sb-setting-inline-copy-center">
                                                 <label for="openai_verbosity">
@@ -2112,7 +2112,7 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="claude">
+                                    <div class="range-block" data-source="claude,linkapi">
                                         <div class="wide100p">
                                             <div class="flex-container alignItemsCenter">
                                                 <span id="claude_assistant_prefill_text" data-i18n="Assistant Prefill">Assistant Prefill</span>
@@ -2829,6 +2829,7 @@
                                 <option value="groq">Groq</option>
                                 <option value="makersuite">Google AI Studio</option>
                                 <option value="vertexai">Google Vertex AI</option>
+                                <option value="linkapi">LinkAPI</option>
                                 <option value="mistralai">MistralAI</option>
                                 <option value="minimax">MiniMax</option>
                                 <option value="moonshot">Moonshot AI</option>
@@ -2842,7 +2843,7 @@
                                 <option value="zai">Z.AI (GLM)</option>
                             </optgroup>
                         </select>
-                        <div id="oai_max_context_unlocked_block" class="range-block" data-source="openrouter,nanogpt">
+                        <div id="oai_max_context_unlocked_block" class="range-block" data-source="openrouter,nanogpt,linkapi">
                             <label class="checkbox_label" for="oai_max_context_unlocked">
                                 <input id="oai_max_context_unlocked" type="checkbox">
                                 <span data-i18n="Unlocked Context Size">Unlocked Context Size</span>
@@ -4036,6 +4037,38 @@
                                 </optgroup>
                                 <optgroup id="zai_other_models" label="From API"></optgroup>
                             </select>
+                        </div>
+                        <div id="linkapi_form" data-source="linkapi">
+                            <h4>
+                                <a data-i18n="LinkAPI Key" href="https://linkapi.ai/keys" target="_blank" rel="noopener noreferrer">
+                                    LinkAPI Key
+                                </a>
+                            </h4>
+                            <div class="flex-container">
+                                <input id="api_key_linkapi" name="api_key_linkapi" class="text_pole flex1" value="" type="text" autocomplete="off">
+                                <div title="Manage API keys" data-i18n="[title]Manage API keys" class="menu_button fa-solid fa-key fa-fw manage-api-keys" data-key="api_key_linkapi"></div>
+                            </div>
+                            <div data-for="api_key_linkapi" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
+                                For privacy reasons, your API key will be hidden after you click 'Connect'.
+                            </div>
+                            <h4 data-i18n="LinkAPI Region">LinkAPI Region</h4>
+                            <select id="linkapi_endpoint">
+                                <option value="global" data-i18n="Global (linkapi.ai)">Global (linkapi.ai)</option>
+                                <option value="us" data-i18n="US (api.linkapi.ai)">US (api.linkapi.ai)</option>
+                                <option value="hk" data-i18n="Hong Kong (hk.linkapi.ai)">Hong Kong (hk.linkapi.ai)</option>
+                            </select>
+                            <h4 data-i18n="Model ID">Model ID</h4>
+                            <div class="flex-container">
+                                <input id="linkapi_model_id" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: claude-sonnet-4-5" placeholder="Example: claude-sonnet-4-5">
+                            </div>
+                            <h4 data-i18n="Available Models">Available Models</h4>
+                            <select id="model_linkapi_select">
+                                <optgroup id="linkapi_other_models" label="From API"></optgroup>
+                            </select>
+                            <small data-i18n="Models route automatically: Claude models use the Anthropic API, Gemini models use the Gemini API, everything else (including bracket-tagged per-request channels like [SP]) uses the OpenAI-compatible API. Keys are group-scoped on LinkAPI; the list shows only models your key's group can access.">
+                                Models route automatically: Claude models use the Anthropic API, Gemini models use the Gemini API, everything else (including bracket-tagged per-request channels like [SP]) uses the OpenAI-compatible API.
+                                Keys are group-scoped on LinkAPI; the list shows only models your key's group can access.
+                            </small>
                         </div>
                         <div id="azure_openai_settings" data-source="azure_openai">
                             <!-- Azure Base URL -->

--- a/public/script.js
+++ b/public/script.js
@@ -9090,6 +9090,15 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.CLAUDE:
                     result = data?.content?.find(x => x.type === 'tool_use')?.input;
                     break;
+                case chat_completion_sources.LINKAPI:
+                    // Anthropic-leg responses carry raw content blocks; other legs return plain text.
+                    result = Array.isArray(data?.content)
+                        ? data.content.find(x => x.type === 'tool_use')?.input
+                        : tryParse(text);
+                    if (!result && returnInvalidJson) {
+                        return text;
+                    }
+                    break;
                 case chat_completion_sources.PERPLEXITY:
                     result = tryParse(removeReasoningFromString(text));
                     if (!result && returnInvalidJson) {

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -469,6 +469,7 @@ function RA_autoconnect(PrevApi) {
                     || (secret_state[SECRET_KEYS.POLLINATIONS] && oai_settings.chat_completion_source === chat_completion_sources.POLLINATIONS)
                     || (secret_state[SECRET_KEYS.WORKERS_AI] && oai_settings.chat_completion_source == chat_completion_sources.WORKERS_AI)
                     || (secret_state[SECRET_KEYS.MINIMAX] && oai_settings.chat_completion_source == chat_completion_sources.MINIMAX)
+                    || (secret_state[SECRET_KEYS.LINKAPI] && oai_settings.chat_completion_source == chat_completion_sources.LINKAPI)
                     || (isValidUrl(oai_settings.custom_url) && oai_settings.chat_completion_source == chat_completion_sources.CUSTOM)
                     || (secret_state[SECRET_KEYS.AZURE_OPENAI] && oai_settings.chat_completion_source == chat_completion_sources.AZURE_OPENAI)
                 ) {

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -661,6 +661,7 @@ export class ChatCompletionService {
             [chat_completion_sources.ZAI]: 'zai_endpoint',
             [chat_completion_sources.SILICONFLOW]: 'siliconflow_endpoint',
             [chat_completion_sources.MINIMAX]: 'minimax_endpoint',
+            [chat_completion_sources.LINKAPI]: 'linkapi_endpoint',
         };
 
         if (overridePayload.chat_completion_source) {
@@ -672,7 +673,7 @@ export class ChatCompletionService {
             }
         } else {
             // Fallback: apply URL fields for all sources (legacy behavior)
-            ['custom_url', 'vertexai_region', 'zai_endpoint', 'siliconflow_endpoint'].forEach(field => {
+            ['custom_url', 'vertexai_region', 'zai_endpoint', 'siliconflow_endpoint', 'linkapi_endpoint'].forEach(field => {
                 overridePayload[field] = overridePayload[field] || settings[field] || oai_settings[field];
             });
         }
@@ -707,6 +708,9 @@ export class ChatCompletionService {
         }
         if (overridePayload.minimax_endpoint !== undefined) {
             settings.minimax_endpoint = overridePayload.minimax_endpoint;
+        }
+        if (overridePayload.linkapi_endpoint !== undefined) {
+            settings.linkapi_endpoint = overridePayload.linkapi_endpoint;
         }
         if (overridePayload.custom_include_body !== undefined) {
             settings.custom_include_body = overridePayload.custom_include_body;

--- a/public/scripts/linkapi-utils.js
+++ b/public/scripts/linkapi-utils.js
@@ -1,0 +1,50 @@
+export const LINKAPI_ENDPOINT = {
+    GLOBAL: 'global',
+    US: 'us',
+    HK: 'hk',
+};
+
+const LINKAPI_BASE_URLS = {
+    [LINKAPI_ENDPOINT.GLOBAL]: 'https://linkapi.ai',
+    [LINKAPI_ENDPOINT.US]: 'https://api.linkapi.ai',
+    [LINKAPI_ENDPOINT.HK]: 'https://hk.linkapi.ai',
+};
+
+/**
+ * Gets the LinkAPI base URL for a region endpoint value.
+ * @param {string} [endpoint] Region endpoint value (LINKAPI_ENDPOINT)
+ * @returns {string} Base URL without a trailing slash or API version suffix
+ */
+export function getLinkApiBaseUrl(endpoint) {
+    return LINKAPI_BASE_URLS[endpoint] ?? LINKAPI_BASE_URLS[LINKAPI_ENDPOINT.GLOBAL];
+}
+
+/**
+ * Picks the upstream wire format for a LinkAPI model id.
+ * Claude models use the Anthropic-native relay and Gemini models the Google-native
+ * relay; everything else (including gemma/learnlm) goes through the
+ * OpenAI-compatible endpoint. Bracket-tagged ids (e.g. '[SP]claude-...', '[次]claude-...')
+ * are flat-rate per-request channels that only relay through the OpenAI-compatible
+ * endpoint, regardless of the underlying model family.
+ * @param {string} model LinkAPI model id
+ * @returns {'anthropic'|'google'|'openai'} Wire format for the request
+ */
+export function getLinkApiRequestFormat(model) {
+    const raw = String(model ?? '').trim();
+
+    if (raw.startsWith('[')) {
+        return 'openai';
+    }
+
+    const id = raw.toLowerCase().replace(/^.*\//, '');
+
+    if (id.includes('claude')) {
+        return 'anthropic';
+    }
+
+    if (id.includes('gemini')) {
+        return 'google';
+    }
+
+    return 'openai';
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -99,6 +99,7 @@ import {
     shouldIncludeSamplingFieldsInPreset,
 } from './openai-preset-utils.js';
 import { TOOL_CALL_RECURSE_LIMIT_DEFAULT, normalizeToolCallRecurseLimit } from './tool-call-recurse-limit.js';
+import { LINKAPI_ENDPOINT, getLinkApiRequestFormat } from './linkapi-utils.js';
 
 export {
     openai_messages_count,
@@ -252,6 +253,7 @@ export const chat_completion_sources = {
     SILICONFLOW: 'siliconflow',
     MINIMAX: 'minimax',
     WORKERS_AI: 'workers_ai',
+    LINKAPI: 'linkapi',
 };
 
 export const REVERSE_PROXY_SUPPORTED_SOURCES = [
@@ -289,6 +291,7 @@ const MODEL_ID_SEARCH_CONTROLS = [
     { source: chat_completion_sources.VERTEXAI, setting: 'vertexai_model', input: '#vertexai_model_id', select: '#model_vertexai_select', dynamicGroupId: 'vertexai_other_models' },
     { source: chat_completion_sources.CUSTOM, setting: 'custom_model', input: '#custom_model_id', select: '#model_custom_select', datalist: '#model_custom_select_fill', dynamicOnly: true },
     { source: chat_completion_sources.ZAI, setting: 'zai_model', input: '#zai_model_id', select: '#model_zai_select', dynamicGroupId: 'zai_other_models' },
+    { source: chat_completion_sources.LINKAPI, setting: 'linkapi_model', input: '#linkapi_model_id', select: '#model_linkapi_select', dynamicGroupId: 'linkapi_other_models', dynamicOnly: true },
 ];
 
 const INLINE_SELECT_PICKER_CONTROLS = [
@@ -480,6 +483,8 @@ export const settingsToUpdate = {
     vertexai_model: ['#model_vertexai_select', 'vertexai_model', false, true],
     zai_model: ['#model_zai_select', 'zai_model', false, true],
     zai_endpoint: ['#zai_endpoint', 'zai_endpoint', false, true],
+    linkapi_model: ['#model_linkapi_select', 'linkapi_model', false, true],
+    linkapi_endpoint: ['#linkapi_endpoint', 'linkapi_endpoint', false, true],
     workers_ai_model: ['#model_workers_ai_select', 'workers_ai_model', false, true],
     workers_ai_account_id: ['#workers_ai_account_id', 'workers_ai_account_id', false, true],
     openai_max_context: ['#openai_max_context', 'openai_max_context', false, false],
@@ -592,6 +597,8 @@ const default_settings = {
     fireworks_model: 'accounts/fireworks/models/kimi-k2-instruct',
     zai_model: 'glm-5.2',
     zai_endpoint: ZAI_ENDPOINT.COMMON,
+    linkapi_model: 'claude-sonnet-4-5',
+    linkapi_endpoint: LINKAPI_ENDPOINT.GLOBAL,
     workers_ai_model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
     workers_ai_account_id: '',
     azure_base_url: '',
@@ -2000,6 +2007,8 @@ export function getChatCompletionModel(settings = null) {
             return settings.zai_model;
         case chat_completion_sources.WORKERS_AI:
             return settings.workers_ai_model;
+        case chat_completion_sources.LINKAPI:
+            return settings.linkapi_model;
         default:
             console.error(`Unknown chat completion source: ${source}`);
             return '';
@@ -4728,6 +4737,23 @@ function saveModelList(data) {
         }
     }
 
+    // LinkAPI - dynamic list only (models are scoped to the active key's group)
+    if (oai_settings.chat_completion_source == chat_completion_sources.LINKAPI) {
+        $('#linkapi_other_models').empty();
+        model_list.forEach((model) => {
+            $('#linkapi_other_models').append(
+                $('<option>', { value: model.id, text: model.id }),
+            );
+        });
+        if (model_list.length > 0) {
+            const selectedModel = model_list.map(m => m.id).includes(oai_settings.linkapi_model)
+                ? oai_settings.linkapi_model
+                : model_list[0]?.id || oai_settings.linkapi_model;
+            $('#model_linkapi_select').val(selectedModel).trigger('change');
+            $('#linkapi_model_id').val(selectedModel);
+        }
+    }
+
     // VertexAI - hybrid approach: keep static optgroups, add dynamic to "From API" optgroup
     if (oai_settings.chat_completion_source === chat_completion_sources.VERTEXAI) {
         // Clear only dynamic models from "From API" optgroup
@@ -5075,6 +5101,7 @@ export async function createGenerationParameters(settings, model, type, messages
         chat_completion_sources.VERTEXAI,
         chat_completion_sources.MAKERSUITE,
         chat_completion_sources.CHUTES,
+        chat_completion_sources.LINKAPI,
     ];
 
     // Sources that support logprobs
@@ -5372,6 +5399,29 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
+    if (settings.chat_completion_source === chat_completion_sources.LINKAPI) {
+        generate_data.linkapi_endpoint = settings.linkapi_endpoint || LINKAPI_ENDPOINT.GLOBAL;
+        const linkApiFormat = getLinkApiRequestFormat(model);
+        if (linkApiFormat === 'anthropic') {
+            generate_data.top_k = settings.top_k_openai > 0 ? Number(settings.top_k_openai) : undefined;
+            generate_data.use_sysprompt = settings.use_sysprompt;
+            generate_data.claude_disable_temperature = Boolean(settings.claude_disable_temperature);
+            generate_data.claude_disable_top_p = Boolean(settings.claude_disable_top_p);
+            generate_data.stop = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
+            // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
+            if (type !== 'quiet' && !(type === 'continue' && settings.continue_prefill)) {
+                generate_data.assistant_prefill = type === 'impersonate'
+                    ? getEffectiveAssistantImpersonationPrefill(settings)
+                    : substituteParams(settings.assistant_prefill);
+            }
+        } else if (linkApiFormat === 'google') {
+            const stopStringsLimit = 5;
+            generate_data.top_k = settings.top_k_openai > 0 ? Number(settings.top_k_openai) : undefined;
+            generate_data.use_sysprompt = settings.use_sysprompt;
+            generate_data.stop = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
+        }
+    }
+
     if (seedSupportedSources.includes(settings.chat_completion_source) && settings.seed >= 0) {
         generate_data.seed = settings.seed;
     }
@@ -5433,7 +5483,8 @@ export async function createGenerationParameters(settings, model, type, messages
         delete generate_data.presence_penalty;
         // Keep reasoning_effort for the native Claude source (the backend maps it to adaptive thinking);
         // strip it for proxies, which may translate it into a thinking budget that fable rejects.
-        if (settings.chat_completion_source !== chat_completion_sources.CLAUDE) {
+        // LinkAPI routes claude models through the native Claude handler, so it keeps effort too.
+        if (![chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source)) {
             delete generate_data.reasoning_effort;
             delete generate_data.custom_reasoning_param_name;
         }
@@ -5559,7 +5610,42 @@ export function getStreamingReply(data, state, { chatCompletionSource = null, ov
     const chat_completion_source = chatCompletionSource ?? oai_settings.chat_completion_source;
     const show_thoughts = overrideShowThoughts ?? shouldRequestReasoning(oai_settings);
 
-    if (chat_completion_source === chat_completion_sources.CLAUDE) {
+    if (chat_completion_source === chat_completion_sources.LINKAPI) {
+        // LinkAPI relays Anthropic, Gemini, or OpenAI SSE depending on the model's routing leg,
+        // so detect the payload shape instead of assuming a single format.
+        if (Array.isArray(data?.candidates)) {
+            // Gemini leg
+            const inlineData = data?.candidates?.[0]?.content?.parts?.filter(x => x.inlineData && !x.thought)?.map(x => x.inlineData) || [];
+            if (Array.isArray(inlineData) && inlineData.length > 0) {
+                state.images.push(...inlineData.map(x => `data:${x.mimeType};base64,${x.data}`).filter(isDataURL));
+            }
+            if (show_thoughts) {
+                state.reasoning += (data?.candidates?.[0]?.content?.parts?.filter(x => x.thought)?.map(x => x.text)?.[0] || '');
+            }
+            const parts = data?.candidates?.[0]?.content?.parts || [];
+            parts.forEach((part) => {
+                if (part.thoughtSignature && typeof part.text === 'string') {
+                    state.signature = part.thoughtSignature;
+                }
+            });
+            return data?.candidates?.[0]?.content?.parts?.filter(x => !x.thought)?.map(x => x.text)?.[0] || '';
+        }
+        if (Array.isArray(data?.choices)) {
+            // OpenAI-compatible leg
+            if (show_thoughts) {
+                state.reasoning +=
+                    data.choices?.filter(x => x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content ??
+                    data.choices?.filter(x => x?.delta?.reasoning)?.[0]?.delta?.reasoning ??
+                    '';
+            }
+            return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
+        }
+        // Anthropic leg (content_block_delta events); other event types yield an empty string.
+        if (show_thoughts) {
+            state.reasoning += data?.delta?.thinking || '';
+        }
+        return data?.delta?.text || '';
+    } else if (chat_completion_source === chat_completion_sources.CLAUDE) {
         if (show_thoughts) {
             state.reasoning += data?.delta?.thinking || '';
         }
@@ -7049,6 +7135,10 @@ async function getStatusOpen() {
         data.minimax_endpoint = oai_settings.minimax_endpoint;
     }
 
+    if (oai_settings.chat_completion_source === chat_completion_sources.LINKAPI) {
+        data.linkapi_endpoint = oai_settings.linkapi_endpoint;
+    }
+
     if (oai_settings.chat_completion_source === chat_completion_sources.VERTEXAI) {
         data.vertexai_auth_mode = oai_settings.vertexai_auth_mode;
         data.vertexai_region = oai_settings.vertexai_region;
@@ -8094,6 +8184,12 @@ async function onModelChange() {
             $('#model_zai_select').val(value);
         }
     }
+    if ($(this).is('#linkapi_model_id')) {
+        if (value) {
+            oai_settings.linkapi_model = value;
+            $('#model_linkapi_select').val(value);
+        }
+    }
     if ($(this).is('#vertexai_model_id')) {
         if (value) {
             oai_settings.vertexai_model = value;
@@ -8322,6 +8418,12 @@ async function onModelChange() {
         console.log('ZAI model changed to', value);
         oai_settings.zai_model = value;
         $('#zai_model_id').val(value);
+    }
+
+    if (value && $(this).is('#model_linkapi_select')) {
+        console.log('LinkAPI model changed to', value);
+        oai_settings.linkapi_model = value;
+        $('#linkapi_model_id').val(value);
     }
 
     if ([chat_completion_sources.MAKERSUITE, chat_completion_sources.VERTEXAI].includes(oai_settings.chat_completion_source)) {
@@ -8650,6 +8752,27 @@ async function onModelChange() {
         $('#temp_openai').attr('max', claude_max_temp).val(oai_settings.temp_openai).trigger('input');
     }
 
+    if (oai_settings.chat_completion_source == chat_completion_sources.LINKAPI) {
+        const linkApiFormat = getLinkApiRequestFormat(oai_settings.linkapi_model);
+        // Context size follows the underlying model family, not the wire format:
+        // bracket-tagged per-request channels route via the OpenAI leg but keep native context.
+        const linkApiModelId = String(oai_settings.linkapi_model || '').toLowerCase();
+        const maxContext = maxContextUnlocked ? unlocked_max
+            : linkApiModelId.includes('gemini') ? max_1mil
+                : linkApiModelId.includes('claude') ? max_200k
+                    : max_128k;
+        $('#openai_max_context').attr('max', maxContext);
+        oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
+        $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
+        // Anthropic and Gemini relays reject temperatures above 1.0.
+        if (linkApiFormat !== 'openai') {
+            oai_settings.temp_openai = Math.min(claude_max_temp, oai_settings.temp_openai);
+            $('#temp_openai').attr('max', claude_max_temp).val(oai_settings.temp_openai).trigger('input');
+        } else {
+            $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');
+        }
+    }
+
     $('#openai_max_context_counter').attr('max', Number($('#openai_max_context').attr('max')));
 
     saveSettingsDebounced();
@@ -8721,6 +8844,7 @@ async function onConnectButtonClick(e) {
         [chat_completion_sources.POLLINATIONS]: { key: SECRET_KEYS.POLLINATIONS, selector: '#api_key_pollinations', proxy: false },
         [chat_completion_sources.WORKERS_AI]: { key: SECRET_KEYS.WORKERS_AI, selector: '#api_key_workers_ai', proxy: false },
         [chat_completion_sources.MINIMAX]: { key: SECRET_KEYS.MINIMAX, selector: '#api_key_minimax', proxy: false },
+        [chat_completion_sources.LINKAPI]: { key: SECRET_KEYS.LINKAPI, selector: '#api_key_linkapi', proxy: false },
     };
 
     // Vertex AI Express version - use API key
@@ -8824,6 +8948,9 @@ function toggleChatCompletionForms() {
         $('#model_zai_select').trigger('change');
     } else if (oai_settings.chat_completion_source == chat_completion_sources.WORKERS_AI) {
         $('#model_workers_ai_select').trigger('change');
+    } else if (oai_settings.chat_completion_source == chat_completion_sources.LINKAPI) {
+        $('#linkapi_model_id').val(oai_settings.linkapi_model);
+        $('#model_linkapi_select').val(oai_settings.linkapi_model).trigger('change');
     }
 
     $('[data-source]').each(function () {
@@ -9061,6 +9188,8 @@ export function isImageInliningSupported() {
             return (Array.isArray(model_list) && model_list.find(m => m.id === oai_settings.nanogpt_model)?.capabilities?.vision);
         case chat_completion_sources.ZAI:
             return visionSupportedModels.some(model => oai_settings.zai_model.includes(model));
+        case chat_completion_sources.LINKAPI:
+            return visionSupportedModels.some(model => oai_settings.linkapi_model.includes(model));
         case chat_completion_sources.SILICONFLOW:
             return visionSupportedModels.some(model => oai_settings.siliconflow_model.includes(model));
         case chat_completion_sources.WORKERS_AI: {
@@ -9106,6 +9235,8 @@ export function isVideoInliningSupported() {
             return (Array.isArray(model_list) && model_list.find(m => m.id === oai_settings.openrouter_model)?.architecture?.input_modalities?.includes('video'));
         case chat_completion_sources.ZAI:
             return videoSupportedModels.some(model => oai_settings.zai_model.includes(model));
+        case chat_completion_sources.LINKAPI:
+            return videoSupportedModels.some(model => oai_settings.linkapi_model.includes(model));
         default:
             return false;
     }
@@ -10456,6 +10587,10 @@ export function initOpenAI() {
         oai_settings.zai_model = String($(this).val());
         saveSettingsDebounced();
     });
+    $('#linkapi_model_id').on('input', function () {
+        oai_settings.linkapi_model = String($(this).val());
+        saveSettingsDebounced();
+    });
     $('#vertexai_model_id').on('input', function () {
         oai_settings.vertexai_model = String($(this).val());
         saveSettingsDebounced();
@@ -10759,6 +10894,10 @@ export function initOpenAI() {
         oai_settings.zai_endpoint = String($(this).val());
         saveSettingsDebounced();
     });
+    $('#linkapi_endpoint').on('input', function () {
+        oai_settings.linkapi_endpoint = String($(this).val());
+        saveSettingsDebounced();
+    });
     $('#siliconflow_endpoint').on('input', function () {
         oai_settings.siliconflow_endpoint = String($(this).val());
         saveSettingsDebounced();
@@ -10801,6 +10940,7 @@ export function initOpenAI() {
     $('#azure_openai_model').on('change', onModelChange);
     $('#model_zai_select').on('change', onModelChange);
     $('#model_workers_ai_select').on('change', onModelChange);
+    $('#model_linkapi_select').on('change', onModelChange);
     $('#settings_preset_openai').on('change', onSettingsPresetChange);
     $('#new_oai_preset').on('click', onNewPresetClick);
     $('#delete_oai_preset').on('click', onDeletePresetClick);

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -230,6 +230,18 @@ export function extractReasoningFromData(data, {
                         ?? data?.choices?.[0]?.message?.reasoning
                         ?? '';
                 }
+                case chat_completion_sources.LINKAPI: {
+                    // Response shape depends on the model's routing leg (Anthropic/Gemini/OpenAI).
+                    if (Array.isArray(data?.content)) {
+                        return data.content.filter(part => part.type === 'thinking').map(part => part.thinking).join('\n\n') ?? '';
+                    }
+                    if (Array.isArray(data?.responseContent?.parts)) {
+                        return data.responseContent.parts.filter(part => part.thought).map(part => part.text).join('\n\n') ?? '';
+                    }
+                    return data?.choices?.[0]?.message?.reasoning_content
+                        ?? data?.choices?.[0]?.message?.reasoning
+                        ?? '';
+                }
             }
             break;
     }
@@ -256,7 +268,8 @@ export function extractReasoningSignatureFromData(data, {
     }
 
     const source = chatCompletionSource ?? oai_settings.chat_completion_source;
-    const isGemini = source === chat_completion_sources.MAKERSUITE || source === chat_completion_sources.VERTEXAI;
+    const isGemini = source === chat_completion_sources.MAKERSUITE || source === chat_completion_sources.VERTEXAI
+        || (source === chat_completion_sources.LINKAPI && Boolean(data?.responseContent || data?.candidates));
     const isOpenRouter = source === chat_completion_sources.OPENROUTER;
 
     if (!isGemini && !isOpenRouter) {

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -79,6 +79,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    LINKAPI: 'api_key_linkapi',
 };
 
 const FRIENDLY_NAMES = {
@@ -144,6 +145,7 @@ const FRIENDLY_NAMES = {
     [SECRET_KEYS.VOLCENGINE_APP_ID]: 'Volcengine App ID',
     [SECRET_KEYS.VOLCENGINE_ACCESS_KEY]: 'Volcengine Access Key',
     [SECRET_KEYS.WORKERS_AI]: 'Cloudflare Workers AI',
+    [SECRET_KEYS.LINKAPI]: 'LinkAPI',
 };
 
 const INPUT_MAP = {
@@ -190,6 +192,7 @@ const INPUT_MAP = {
     [SECRET_KEYS.POLLINATIONS]: '#api_key_pollinations',
     [SECRET_KEYS.MINIMAX]: '#api_key_minimax',
     [SECRET_KEYS.WORKERS_AI]: '#api_key_workers_ai',
+    [SECRET_KEYS.LINKAPI]: '#api_key_linkapi',
 };
 
 const getLabel = () => moment().format('L LT');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -6345,6 +6345,7 @@ function getModelOptions(quiet) {
         { id: 'model_cometapi_select', api: 'openai', type: chat_completion_sources.COMETAPI },
         { id: 'model_zai_select', api: 'openai', type: chat_completion_sources.ZAI },
         { id: 'model_workers_ai_select', api: 'openai', type: chat_completion_sources.WORKERS_AI },
+        { id: 'model_linkapi_select', api: 'openai', type: chat_completion_sources.LINKAPI },
         { id: 'model_novel_select', api: 'novel', type: null },
         { id: 'horde_model', api: 'koboldhorde', type: null },
     ];

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -757,6 +757,11 @@ export function getTokenizerModel() {
         return oai_settings.custom_model;
     }
 
+    if (oai_settings.chat_completion_source == chat_completion_sources.LINKAPI) {
+        // Mixed vendor list; the server-side tokenizer resolver maps the raw id by name.
+        return oai_settings.linkapi_model;
+    }
+
     if (oai_settings.chat_completion_source === chat_completion_sources.PERPLEXITY) {
         if (oai_settings.perplexity_model.includes('sonar-reasoning') || oai_settings.perplexity_model.includes('r1-1776')) {
             return deepseekTokenizer;

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -668,6 +668,7 @@ export class ToolManager {
             chat_completion_sources.NANOGPT,
             chat_completion_sources.WORKERS_AI,
             chat_completion_sources.MINIMAX,
+            chat_completion_sources.LINKAPI,
         ];
         return supportedSources.includes(settings.chat_completion_source);
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -214,6 +214,7 @@ export const CHAT_COMPLETION_SOURCES = {
     SILICONFLOW: 'siliconflow',
     MINIMAX: 'minimax',
     WORKERS_AI: 'workers_ai',
+    LINKAPI: 'linkapi',
 };
 
 /**

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -5,6 +5,7 @@ import express from 'express';
 import fetch from 'node-fetch';
 import urlJoin from 'url-join';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
+import { getLinkApiBaseUrl, getLinkApiRequestFormat } from '../../../public/scripts/linkapi-utils.js';
 
 import {
     AIMLAPI_HEADERS,
@@ -2203,6 +2204,10 @@ router.post('/status', async function (request, statusResponse) {
                 console.error('Error fetching Cloudflare Workers AI models:', error);
                 return statusResponse.status(500).send({ error: true });
             }
+        } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.LINKAPI) {
+            apiUrl = `${getLinkApiBaseUrl(request.body.linkapi_endpoint)}/v1`;
+            apiKey = readSecret(request.user.directories, SECRET_KEYS.LINKAPI, request.body.secret_id);
+            headers = {};
         } else {
             console.warn('This chat completion source is not supported yet.');
             return statusResponse.status(400).send({ error: true });
@@ -2814,6 +2819,26 @@ router.post('/generate', async function (request, response) {
             case CHAT_COMPLETION_SOURCES.ELECTRONHUB: return await sendElectronHubRequest(request, response);
             case CHAT_COMPLETION_SOURCES.AZURE_OPENAI: return await sendAzureOpenAIRequest(request, response);
             case CHAT_COMPLETION_SOURCES.OPENAI_RESPONSES: return await sendOpenAIResponsesRequest(request, response);
+            case CHAT_COMPLETION_SOURCES.LINKAPI: {
+                const format = getLinkApiRequestFormat(request.body.model);
+                if (format === 'openai') {
+                    break; // OpenAI-compatible models use the shared chat/completions path below
+                }
+                const baseUrl = getLinkApiBaseUrl(request.body.linkapi_endpoint);
+                const apiKey = readSecret(request.user.directories, SECRET_KEYS.LINKAPI, request.body.secret_id);
+                if (!apiKey) {
+                    console.warn('LinkAPI key is missing.');
+                    return response.status(400).send({ error: true });
+                }
+                // Delegate to the native handlers through their reverse-proxy override path.
+                request.body.proxy_password = apiKey;
+                if (format === 'anthropic') {
+                    request.body.reverse_proxy = `${baseUrl}/v1`; // handler appends '/messages'
+                    return await sendClaudeRequest(request, response);
+                }
+                request.body.reverse_proxy = baseUrl; // getGoogleApiBaseUrl appends '/v1beta'
+                return await sendMakerSuiteRequest(request, response);
+            }
         }
 
         let apiUrl;
@@ -3105,6 +3130,16 @@ router.post('/generate', async function (request, response) {
                     type: 'json_schema',
                     json_schema: request.body.json_schema.value,
                 };
+            }
+        } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.LINKAPI) {
+            apiUrl = `${getLinkApiBaseUrl(request.body.linkapi_endpoint)}/v1`;
+            apiKey = readSecret(request.user.directories, SECRET_KEYS.LINKAPI, request.body.secret_id);
+            headers = {};
+            bodyParams = {};
+            if (request.body.reasoning_effort && request.body.reasoning_effort !== 'none') {
+                // Client-side aliases min/max are not valid OpenAI-style effort values.
+                const effortMap = { min: 'low', max: 'high' };
+                bodyParams['reasoning_effort'] = effortMap[request.body.reasoning_effort] ?? request.body.reasoning_effort;
             }
         } else {
             console.warn('This chat completion source is not supported yet.');

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -70,6 +70,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    LINKAPI: 'api_key_linkapi',
 };
 
 /**


### PR DESCRIPTION
I've added LinkAPI as a chat completion provider in SB.
One provider entry covers the gateway's three API formats.

---
As per Claude:
Requests are routed automatically by model id — claude-* uses the Anthropic-native /v1/messages relay, gemini-* uses the Gemini-native /v1beta/...:generateContent relay, and everything else (gpt/deepseek/grok/glm, plus bracket-tagged flat-rate per-request channels like [SP].../[次]...) uses the OpenAI-compatible /v1/chat/completions relay.
Includes a region selector (Global linkapi.ai, US api.linkapi.ai, HK hk.linkapi.ai), a dynamic model list, and standard secret storage.
---


For the why: Sick of juggling custom profiles? This provider has you sorted based on just the key. Switch keys > Switch groups basically.

---
Per Claude:
LinkAPI exposes native Anthropic/Gemini endpoints alongside the OpenAI-compatible one, and its docs recommend the native formats for reliable tool calls, streaming, and thinking output. Using it through the generic Custom endpoint loses all of that (plus Claude prompt caching, prefill, thinking budgets, and Gemini thought signatures).
A dedicated source with per-model format routing gets full native behavior without asking users to juggle three Custom profiles. 
LinkAPI keys are group-scoped upstream (a key's group decides pricing/channels and which models `/v1/models` returns), so the existing multi-key secret storage covers "one labeled key per group" with no new UI.

### Technical deets:
- **New shared module `public/scripts/linkapi-utils.js`** (imported by both client and server, same pattern as `local-url-utils.js`): region → base-URL map plus `getLinkApiRequestFormat(model)`. Bracket-tagged ids short-circuit to `openai` because those per-request channels only relay through the OpenAI-compatible endpoint.
- **Server (`chat-completions.js`)**: the generate switch delegates claude/gemini models to the existing `sendClaudeRequest` / `sendMakerSuiteRequest` by synthesizing their reverse-proxy override fields (`reverse_proxy` = LinkAPI base, `proxy_password` = LinkAPI key) — no duplication of the native handlers, so Claude caching/thinking/websearch and Gemini streaming work unchanged. OpenAI-format models fall through to the shared `chat/completions` path; `/status` reuses the shared Bearer `/models` fetch.
- **Client**: streaming (`getStreamingReply`), reasoning extraction, and structured-output extraction detect the payload shape (`candidates` → Gemini, `choices` → OpenAI, else Anthropic deltas) rather than assuming one format, since one source can return any of the three. Generation params send the Claude-only / Gemini-only fields (sysprompt, prefill, top_k, stop-string limits) only for the matching leg. Context caps follow the underlying model family (claude → 200k, gemini → 1M, else 128k) independent of wire format, with the unlocked-context checkbox enabled for this source; the temperature cap is 1.0 on native legs and 2.0 on the OpenAI leg.
- Everything else follows the established Z.AI/SiliconFlow sub-endpoint provider pattern (enum entries, `settingsToUpdate`, model-id search control, connect config, tokenizer/tool-calling/slash-command/auto-connect registrations).

### Testing?

- `node --check` and ESLint pass on all 14 touched files on this branch; `getLinkApiRequestFormat` probed directly (`[SP]claude-opus-4-7 → openai`, `claude-sonnet-4-5 → anthropic`, `gemini-3.5-flash → google`, `gpt-5.5 → openai`).
- The identical change set was runtime-tested on the development tree it was authored on: server boots clean; browser check confirmed the source appears in the dropdown, the form shows/hides correctly, and settings persist with no new console errors.
- Keyless probes against the live backend confirmed each routing leg reaches the intended code path (`/status` → shared models fetch; claude model → native handler key check; gpt model → shared OpenAI-compatible chain).
- Not yet run: end-to-end generation against LinkAPI with a real key (all three legs, streaming, tool calls). The native handlers themselves are untouched, so residual risk is concentrated in the new routing/param plumbing.
---

Let me know if screenshots are needed, though nothing new on the UI is epected.
The UI addition is a standard provider settings form (key input, region dropdown, model picker) built from the same markup as the existing Z.AI form, with no visual changes elsewhere.