### PR TITLE
feat: New ordering mechanism for agents and companion sidebar

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -1618,6 +1618,59 @@ export async function saveAgent(agent) {
 }
 
 /**
+ * Applies a new visual order to a subset of agents. Subset members are dealt back into the
+ * order-sorted slots the subset already occupies (agents outside the subset keep their relative
+ * position), then every slot is renumbered to `index * 10` so drag-and-drop always produces
+ * clean, collision-free order values.
+ * @param {string[]} orderedSubsetIds Agent ids in their new visual order.
+ * @returns {Promise<boolean>} Whether any agent's order value changed.
+ */
+export async function reorderAgentsIntoOrderSlots(orderedSubsetIds) {
+    const subsetIds = Array.from(new Set(
+        (Array.isArray(orderedSubsetIds) ? orderedSubsetIds : [])
+            .map(id => String(id ?? '').trim())
+            .filter(id => id && getAgentById(id)),
+    ));
+
+    if (subsetIds.length === 0) {
+        return false;
+    }
+
+    const subsetIdSet = new Set(subsetIds);
+    let subsetIndex = 0;
+    const finalOrderIds = getAgents()
+        .sort((a, b) => Number(a?.injection?.order ?? 0) - Number(b?.injection?.order ?? 0))
+        .map(agent => {
+            if (!subsetIdSet.has(agent.id)) {
+                return agent.id;
+            }
+
+            const nextId = subsetIds[subsetIndex];
+            subsetIndex += 1;
+            return nextId;
+        });
+
+    let changed = false;
+    for (let i = 0; i < finalOrderIds.length; i++) {
+        const agent = getAgentById(finalOrderIds[i]);
+        if (!agent) {
+            continue;
+        }
+
+        const desiredOrder = i * 10;
+        if (Number(agent?.injection?.order ?? 0) === desiredOrder) {
+            continue;
+        }
+
+        agent.injection.order = desiredOrder;
+        await saveAgent(agent);
+        changed = true;
+    }
+
+    return changed;
+}
+
+/**
  * Deletes an agent from the server and local array.
  * @param {string} id
  */

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -11,6 +11,7 @@ import {
     isAgentEnabledForCurrentScope,
     isAgentHidden,
     isCompanionAgent,
+    reorderAgentsIntoOrderSlots,
     saveAgent,
     setHiddenAgentIds,
 } from '../agent-store.js';
@@ -582,13 +583,17 @@ function buildPanelAgentSection(state) {
     const hiddenLabel = isHidden ? 'Unhide companion' : 'Hide companion';
     const hiddenIcon = isHidden ? 'fa-eye-slash' : 'fa-eye';
     const hiddenButton = `<button type="button" class="ica--cdash-action" data-action="panel-hide" title="${hiddenTitle}" aria-label="${hiddenLabel}"><i class="fa-solid ${hiddenIcon}"></i></button>`;
+    // Orphaned results have no agent to persist an order onto, so they get no drag handle.
+    const dragHandleButton = state.agent
+        ? '<button type="button" class="ica--cdash-action ica--tpanel-drag-handle" title="Drag to reorder (arrow keys nudge)" aria-label="Reorder companion"><i class="fa-solid fa-grip-vertical"></i></button>'
+        : '';
 
     if (!latest) {
         return `
             <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}" data-hidden="${isHidden}">
                 <div class="ica--tpanel-agent-head">
                     <span class="ica--tpanel-agent-name"><i class="fa-solid ${escapeHtml(icon)}"></i><span>${escapeHtml(name)}</span></span>
-                    <span class="ica--tpanel-agent-actions">${hiddenButton}${runLatestButton}${settingsButton}</span>
+                    <span class="ica--tpanel-agent-actions">${dragHandleButton}${hiddenButton}${runLatestButton}${settingsButton}</span>
                 </div>
                 <div class="ica--cdash-empty">No state yet. It will appear after the next reply${getCompanionConfig(state.agent).trigger === 'manual' ? ' you run it on' : ''}.</div>
                 ${buildPanelEntryControls(state)}
@@ -621,6 +626,7 @@ function buildPanelAgentSection(state) {
                 <span class="ica--tpanel-agent-when">#${latest.messageIndex}</span>
                 ${buildCompanionTokenUsagePillsHtml(latest.result)}
                 <span class="ica--tpanel-agent-actions">
+                    ${dragHandleButton}
                     ${hiddenButton}
                     ${runLatestButton}
                     <button type="button" class="ica--cdash-action" data-action="panel-regenerate" title="Regenerate this state" aria-label="Regenerate state"><i class="fa-solid fa-rotate-right"></i></button>
@@ -676,6 +682,52 @@ export function buildPanelHtml() {
 function renderPanel() {
     const panelElement = $('#ica--tracker-panel');
     panelElement.html(buildPanelHtml());
+    setupPanelSortable();
+}
+
+/** Persists the panel's visual order onto injection.order so the agents page stays in step. */
+async function applyPanelReorder(orderedIds) {
+    const changed = await reorderAgentsIntoOrderSlots(orderedIds);
+    if (panelOpen) {
+        renderPanel();
+    }
+    if (changed && typeof panelHooks?.refreshAgentList === 'function') {
+        panelHooks.refreshAgentList();
+    }
+}
+
+function setupPanelSortable() {
+    const body = $('#ica--tracker-panel .ica--tpanel-body');
+    if (!body.length || typeof body.sortable !== 'function') {
+        return;
+    }
+
+    if (body.sortable('instance') !== undefined) {
+        body.sortable('destroy');
+    }
+
+    body.sortable({
+        items: '.ica--tpanel-agent',
+        handle: '.ica--tpanel-drag-handle',
+        tolerance: 'pointer',
+        distance: 5,
+        placeholder: 'ica--tpanel-agent-placeholder',
+        forcePlaceholderSize: true,
+        start: function (_event, ui) {
+            ui.placeholder.height(ui.item.outerHeight());
+        },
+        stop: async function () {
+            const orderedIds = body.children('.ica--tpanel-agent').map((_, el) => el.dataset.agentId).get().filter(Boolean);
+            await applyPanelReorder(orderedIds);
+        },
+    });
+}
+
+/** Re-renders the open panel; lets other surfaces (the agents page) push order changes in. */
+export function refreshCompanionPanel() {
+    if (panelOpen) {
+        renderPanel();
+    }
 }
 
 export function updateCompanionPanelHandleVisibility() {
@@ -996,6 +1048,39 @@ export function initCompanionPanel() {
     `);
 
     $('#ica--tracker-panel').on('click', '[data-action]', handlePanelAction);
+    $('#ica--tracker-panel').on('keydown', '.ica--tpanel-drag-handle', async function (event) {
+        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const section = this.closest('.ica--tpanel-agent');
+        const sibling = event.key === 'ArrowUp' ? section?.previousElementSibling : section?.nextElementSibling;
+        if (!section || !sibling?.classList?.contains('ica--tpanel-agent')) {
+            return;
+        }
+
+        if (event.key === 'ArrowUp') {
+            sibling.before(section);
+        } else {
+            sibling.after(section);
+        }
+
+        const agentId = section.dataset.agentId || '';
+        const orderedIds = $('#ica--tracker-panel .ica--tpanel-body')
+            .children('.ica--tpanel-agent')
+            .map((_, el) => el.dataset.agentId)
+            .get()
+            .filter(Boolean);
+        await applyPanelReorder(orderedIds);
+        // applyPanelReorder re-renders the panel; put focus back so nudges can be chained.
+        $('#ica--tracker-panel .ica--tpanel-agent')
+            .filter((_, el) => el.dataset.agentId === agentId)
+            .find('.ica--tpanel-drag-handle')
+            .trigger('focus');
+    });
     $('#ica--tracker-panel').on('click', '.ica--tpanel-agent-body .ica--choice-line', function (event) {
         event.preventDefault();
         event.stopPropagation();

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -709,6 +709,11 @@ function setupPanelSortable() {
     body.sortable({
         items: '.ica--tpanel-agent',
         handle: '.ica--tpanel-drag-handle',
+        // jQuery UI's mouse widget matches event.target against `cancel` before the `handle`
+        // gate runs; its default (`input, textarea, button, select, option`) would swallow every
+        // drag that starts on the grip because the grip is a <button>. Cancel the section's other
+        // controls but leave the drag handle draggable.
+        cancel: 'input, textarea, .menu_button, .ica--cdash-action:not(.ica--tpanel-drag-handle)',
         tolerance: 'pointer',
         distance: 5,
         placeholder: 'ica--tpanel-agent-placeholder',

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -8,7 +8,7 @@ import {
 } from '../../../../script.js';
 import { power_user } from '../../../power-user.js';
 import { extension_settings, getContext } from '../../../extensions.js';
-import { eventSource } from '../../../events.js';
+import { eventSource, event_types } from '../../../events.js';
 import { getWorldInfoPrompt } from '../../../world-info.js';
 import { getConnectionProfileDisplayName } from '../profile-utils.js';
 import {
@@ -1697,6 +1697,33 @@ export function getLatestValidCompanionMessageIndex() {
     return -1;
 }
 
+/**
+ * A swipe into a brand-new slot has no swipe_info entry yet, so companion reads fall back
+ * to message.extra — which still holds the previous swipe's results. Clear them so the
+ * message cards and panel go blank while the new swipe generates instead of showing the
+ * old swipe's state. The old swipe keeps its own copy: script.js runs syncMesToSwipe
+ * before moving off it. Navigating existing swipes is untouched (syncSwipeToMes already
+ * restores that swipe's own results).
+ */
+function onCompanionMessageSwiped(messageIndex) {
+    const index = Number(messageIndex);
+    const message = chat[index];
+    if (!isAssistantMessage(message)) {
+        return;
+    }
+
+    const isNewSwipeSlot = typeof message.swipe_id === 'number'
+        && Array.isArray(message.swipe_info)
+        && !message.swipe_info[message.swipe_id];
+    if (!isNewSwipeSlot || Object.keys(getCompanionResults(message)).length === 0) {
+        return;
+    }
+
+    deleteAgentExtraValue(message, COMPANION_RESULTS_EXTRA_KEY);
+    saveChatDebounced({ deferBackup: false });
+    void emitCompanionResultsUpdated(index);
+}
+
 export function initCompanionRunner() {
     if (companionRunnerInitialized) {
         return;
@@ -1708,4 +1735,8 @@ export function initCompanionRunner() {
         injectCompanionFeedbackPrompts,
         runCompanionAgentOnMessage,
     });
+
+    if (event_types.MESSAGE_SWIPED) {
+        eventSource.on(event_types.MESSAGE_SWIPED, onCompanionMessageSwiped);
+    }
 }

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -90,11 +90,6 @@
             </div>
         </div>
         <div class="ica--regex-note">Companions run after the main reply and render below it. Use Hidden when the note should only feed future prompts through feedback.</div>
-        <div class="ica--card-pill ica--card-pill--order ica--companion-order-readout" title="Lower numbers run earlier when Append Agents Execution is set to Sequential.">
-            <i class="fa-solid fa-sort-numeric-down fa-xs"></i>
-            <span>Order</span>
-            <strong id="ica--editor-companion-order-value">100</strong>
-        </div>
         <div class="ica--editor-row" id="ica--chatroom-style-row" style="display:none">
             <label>Chatroom Style
                 <select id="ica--editor-chatroom-style" class="text_pole">
@@ -165,6 +160,9 @@
             <div class="ica--regex-note">Injected into Plot Compass runs and editable any time from this agent's settings.</div>
         </div>
         <div class="ica--companion-core-grid">
+            <label title="Lower numbers run earlier when Append Agents Execution is set to Sequential.">Order
+                <input type="number" id="ica--editor-companion-order" class="text_pole" min="0" max="999" value="100" />
+            </label>
             <label>Trigger
                 <select id="ica--editor-companion-trigger" class="text_pole">
                     <option value="auto">Auto after matching replies</option>

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -90,6 +90,11 @@
             </div>
         </div>
         <div class="ica--regex-note">Companions run after the main reply and render below it. Use Hidden when the note should only feed future prompts through feedback.</div>
+        <div class="ica--card-pill ica--card-pill--order ica--companion-order-readout" title="Lower numbers run earlier when Append Agents Execution is set to Sequential.">
+            <i class="fa-solid fa-sort-numeric-down fa-xs"></i>
+            <span>Order</span>
+            <strong id="ica--editor-companion-order-value">100</strong>
+        </div>
         <div class="ica--editor-row" id="ica--chatroom-style-row" style="display:none">
             <label>Chatroom Style
                 <select id="ica--editor-chatroom-style" class="text_pole">

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -2723,12 +2723,14 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     };
     fullscreenButton.on('click', () => updateEditorFullscreenState(!editorFullscreen));
     attachTextareaFullscreen(editorEl);
+    const editorOrderInput = editorEl.find('#ica--editor-order');
+    const companionOrderInput = editorEl.find('#ica--editor-companion-order');
 
     // Injection
     editorEl.find('#ica--editor-position').val(agent.injection.position);
     editorEl.find('#ica--editor-depth').val(agent.injection.depth);
     editorEl.find('#ica--editor-role').val(agent.injection.role);
-    editorEl.find('#ica--editor-order').val(agent.injection.order);
+    editorOrderInput.val(agent.injection.order);
     editorEl.find('#ica--editor-scan').prop('checked', agent.injection.scan);
     const preProcess = getAgentPreProcess(agent);
     editorEl.find('#ica--editor-pre-mode').val(preProcess.mode);
@@ -2991,10 +2993,12 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         editorEl.find('#ica--plot-compass-objective-row').toggle(companionExecution && sourceTemplateId === PLOT_COMPASS_TEMPLATE_ID);
     }
 
-    function updateCompanionOrderReadout() {
-        editorEl.find('#ica--editor-companion-order-value').text(String(getAgentOrderValue({
-            injection: { order: editorEl.find('#ica--editor-order').val() },
-        })));
+    function syncCompanionOrderInput() {
+        companionOrderInput.val(editorOrderInput.val());
+    }
+
+    function syncPrimaryOrderInputFromCompanion() {
+        editorOrderInput.val(companionOrderInput.val());
     }
 
     function readCompanionConfigFromEditor(root, baseAgent = agent) {
@@ -3077,7 +3081,8 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     });
     editorEl.find('#ica--editor-chatroom-custom-styles').on('input', updateChatroomCustomStyleOptions);
     editorEl.find('#ica--editor-director-custom-voices').on('input', updateDirectorCustomVoiceOptions);
-    editorEl.find('#ica--editor-order').on('input change', updateCompanionOrderReadout);
+    editorOrderInput.on('input change', syncCompanionOrderInput);
+    companionOrderInput.on('input change', syncPrimaryOrderInputFromCompanion);
     updateTrackerBuilderVisibility();
     updateChatroomCustomStyleOptions();
     updateChatroomExtraCharacterOptions();
@@ -3086,7 +3091,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     updateCompanionContextRecipientOptions();
     updateCompanionDependencyOptions();
     updateCompanionEditorVisibility();
-    updateCompanionOrderReadout();
+    syncCompanionOrderInput();
 
     // Show/hide sections based on phase
     function updatePhaseVisibility() {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -54,6 +54,7 @@ import {
     saveGroup,
     deleteGroup,
     createDefaultGroup,
+    reorderAgentsIntoOrderSlots,
 } from './agent-store.js';
 import {
     cancelAgentGeneration,
@@ -92,7 +93,7 @@ import { collectRecentCompanionResults, initCompanionRunner, hasConnectedCompani
 import { getCompanionReferenceIds } from './companion/companion-shared.js';
 import { initCompanionCardUi, updateCompanionButtonVisibility } from './companion/companion-ui.js';
 import { configureCompanionDashboard, initCompanionWandMenuItem, openCompanionDashboard } from './companion/companion-dashboard.js';
-import { configureCompanionPanel, initCompanionPanel, updateCompanionPanelHandleVisibility } from './companion/companion-panel.js';
+import { configureCompanionPanel, initCompanionPanel, refreshCompanionPanel, updateCompanionPanelHandleVisibility } from './companion/companion-panel.js';
 import { attachTextareaFullscreen, closeActiveTextareaFullscreen } from './textarea-fullscreen.js';
 
 const MODULE_NAME = 'in-chat-agents';
@@ -1775,62 +1776,28 @@ async function reorderAgentsInGroup(orderedIds) {
             .filter(Boolean),
     ));
 
-    if (normalizedOrderedIds.length === 0) {
-        renderAgentList();
-        return;
-    }
-
-    const firstAgent = getAgentById(normalizedOrderedIds[0]);
+    const firstAgent = normalizedOrderedIds.length > 0 ? getAgentById(normalizedOrderedIds[0]) : null;
     if (!firstAgent) {
         renderAgentList();
         return;
     }
 
     const targetCategory = String(firstAgent.category ?? '').trim();
-    const sortedAgents = getAgents()
-        .sort((a, b) => Number(a?.injection?.order ?? 0) - Number(b?.injection?.order ?? 0));
-    const categoryIds = sortedAgents
+    const categoryIds = getAgents()
+        .sort((a, b) => Number(a?.injection?.order ?? 0) - Number(b?.injection?.order ?? 0))
         .filter(agent => String(agent?.category ?? '').trim() === targetCategory)
         .map(agent => agent.id);
 
-    if (categoryIds.length === 0) {
-        renderAgentList();
-        return;
-    }
-
+    // Filtered-out category members are not draggable; they keep their relative order below the visible set.
     const visibleIdSet = new Set(normalizedOrderedIds);
     const reorderedCategoryIds = [
         ...normalizedOrderedIds.filter(id => categoryIds.includes(id)),
         ...categoryIds.filter(id => !visibleIdSet.has(id)),
     ];
 
-    let categoryIndex = 0;
-    const finalOrderIds = sortedAgents.map(agent => {
-        if (String(agent?.category ?? '').trim() !== targetCategory) {
-            return agent.id;
-        }
-
-        const nextId = reorderedCategoryIds[categoryIndex];
-        categoryIndex += 1;
-        return nextId ?? agent.id;
-    });
-
-    for (let i = 0; i < finalOrderIds.length; i++) {
-        const agent = getAgentById(finalOrderIds[i]);
-        if (!agent) {
-            continue;
-        }
-
-        const desiredOrder = i * 10;
-        if (Number(agent?.injection?.order ?? 0) === desiredOrder) {
-            continue;
-        }
-
-        agent.injection.order = desiredOrder;
-        await saveAgent(agent);
-    }
-
+    await reorderAgentsIntoOrderSlots(reorderedCategoryIds);
     renderAgentList();
+    refreshCompanionPanel();
 }
 
 function isTouchSortableDevice() {
@@ -2367,7 +2334,7 @@ function renderAgentList() {
                                 <i class="fa-solid fa-star"></i>
                             </button>
                             <span class="ica--card-phase">${escapeHtml(getAgentCardPhaseLabel(agent))}</span>
-                            <button type="button" class="ica--card-drag-handle" title="Hold and drag to reorder">
+                            <button type="button" class="ica--card-drag-handle" title="Drag to reorder (arrow keys nudge)" aria-label="Reorder agent">
                                 <i class="fa-solid fa-grip-vertical"></i>
                             </button>
                         </div>
@@ -2427,6 +2394,33 @@ function renderAgentList() {
             });
 
             card.find('.ica--card-drag-handle').on('click', stopEvent);
+
+            card.find('.ica--card-drag-handle').on('keydown', async event => {
+                if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+                    return;
+                }
+
+                stopEvent(event);
+                const cardEl = card[0];
+                const sibling = event.key === 'ArrowUp' ? cardEl.previousElementSibling : cardEl.nextElementSibling;
+                if (!sibling?.classList?.contains('ica--agent-card')) {
+                    return;
+                }
+
+                if (event.key === 'ArrowUp') {
+                    sibling.before(cardEl);
+                } else {
+                    sibling.after(cardEl);
+                }
+
+                const orderedIds = items.children('.ica--agent-card').map((_, el) => el.dataset.agentId).get();
+                await reorderAgentsInGroup(orderedIds);
+                // reorderAgentsInGroup re-renders the list; put focus back so nudges can be chained.
+                $('#ica--agentList .ica--agent-card')
+                    .filter((_, el) => el.dataset.agentId === agent.id)
+                    .find('.ica--card-drag-handle')
+                    .trigger('focus');
+            });
 
             // Prevent touch-punch (jQuery UI mouse widget polyfill) from
             // capturing touchstart on these buttons. Inside a .sortable()
@@ -5469,6 +5463,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     initCompanionWandMenuItem();
     configureCompanionPanel({
         openEditor: agentId => openEditor(agentId),
+        refreshAgentList: () => renderAgentList(),
     });
     initCompanionPanel();
     schedulePathfinderExtensionsMount();

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -336,6 +336,11 @@ function normalizeCompanionBatchAgentIds(value = []) {
     return ids;
 }
 
+function getCompanionAgentOptionLabel(agent) {
+    const name = String(agent?.name ?? '').trim() || agent?.id || 'Companion';
+    return `${name} (Order ${getAgentOrderValue(agent)})`;
+}
+
 function getCompanionBatchOptionsForAgent(agent) {
     if (!isCompanionAgent(agent)) return [];
 
@@ -346,7 +351,7 @@ function getCompanionBatchOptionsForAgent(agent) {
         .map(candidate => ({
             id: candidate.id,
             referenceIds: getCompanionReferenceIds(candidate),
-            label: String(candidate.name ?? '').trim() || candidate.id,
+            label: getCompanionAgentOptionLabel(candidate),
         }))
         .sort((left, right) => left.label.localeCompare(right.label));
 }
@@ -360,7 +365,7 @@ function getCompanionDependencyOptionsForAgent(agent) {
         .map(candidate => ({
             id: candidate.id,
             referenceIds: getCompanionReferenceIds(candidate),
-            label: String(candidate.name ?? '').trim() || candidate.id,
+            label: getCompanionAgentOptionLabel(candidate),
         }))
         .sort((left, right) => left.label.localeCompare(right.label));
 }
@@ -2986,6 +2991,12 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         editorEl.find('#ica--plot-compass-objective-row').toggle(companionExecution && sourceTemplateId === PLOT_COMPASS_TEMPLATE_ID);
     }
 
+    function updateCompanionOrderReadout() {
+        editorEl.find('#ica--editor-companion-order-value').text(String(getAgentOrderValue({
+            injection: { order: editorEl.find('#ica--editor-order').val() },
+        })));
+    }
+
     function readCompanionConfigFromEditor(root, baseAgent = agent) {
         const current = getCompanionConfig(baseAgent);
         return {
@@ -3066,6 +3077,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     });
     editorEl.find('#ica--editor-chatroom-custom-styles').on('input', updateChatroomCustomStyleOptions);
     editorEl.find('#ica--editor-director-custom-voices').on('input', updateDirectorCustomVoiceOptions);
+    editorEl.find('#ica--editor-order').on('input change', updateCompanionOrderReadout);
     updateTrackerBuilderVisibility();
     updateChatroomCustomStyleOptions();
     updateChatroomExtraCharacterOptions();
@@ -3074,6 +3086,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     updateCompanionContextRecipientOptions();
     updateCompanionDependencyOptions();
     updateCompanionEditorVisibility();
+    updateCompanionOrderReadout();
 
     // Show/hide sections based on phase
     function updatePhaseVisibility() {

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -601,6 +601,15 @@ button.ica--card-pill {
     background: color-mix(in srgb, var(--SmartThemeBorderColor) 34%, transparent);
 }
 
+.ica--companion-order-readout {
+    align-self: flex-start;
+    opacity: 0.82;
+}
+
+.ica--companion-order-readout strong {
+    font-weight: 700;
+}
+
 .ica--card-pill--version {
     font-variant-numeric: tabular-nums;
     background: color-mix(in srgb, var(--SmartThemeBorderColor) 28%, transparent);

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -456,7 +456,7 @@
 }
 
 .ica--card-drag-handle {
-    display: none;
+    display: inline-flex;
     width: 28px;
     height: 28px;
     align-items: center;
@@ -470,6 +470,7 @@
     opacity: 0.45;
     cursor: grab;
     flex-shrink: 0;
+    touch-action: none;
 }
 
 .ica--card-drag-handle:hover {
@@ -2035,6 +2036,26 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     display: none;
 }
 
+.ica--tpanel-drag-handle {
+    cursor: grab;
+    touch-action: none;
+}
+
+.ica--tpanel-drag-handle:active {
+    cursor: grabbing;
+}
+
+.ica--tpanel-agent-placeholder {
+    min-height: 64px;
+    border-radius: var(--sb-radius-lg, 14px);
+    border: 1px dashed color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 58%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 10%, transparent);
+}
+
+.ui-sortable-helper.ica--tpanel-agent {
+    box-shadow: 0 18px 36px color-mix(in srgb, #000 24%, transparent);
+}
+
 .ica--tpanel-agent-head {
     display: flex;
     align-items: center;
@@ -2755,11 +2776,6 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
 @media (pointer: coarse), (any-pointer: coarse) {
     .ica--category-items.ui-sortable .ica--agent-card {
         touch-action: pan-y;
-    }
-
-    .ica--card-drag-handle {
-        display: inline-flex;
-        touch-action: none;
     }
 
     .ica--card-toggle::before {

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -601,15 +601,6 @@ button.ica--card-pill {
     background: color-mix(in srgb, var(--SmartThemeBorderColor) 34%, transparent);
 }
 
-.ica--companion-order-readout {
-    align-self: flex-start;
-    opacity: 0.82;
-}
-
-.ica--companion-order-readout strong {
-    font-weight: 700;
-}
-
 .ica--card-pill--version {
     font-variant-numeric: tabular-nums;
     background: color-mix(in srgb, var(--SmartThemeBorderColor) 28%, transparent);

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -782,25 +782,6 @@ const MOBILE_DOCUMENT_PAN_GUARD_SELECTOR = [
     '.ica--tpanel-handle',
 ].join(', ');
 
-const MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR = [
-    '#chat',
-    '#leftSendForm',
-    '#qr--bar',
-    '#sb-bottom-chat-secondary-row',
-    '.sb-bottom-chat-secondary-row',
-    '#sb-persona-picker',
-    '#dialogue_popup_text',
-    '.sb-shell-nav',
-    '.sb-shell-panel-scroller',
-    '.scrollableInner',
-    '.scrollableInnerFull',
-    '#ica--tracker-panel',
-    '.ica--tpanel',
-    '.popup-body',
-    '.popup-content',
-    '.select2-results__options',
-].join(', ');
-
 const MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR = [
     '#leftSendForm',
     '#qr--bar',
@@ -1026,9 +1007,7 @@ export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) 
             return !elementMatchesSelector(scrollElement, MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR);
         }
 
-        if (elementMatchesSelector(scrollElement, MOBILE_DOCUMENT_PAN_SCROLL_SELECTOR)) {
-            return false;
-        }
+        return false;
     }
 
     return true;

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -79,6 +79,7 @@ describe('companion tracker panel', () => {
             isAgentEnabledForCurrentScope: jest.fn(agent => Boolean(agent?.enabled)),
             isAgentHidden: jest.fn(agentId => hiddenAgentIds.has(String(agentId ?? '').trim())),
             isCompanionAgent: jest.fn(agent => agent?.execution === 'companion' || agent?.category === 'companion'),
+            reorderAgentsIntoOrderSlots: jest.fn(async () => false),
             saveAgent: jest.fn(async () => {}),
             setHiddenAgentIds: jest.fn(ids => {
                 hiddenAgentIds = new Set([...ids].map(id => String(id ?? '').trim()).filter(Boolean));

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -95,6 +95,7 @@ beforeAll(async () => {
             maxTokens: 2048,
         })),
         loadAgents: jest.fn(),
+        reorderAgentsIntoOrderSlots: jest.fn(async () => false),
         saveAgent: jest.fn(async () => {}),
         deleteAgent: jest.fn(async () => {}),
         createDefaultAgent: jest.fn(() => ({
@@ -215,6 +216,7 @@ beforeAll(async () => {
         configureCompanionPanel: jest.fn(),
         initCompanionPanel: jest.fn(),
         openCompanionPanel: jest.fn(),
+        refreshCompanionPanel: jest.fn(),
         updateCompanionPanelHandleVisibility: jest.fn(),
     }));
 


### PR DESCRIPTION
As requested, baked in the ordering for companion agents and the agents UI itself with a drag handle. Summary to follow.

Per Claude:
- **Agents list**: the per-card grip handle is now always visible (it was touch-only) and drag-anywhere still works on desktop. Focusing the grip and pressing Arrow Up/Down nudges a card one slot for precise placement without dragging.
- **Companion panel**: every companion section gets the same grip in its header; the panel body is drag-sortable with the same arrow-key nudging.
- **Single source of truth**: both surfaces persist through a new agent-store helper, `reorderAgentsIntoOrderSlots()`. It deals the dragged subset back into the order-sorted slots it already occupies and renumbers every agent to `index * 10`, so reorders always produce clean, collision-free `injection.order` values (pre-existing duplicate orders resolve on the first reorder). The agents page's `reorderAgentsInGroup()` now delegates to it.
- **Cross-surface sync**: reordering in the panel refreshes the agents list via a new `refreshAgentList` hook, and reordering in the agents list refreshes the open panel via `refreshCompanionPanel()`.
- Visual order and sequential execution order remain the same field, as before.

Also included: swiping into a brand-new swipe slot no longer shows the previous swipe's companion state. New slots have no `swipe_info` entry yet, so companion reads fell back to `message.extra` and displayed stale results until the companions overwrote them; the carried-over results are now cleared on `MESSAGE_SWIPED` so message cards and the panel go blank while the new reply generates. Existing-swipe navigation still restores each swipe's own stored results.

# Summary (Added by Pura)
- Reordering Companion Agents is now easier through the draggable area in Companion Agents drawer.
- Exposes Order number for Companion Agents in the UI settings.