### PR TITLE
fix: Related fixes that were unrelated to the mobile performance bit in PR 627

### DIFF
--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -250,10 +250,20 @@ describe('Chat Completion preset utilities', () => {
         })).toEqual({
             name: 'Story proxy',
             url: 'https://proxy.example/v1',
+            // Plaintext key is not persisted when the profile is bound to a saved secret
             key: '',
             model: 'gpt-4o',
             secretId: 'secret-story',
         });
+    });
+
+    test('keeps the plaintext key only while no secret id is bound', () => {
+        expect(buildCustomEndpointPresetForSave({
+            name: 'Unbound proxy',
+            url: 'https://proxy.example/v1',
+            key: 'sk-unbound',
+            model: 'gpt-4o',
+        }).key).toBe('sk-unbound');
     });
 
     test('clears Custom endpoint profile fields for None', () => {


### PR DESCRIPTION
This is just an amalgamation of the various fixes in PR 627 that were latching on assuming a quicker time to merge. I'm splitting them so that fixes don't get stuck due to performance regression fixes that need validation from all 3 maintainers.

List of fixes per Claude:

**Already split out and merged into staging via earlier PRs:**
- #639 — Custom endpoint secret persistence: no more empty secrets breaking authentication, existing `secretId` preserved when saving without a new key, plaintext keys stripped from settings files. Connection profile apply failures surfaced as warning toasts with failure details. Sampling profile save button success flash (respects reduced motion).
- #641 — Custom endpoint profiles working end to end.
- #642 (commit `344f38d9`) — Selecting existing secrets via the secret manager dialog now binds them to the profile instead of blocking the save.
- #640 — Batch embedded lorebook import: selectable in one shot, already-imported cards no longer re-prompt.
- #652 — Mobile viewport pan hardening (composer, modal chrome, message text, companion handles, shell edges, background gaps) plus popup inputs kept above the keyboard.

**Carried by this PR (the last non-perf piece not yet in staging):**
- Unit test covering that custom endpoint profiles bound to a saved secret drop plaintext keys on save, while unbound profiles keep the key (from `ba50a46e` on the PR 627 branch).

**Testing:** `bun test tests/openai-preset-utils.test.js` — 39 pass, 0 fail.

Once this merges and staging is synced back into `fix/android-mobile-performance`, PR 627's diff is purely mobile performance work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)