### PR TITLE
fix(mobile): restore viewport pan hardening and keep popup inputs above the keyboard

### DIFF
--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -741,16 +741,83 @@ export const MOBILE_SHELL_VIEWPORT_SYNC_STEP = Object.freeze({
     SYNC_MOBILE_MODAL_STATE: 'sync-mobile-modal-state',
 });
 
+const MOBILE_DOCUMENT_PAN_BACKGROUND_SELECTOR = [
+    'html',
+    'body',
+    '#bg1',
+    '#bg_custom',
+].join(', ');
+
 const MOBILE_DOCUMENT_PAN_GUARD_SELECTOR = [
+    '#sheld',
+    '#chat',
+    '#form_sheld',
+    '#top-bar',
+    '#top-settings-holder',
+    '#send_form',
     '#nonQRFormItems',
     '#leftSendForm',
     '#qr--bar',
     '#rightSendForm',
+    '#sb-mobile-nav',
+    '#sb-mobile-chat-tools',
+    '#sb-mobile-chat-tools-panel',
+    '#sb-bottom-chat-bar',
+    '#sb-persona-picker',
+    '#select2-sb-bottom-chat-select-container',
+    '[aria-labelledby="select2-sb-bottom-chat-select-container"]',
+    '.select2-selection',
+    '#shadow_popup',
+    '#dialogue_popup',
+    '#left-nav-panel',
+    '#right-nav-panel',
+    '#user-settings-block',
+    '#ica--tracker-panel',
+    '#ica--tracker-panel-handle',
+    'dialog.popup',
+    '.popup',
+    '.sb-shell-root',
+    '.sb-shell-header',
+    '.ica--tpanel',
+    '.ica--tpanel-handle',
 ].join(', ');
 
 const MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR = [
+    '#chat',
     '#leftSendForm',
     '#qr--bar',
+    '#sb-bottom-chat-secondary-row',
+    '.sb-bottom-chat-secondary-row',
+    '#sb-persona-picker',
+    '#dialogue_popup_text',
+    '.sb-shell-nav',
+    '.sb-shell-panel-scroller',
+    '.scrollableInner',
+    '.scrollableInnerFull',
+    '#ica--tracker-panel',
+    '.ica--tpanel',
+    '.popup-body',
+    '.popup-content',
+    '.select2-results__options',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR = [
+    '#leftSendForm',
+    '#qr--bar',
+    '#sb-bottom-chat-secondary-row',
+    '.sb-bottom-chat-secondary-row',
+    '#sb-persona-picker',
+    '.sb-shell-nav',
+    '.select2-results__options',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_OPEN_MENU_SELECTOR = [
+    '#left-nav-panel.openDrawer',
+    '#right-nav-panel.openDrawer',
+    '#user-settings-block.openDrawer',
+    '.sb-shell-root.openDrawer',
+    '#ica--tracker-panel.is-open',
+    '.ica--tpanel.is-open',
 ].join(', ');
 
 const MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR = [
@@ -760,13 +827,47 @@ const MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR = [
     '[contenteditable="true"]',
 ].join(', ');
 
-const MOBILE_DOCUMENT_PAN_OWNED_GESTURE_SELECTOR = '#ica--tracker-panel-handle';
+const MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR = [
+    '#dialogue_popup_controls',
+    '.popup-controls',
+    '.popup-button-close',
+    '.select2-selection',
+    '#ica--tracker-panel-handle',
+    '.ica--tpanel-handle',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX = 3;
+const SCROLLABLE_OVERFLOW_VALUES = new Set(['auto', 'scroll', 'overlay']);
+
+function elementMatchesSelector(element, selector) {
+    return Boolean(element && typeof element.matches === 'function' && element.matches(selector));
+}
+
+function getParentElementLike(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+
+    if (element.parentElement && typeof element.parentElement === 'object') {
+        return element.parentElement;
+    }
+
+    if (element.parentNode && typeof element.parentNode === 'object' && element.parentNode !== element) {
+        return element.parentNode;
+    }
+
+    if (element.host && typeof element.host === 'object' && element.host !== element) {
+        return element.host;
+    }
+
+    return null;
+}
 
 function closestMatchingElement(target, selector) {
     let element = target;
 
     while (element && typeof element === 'object') {
-        if (typeof element.matches === 'function' && element.matches(selector)) {
+        if (elementMatchesSelector(element, selector)) {
             return element;
         }
 
@@ -777,7 +878,7 @@ function closestMatchingElement(target, selector) {
             }
         }
 
-        element = element.parentElement ?? null;
+        element = getParentElementLike(element);
     }
 
     return null;
@@ -785,6 +886,17 @@ function closestMatchingElement(target, selector) {
 
 function findTouchByIdentifier(touches, identifier) {
     return Array.from(touches ?? []).find(touch => touch?.identifier === identifier) ?? null;
+}
+
+function isHorizontalGesture(delta) {
+    if (!delta) {
+        return false;
+    }
+
+    const absX = Math.abs(delta.x);
+    const absY = Math.abs(delta.y);
+
+    return absX > MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX && absX > absY;
 }
 
 function getGestureDelta(event, touchStart) {
@@ -803,7 +915,22 @@ function getGestureDelta(event, touchStart) {
     };
 }
 
-function canElementScrollForGesture(element, delta) {
+function canElementScrollOnAxis(element, axis) {
+    if (typeof Element === 'undefined' || !(element instanceof Element) || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+        return true;
+    }
+
+    if (typeof document !== 'undefined' && element === document.scrollingElement) {
+        return true;
+    }
+
+    const style = window.getComputedStyle(element);
+    const overflow = axis === 'x' ? style.overflowX : style.overflowY;
+
+    return SCROLLABLE_OVERFLOW_VALUES.has(overflow);
+}
+
+function canElementScrollForGesture(element, delta, { requireAvailableScrollInDirection = false } = {}) {
     if (!element || !delta) {
         return false;
     }
@@ -811,15 +938,49 @@ function canElementScrollForGesture(element, delta) {
     const absX = Math.abs(delta.x);
     const absY = Math.abs(delta.y);
     const wantsHorizontalScroll = absX > absY;
-    const canScrollX = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth) > 1;
-    const canScrollY = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight) > 1;
+    const canScrollX = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth) > 1 && canElementScrollOnAxis(element, 'x');
+    const canScrollY = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight) > 1 && canElementScrollOnAxis(element, 'y');
 
-    return wantsHorizontalScroll ? canScrollX : canScrollY;
+    if (!requireAvailableScrollInDirection) {
+        return wantsHorizontalScroll ? canScrollX : canScrollY;
+    }
+
+    if (wantsHorizontalScroll) {
+        if (!canScrollX) {
+            return false;
+        }
+
+        const scrollLeft = normalizeNumber(element.scrollLeft);
+        const maxScrollLeft = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth);
+        return delta.x > 0 ? scrollLeft > 0 : scrollLeft < maxScrollLeft - 1;
+    }
+
+    if (!canScrollY) {
+        return false;
+    }
+
+    const scrollTop = normalizeNumber(element.scrollTop);
+    const maxScrollTop = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight);
+    return delta.y > 0 ? scrollTop > 0 : scrollTop < maxScrollTop - 1;
+}
+
+function closestScrollableElementForGesture(target, delta, { requireAvailableScrollInDirection = false } = {}) {
+    let element = target;
+
+    while (element && typeof element === 'object') {
+        if (canElementScrollForGesture(element, delta, { requireAvailableScrollInDirection })) {
+            return element;
+        }
+
+        element = getParentElementLike(element);
+    }
+
+    return null;
 }
 
 /**
- * Decides whether a mobile touchmove started on non-scrollable composer chrome
- * should be cancelled before the browser pans the visual viewport.
+ * Decides whether a mobile touchmove started on fixed mobile chrome should be
+ * cancelled before the browser pans the visual viewport.
  * @param {TouchEvent|object} event Touchmove-like event.
  * @param {object} [options] Options.
  * @param {{identifier: number, clientX: number, clientY: number}|null} [options.touchStart=null] Starting touch point.
@@ -830,18 +991,44 @@ export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) 
         return false;
     }
 
-    if (closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_OWNED_GESTURE_SELECTOR)
-        || closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR)) {
+    const target = event.target;
+    const backgroundElement = elementMatchesSelector(target, MOBILE_DOCUMENT_PAN_BACKGROUND_SELECTOR);
+    const guardedElement = backgroundElement ? null : closestMatchingElement(target, MOBILE_DOCUMENT_PAN_GUARD_SELECTOR);
+
+    if (!guardedElement && !backgroundElement) {
         return false;
     }
 
-    if (!closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_GUARD_SELECTOR)) {
+    if (closestMatchingElement(target, MOBILE_DOCUMENT_PAN_OPEN_MENU_SELECTOR)) {
         return false;
     }
 
-    const scrollElement = closestMatchingElement(event.target, MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR);
-    if (canElementScrollForGesture(scrollElement, getGestureDelta(event, touchStart))) {
-        return false;
+    const editableElement = closestMatchingElement(target, MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR);
+    if (editableElement) {
+        const isScrollableEditable = elementMatchesSelector(editableElement, 'textarea, [contenteditable="true"]');
+        if (isScrollableEditable) {
+            const gestureDelta = getGestureDelta(event, touchStart);
+            if (gestureDelta && canElementScrollForGesture(editableElement, gestureDelta, { requireAvailableScrollInDirection: true })) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    if (closestMatchingElement(target, MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR)) {
+        return true;
+    }
+
+    const gestureDelta = getGestureDelta(event, touchStart);
+    const scrollElement = closestScrollableElementForGesture(target, gestureDelta, { requireAvailableScrollInDirection: true });
+    if (scrollElement) {
+        if (isHorizontalGesture(gestureDelta)) {
+            return !elementMatchesSelector(scrollElement, MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR);
+        }
+
+        if (elementMatchesSelector(scrollElement, MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR)) {
+            return false;
+        }
     }
 
     return true;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2622,6 +2622,104 @@ function scrollMobileFocusedInputIntoView(event) {
     window.setTimeout(tryScroll, 200);
 }
 
+const MOBILE_POPUP_KEYBOARD_CLEARANCE_PX = 16;
+
+function getMobilePopupDialogForKeyboard(element) {
+    if (!(element instanceof HTMLElement)) {
+        return null;
+    }
+
+    const dialog = element.closest('dialog.popup');
+    return dialog instanceof HTMLElement && dialog.open ? dialog : null;
+}
+
+function clearMobilePopupKeyboardShift(dialog) {
+    if (!(dialog instanceof HTMLElement) || !dialog.dataset.sbKeyboardShift) {
+        return;
+    }
+
+    delete dialog.dataset.sbKeyboardShift;
+    dialog.style.removeProperty('transform');
+}
+
+function clearAllMobilePopupKeyboardShifts(except = null) {
+    for (const dialog of document.querySelectorAll('dialog.popup[data-sb-keyboard-shift]')) {
+        if (dialog !== except) {
+            clearMobilePopupKeyboardShift(dialog);
+        }
+    }
+}
+
+/**
+ * SillyBunny: popup dialogs are centered against the layout viewport, which
+ * does not shrink with the virtual keyboard (interactive-widget=resizes-visual).
+ * When a focused popup input sits behind the keyboard, the browser pans the
+ * visual viewport to reveal it, pushing the top bar off screen (e.g. the
+ * connection profile name popup). Scroll the popup body first, then shift the
+ * dialog up so the input clears the keyboard and the browser never needs to pan.
+ */
+function syncMobilePopupKeyboardShift() {
+    const activeElement = document.activeElement;
+    const dialog = isMobileViewport() && isEditableElement(activeElement)
+        ? getMobilePopupDialogForKeyboard(activeElement)
+        : null;
+
+    clearAllMobilePopupKeyboardShifts(dialog);
+
+    if (!dialog) {
+        return;
+    }
+
+    const layoutViewport = getLayoutViewportSize();
+    const viewportSize = getVisualViewportSize(layoutViewport);
+
+    if (!isVisualViewportKeyboardOpen(layoutViewport, viewportSize)) {
+        clearMobilePopupKeyboardShift(dialog);
+        return;
+    }
+
+    // Measure without the current shift so a shrinking keyboard relaxes it.
+    clearMobilePopupKeyboardShift(dialog);
+
+    // visualViewport tracks the keyboard: top grows and height shrinks as the
+    // keyboard rises, so (top + height) is the bottom of the visible area.
+    const viewportBottom = viewportSize.top + viewportSize.height;
+    const scroller = activeElement.closest('.popup-content');
+
+    if (scroller instanceof HTMLElement) {
+        const scrollOverflow = activeElement.getBoundingClientRect().bottom + MOBILE_POPUP_KEYBOARD_CLEARANCE_PX - viewportBottom;
+        if (scrollOverflow > 0) {
+            scroller.scrollTop += scrollOverflow;
+        }
+    }
+
+    const overflow = activeElement.getBoundingClientRect().bottom + MOBILE_POPUP_KEYBOARD_CLEARANCE_PX - viewportBottom;
+
+    if (overflow <= 0) {
+        return;
+    }
+
+    const dialogTop = dialog.getBoundingClientRect().top;
+    const maxShift = Math.max(0, dialogTop - viewportSize.top - MOBILE_POPUP_KEYBOARD_CLEARANCE_PX);
+    const shift = Math.round(Math.min(overflow, maxShift));
+
+    if (shift <= 0) {
+        return;
+    }
+
+    dialog.dataset.sbKeyboardShift = String(shift);
+    dialog.style.transform = `translateY(-${shift}px)`;
+}
+
+let sbMobilePopupKeyboardSyncTimer = 0;
+
+function scheduleMobilePopupKeyboardSync() {
+    window.requestAnimationFrame(syncMobilePopupKeyboardShift);
+    window.clearTimeout(sbMobilePopupKeyboardSyncTimer);
+    // Run again after the keyboard animation / visualViewport resize settles.
+    sbMobilePopupKeyboardSyncTimer = window.setTimeout(syncMobilePopupKeyboardShift, 200);
+}
+
 function getMobileShellBoundDrawers() {
     return Array.from(new Set([
         ...document.querySelectorAll('#left-nav-panel, #user-settings-block, .sb-shell-root, #right-nav-panel'),
@@ -16361,6 +16459,13 @@ function initAll() {
     // virtual keyboard. The fixed/clipped body blocks native scrolling, so the
     // scroller is nudged manually (see scrollMobileFocusedInputIntoView).
     document.addEventListener('focusin', scrollMobileFocusedInputIntoView);
+
+    // SillyBunny: popup dialogs sit outside the shell scrollers; shift them
+    // above the virtual keyboard instead so the browser never pans the visual
+    // viewport away from the top bar (see syncMobilePopupKeyboardShift).
+    document.addEventListener('focusin', scheduleMobilePopupKeyboardSync);
+    document.addEventListener('focusout', scheduleMobilePopupKeyboardSync);
+    window.visualViewport?.addEventListener('resize', scheduleMobilePopupKeyboardSync, { passive: true });
 
     // SillyBunny: keep iOS drawer scroller padding in sync with keyboard focus;
     // this provides scroll range for bottom inputs without fixing the document.

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -65,3 +65,47 @@ describe('mobile keyboard focused-input scroll wiring', () => {
         expect(tabsSource).toContain('document.addEventListener(\'focusin\', scrollMobileFocusedInputIntoView)');
     });
 });
+
+describe('mobile popup keyboard shift wiring', () => {
+    test('defines the popup keyboard shift helper', () => {
+        expect(tabsSource).toContain('function syncMobilePopupKeyboardShift(');
+        expect(tabsSource).toContain('function scheduleMobilePopupKeyboardSync(');
+    });
+
+    test('only targets editable focus inside open popup dialogs on mobile', () => {
+        expect(tabsSource).toContain('function getMobilePopupDialogForKeyboard(');
+        expect(tabsSource).toMatch(/\.closest\('dialog\.popup'\)/);
+        expect(tabsSource).toMatch(/isMobileViewport\(\) && isEditableElement\(activeElement\)/);
+        expect(tabsSource).toMatch(/dialog instanceof HTMLElement && dialog\.open/);
+    });
+
+    test('shifts against the visual-viewport bottom so the input clears the keyboard', () => {
+        const helperSource = tabsSource.slice(
+            tabsSource.indexOf('function syncMobilePopupKeyboardShift('),
+            tabsSource.indexOf('function scheduleMobilePopupKeyboardSync('),
+        );
+
+        expect(helperSource).toContain('const viewportBottom = viewportSize.top + viewportSize.height;');
+        expect(helperSource).toMatch(/if \(!isVisualViewportKeyboardOpen\(layoutViewport, viewportSize\)\) \{/);
+        expect(helperSource).toContain('scroller.scrollTop += scrollOverflow;');
+        expect(helperSource).toContain('dialog.style.transform = `translateY(-${shift}px)`;');
+    });
+
+    test('clamps the shift so the dialog top stays inside the visible viewport', () => {
+        expect(tabsSource).toContain('const maxShift = Math.max(0, dialogTop - viewportSize.top - MOBILE_POPUP_KEYBOARD_CLEARANCE_PX);');
+        expect(tabsSource).toContain('const shift = Math.round(Math.min(overflow, maxShift));');
+    });
+
+    test('clears the shift when focus leaves or the keyboard closes', () => {
+        expect(tabsSource).toContain('function clearMobilePopupKeyboardShift(');
+        expect(tabsSource).toContain('function clearAllMobilePopupKeyboardShifts(');
+        expect(tabsSource).toMatch(/dialog\.style\.removeProperty\('transform'\)/);
+        expect(tabsSource).toContain('delete dialog.dataset.sbKeyboardShift;');
+    });
+
+    test('wires the sync on focus changes and visualViewport resize inside initAll', () => {
+        expect(tabsSource).toContain('document.addEventListener(\'focusin\', scheduleMobilePopupKeyboardSync)');
+        expect(tabsSource).toContain('document.addEventListener(\'focusout\', scheduleMobilePopupKeyboardSync)');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', scheduleMobilePopupKeyboardSync, { passive: true })');
+    });
+});

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -22,6 +22,8 @@ function createElementStub({
     clientWidth = 0,
     scrollHeight = 0,
     clientHeight = 0,
+    scrollLeft = 0,
+    scrollTop = 0,
 } = {}) {
     return {
         parentElement,
@@ -31,6 +33,8 @@ function createElementStub({
         clientWidth,
         scrollHeight,
         clientHeight,
+        scrollLeft,
+        scrollTop,
     };
 }
 
@@ -98,7 +102,7 @@ function getFunctionSource(name) {
 }
 
 describe('mobile shell lifecycle wiring', () => {
-    test('blocks mobile document panning from non-scrollable composer chrome only', () => {
+    test('blocks mobile document panning from fixed chrome and scroll edges', () => {
         expect(browserFixesSource).toContain('blockDocumentPanFromShellGaps');
         expect(browserFixesSource).toContain('captureDocumentPanStart');
         expect(browserFixesSource).toContain('document.addEventListener(\'touchmove\', blockDocumentPanFromShellGaps, { passive: false, capture: true });');
@@ -107,60 +111,300 @@ describe('mobile shell lifecycle wiring', () => {
             matches: selector => selectorListIncludes(selector, '#chat'),
             scrollHeight: 1200,
             clientHeight: 600,
+            scrollTop: 120,
+        });
+        const chatScrollerAtTop = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#chat'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+        });
+        const wideMessageText = createElementStub({
+            parentElement: chatScroller,
+            matches: selector => selectorListIncludes(selector, '.mes_text'),
+            scrollWidth: 900,
+            clientWidth: 320,
+        });
+        const wideMessageTextNode = { parentNode: wideMessageText };
+        const shellSurface = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#sheld'),
         });
         const composerChrome = createElementStub({
             matches: selector => selectorListIncludes(selector, '#nonQRFormItems'),
         });
+        const sendFormChrome = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#send_form'),
+        });
         const composerGap = createElementStub({ parentElement: composerChrome });
         const textarea = createElementStub({
+            parentElement: composerChrome,
             matches: selector => selector.includes('textarea'),
+        });
+        const scrollableTextarea = createElementStub({
+            parentElement: composerChrome,
+            matches: selector => selector.includes('textarea'),
+            scrollHeight: 400,
+            clientHeight: 120,
+            scrollTop: 100,
+        });
+        const textareaAtBottom = createElementStub({
+            parentElement: composerChrome,
+            matches: selector => selector.includes('textarea'),
+            scrollHeight: 400,
+            clientHeight: 120,
+            scrollTop: 280,
         });
         const quickReplyRail = createElementStub({
             parentElement: composerChrome,
             matches: selector => selectorListIncludes(selector, '#leftSendForm'),
             scrollWidth: 600,
             clientWidth: 240,
+            scrollLeft: 120,
+        });
+        const quickReplyRailAtStart = createElementStub({
+            parentElement: composerChrome,
+            matches: selector => selectorListIncludes(selector, '#leftSendForm'),
+            scrollWidth: 600,
+            clientWidth: 240,
         });
         const quickReplyButton = createElementStub({ parentElement: quickReplyRail });
+        const quickReplyStartButton = createElementStub({ parentElement: quickReplyRailAtStart });
+        const sendFormButton = createElementStub({ parentElement: sendFormChrome });
         const genericButton = createElementStub({
             matches: selector => selectorListIncludes(selector, 'button'),
         });
         const companionHandle = createElementStub({
             closest: selector => selectorListIncludes(selector, '#ica--tracker-panel-handle') ? companionHandle : null,
         });
+        const companionPanel = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#ica--tracker-panel') || selectorListIncludes(selector, '.ica--tpanel'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+            scrollTop: 120,
+        });
+        const companionPanelAtTop = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#ica--tracker-panel') || selectorListIncludes(selector, '.ica--tpanel'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+        });
+        const companionPanelBody = createElementStub({ parentElement: companionPanel });
+        const guidedActionsContainer = createElementStub({
+            parentElement: sendFormChrome,
+            matches: selector => selectorListIncludes(selector, '.gg-action-buttons-container'),
+        });
+        const guidedActionsGap = createElementStub({ parentElement: guidedActionsContainer });
+        const bottomChatBar = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#sb-bottom-chat-bar'),
+        });
+        const bottomChatButton = createElementStub({ parentElement: bottomChatBar });
+        const bottomChatSelect = createElementStub({
+            parentElement: bottomChatBar,
+            matches: selector => selector.includes('select'),
+        });
+        const bottomChatLongNameSelect = createElementStub({
+            parentElement: bottomChatBar,
+            matches: selector => selector.includes('select'),
+            scrollWidth: 900,
+            clientWidth: 180,
+        });
+        const bottomChatSelect2Selection = createElementStub({
+            matches: selector => selectorListIncludes(selector, '.select2-selection') || selectorListIncludes(selector, '[aria-labelledby="select2-sb-bottom-chat-select-container"]'),
+            scrollWidth: 900,
+            clientWidth: 180,
+        });
+        const bottomChatSecondaryRow = createElementStub({
+            parentElement: bottomChatBar,
+            matches: selector => selectorListIncludes(selector, '#sb-bottom-chat-secondary-row') || selectorListIncludes(selector, '.sb-bottom-chat-secondary-row'),
+            scrollWidth: 700,
+            clientWidth: 260,
+            scrollLeft: 120,
+        });
+        const bottomChatSecondaryRowAtStart = createElementStub({
+            parentElement: bottomChatBar,
+            matches: selector => selectorListIncludes(selector, '#sb-bottom-chat-secondary-row') || selectorListIncludes(selector, '.sb-bottom-chat-secondary-row'),
+            scrollWidth: 700,
+            clientWidth: 260,
+        });
+        const bottomChatSecondaryButton = createElementStub({ parentElement: bottomChatSecondaryRow });
+        const bottomChatSecondaryStartButton = createElementStub({ parentElement: bottomChatSecondaryRowAtStart });
         const presetPopupBody = createElementStub({
             matches: selector => selectorListIncludes(selector, '.popup-body'),
             scrollHeight: 1200,
             clientHeight: 600,
         });
         const presetButton = createElementStub({ parentElement: presetPopupBody });
+        const legacyDialog = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#dialogue_popup'),
+        });
+        const legacyDialogText = createElementStub({
+            parentElement: legacyDialog,
+            matches: selector => selectorListIncludes(selector, '#dialogue_popup_text'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+        });
+        const legacyDialogInput = createElementStub({
+            parentElement: legacyDialog,
+            matches: selector => selector.includes('textarea'),
+        });
+        const legacyDialogControls = createElementStub({
+            parentElement: legacyDialog,
+            matches: selector => selectorListIncludes(selector, '#dialogue_popup_controls'),
+        });
+        const legacyDialogButton = createElementStub({ parentElement: legacyDialogControls });
+        const genericPopup = createElementStub({
+            matches: selector => selectorListIncludes(selector, 'dialog.popup') || selectorListIncludes(selector, '.popup'),
+        });
+        const genericPopupBody = createElementStub({
+            parentElement: genericPopup,
+            matches: selector => selectorListIncludes(selector, '.popup-body'),
+            scrollHeight: 1200,
+            clientHeight: 600,
+        });
+        const genericPopupInput = createElementStub({
+            parentElement: genericPopupBody,
+            matches: selector => selector.includes('textarea') || selectorListIncludes(selector, '.popup-input'),
+        });
+        const genericPopupControls = createElementStub({
+            parentElement: genericPopupBody,
+            matches: selector => selectorListIncludes(selector, '.popup-controls'),
+        });
+        const genericPopupButton = createElementStub({ parentElement: genericPopupControls });
         const characterDrawerScroller = createElementStub({
             matches: selector => selectorListIncludes(selector, '.sb-shell-panel-scroller'),
             scrollHeight: 1600,
             clientHeight: 600,
         });
         const characterCard = createElementStub({ parentElement: characterDrawerScroller });
+        const shellNavScroller = createElementStub({
+            parentElement: shellSurface,
+            matches: selector => selectorListIncludes(selector, '.sb-shell-nav'),
+            scrollWidth: 900,
+            clientWidth: 300,
+            scrollLeft: 200,
+        });
+        const shellNavScrollerAtStart = createElementStub({
+            parentElement: shellSurface,
+            matches: selector => selectorListIncludes(selector, '.sb-shell-nav'),
+            scrollWidth: 900,
+            clientWidth: 300,
+        });
+        const shellNavTab = createElementStub({ parentElement: shellNavScroller });
+        const shellNavStartTab = createElementStub({ parentElement: shellNavScrollerAtStart });
         const chatMove = createTouchMove(chatScroller, { y: -40 });
+        const chatHorizontalMove = createTouchMove(chatScroller, { x: -70, y: 4 });
+        const chatAtTopPullDownMove = createTouchMove(chatScrollerAtTop, { x: 2, y: 40 });
+        const wideMessageTextMove = createTouchMove(wideMessageText, { x: -70, y: 4 });
+        const wideMessageTextNodeMove = createTouchMove(wideMessageTextNode, { x: -70, y: 4 });
+        const wideMessageTextVerticalMove = createTouchMove(wideMessageTextNode, { x: 2, y: -40 });
+        const shellRightEdgeHorizontalMove = createTouchMove(shellSurface, { startX: 390, x: 310, y: 4 });
         const railHorizontalMove = createTouchMove(quickReplyButton, { x: 40, y: 2 });
+        const railAtStartEdgeMove = createTouchMove(quickReplyStartButton, { x: 40, y: 2 });
         const railVerticalMove = createTouchMove(quickReplyButton, { x: 2, y: -40 });
+        const companionHandleHorizontalMove = createTouchMove(companionHandle, { x: -40, y: 1 });
+        const companionHandleVerticalMove = createTouchMove(companionHandle, { x: 1, y: 40 });
+        const companionPanelVerticalMove = createTouchMove(companionPanelBody, { x: 1, y: -40 });
+        const companionPanelAtTopPullDownMove = createTouchMove(companionPanelAtTop, { x: 1, y: 40 });
+        const companionPanelHorizontalMove = createTouchMove(companionPanelBody, { x: -40, y: 1 });
         const gapMove = createTouchMove(composerGap, { y: -40 });
+        const guidedActionsGapMove = createTouchMove(guidedActionsGap, { y: -40 });
+        const textareaMove = createTouchMove(textarea, { y: -40 });
+        const scrollableTextareaMove = createTouchMove(scrollableTextarea, { y: -40 });
+        const textareaAtBottomMove = createTouchMove(textareaAtBottom, { y: -40 });
+        const sendFormButtonMove = createTouchMove(sendFormButton, { y: -40 });
         const buttonMove = createTouchMove(genericButton, { y: -40 });
+        const bottomChatButtonMove = createTouchMove(bottomChatButton, { y: -40 });
+        const bottomChatSelectMove = createTouchMove(bottomChatSelect, { y: -40 });
+        const bottomChatLongNameSelectMove = createTouchMove(bottomChatLongNameSelect, { x: -50, y: 1 });
+        const bottomChatSelect2SelectionMove = createTouchMove(bottomChatSelect2Selection, { x: -50, y: 1 });
+        const bottomChatHorizontalMove = createTouchMove(bottomChatSecondaryButton, { x: 40, y: 2 });
+        const bottomChatHorizontalAtStartEdgeMove = createTouchMove(bottomChatSecondaryStartButton, { x: 40, y: 2 });
+        const bottomChatVerticalMove = createTouchMove(bottomChatSecondaryButton, { x: 2, y: -40 });
         const presetMove = createTouchMove(presetButton, { y: -40 });
+        const legacyDialogTextMove = createTouchMove(legacyDialogText, { y: -40 });
+        const legacyDialogInputMove = createTouchMove(legacyDialogInput, { y: -40 });
+        const legacyDialogButtonMove = createTouchMove(legacyDialogButton, { y: -40 });
+        const genericPopupBodyMove = createTouchMove(genericPopupBody, { y: -40 });
+        const genericPopupInputMove = createTouchMove(genericPopupInput, { y: -40 });
+        const genericPopupButtonMove = createTouchMove(genericPopupButton, { y: -40 });
         const characterDrawerMove = createTouchMove(characterCard, { y: -40 });
+        const shellNavHorizontalMove = createTouchMove(shellNavTab, { x: -50, y: 1 });
+        const shellNavHorizontalAtStartEdgeMove = createTouchMove(shellNavStartTab, { x: 50, y: 1 });
         const multiTouchMove = createTouchMove(composerGap, { touches: [{}, {}] });
         const nonCancelableMove = createTouchMove(composerGap, { cancelable: false });
 
         expect(shouldBlockMobileDocumentPan(chatMove.event, { touchStart: chatMove.touchStart })).toBe(false);
-        expect(shouldBlockMobileDocumentPan(createTouchMove(textarea, { y: -40 }).event)).toBe(false);
+        expect(shouldBlockMobileDocumentPan(chatHorizontalMove.event, { touchStart: chatHorizontalMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(chatAtTopPullDownMove.event, { touchStart: chatAtTopPullDownMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(wideMessageTextMove.event, { touchStart: wideMessageTextMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(wideMessageTextNodeMove.event, { touchStart: wideMessageTextNodeMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(wideMessageTextVerticalMove.event, { touchStart: wideMessageTextVerticalMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(shellRightEdgeHorizontalMove.event, { touchStart: shellRightEdgeHorizontalMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(textareaMove.event, { touchStart: textareaMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(scrollableTextareaMove.event, { touchStart: scrollableTextareaMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(textareaAtBottomMove.event, { touchStart: textareaAtBottomMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(railHorizontalMove.event, { touchStart: railHorizontalMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(railAtStartEdgeMove.event, { touchStart: railAtStartEdgeMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(railVerticalMove.event, { touchStart: railVerticalMove.touchStart })).toBe(true);
-        expect(shouldBlockMobileDocumentPan(createTouchMove(companionHandle, { x: -40 }).event)).toBe(false);
+        expect(shouldBlockMobileDocumentPan(companionHandleHorizontalMove.event, { touchStart: companionHandleHorizontalMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(companionHandleVerticalMove.event, { touchStart: companionHandleVerticalMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(companionPanelVerticalMove.event, { touchStart: companionPanelVerticalMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(companionPanelAtTopPullDownMove.event, { touchStart: companionPanelAtTopPullDownMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(companionPanelHorizontalMove.event, { touchStart: companionPanelHorizontalMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(gapMove.event, { touchStart: gapMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(guidedActionsGapMove.event, { touchStart: guidedActionsGapMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(sendFormButtonMove.event, { touchStart: sendFormButtonMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(buttonMove.event, { touchStart: buttonMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(bottomChatButtonMove.event, { touchStart: bottomChatButtonMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(bottomChatSelectMove.event, { touchStart: bottomChatSelectMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(bottomChatLongNameSelectMove.event, { touchStart: bottomChatLongNameSelectMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(bottomChatSelect2SelectionMove.event, { touchStart: bottomChatSelect2SelectionMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(bottomChatHorizontalMove.event, { touchStart: bottomChatHorizontalMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(bottomChatHorizontalAtStartEdgeMove.event, { touchStart: bottomChatHorizontalAtStartEdgeMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(bottomChatVerticalMove.event, { touchStart: bottomChatVerticalMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(presetMove.event, { touchStart: presetMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(legacyDialogTextMove.event, { touchStart: legacyDialogTextMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(legacyDialogInputMove.event, { touchStart: legacyDialogInputMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(legacyDialogButtonMove.event, { touchStart: legacyDialogButtonMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(genericPopupBodyMove.event, { touchStart: genericPopupBodyMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(genericPopupInputMove.event, { touchStart: genericPopupInputMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(genericPopupButtonMove.event, { touchStart: genericPopupButtonMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(characterDrawerMove.event, { touchStart: characterDrawerMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(shellNavHorizontalMove.event, { touchStart: shellNavHorizontalMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(shellNavHorizontalAtStartEdgeMove.event, { touchStart: shellNavHorizontalAtStartEdgeMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(multiTouchMove.event, { touchStart: multiTouchMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
+    });
+
+    test('relaxes document pan guards inside open mobile shell menus', () => {
+        const createMenuRoot = rootSelector => createElementStub({
+            matches: selector => selectorListIncludes(selector, rootSelector) || selectorListIncludes(selector, `${rootSelector}.openDrawer`),
+            scrollHeight: 1600,
+            clientHeight: 600,
+        });
+        const workspaceRoot = createMenuRoot('#left-nav-panel');
+        const customizeRoot = createMenuRoot('#user-settings-block');
+        const characterRoot = createMenuRoot('#right-nav-panel');
+        const closedWorkspaceRoot = createElementStub({
+            matches: selector => selectorListIncludes(selector, '#left-nav-panel'),
+            scrollHeight: 1600,
+            clientHeight: 600,
+        });
+        const workspaceButton = createElementStub({ parentElement: workspaceRoot });
+        const customizeSelect = createElementStub({
+            parentElement: customizeRoot,
+            matches: selector => selector.includes('select'),
+        });
+        const characterCard = createElementStub({ parentElement: characterRoot });
+        const closedWorkspaceButton = createElementStub({ parentElement: closedWorkspaceRoot });
+
+        const workspaceAtTopPullDownMove = createTouchMove(workspaceButton, { x: 1, y: 40 });
+        const customizeSelectMove = createTouchMove(customizeSelect, { x: 1, y: -40 });
+        const characterAtTopPullDownMove = createTouchMove(characterCard, { x: 1, y: 40 });
+        const closedWorkspaceAtTopPullDownMove = createTouchMove(closedWorkspaceButton, { x: 1, y: 40 });
+
+        expect(shouldBlockMobileDocumentPan(workspaceAtTopPullDownMove.event, { touchStart: workspaceAtTopPullDownMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(customizeSelectMove.event, { touchStart: customizeSelectMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(characterAtTopPullDownMove.event, { touchStart: characterAtTopPullDownMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(closedWorkspaceAtTopPullDownMove.event, { touchStart: closedWorkspaceAtTopPullDownMove.touchStart })).toBe(true);
     });
 
     test('imports the mobile shell lifecycle seam into the shell adapter', () => {

--- a/tests/mobile-shell-lifecycle.test.js
+++ b/tests/mobile-shell-lifecycle.test.js
@@ -15,6 +15,7 @@ import {
     resolveMobileNavToggleIntent,
     resolveMobileShellNavDragEnd,
     resolveMobileShellNavDragMove,
+    shouldBlockMobileDocumentPan,
     shouldAutoCloseMobileNav,
     shouldSuppressMobileShellNavClick,
 } from '../public/scripts/mobile-shell-lifecycle/index.js';
@@ -306,6 +307,25 @@ describe('mobile shell lifecycle helper', () => {
             shouldInertShell: true,
             shouldInertTopBar: true,
         });
+    });
+
+    test('blocks mobile document pan from body background gaps', () => {
+        const matchesBackgroundSelector = selector => selector.split(',').map(value => value.trim()).includes('#bg1');
+        const closestBackgroundSelector = selector => [null, target][Number(matchesBackgroundSelector(selector))];
+        const target = {
+            matches: matchesBackgroundSelector,
+            closest: closestBackgroundSelector,
+        };
+        const event = {
+            cancelable: true,
+            defaultPrevented: false,
+            target,
+            touches: [{ identifier: 1, clientX: 120, clientY: 790 }],
+        };
+
+        expect(shouldBlockMobileDocumentPan(event, {
+            touchStart: { identifier: 1, clientX: 120, clientY: 800 },
+        })).toBe(true);
     });
 
     test('creates a stable lifecycle seam for future runtime wiring', () => {


### PR DESCRIPTION
This fixes the mobile document pan guards for typical viewport escapism (again) which made the top menu bar inaccessible, making sure it works within popouts like the connection profile manager too. Specifically a mobile fix.

The workaround was to toggle the companion sidebar button which forces a reload of the viewport and resets it, but yeah, this fix should prevent it from occurring in the first place.

It was occurring again on my end on certain menus, I will single out and squash them all as we go.

In Claude's words:

> **## What?**
> Restores the mobile document pan guards for fixed shell chrome (modal chrome, message text, companion handles, composer drag, background gaps, shell edges) and adds keyboard-aware shifting for popup dialogs so a focused popup input never makes the browser pan the visual viewport.
>
> **## How?**
> Re-lands the net pan-guard state in `mobile-shell-lifecycle/index.js`: axis-aware scroll allowances, editable/control handling, and open-menu relaxation. Adds `syncMobilePopupKeyboardShift` in `sillybunny-tabs.js`: on editable focus inside an open `dialog.popup`, scroll `.popup-content` first, then `translateY` the dialog so the input clears the visual-viewport bottom, clamped to keep the dialog top visible; the shift relaxes as the keyboard resizes and clears on focusout.
>
> **## Testing?**
> Full unit suite passes (1470 tests, 156 suites) including restored pan-guard wiring tests and six new popup-shift tests; ESLint clean on touched files. Manually verified on a live instance running this branch. No automated coverage of real device keyboard behavior — verified by hand on Android.