### PR TITLE
fix(ica): viewing the in-chat agents injected into the preset should show their actual names

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -13716,11 +13716,14 @@ function select_rm_characters() {
  * @param {string} value Prompt injection value.
  * @param {number} position Insertion position. 0 is after story string, 1 is in-chat with custom depth.
  * @param {number} depth Insertion depth. 0 represets the last message in context. Expected values up to MAX_INJECTION_DEPTH.
- * @param {number} role Extension prompt role. Defaults to SYSTEM.
  * @param {boolean} scan Should the prompt be included in the world info scan.
+ * @param {number} role Extension prompt role. Defaults to SYSTEM.
  * @param {(function(): Promise<boolean>|boolean)} filter Filter function to determine if the prompt should be injected.
+ * @param {string|null} name Display name shown in Prompt Manager.
  */
-export function setExtensionPrompt(key, value, position, depth, scan = false, role = extension_prompt_roles.SYSTEM, filter = null) {
+export function setExtensionPrompt(key, value, position, depth, scan = false, role = extension_prompt_roles.SYSTEM, filter = null, name = null) {
+    const promptName = typeof name === 'string' ? name.trim() : '';
+
     extension_prompts[key] = {
         value: String(value),
         position: Number(position),
@@ -13728,6 +13731,7 @@ export function setExtensionPrompt(key, value, position, depth, scan = false, ro
         scan: !!scan,
         role: Number(role ?? extension_prompt_roles.SYSTEM),
         filter: filter,
+        ...(promptName && { name: promptName }),
     };
 }
 

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -1845,7 +1845,7 @@ class PromptManager {
 
         const createInlineDrawer = (message) => {
             const truncatedTitle = message.content.length > 32 ? message.content.slice(0, 32) + '...' : message.content;
-            const title = message.identifier || truncatedTitle;
+            const title = message.displayName || message.identifier || truncatedTitle;
             const role = message.role;
             const content = message.content || 'No Content';
             const tokens = message.getTokens();

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -3411,6 +3411,8 @@ function injectPreGenerationAgentPrompts(activeAgents, generationType) {
             agent.injection.depth,
             agent.injection.scan,
             agent.injection.role,
+            null,
+            agent.name,
         );
     }
 }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -1594,6 +1594,8 @@ export function injectCompanionFeedbackPrompts(activeAgents = []) {
             agent.injection.depth,
             agent.injection.scan,
             agent.injection.role,
+            null,
+            agent.name,
         );
     }
 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1684,12 +1684,14 @@ async function preparePromptsForChatCompletion({ scenario, charPersonality, name
 
             const hasFilter = typeof prompt.filter === 'function';
             if (hasFilter && !await prompt.filter()) continue;
+            const promptName = typeof prompt.name === 'string' ? prompt.name.trim() : '';
 
             systemPrompts.push({
                 identifier: key.replace(/\W/g, '_'),
                 position: getPromptPosition(prompt.position),
                 role: getPromptRole(prompt.role),
                 content: prompt.value,
+                ...(promptName && { name: promptName }),
                 extension: true,
             });
         }
@@ -5947,6 +5949,8 @@ class Message {
     content;
     /** @type {string} */
     name;
+    /** @type {string} */
+    displayName;
     /** @type {object} */
     tool_call = null;
     /** @type {string?} */
@@ -6215,8 +6219,13 @@ class Message {
      * @param {Object} prompt - The prompt object.
      * @returns {Promise<Message>} A new instance of Message.
      */
-    static fromPromptAsync(prompt) {
-        return Message.createAsync(prompt.role, prompt.content, prompt.identifier);
+    static async fromPromptAsync(prompt) {
+        const message = await Message.createAsync(prompt.role, prompt.content, prompt.identifier);
+        const promptName = typeof prompt.name === 'string' ? prompt.name.trim() : '';
+        if (prompt.extension && promptName) {
+            message.displayName = promptName;
+        }
+        return message;
     }
 
     /**

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -203,8 +203,9 @@ describe('in-chat agent post-processing runner', () => {
             extension_prompts: extensionPrompts,
             eventSource,
             event_types: eventTypes,
-            setExtensionPrompt: jest.fn((key, value) => {
-                extensionPrompts[key] = { value };
+            setExtensionPrompt: jest.fn((key, value, _position, _depth, _scan, _role, _filter = null, name = null) => {
+                const promptName = typeof name === 'string' ? name.trim() : '';
+                extensionPrompts[key] = { value, ...(promptName && { name: promptName }) };
             }),
             substituteParams: jest.fn((value, options = {}) => String(value ?? '')
                 .replaceAll('{{user}}', 'Traveler')
@@ -817,7 +818,7 @@ describe('in-chat agent post-processing runner', () => {
         await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, true);
 
         expect(extensionPrompts.inchat_agent_stale).toBeUndefined();
-        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
+        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.', name: 'Pre Prompt' });
     });
 
     test('delegates companion feedback prompt injection through registered runtime', async () => {
@@ -1317,6 +1318,7 @@ describe('in-chat agent post-processing runner', () => {
         // Assistant tail = swipe/regenerate of that message: its own state must not feed back.
         companionRunner.injectCompanionFeedbackPrompts([feedbackCompanion]);
         const injected = extensionPrompts['inchat_agent_companion_feedback-companion'];
+        expect(injected.name).toBe('Companion');
         expect(injected.value).toContain('State one');
         expect(injected.value).not.toContain('Stale swipe state');
 
@@ -2230,7 +2232,9 @@ describe('in-chat agent post-processing runner', () => {
 
         chat.push({ mes: 'Continue.', name: 'Traveler', is_user: true, is_system: false, extra: {} });
         companionRunner.injectCompanionFeedbackPrompts([companionAgent]);
-        const injected = extensionPrompts['inchat_agent_companion_plot-compass'].value;
+        const injectedPrompt = extensionPrompts['inchat_agent_companion_plot-compass'];
+        const injected = injectedPrompt.value;
+        expect(injectedPrompt.name).toBe('Plot Compass');
         expect(injected).toContain('Objective: Traveler ends up living with Mira after Mira sees literal {{char}} text.');
         expect(injected).not.toContain('{{user}}');
     });
@@ -2365,7 +2369,7 @@ describe('in-chat agent post-processing runner', () => {
         await generationPromise;
 
         expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
-        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
+        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.', name: 'Pre Prompt' });
     });
 
     test('reuses cached Pathfinder retrieval when swiping the same assistant message', async () => {
@@ -2435,7 +2439,7 @@ describe('in-chat agent post-processing runner', () => {
 
         expect(runSidecarRetrieval).toHaveBeenCalledTimes(1);
         expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
-        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
+        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.', name: 'Pre Prompt' });
     });
 
     test('shows a processing toast while Pathfinder pipeline retrieval is running', async () => {

--- a/tests/prompt-display-names.test.js
+++ b/tests/prompt-display-names.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+const promptManagerSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'PromptManager.js'), 'utf8');
+
+function getMethodSource(source, name) {
+    const markers = [`\n    ${name}(`, `\n    async ${name}(`, `\n    static ${name}(`, `\n    static async ${name}(`];
+    const start = markers.reduce((match, marker) => {
+        const index = source.indexOf(marker);
+        return match === -1 || (index !== -1 && index < match) ? index : match;
+    }, -1);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index++) {
+        const char = source[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return source.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find method source for ${name}`);
+}
+
+describe('prompt display names', () => {
+    test('carries extension prompt names into prepared prompts', () => {
+        expect(openAiSource).toContain('const promptName = typeof prompt.name === \'string\' ? prompt.name.trim() : \'\';');
+        expect(openAiSource).toContain('...(promptName && { name: promptName }),');
+    });
+
+    test('uses prompt names as inspector-only display names', () => {
+        const fromPromptSource = getMethodSource(openAiSource, 'fromPromptAsync');
+        const getChatSource = getMethodSource(openAiSource, 'getChat');
+
+        expect(fromPromptSource).toContain('if (prompt.extension && promptName)');
+        expect(fromPromptSource).toContain('message.displayName = promptName;');
+        expect(promptManagerSource).toContain('message.displayName || message.identifier || truncatedTitle');
+        expect(getChatSource).toContain('...(message.name && { name: message.name }),');
+        expect(getChatSource).not.toContain('displayName');
+    });
+});


### PR DESCRIPTION
# Summary
## Issue
In-Chat Agents show the filenames whenever you preview them in the preset (e.g. inchat_agent (bunch of numbers)) instead of the actual title.

## Fix
Should show the *actual* title of the agent, such as "Event Tracker", "Plot Compass", rather than the file names.