### PR TITLE
feat(agents): let post-generation passes target companion outputs, impersonation text, and picked targets

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -7,6 +7,7 @@ import {
     extension_prompts,
     setExtensionPrompt,
     substituteParams,
+    substituteParamsExtended,
     generateQuietPrompt,
     getCurrentChatId,
     normalizeContentText,
@@ -58,6 +59,8 @@ import { getContextualLorebooks } from './pathfinder/pathfinder-tool-bridge.js';
 import { PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
 import { shouldAutoSummarize } from './pathfinder/auto-summary.js';
 import { buildRegexScriptRefsForAgent, cacheAgentRegexScripts, migrateLegacyRegexSnapshotsInMessages } from './regex-snapshot-store.js';
+import { AGENT_REGEX_PLACEMENT, applyRegexScriptList } from './regex-scripts.js';
+import { getCompanionReferenceIds } from './companion/companion-shared.js';
 
 const PROMPT_KEY_PREFIX = 'inchat_agent_';
 const PATHFINDER_AUTO_SUMMARY_PROMPT_KEY = 'pathfinder_zz_auto_summary';
@@ -75,6 +78,7 @@ const pendingRegexSnapshotSaves = new WeakSet();
 const migratedLegacyRegexSnapshotChatIds = new Set();
 const GREETING_GENERATION_TYPE = 'first_message';
 const IMPERSONATE_GENERATION_TYPE = 'impersonate';
+export const COMPANION_OUTPUT_GENERATION_TYPE = 'companion_output';
 const PREPEND_PROMPT_TRANSFORM_TEMPLATE_IDS = new Set([
     'tpl-scene-tracker',
     'tpl-time-tracker',
@@ -412,7 +416,7 @@ async function processManualAgentRunQueue() {
             notifyAgentGenerationStateChanged();
 
             try {
-                const result = await executeManualAgentRun(queuedRun.agentId, queuedRun.messageIndex, queuedRun.cancelRevision);
+                const result = await executeManualAgentRun(queuedRun.agentId, queuedRun.target, queuedRun.cancelRevision);
                 queuedRun.resolve(result);
             } catch (error) {
                 queuedRun.reject(error);
@@ -430,7 +434,30 @@ async function processManualAgentRunQueue() {
     }
 }
 
-function enqueueManualAgentRun(agentId, messageIndex) {
+/**
+ * Normalizes a manual-run target. Plain numbers/strings keep the historical
+ * "run on this chat message" meaning; objects can address the composer text box
+ * or a companion result on a message.
+ * @param {number|string|{ kind?: string, messageIndex?: number, companionAgentId?: string }} target
+ * @returns {{ kind: 'message'|'composer'|'companion', messageIndex: number, companionAgentId: string }}
+ */
+function normalizeManualRunTarget(target) {
+    if (typeof target === 'number' || typeof target === 'string') {
+        return { kind: 'message', messageIndex: Number(target), companionAgentId: '' };
+    }
+
+    const kind = ['message', 'composer', 'companion'].includes(String(target?.kind ?? '').trim())
+        ? String(target.kind).trim()
+        : 'message';
+
+    return {
+        kind,
+        messageIndex: Number(target?.messageIndex ?? -1),
+        companionAgentId: String(target?.companionAgentId ?? '').trim(),
+    };
+}
+
+function enqueueManualAgentRun(agentId, target) {
     const wasAlreadyActive = isAgentGenerationActive();
     manualAgentRunCancelRequested = false;
     if (!isGenerationInProgress) {
@@ -450,7 +477,7 @@ function enqueueManualAgentRun(agentId, messageIndex) {
 
         return (async () => {
             try {
-                return await executeManualAgentRun(agentId, messageIndex, cancelRevision);
+                return await executeManualAgentRun(agentId, target, cancelRevision);
             } finally {
                 parallelManualRunCount = Math.max(0, parallelManualRunCount - 1);
                 notifyAgentGenerationStateChanged();
@@ -461,7 +488,7 @@ function enqueueManualAgentRun(agentId, messageIndex) {
     return new Promise((resolve, reject) => {
         manualAgentRunQueue.push({
             agentId,
-            messageIndex,
+            target,
             cancelRevision,
             resolve,
             reject,
@@ -677,6 +704,7 @@ function normalizeGenerationType(generationType) {
         case GREETING_GENERATION_TYPE:
         case 'impersonate':
         case 'quiet':
+        case COMPANION_OUTPUT_GENERATION_TYPE:
             return String(generationType).trim().toLowerCase();
         default:
             return 'normal';
@@ -2105,15 +2133,90 @@ function getPromptTransformAgentsForMessage(activeAgents, generationType) {
     return getPromptTransformAgents(activeAgents);
 }
 
+function agentOptedIntoImpersonatePasses(agent) {
+    if (agent?.conditions?.runOnImpersonate) {
+        return true;
+    }
+
+    const sourceTemplateId = String(agent?.sourceTemplateId ?? '').trim();
+    return IMPERSONATE_PROMPT_TRANSFORM_TEMPLATE_IDS.has(sourceTemplateId);
+}
+
 function getPromptTransformAgentsForImpersonate(activeAgents) {
-    return getPromptTransformAgents(activeAgents).filter(agent => {
-        if (agent?.conditions?.runOnImpersonate) {
-            return true;
+    return getPromptTransformAgents(activeAgents).filter(agentOptedIntoImpersonatePasses);
+}
+
+function getRegexAgentsForImpersonate(activeAgents) {
+    return activeAgents.filter(agent =>
+        !isCompanionAgent(agent) &&
+        !isToolAgent(agent) &&
+        agentOptedIntoImpersonatePasses(agent) &&
+        getAgentRegexScripts(agent).length > 0,
+    );
+}
+
+/**
+ * Applies the given agents' ST-style regex scripts directly to a plain text value
+ * (impersonation composer text or a companion result), outside the message
+ * regex-snapshot display pipeline. Runs the display-mode pass first so the common
+ * markdownOnly scripts apply, then the raw-text pass for scripts with both mode
+ * flags off.
+ * @param {object[]} agents
+ * @param {string} text
+ * @param {{ characterOverride?: string }} [options]
+ * @returns {string}
+ */
+function applyAgentRegexScriptsToText(agents, text, { characterOverride = '' } = {}) {
+    let output = String(text ?? '');
+    if (!output) {
+        return output;
+    }
+
+    const baseOptions = {
+        characterOverride,
+        substituteParamsFn: substituteParams,
+        substituteParamsExtendedFn: substituteParamsExtended,
+    };
+
+    for (const agent of agents) {
+        const scripts = getAgentRegexScripts(agent);
+        if (scripts.length === 0) {
+            continue;
         }
 
-        const sourceTemplateId = String(agent?.sourceTemplateId ?? '').trim();
-        return IMPERSONATE_PROMPT_TRANSFORM_TEMPLATE_IDS.has(sourceTemplateId);
-    });
+        output = applyRegexScriptList(output, scripts, AGENT_REGEX_PLACEMENT.AI_OUTPUT, { ...baseOptions, isMarkdown: true });
+        output = applyRegexScriptList(output, scripts, AGENT_REGEX_PLACEMENT.AI_OUTPUT, baseOptions);
+    }
+
+    return output;
+}
+
+function companionOutputPassTargetsCompanion(agent, companionReferenceIdSet) {
+    const targetIds = Array.isArray(agent?.conditions?.companionOutputTargetAgentIds)
+        ? agent.conditions.companionOutputTargetAgentIds.map(id => String(id ?? '').trim().toLowerCase()).filter(Boolean)
+        : [];
+
+    if (targetIds.length === 0) {
+        return true;
+    }
+
+    return targetIds.some(id => companionReferenceIdSet.has(id));
+}
+
+function getCompanionOutputPostPassAgents(companionAgent) {
+    if (!areAgentsGloballyEnabled()) {
+        return [];
+    }
+
+    const companionReferenceIdSet = new Set(getCompanionReferenceIds(companionAgent).map(id => id.toLowerCase()));
+
+    return getEnabledAgents().filter(agent =>
+        agent.id !== companionAgent?.id &&
+        !isCompanionAgent(agent) &&
+        !isToolAgent(agent) &&
+        agent?.conditions?.runOnCompanionOutputs &&
+        companionOutputPassTargetsCompanion(agent, companionReferenceIdSet),
+    );
 }
 
 function getPreGenerationInterceptAgents(activeAgents) {
@@ -2611,14 +2714,27 @@ function applyContextInterceptText(originalText, interceptText, preProcess = {})
 
 function buildPromptTransformMessages(agentPrompt, messageText, assistantName, generationType, mode) {
     const isImpersonate = isImpersonateGenerationType(generationType);
-    const targetLabel = isImpersonate ? 'generated impersonation text' : 'assistant response';
-    const originalLabel = isImpersonate ? 'original text' : 'original response';
-    const contentLabel = isImpersonate ? 'text' : 'response';
+    const isCompanionOutput = normalizeGenerationType(generationType) === COMPANION_OUTPUT_GENERATION_TYPE;
+    const targetLabel = isImpersonate
+        ? 'generated impersonation text'
+        : isCompanionOutput
+            ? 'companion agent note'
+            : 'assistant response';
+    const originalLabel = isImpersonate
+        ? 'original text'
+        : isCompanionOutput
+            ? 'original note'
+            : 'original response';
+    const contentLabel = isImpersonate ? 'text' : isCompanionOutput ? 'note' : 'response';
     const actionInstruction = mode === 'append'
         ? `Generate only the new content that should be appended after the ${targetLabel} according to the instructions above. Do not repeat, rewrite, summarize, or quote the original ${targetLabel}. Return only the appended content, with no labels or commentary unless the appended content itself requires them.`
         : `Rewrite the ${targetLabel} according to the instructions above. Return only the final rewritten ${targetLabel}. If no changes are needed, return the ${originalLabel} verbatim. Do not add commentary, labels, or code fences unless the ${contentLabel} itself requires them.`;
     const currentAssistantResponse = unwrapAssistantResponseWrapper(messageText);
-    const responseLabel = isImpersonate ? 'Current generated impersonation text' : 'Current assistant response';
+    const responseLabel = isImpersonate
+        ? 'Current generated impersonation text'
+        : isCompanionOutput
+            ? 'Current companion agent note'
+            : 'Current assistant response';
 
     return [
         {
@@ -3960,13 +4076,14 @@ function onMessageEdited(messageIndex) {
     saveChatDebouncedForAgent();
 }
 
-async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType) {
+async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType, { messageContext = {} } = {}) {
     const message = {
         mes: initialText,
         name: getUserMessageName(),
         is_user: true,
         is_system: false,
         extra: {},
+        ...messageContext,
     };
     const promptRuns = [];
     let currentPromptTransformText = unwrapAssistantResponseWrapper(initialText);
@@ -4026,6 +4143,56 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
         text: currentPromptTransformText,
         changed: currentPromptTransformText !== unwrapAssistantResponseWrapper(initialText),
     };
+}
+
+/**
+ * Runs the post passes of every enabled inline agent that opted into companion-output
+ * targeting (prompt pass first, agent regex second) against a completed companion result.
+ * The caller stores the returned text back into the companion result so downstream
+ * consumers (panel display, feedback injection, dependent companions) all see it.
+ * @param {object} companionAgent The companion whose output is being transformed
+ * @param {string} initialText The companion result content
+ * @param {{ messageIndex?: number }} [options]
+ * @returns {Promise<{ text: string, changed: boolean }>}
+ */
+export async function runCompanionOutputPostPasses(companionAgent, initialText, { messageIndex = -1 } = {}) {
+    const baseText = String(initialText ?? '');
+    if (!baseText.trim()) {
+        return { text: baseText, changed: false };
+    }
+
+    const transformers = getCompanionOutputPostPassAgents(companionAgent);
+    if (transformers.length === 0) {
+        return { text: baseText, changed: false };
+    }
+
+    const sourceMessage = chat[Number(messageIndex)] ?? null;
+    const characterName = String(sourceMessage?.name ?? '').trim();
+    let currentText = baseText;
+    let changed = false;
+
+    const promptAgents = getPromptTransformAgents(transformers);
+    if (promptAgents.length > 0) {
+        const promptResult = await runPromptTransformAgentsForText(
+            promptAgents,
+            currentText,
+            COMPANION_OUTPUT_GENERATION_TYPE,
+            { messageContext: characterName ? { name: characterName } : {} },
+        );
+        currentText = promptResult.text;
+        changed = changed || promptResult.changed;
+    }
+
+    const regexAgents = transformers.filter(agent => getAgentRegexScripts(agent).length > 0);
+    if (regexAgents.length > 0) {
+        const regexText = applyAgentRegexScriptsToText(regexAgents, currentText, { characterOverride: characterName });
+        if (regexText !== currentText) {
+            currentText = regexText;
+            changed = true;
+        }
+    }
+
+    return { text: currentText, changed };
 }
 
 async function runContextInterceptAgent(agent, currentContextText, generationType, contextFormat, options = {}) {
@@ -4567,22 +4734,39 @@ async function onImpersonateReady(text = '') {
         : buildActivationSnapshot(IMPERSONATE_GENERATION_TYPE);
     const activeAgents = getSnapshotAgents(activationSnapshot);
     const promptTransformAgents = getPromptTransformAgentsForImpersonate(activeAgents);
-    if (promptTransformAgents.length === 0) {
+    const regexAgents = getRegexAgentsForImpersonate(activeAgents);
+    if (promptTransformAgents.length === 0 && regexAgents.length === 0) {
         return;
     }
 
     // Impersonate produces user-side text; rewrite only the composer value, never the last assistant swipe.
-    const result = await runPromptTransformAgentsForText(promptTransformAgents, initialText, IMPERSONATE_GENERATION_TYPE);
-    if (!result.changed) {
+    let transformedText = initialText;
+    let changed = false;
+
+    if (promptTransformAgents.length > 0) {
+        const result = await runPromptTransformAgentsForText(promptTransformAgents, transformedText, IMPERSONATE_GENERATION_TYPE);
+        transformedText = result.text;
+        changed = changed || result.changed;
+    }
+
+    if (regexAgents.length > 0) {
+        const regexText = applyAgentRegexScriptsToText(regexAgents, transformedText, { characterOverride: getUserMessageName() });
+        if (regexText !== transformedText) {
+            transformedText = regexText;
+            changed = true;
+        }
+    }
+
+    if (!changed) {
         return;
     }
 
     if (normalizeContentText(textarea.value) !== textareaTextAtStart) {
-        toastr.warning('Skipped applying the impersonation prompt pass because the input changed while it was running.', 'In-Chat Agents');
+        toastr.warning('Skipped applying the impersonation post passes because the input changed while they were running.', 'In-Chat Agents');
         return;
     }
 
-    textarea.value = result.text;
+    textarea.value = transformedText;
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
@@ -4815,14 +4999,105 @@ export function initAgentRunner() {
     migrateLegacyRegexSnapshotsForCurrentChat();
 }
 
-async function executeManualAgentRun(agentId, messageIndex, cancelRevision = agentGenerationCancelRevision) {
-    await commitOpenEditorForMessage(messageIndex);
+/**
+ * Runs a single inline agent's post passes (forced prompt pass, then agent regex)
+ * on a plain text value that is not a chat message.
+ * @param {object} agent
+ * @param {string} text
+ * @param {string} generationType Labeling context for the prompt pass
+ * @param {{ characterOverride?: string, messageContext?: object }} [options]
+ * @returns {Promise<{ text: string, changed: boolean }>}
+ */
+export async function runSingleAgentPostPassesOnText(agent, text, generationType, { characterOverride = '', messageContext = {} } = {}) {
+    let currentText = String(text ?? '');
+    let changed = false;
 
+    if (String(agent?.prompt ?? '').trim()) {
+        const promptResult = await runPromptTransformAgentsForText([agent], currentText, generationType, { messageContext });
+        currentText = promptResult.text;
+        changed = changed || promptResult.changed;
+    }
+
+    if (getAgentRegexScripts(agent).length > 0) {
+        const regexText = applyAgentRegexScriptsToText([agent], currentText, { characterOverride });
+        if (regexText !== currentText) {
+            currentText = regexText;
+            changed = true;
+        }
+    }
+
+    return { text: currentText, changed };
+}
+
+async function executeManualComposerAgentRun(agent, cancelRevision) {
+    if (isCompanionAgent(agent)) {
+        toastr.warning('Companion agents attach notes to messages and cannot rewrite the composer text.');
+        return null;
+    }
+
+    const textarea = document.querySelector('#send_textarea');
+    if (!textarea) {
+        toastr.error('Composer text box not found.');
+        return null;
+    }
+
+    const initialText = normalizeContentText(textarea.value);
+    if (!initialText.trim()) {
+        toastr.warning('The composer text box is empty.');
+        return null;
+    }
+
+    const result = await runSingleAgentPostPassesOnText(agent, initialText, IMPERSONATE_GENERATION_TYPE, {
+        characterOverride: getUserMessageName(),
+    });
+
+    if (agentGenerationCancelRevision !== cancelRevision) {
+        return null;
+    }
+
+    if (!result.changed) {
+        toastr.info(`"${agent.name}" made no changes to the composer text.`, 'In-Chat Agents');
+        return result;
+    }
+
+    if (normalizeContentText(textarea.value) !== initialText) {
+        toastr.warning('Skipped applying the agent because the composer text changed while it was running.', 'In-Chat Agents');
+        return null;
+    }
+
+    textarea.value = result.text;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    return result;
+}
+
+async function executeManualAgentRun(agentId, target, cancelRevision = agentGenerationCancelRevision) {
+    const runTarget = normalizeManualRunTarget(target);
     const agent = getAgentById(agentId);
     if (!agent) {
         toastr.error('Agent not found.');
         return null;
     }
+
+    if (runTarget.kind === 'composer') {
+        return await executeManualComposerAgentRun(agent, cancelRevision);
+    }
+
+    if (runTarget.kind === 'companion') {
+        if (isCompanionAgent(agent)) {
+            toastr.warning('Companion agents cannot post-process other companion notes.');
+            return null;
+        }
+
+        if (!companionRuntime?.applyAgentPostPassesToCompanionResult) {
+            toastr.error('Companion runtime is unavailable.');
+            return null;
+        }
+
+        return await companionRuntime.applyAgentPostPassesToCompanionResult(agent.id, runTarget.messageIndex, runTarget.companionAgentId, { cancelRevision });
+    }
+
+    const messageIndex = runTarget.messageIndex;
+    await commitOpenEditorForMessage(messageIndex);
 
     const message = chat[messageIndex];
     if (!message || message.is_user || message.is_system) {
@@ -4884,12 +5159,22 @@ async function executeManualAgentRun(agentId, messageIndex, cancelRevision = age
  * @returns {Promise<import('./agent-store.js').InChatAgent | null>}
  */
 export async function runAgentOnMessage(agentId, messageIndex) {
+    return await runAgentOnTarget(agentId, { kind: 'message', messageIndex: Number(messageIndex) });
+}
+
+/**
+ * Manually runs a single agent on a chosen target: a chat message, the composer
+ * text box, or a companion result on a message. Queued like other manual runs.
+ * @param {string} agentId
+ * @param {number|{ kind: 'message'|'composer'|'companion', messageIndex?: number, companionAgentId?: string }} target
+ */
+export async function runAgentOnTarget(agentId, target) {
     if (!areAgentsGloballyEnabled()) {
         toastr.warning('In-Chat Agents are disabled.');
         return null;
     }
 
-    return await enqueueManualAgentRun(agentId, messageIndex);
+    return await enqueueManualAgentRun(agentId, target);
 }
 
 export async function runTrackerFixOnMessage(messageIndex) {

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -3332,22 +3332,40 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
     }
 }
 
-async function runPromptTransformAppendBatch(agents, message, generationType, messageTextOverride = null, messageIndex = null) {
+async function runPromptTransformAppendBatch(agents, message, generationType, messageTextOverride = null, messageIndex = null, { cancelRevision = null } = {}) {
     const currentMessageText = unwrapAssistantResponseWrapper(
         messageTextOverride !== null ? messageTextOverride : message?.mes,
     );
+    const isCancelled = () => cancelRevision !== null && agentGenerationCancelRevision !== cancelRevision;
     const globalSettings = getGlobalSettings();
     const executionMode = globalSettings.appendAgentsExecutionMode === 'sequential' ? 'sequential' : 'parallel';
 
     let results = [];
 
+    if (isCancelled()) {
+        return {
+            results,
+            changed: false,
+            nextMessageText: currentMessageText,
+            beforeText: currentMessageText,
+            cancelled: true,
+        };
+    }
+
     if (executionMode === 'sequential') {
         for (const agent of agents) {
+            if (isCancelled()) {
+                break;
+            }
+
             try {
                 const result = await runPromptTransformAgent(agent, message, generationType, currentMessageText, messageIndex, {
                     applyToMessage: false,
                 });
                 results.push(result);
+                if (isCancelled() || result.status === 'cancelled') {
+                    break;
+                }
             } catch (error) {
                 results.push({
                     agentId: agent.id,
@@ -3388,6 +3406,16 @@ async function runPromptTransformAppendBatch(agents, message, generationType, me
                 }
             }),
         );
+    }
+
+    if (isCancelled() || results.some(result => result?.status === 'cancelled')) {
+        return {
+            results,
+            changed: false,
+            nextMessageText: currentMessageText,
+            beforeText: currentMessageText,
+            cancelled: true,
+        };
     }
 
     const consolidated = consolidateAppendPromptTransformOutputs(currentMessageText, agents, results);
@@ -4076,7 +4104,7 @@ function onMessageEdited(messageIndex) {
     saveChatDebouncedForAgent();
 }
 
-async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType, { messageContext = {} } = {}) {
+async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType, { messageContext = {}, cancelRevision = null, stopOnFailure = false } = {}) {
     const message = {
         mes: initialText,
         name: getUserMessageName(),
@@ -4086,12 +4114,30 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
         ...messageContext,
     };
     const promptRuns = [];
-    let currentPromptTransformText = unwrapAssistantResponseWrapper(initialText);
+    const initialPromptTransformText = unwrapAssistantResponseWrapper(initialText);
+    const isCancelled = () => cancelRevision !== null && agentGenerationCancelRevision !== cancelRevision;
+    const cancelledResult = () => ({
+        promptRuns,
+        text: initialPromptTransformText,
+        changed: false,
+        cancelled: true,
+    });
+    const failedResult = () => ({
+        promptRuns,
+        text: initialPromptTransformText,
+        changed: false,
+        failed: true,
+    });
+    let currentPromptTransformText = initialPromptTransformText;
     let appendBatch = [];
 
     const flushAppendBatch = async () => {
         if (appendBatch.length === 0) {
-            return;
+            return null;
+        }
+
+        if (isCancelled()) {
+            return { cancelled: true };
         }
 
         const batchAgents = appendBatch;
@@ -4103,26 +4149,59 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
             generationType,
             currentPromptTransformText,
             null,
+            { cancelRevision },
         );
         promptRuns.push(...batchResult.results);
+
+        if (batchResult.cancelled || isCancelled() || batchResult.results.some(result => result?.status === 'cancelled')) {
+            return { cancelled: true };
+        }
+
+        if (stopOnFailure && batchResult.results.some(result => result?.status === 'error')) {
+            return { failed: true };
+        }
+
         currentPromptTransformText = batchResult.nextMessageText;
+        return null;
     };
 
     for (const agent of promptTransformAgents) {
+        if (isCancelled()) {
+            return cancelledResult();
+        }
+
         if (getPromptTransformMode(agent) === 'append') {
             appendBatch.push(agent);
             continue;
         }
 
-        await flushAppendBatch();
+        const appendResult = await flushAppendBatch();
+        if (appendResult?.cancelled) {
+            return cancelledResult();
+        }
+        if (appendResult?.failed) {
+            return failedResult();
+        }
 
         try {
             const result = await runPromptTransformAgent(agent, message, generationType, currentPromptTransformText, null, {
                 applyToMessage: false,
             });
             promptRuns.push(result);
+
+            if (isCancelled() || result.status === 'cancelled') {
+                return cancelledResult();
+            }
+            if (stopOnFailure && result.status === 'error') {
+                return failedResult();
+            }
+
             currentPromptTransformText = result.nextMessageText;
         } catch (error) {
+            if (isCancelled()) {
+                return cancelledResult();
+            }
+
             promptRuns.push({
                 agentId: agent.id,
                 agentName: agent.name,
@@ -4133,10 +4212,20 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
                 runner: 'error',
                 timestamp: new Date().toISOString(),
             });
+
+            if (stopOnFailure) {
+                return failedResult();
+            }
         }
     }
 
-    await flushAppendBatch();
+    const appendResult = await flushAppendBatch();
+    if (appendResult?.cancelled) {
+        return cancelledResult();
+    }
+    if (appendResult?.failed) {
+        return failedResult();
+    }
 
     return {
         promptRuns,
@@ -4152,13 +4241,18 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
  * consumers (panel display, feedback injection, dependent companions) all see it.
  * @param {object} companionAgent The companion whose output is being transformed
  * @param {string} initialText The companion result content
- * @param {{ messageIndex?: number }} [options]
- * @returns {Promise<{ text: string, changed: boolean }>}
+ * @param {{ messageIndex?: number, cancelRevision?: number }} [options]
+ * @returns {Promise<{ text: string, changed: boolean, cancelled?: boolean }>}
  */
-export async function runCompanionOutputPostPasses(companionAgent, initialText, { messageIndex = -1 } = {}) {
+export async function runCompanionOutputPostPasses(companionAgent, initialText, { messageIndex = -1, cancelRevision = getAgentGenerationCancelRevision() } = {}) {
     const baseText = String(initialText ?? '');
     if (!baseText.trim()) {
         return { text: baseText, changed: false };
+    }
+
+    const isCancelled = () => agentGenerationCancelRevision !== cancelRevision;
+    if (isCancelled()) {
+        return { text: baseText, changed: false, cancelled: true };
     }
 
     const transformers = getCompanionOutputPostPassAgents(companionAgent);
@@ -4177,10 +4271,26 @@ export async function runCompanionOutputPostPasses(companionAgent, initialText, 
             promptAgents,
             currentText,
             COMPANION_OUTPUT_GENERATION_TYPE,
-            { messageContext: characterName ? { name: characterName } : {} },
+            {
+                messageContext: characterName ? { name: characterName } : {},
+                cancelRevision,
+                stopOnFailure: true,
+            },
         );
+        if (promptResult.cancelled || isCancelled()) {
+            return { text: baseText, changed: false, cancelled: true };
+        }
+        if (promptResult.failed) {
+            const failure = promptResult.promptRuns.find(run => run?.status === 'error');
+            throw new Error(failure?.error || 'Companion output prompt transform failed.');
+        }
+
         currentText = promptResult.text;
         changed = changed || promptResult.changed;
+    }
+
+    if (isCancelled()) {
+        return { text: baseText, changed: false, cancelled: true };
     }
 
     const regexAgents = transformers.filter(agent => getAgentRegexScripts(agent).length > 0);

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -82,7 +82,9 @@ import {
  * @property {string[]} triggerKeywords
  * @property {number} triggerProbability - 0-100
  * @property {string[]} generationTypes
- * @property {boolean} runOnImpersonate - Allows prompt-based post passes to rewrite generated impersonation text
+ * @property {boolean} runOnImpersonate - Allows this agent's post passes (prompt pass + agent regex) to rewrite generated impersonation text
+ * @property {boolean} runOnCompanionOutputs - Allows this agent's post passes (prompt pass + agent regex) to rewrite companion agent outputs
+ * @property {string[]} companionOutputTargetAgentIds - Companion agent/template ids to target; empty targets all companions
  */
 
 /**
@@ -1226,6 +1228,8 @@ export function createDefaultAgent() {
             triggerProbability: 100,
             generationTypes: ['normal', 'continue', 'impersonate'],
             runOnImpersonate: false,
+            runOnCompanionOutputs: false,
+            companionOutputTargetAgentIds: [],
         },
         tools: [],
         settings: {},
@@ -1363,6 +1367,12 @@ export function normalizeAgent(rawAgent = {}) {
             runOnImpersonate: Object.hasOwn(conditions, 'runOnImpersonate')
                 ? Boolean(conditions.runOnImpersonate)
                 : defaults.conditions.runOnImpersonate,
+            runOnCompanionOutputs: Object.hasOwn(conditions, 'runOnCompanionOutputs')
+                ? Boolean(conditions.runOnCompanionOutputs)
+                : defaults.conditions.runOnCompanionOutputs,
+            companionOutputTargetAgentIds: Array.isArray(conditions.companionOutputTargetAgentIds)
+                ? conditions.companionOutputTargetAgentIds.map(id => String(id ?? '').trim()).filter(Boolean)
+                : defaults.conditions.companionOutputTargetAgentIds,
         },
         tools: Array.isArray(rawAgent.tools)
             ? rawAgent.tools.map(tool => normalizeToolDef(tool))

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -25,11 +25,14 @@ import {
 } from '../agent-store.js';
 import {
     buildPromptDynamicMacros,
+    COMPANION_OUTPUT_GENERATION_TYPE,
     deleteAgentExtraValue,
     getAgentExtraValue,
     getAgentGenerationCancelRevision,
     registerCompanionRuntime,
     requestPromptTransform,
+    runCompanionOutputPostPasses,
+    runSingleAgentPostPassesOnText,
     setAgentExtraValue,
 } from '../agent-runner.js';
 import {
@@ -1167,6 +1170,29 @@ function getCompanionResultContent(message, agentId) {
     return normalizeText(getCompanionResults(message)[agentId]?.content);
 }
 
+/**
+ * Runs opted-in inline agents' post passes on a finished companion result. Failures and
+ * mid-pass cancellations fall back to the untouched companion output so the note itself
+ * is never lost to a post-pass problem.
+ */
+async function applyCompanionOutputPostPassesToContent(agent, content, messageIndex, cancelRevision) {
+    if (!normalizeText(content)) {
+        return content;
+    }
+
+    try {
+        const result = await runCompanionOutputPostPasses(agent, content, { messageIndex });
+        if (getAgentGenerationCancelRevision() !== cancelRevision) {
+            return content;
+        }
+
+        return result?.changed ? capResultContent(result.text) : content;
+    } catch (error) {
+        console.warn('[InChatAgents] Companion output post passes failed:', error);
+        return content;
+    }
+}
+
 async function runSingleCompanionAgent(agent, messageIndex, generationType, cancelRevision, { repair = false, extraContextSections = [], allowUserMessage = false, previousContent = null } = {}) {
     const message = chat[messageIndex];
     if (!isValidCompanionTargetMessage(message, { allowUserMessage })) {
@@ -1200,8 +1226,10 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
             return { agentId: agent.id, changed, result };
         }
 
-        const content = capResultContent(response.output);
-        const tokenUsage = await buildCompanionTokenUsage(promptMessages, content);
+        const rawContent = capResultContent(response.output);
+        // Token usage reflects the companion's own generation; post passes run after counting.
+        const tokenUsage = await buildCompanionTokenUsage(promptMessages, rawContent);
+        const content = await applyCompanionOutputPostPassesToContent(agent, rawContent, messageIndex, cancelRevision);
         setCompanionResult(message, agent, {
             status: 'done',
             content,
@@ -1326,14 +1354,16 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
                 continue;
             }
 
-            const content = capResultContent(parsed.get(agent.id));
+            const rawContent = capResultContent(parsed.get(agent.id));
+            const outputTokens = await countCompanionTokens({ role: 'assistant', content: rawContent });
+            const content = await applyCompanionOutputPostPassesToContent(agent, rawContent, messageIndex, cancelRevision);
             setCompanionResult(message, agent, {
                 status: 'done',
                 content,
                 error: '',
                 tokenUsage: {
                     inputTokens: inputTokensByAgentId.get(agent.id) ?? 0,
-                    outputTokens: await countCompanionTokens({ role: 'assistant', content }),
+                    outputTokens,
                 },
                 profileId: response.profileId,
                 profileLabel: getProfileLabel(agent, response.profileId),
@@ -1633,6 +1663,51 @@ export async function runCompanionAgentOnMessage(agentId, messageIndex, { cancel
     return result;
 }
 
+/**
+ * Manually runs one inline agent's post passes on a stored companion result and
+ * writes the transformed note back, so the panel, message cards, feedback
+ * injection, and dependent companions all see the new text.
+ * @param {string} transformerAgentId Inline agent whose post passes should run
+ * @param {number} messageIndex Message hosting the companion result
+ * @param {string} companionAgentId Companion whose note is the target
+ * @param {{ cancelRevision?: number }} [options]
+ * @returns {Promise<{ text: string, changed: boolean } | null>}
+ */
+export async function applyAgentPostPassesToCompanionResult(transformerAgentId, messageIndex, companionAgentId, { cancelRevision = getAgentGenerationCancelRevision() } = {}) {
+    const transformer = getAgentById(transformerAgentId);
+    const message = chat[messageIndex];
+    if (!transformer || isCompanionAgent(transformer) || !message || message.is_system) {
+        toastr.warning('This agent cannot be applied to that companion note.');
+        return null;
+    }
+
+    const result = getCompanionResults(message)[companionAgentId];
+    if (result?.status !== 'done' || !normalizeText(result?.content)) {
+        toastr.info('No finished companion note to apply this agent to.');
+        return null;
+    }
+
+    const characterName = String(message?.name ?? '').trim();
+    const passResult = await runSingleAgentPostPassesOnText(transformer, result.content, COMPANION_OUTPUT_GENERATION_TYPE, {
+        characterOverride: characterName,
+        messageContext: characterName ? { name: characterName } : {},
+    });
+
+    if (getAgentGenerationCancelRevision() !== cancelRevision) {
+        return null;
+    }
+
+    if (!passResult.changed) {
+        toastr.info(`"${transformer.name}" made no changes to the companion note.`, 'In-Chat Agents');
+        return passResult;
+    }
+
+    updateCompanionResult(message, companionAgentId, { content: capResultContent(passResult.text) });
+    await emitCompanionResultsUpdated(messageIndex, companionAgentId);
+    saveChatDebounced({ deferBackup: false });
+    return passResult;
+}
+
 export async function runCompanionsOnMessage(messageIndex, { allowUserMessage = true } = {}) {
     const message = chat[messageIndex];
     if (!isValidCompanionTargetMessage(message, { allowUserMessage })) {
@@ -1734,6 +1809,7 @@ export function initCompanionRunner() {
         runCompanionStage,
         injectCompanionFeedbackPrompts,
         runCompanionAgentOnMessage,
+        applyAgentPostPassesToCompanionResult,
     });
 
     if (event_types.MESSAGE_SWIPED) {

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -1181,8 +1181,8 @@ async function applyCompanionOutputPostPassesToContent(agent, content, messageIn
     }
 
     try {
-        const result = await runCompanionOutputPostPasses(agent, content, { messageIndex });
-        if (getAgentGenerationCancelRevision() !== cancelRevision) {
+        const result = await runCompanionOutputPostPasses(agent, content, { messageIndex, cancelRevision });
+        if (result?.cancelled || getAgentGenerationCancelRevision() !== cancelRevision) {
             return content;
         }
 
@@ -1230,6 +1230,9 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
         // Token usage reflects the companion's own generation; post passes run after counting.
         const tokenUsage = await buildCompanionTokenUsage(promptMessages, rawContent);
         const content = await applyCompanionOutputPostPassesToContent(agent, rawContent, messageIndex, cancelRevision);
+        if (getAgentGenerationCancelRevision() !== cancelRevision) {
+            throw new DOMException('Companion run cancelled.', 'AbortError');
+        }
         setCompanionResult(message, agent, {
             status: 'done',
             content,
@@ -1311,6 +1314,21 @@ async function buildBatchPromptPayload(agents, messageIndex, generationType, { e
     return { promptMessages, taskPayloads };
 }
 
+async function cancelCompanionAgentResults(message, agents, messageIndex, profileId = '') {
+    for (const agent of agents) {
+        setCompanionResult(message, agent, {
+            status: 'cancelled',
+            content: '',
+            error: 'Cancelled.',
+            tokenUsage: null,
+            profileId,
+            profileLabel: getProfileLabel(agent, profileId),
+            modelLabel: getModelLabel(agent),
+        });
+        await emitCompanionResultsUpdated(messageIndex, agent.id);
+    }
+}
+
 async function runBatchCompanionAgents(agents, messageIndex, generationType, cancelRevision, { allowUserMessage = false, previousContents = null, extraContextSectionsByAgentId = null } = {}) {
     const message = chat[messageIndex];
     if (!isValidCompanionTargetMessage(message, { allowUserMessage })) {
@@ -1318,31 +1336,26 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
     }
 
     const previousMap = previousContents ?? new Map(agents.map(agent => [agent.id, getCompanionResultContent(message, agent.id)]));
+    const getResults = () => agents.map(agent => {
+        const result = getCompanionResults(message)[agent.id];
+        const changed = result?.status === 'done' && previousMap.get(agent.id) !== getCompanionResultContent(message, agent.id);
+        return { agentId: agent.id, changed, result };
+    });
 
     try {
+        if (getAgentGenerationCancelRevision() !== cancelRevision) {
+            await cancelCompanionAgentResults(message, agents, messageIndex);
+            return getResults();
+        }
+
         const extraContextSections = getUnitExtraContextSections(agents, extraContextSectionsByAgentId);
         const { promptMessages, taskPayloads } = await buildBatchPromptPayload(agents, messageIndex, generationType, { extraContextSections });
         const maxTokens = Math.min(MAX_AGENT_MAX_TOKENS, agents.reduce((sum, agent) => sum + getCompanionConfig(agent).maxTokens, 0));
         const response = await requestPromptTransform(agents[0], promptMessages, maxTokens);
 
         if (getAgentGenerationCancelRevision() !== cancelRevision) {
-            for (const agent of agents) {
-                setCompanionResult(message, agent, {
-                    status: 'cancelled',
-                    content: '',
-                    error: 'Cancelled.',
-                    tokenUsage: null,
-                    profileId: response.profileId,
-                    profileLabel: getProfileLabel(agent, response.profileId),
-                    modelLabel: getModelLabel(agent),
-                });
-                await emitCompanionResultsUpdated(messageIndex, agent.id);
-            }
-            return agents.map(agent => {
-                const result = getCompanionResults(message)[agent.id];
-                const changed = result?.status === 'done' && previousMap.get(agent.id) !== getCompanionResultContent(message, agent.id);
-                return { agentId: agent.id, changed, result };
-            });
+            await cancelCompanionAgentResults(message, agents, messageIndex, response.profileId);
+            return getResults();
         }
 
         const inputTokensByAgentId = await buildBatchInputTokenUsage(promptMessages, taskPayloads);
@@ -1357,6 +1370,10 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
             const rawContent = capResultContent(parsed.get(agent.id));
             const outputTokens = await countCompanionTokens({ role: 'assistant', content: rawContent });
             const content = await applyCompanionOutputPostPassesToContent(agent, rawContent, messageIndex, cancelRevision);
+            if (getAgentGenerationCancelRevision() !== cancelRevision) {
+                await cancelCompanionAgentResults(message, agents, messageIndex, response.profileId);
+                return getResults();
+            }
             setCompanionResult(message, agent, {
                 status: 'done',
                 content,
@@ -1373,6 +1390,11 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
         }
 
         for (const agent of missingAgents) {
+            if (getAgentGenerationCancelRevision() !== cancelRevision) {
+                await cancelCompanionAgentResults(message, agents, messageIndex, response.profileId);
+                return getResults();
+            }
+
             await runSingleCompanionAgent(agent, messageIndex, generationType, cancelRevision, {
                 allowUserMessage,
                 previousContent: previousMap.get(agent.id),
@@ -1380,8 +1402,18 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
             });
         }
     } catch (error) {
+        if (getAgentGenerationCancelRevision() !== cancelRevision) {
+            await cancelCompanionAgentResults(message, agents, messageIndex);
+            return getResults();
+        }
+
         console.warn('[InChatAgents] Companion batch failed, falling back to individual runs:', error);
         for (const agent of agents) {
+            if (getAgentGenerationCancelRevision() !== cancelRevision) {
+                await cancelCompanionAgentResults(message, agents, messageIndex);
+                return getResults();
+            }
+
             await runSingleCompanionAgent(agent, messageIndex, generationType, cancelRevision, {
                 allowUserMessage,
                 previousContent: previousMap.get(agent.id),
@@ -1390,11 +1422,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
         }
     }
 
-    return agents.map(agent => {
-        const result = getCompanionResults(message)[agent.id];
-        const changed = result?.status === 'done' && previousMap.get(agent.id) !== getCompanionResultContent(message, agent.id);
-        return { agentId: agent.id, changed, result };
-    });
+    return getResults();
 }
 
 async function runCompanionUnit(unit, messageIndex, generationType, cancelRevision, { allowUserMessage = false, previousContents = null, extraContextSectionsByAgentId = null } = {}) {

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -403,11 +403,23 @@
                 <input type="checkbox" id="ica--editor-pp-promptShowNotifications" />
                 <span>Show toast notifications while this prompt pass runs</span>
             </label>
-            <label class="checkbox_label">
-                <input type="checkbox" id="ica--editor-pp-runOnImpersonate" />
-                <span>Allow this prompt pass to rewrite generated impersonation text</span>
-            </label>
             <div class="ica--regex-note">The prompt pass runs after the main reply using this agent's prompt and connection profile. In <b>rewrite</b> mode it replaces the message. In <b>append</b> mode it only adds newly generated text after the original reply. Useful macros inside the prompt include <code>&#123;&#123;currentMessage&#125;&#125;</code>, <code>&#123;&#123;response&#125;&#125;</code>, and <code>&#123;&#123;original&#125;&#125;</code>.</div>
+        </div>
+        <label class="checkbox_label">
+            <input type="checkbox" id="ica--editor-pp-runOnImpersonate" />
+            <span>Run this agent's post passes (prompt pass + Agent Regex) on generated impersonation text</span>
+        </label>
+        <label class="checkbox_label">
+            <input type="checkbox" id="ica--editor-pp-runOnCompanionOutputs" />
+            <span>Run this agent's post passes (prompt pass + Agent Regex) on companion agent outputs</span>
+        </label>
+        <div id="ica--pp-companion-target-options" style="display:none">
+            <div class="ica--editor-row">
+                <label class="flex1">Companion targets <small>(none selected = all companions)</small>
+                    <select id="ica--editor-pp-companionTargets" class="text_pole" multiple size="5"></select>
+                </label>
+            </div>
+            <div class="ica--regex-note">When a targeted companion finishes a note, this agent's post-generation prompt pass and Agent Regex scripts run on that note before it is stored, so the panel, message cards, feedback injection, and dependent companions all see the transformed version. Avoid targeting structured tracker companions with prose rewrites.</div>
         </div>
         <label class="checkbox_label">
             <input type="checkbox" id="ica--editor-pp-enabled" />

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -493,9 +493,9 @@ function getLastAssistantMessageIndex() {
 /**
  * Shows a picker for the manual "Apply to…" action listing what exists right now:
  * the last assistant reply, the composer text box, and the finished companion notes
- * on that reply. Returns a runAgentOnTarget-compatible target, or null on cancel.
+ * on that reply. Returns runAgentOnTarget-compatible targets, or null on cancel.
  */
-async function pickManualAgentRunTarget(agent) {
+async function pickManualAgentRunTargets(agent) {
     const lastAssistantIndex = getLastAssistantMessageIndex();
     const composerText = String(document.getElementById('send_textarea')?.value ?? '').trim();
     const options = [];
@@ -538,7 +538,7 @@ async function pickManualAgentRunTarget(agent) {
     options.forEach((option, index) => {
         picker.append($(`
             <label class="checkbox_label">
-                <input type="radio" name="ica--run-target" value="${escapeHtml(option.value)}" ${index === 0 ? 'checked' : ''} />
+                <input type="checkbox" name="ica--run-target" value="${escapeHtml(option.value)}" ${index === 0 ? 'checked' : ''} />
                 <span>${escapeHtml(option.label)}</span>
             </label>
         `));
@@ -549,20 +549,27 @@ async function pickManualAgentRunTarget(agent) {
         return null;
     }
 
-    const selected = String(picker.find('input[name="ica--run-target"]:checked').val() ?? '');
-    if (selected === 'composer') {
-        return { kind: 'composer' };
+    const selected = picker.find('input[name="ica--run-target"]:checked').map((_, input) => String(input.value)).get();
+    if (selected.length === 0) {
+        toastr.warning('Select at least one target.');
+        return null;
     }
 
-    if (selected.startsWith('companion:')) {
-        return {
-            kind: 'companion',
-            messageIndex: lastAssistantIndex,
-            companionAgentId: selected.slice('companion:'.length),
-        };
-    }
+    return selected.map(value => {
+        if (value === 'composer') {
+            return { kind: 'composer' };
+        }
 
-    return { kind: 'message', messageIndex: lastAssistantIndex };
+        if (value.startsWith('companion:')) {
+            return {
+                kind: 'companion',
+                messageIndex: lastAssistantIndex,
+                companionAgentId: value.slice('companion:'.length),
+            };
+        }
+
+        return { kind: 'message', messageIndex: lastAssistantIndex };
+    });
 }
 
 function hasTrackerFixAgents() {
@@ -2563,11 +2570,11 @@ function renderAgentList() {
 
             card.find('.ica--btn-run-target').on('click', async event => {
                 stopEvent(event);
-                const target = await pickManualAgentRunTarget(agent);
-                if (!target) {
+                const targets = await pickManualAgentRunTargets(agent);
+                if (!targets) {
                     return;
                 }
-                await runAgentOnTarget(agent.id, target);
+                await Promise.all(targets.map(target => runAgentOnTarget(agent.id, target)));
             });
 
             card.find('.ica--btn-preview-prompt').on('click', async event => {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -490,6 +490,36 @@ function getLastAssistantMessageIndex() {
     return chat.findLastIndex(message => message && !message.is_user && !message.is_system);
 }
 
+function getManualAgentRunMessageIndices(rangeText, lastAssistantIndex) {
+    const range = String(rangeText ?? '').trim();
+    if (!range) {
+        return lastAssistantIndex >= 0 ? [lastAssistantIndex] : [];
+    }
+
+    const indexes = new Set();
+    for (const section of range.split(',')) {
+        const match = section.trim().match(/^(\d+)(?:\s*-\s*(\d+))?$/);
+        if (!match) {
+            return null;
+        }
+
+        const start = Number(match[1]);
+        const end = Number(match[2] ?? match[1]);
+        if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start > end) {
+            return null;
+        }
+
+        for (let index = Math.max(0, start); index <= Math.min(chat.length - 1, end); index++) {
+            const message = chat[index];
+            if (message && !message.is_user && !message.is_system) {
+                indexes.add(index);
+            }
+        }
+    }
+
+    return [...indexes].sort((a, b) => a - b);
+}
+
 /**
  * Shows a picker for the manual "Apply to…" action listing what exists right now:
  * the last assistant reply, the composer text box, and the finished companion notes
@@ -504,7 +534,7 @@ async function pickManualAgentRunTargets(agent) {
         const replyName = String(chat[lastAssistantIndex]?.name ?? '').trim();
         options.push({
             value: 'message',
-            label: `Last assistant reply${replyName ? ` (${replyName})` : ''}`,
+            label: `Last assistant reply #${lastAssistantIndex}${replyName ? ` (${replyName})` : ''}`,
         });
 
         for (const [companionAgentId, result] of Object.entries(getCompanionResults(chat[lastAssistantIndex]))) {
@@ -542,6 +572,14 @@ async function pickManualAgentRunTargets(agent) {
                 <span>${escapeHtml(option.label)}</span>
             </label>
         `));
+        if (option.value === 'message') {
+            picker.append($(`
+                <label class="ica--run-target-range">
+                    <span>Messages</span>
+                    <input type="text" id="ica--run-target-message-range" class="text_pole" placeholder="0-5, 8" inputmode="text" />
+                </label>
+            `));
+        }
     });
 
     const popupResult = await new Popup(picker, POPUP_TYPE.CONFIRM, '', { okButton: 'Apply', cancelButton: 'Cancel' }).show();
@@ -555,20 +593,32 @@ async function pickManualAgentRunTargets(agent) {
         return null;
     }
 
-    return selected.map(value => {
+    const messageIndices = selected.includes('message')
+        ? getManualAgentRunMessageIndices(picker.find('#ica--run-target-message-range').val(), lastAssistantIndex)
+        : [];
+    if (messageIndices === null || (selected.includes('message') && messageIndices.length === 0)) {
+        toastr.warning('Select at least one target.');
+        return null;
+    }
+
+    return selected.flatMap(value => {
         if (value === 'composer') {
-            return { kind: 'composer' };
+            return [{ kind: 'composer' }];
         }
 
         if (value.startsWith('companion:')) {
-            return {
+            return [{
                 kind: 'companion',
                 messageIndex: lastAssistantIndex,
                 companionAgentId: value.slice('companion:'.length),
-            };
+            }];
         }
 
-        return { kind: 'message', messageIndex: lastAssistantIndex };
+        if (value === 'message') {
+            return messageIndices.map(messageIndex => ({ kind: 'message', messageIndex }));
+        }
+
+        return [];
     });
 }
 

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -5732,6 +5732,33 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         }
         exitSelectMode();
     });
+    $('#ica--bulkEnableOnCompanions').on('click', async () => {
+        let changed = 0;
+        let eligible = 0;
+        for (const id of selectedAgentIds) {
+            const agent = getAgentById(id);
+            if (!agent || isCompanionAgent(agent) || isToolAgent(agent) || !['post', 'both'].includes(agent.phase)) {
+                continue;
+            }
+            eligible++;
+            agent.conditions ??= {};
+            if (agent.conditions.runOnCompanionOutputs) {
+                continue;
+            }
+            agent.conditions.runOnCompanionOutputs = true;
+            lockBundledAgentCustomization(agent);
+            await saveAgent(agent);
+            changed++;
+        }
+        if (changed > 0) {
+            toastr.success(`Enabled ${changed} selected post-generation agent(s) on companion outputs.`);
+        } else if (eligible > 0) {
+            toastr.info('Selected post-generation agents are already enabled on companion outputs.');
+        } else {
+            toastr.warning('No selected post-generation agents can run on companion outputs.');
+        }
+        exitSelectMode();
+    });
     $('#ica--bulkDisable').on('click', async () => {
         let changed = false;
         for (const id of selectedAgentIds) {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -67,6 +67,7 @@ import {
     getPromptTransformHistoryForMessage,
     refreshRegexSnapshotsForAgent,
     runAgentOnMessage,
+    runAgentOnTarget,
     runTrackerFixOnMessage,
     syncToolAgentRegistrations,
     undoPromptTransform,
@@ -89,7 +90,7 @@ import {
     getConnectionManagerRequestService,
     populateConnectionProfileSelect,
 } from './profile-utils.js';
-import { collectRecentCompanionResults, initCompanionRunner, hasConnectedCompanionAgents, hasConnectedCompanionAgentCandidates, runConnectedCompanionsOnMessage, getLatestValidCompanionMessageIndex } from './companion/companion-runner.js';
+import { collectRecentCompanionResults, getCompanionResults, initCompanionRunner, hasConnectedCompanionAgents, hasConnectedCompanionAgentCandidates, runConnectedCompanionsOnMessage, getLatestValidCompanionMessageIndex } from './companion/companion-runner.js';
 import { getCompanionReferenceIds } from './companion/companion-shared.js';
 import { initCompanionCardUi, updateCompanionButtonVisibility } from './companion/companion-ui.js';
 import { configureCompanionDashboard, initCompanionWandMenuItem, openCompanionDashboard } from './companion/companion-dashboard.js';
@@ -374,6 +375,18 @@ function getCompanionContextRecipientOptionsForAgent(agent) {
     return getCompanionDependencyOptionsForAgent(agent);
 }
 
+function getCompanionOutputTargetOptionsForAgent(agent) {
+    return getAgents()
+        .filter(candidate => candidate.id !== agent?.id)
+        .filter(candidate => isCompanionAgent(candidate))
+        .map(candidate => ({
+            id: candidate.id,
+            referenceIds: getCompanionReferenceIds(candidate),
+            label: getCompanionAgentOptionLabel(candidate),
+        }))
+        .sort((left, right) => left.label.localeCompare(right.label));
+}
+
 function normalizeDirectorCommentaryVoice(value = '') {
     const normalized = String(value ?? '').trim().toLowerCase();
     return DIRECTOR_COMMENTARY_VOICE_VALUES.includes(normalized) ? normalized : 'active';
@@ -475,6 +488,81 @@ function stopEvent(event) {
 
 function getLastAssistantMessageIndex() {
     return chat.findLastIndex(message => message && !message.is_user && !message.is_system);
+}
+
+/**
+ * Shows a picker for the manual "Apply to…" action listing what exists right now:
+ * the last assistant reply, the composer text box, and the finished companion notes
+ * on that reply. Returns a runAgentOnTarget-compatible target, or null on cancel.
+ */
+async function pickManualAgentRunTarget(agent) {
+    const lastAssistantIndex = getLastAssistantMessageIndex();
+    const composerText = String(document.getElementById('send_textarea')?.value ?? '').trim();
+    const options = [];
+
+    if (lastAssistantIndex >= 0) {
+        const replyName = String(chat[lastAssistantIndex]?.name ?? '').trim();
+        options.push({
+            value: 'message',
+            label: `Last assistant reply${replyName ? ` (${replyName})` : ''}`,
+        });
+
+        for (const [companionAgentId, result] of Object.entries(getCompanionResults(chat[lastAssistantIndex]))) {
+            if (result?.status !== 'done' || !String(result?.content ?? '').trim()) continue;
+
+            const companionLabel = String(result?.agentName ?? '').trim()
+                || getAgentById(companionAgentId)?.name
+                || companionAgentId;
+            options.push({
+                value: `companion:${companionAgentId}`,
+                label: `Companion note: ${companionLabel}`,
+            });
+        }
+    }
+
+    if (composerText) {
+        options.push({ value: 'composer', label: 'Composer text box (current input)' });
+    }
+
+    if (options.length === 0) {
+        toastr.warning('No targets available: no assistant reply yet and the composer is empty.');
+        return null;
+    }
+
+    const picker = $(`
+        <div class="ica--run-target-picker">
+            <h4>Apply "${escapeHtml(agent.name)}" to…</h4>
+        </div>
+    `);
+
+    options.forEach((option, index) => {
+        picker.append($(`
+            <label class="checkbox_label">
+                <input type="radio" name="ica--run-target" value="${escapeHtml(option.value)}" ${index === 0 ? 'checked' : ''} />
+                <span>${escapeHtml(option.label)}</span>
+            </label>
+        `));
+    });
+
+    const popupResult = await new Popup(picker, POPUP_TYPE.CONFIRM, '', { okButton: 'Apply', cancelButton: 'Cancel' }).show();
+    if (popupResult !== POPUP_RESULT.AFFIRMATIVE) {
+        return null;
+    }
+
+    const selected = String(picker.find('input[name="ica--run-target"]:checked').val() ?? '');
+    if (selected === 'composer') {
+        return { kind: 'composer' };
+    }
+
+    if (selected.startsWith('companion:')) {
+        return {
+            kind: 'companion',
+            messageIndex: lastAssistantIndex,
+            companionAgentId: selected.slice('companion:'.length),
+        };
+    }
+
+    return { kind: 'message', messageIndex: lastAssistantIndex };
 }
 
 function hasTrackerFixAgents() {
@@ -2361,6 +2449,7 @@ function renderAgentList() {
                         ${previewCompanionButton}
                         ${previewPromptButton}
                         ${isPathfinderAgent(agent) ? '' : `<button type="button" class="ica--card-btn ica--btn-run" title="${escapeHtml(applyTitle)}" aria-label="${escapeHtml(applyAria)}"><i class="fa-solid ${applyIcon}"></i></button>`}
+                        ${(isPathfinderAgent(agent) || companionExecution) ? '' : '<button type="button" class="ica--card-btn ica--btn-run-target" title="Apply this agent to a chosen target: the last reply, the composer text, or a companion note" aria-label="Apply to Target"><i class="fa-solid fa-crosshairs"></i></button>'}
                         ${convertExecutionButton}
                         <button type="button" class="ica--card-btn ica--btn-edit" title="Edit agent" aria-label="Edit agent"><i class="fa-solid fa-pen-to-square"></i></button>
                         ${isPathfinderAgent(agent) ? '' : '<button type="button" class="ica--card-btn ica--btn-export" title="Export agent" aria-label="Export agent"><i class="fa-solid fa-download"></i></button>'}
@@ -2470,6 +2559,15 @@ function renderAgentList() {
                     return;
                 }
                 await runAgentOnMessage(agent.id, lastCharMessageIndex);
+            });
+
+            card.find('.ica--btn-run-target').on('click', async event => {
+                stopEvent(event);
+                const target = await pickManualAgentRunTarget(agent);
+                if (!target) {
+                    return;
+                }
+                await runAgentOnTarget(agent.id, target);
             });
 
             card.find('.ica--btn-preview-prompt').on('click', async event => {
@@ -2696,6 +2794,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     editorEl.find('#ica--editor-companion-batch').prop('checked', companion.batch);
     const savedCompanionBatchAgentIds = normalizeCompanionBatchAgentIds(companion.batchAgentIds);
     const savedCompanionContextRecipientAgentIds = normalizeCompanionBatchAgentIds(companion.contextRecipientAgentIds);
+    const savedCompanionOutputTargetAgentIds = normalizeCompanionBatchAgentIds(agent.conditions.companionOutputTargetAgentIds);
     const savedCompanionDependencies = normalizeCompanionBatchAgentIds(companion.dependencies);
     editorEl.find('#ica--editor-companion-sendContextToCompanions').prop('checked', companion.sendContextToCompanions);
     editorEl.find('#ica--editor-companion-waitForDependencies').prop('checked', companion.waitForDependencies);
@@ -2750,6 +2849,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     editorEl.find('#ica--editor-pp-promptMaxTokens').val(agent.postProcess.promptTransformMaxTokens ?? DEFAULT_AGENT_MAX_TOKENS);
     editorEl.find('#ica--editor-pp-promptShowNotifications').prop('checked', Boolean(agent.postProcess.promptTransformShowNotifications));
     editorEl.find('#ica--editor-pp-runOnImpersonate').prop('checked', Boolean(agent.conditions.runOnImpersonate));
+    editorEl.find('#ica--editor-pp-runOnCompanionOutputs').prop('checked', Boolean(agent.conditions.runOnCompanionOutputs));
     editorEl.find('#ica--editor-pp-enabled').prop('checked', agent.postProcess.enabled && agent.postProcess.type !== 'regex');
     editorEl.find('#ica--editor-pp-type').val(postProcessType);
     editorEl.find('#ica--editor-pp-extractPattern').val(agent.postProcess.extractPattern);
@@ -2902,6 +3002,41 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         select.empty();
         if (!options.length && !selectedIds.length) {
             select.append($('<option>').val('').text('No other companion agents').prop('disabled', true));
+            return;
+        }
+
+        for (const option of options) {
+            select.append(
+                $('<option>')
+                    .val(option.id)
+                    .text(option.label)
+                    .prop('selected', option.referenceIds.some(id => selectedKeys.has(id.toLowerCase()))),
+            );
+        }
+
+        for (const id of selectedIds) {
+            if (availableKeys.has(id.toLowerCase())) continue;
+
+            select.append(
+                $('<option>')
+                    .val(id)
+                    .text(`Unavailable: ${id}`)
+                    .prop('selected', true),
+            );
+        }
+    }
+
+    function updateCompanionOutputTargetOptions() {
+        const select = editorEl.find('#ica--editor-pp-companionTargets');
+        const currentIds = normalizeCompanionBatchAgentIds(select.val());
+        const selectedIds = currentIds.length ? currentIds : savedCompanionOutputTargetAgentIds;
+        const selectedKeys = new Set(selectedIds.map(id => id.toLowerCase()));
+        const options = getCompanionOutputTargetOptionsForAgent(agent);
+        const availableKeys = new Set(options.flatMap(option => option.referenceIds).map(id => id.toLowerCase()));
+
+        select.empty();
+        if (!options.length && !selectedIds.length) {
+            select.append($('<option>').val('').text('No companion agents').prop('disabled', true));
             return;
         }
 
@@ -3090,6 +3225,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     updateCompanionBatchAgentOptions();
     updateCompanionContextRecipientOptions();
     updateCompanionDependencyOptions();
+    updateCompanionOutputTargetOptions();
     updateCompanionEditorVisibility();
     syncCompanionOrderInput();
 
@@ -3123,6 +3259,9 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         const promptEnabled = editorEl.find('#ica--editor-pp-promptEnabled').prop('checked');
         editorEl.find('#ica--pp-prompt-options').toggle(promptEnabled);
 
+        const runOnCompanionOutputs = editorEl.find('#ica--editor-pp-runOnCompanionOutputs').prop('checked');
+        editorEl.find('#ica--pp-companion-target-options').toggle(runOnCompanionOutputs);
+
         const enabled = editorEl.find('#ica--editor-pp-enabled').prop('checked');
         editorEl.find('#ica--pp-options').toggle(enabled);
 
@@ -3130,7 +3269,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
         editorEl.find('#ica--pp-extract').toggle(type === 'extract');
         editorEl.find('#ica--pp-append').toggle(type === 'append');
     }
-    editorEl.find('#ica--editor-pp-promptEnabled, #ica--editor-pp-enabled, #ica--editor-pp-type').on('change', updatePPVisibility);
+    editorEl.find('#ica--editor-pp-promptEnabled, #ica--editor-pp-runOnCompanionOutputs, #ica--editor-pp-enabled, #ica--editor-pp-type').on('change', updatePPVisibility);
     updatePPVisibility();
 
     editorEl.find('#ica--tracker-builder-generate').on('click', async () => {
@@ -3558,6 +3697,8 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
     agent.postProcess.promptTransformMaxTokens = Number(editorEl.find('#ica--editor-pp-promptMaxTokens').val()) || DEFAULT_AGENT_MAX_TOKENS;
     agent.regexScripts = regexScripts.map(script => normalizeRegexScript(script));
     agent.conditions.runOnImpersonate = editorEl.find('#ica--editor-pp-runOnImpersonate').prop('checked');
+    agent.conditions.runOnCompanionOutputs = editorEl.find('#ica--editor-pp-runOnCompanionOutputs').prop('checked');
+    agent.conditions.companionOutputTargetAgentIds = normalizeCompanionBatchAgentIds(editorEl.find('#ica--editor-pp-companionTargets').val());
 
     agent.conditions.triggerProbability = Number(editorEl.find('#ica--editor-probability').val());
     const kwText = editorEl.find('#ica--editor-keywords').val().toString();

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -72,6 +72,10 @@
                     <i class="fa-solid fa-toggle-on"></i>
                     <span>Enable</span>
                 </button>
+                <button type="button" id="ica--bulkEnableOnCompanions" class="menu_button menu_button_icon" title="Enable selected post-generation agents on Companion Agent outputs">
+                    <i class="fa-solid fa-user-astronaut"></i>
+                    <span>On Companions</span>
+                </button>
                 <button type="button" id="ica--bulkDisable" class="menu_button menu_button_icon" title="Disable selected agents">
                     <i class="fa-solid fa-toggle-off"></i>
                     <span>Disable</span>

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -2834,3 +2834,18 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     align-items: center;
     gap: 8px;
 }
+
+.ica--run-target-range {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-left: 26px;
+}
+
+.ica--run-target-range span {
+    flex: 0 0 auto;
+}
+
+.ica--run-target-range input {
+    min-width: 0;
+}

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -2816,3 +2816,21 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
 }
+
+/* Manual "Apply to..." target picker popup */
+.ica--run-target-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    text-align: left;
+}
+
+.ica--run-target-picker h4 {
+    margin: 0 0 4px 0;
+}
+
+.ica--run-target-picker .checkbox_label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -231,8 +231,22 @@ describe('in-chat agents generation UI wiring', () => {
         expect(pickerSource).toContain('type="checkbox" name="ica--run-target"');
         expect(pickerSource).not.toContain('type="radio" name="ica--run-target"');
         expect(pickerSource).toContain("picker.find('input[name=\"ica--run-target\"]:checked').map((_, input) => String(input.value)).get()");
-        expect(pickerSource).toContain('return selected.map(value => {');
+        expect(pickerSource).toContain('return selected.flatMap(value => {');
         expect(handlerSource).toContain('const targets = await pickManualAgentRunTargets(agent);');
         expect(handlerSource).toContain('await Promise.all(targets.map(target => runAgentOnTarget(agent.id, target)));');
+    });
+
+    test('allows the manual reply target to expand to an assistant message range', () => {
+        const parserSource = getFunctionSource('getManualAgentRunMessageIndices');
+        const pickerSource = getFunctionSource('pickManualAgentRunTargets');
+
+        expect(parserSource).toContain("range.split(',')");
+        expect(parserSource).toContain('!message.is_user && !message.is_system');
+        expect(parserSource).toContain('return [...indexes].sort((a, b) => a - b);');
+        expect(pickerSource).toContain('ica--run-target-message-range');
+        expect(pickerSource).toContain('Last assistant reply #${lastAssistantIndex}');
+        expect(pickerSource).toContain('getManualAgentRunMessageIndices(');
+        expect(pickerSource).toContain('return selected.flatMap(value => {');
+        expect(extensionStyleSource).toContain('.ica--run-target-range');
     });
 });

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -9,6 +9,7 @@ const publicIndexSource = readFileSync(path.join(repoRoot, 'public', 'index.html
 const companionUiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'in-chat-agents', 'companion', 'companion-ui.js'), 'utf8');
 const extensionStyleSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'in-chat-agents', 'style.css'), 'utf8');
 const editorTemplateSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'in-chat-agents', 'editor.html'), 'utf8');
+const settingsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'in-chat-agents', 'settings.html'), 'utf8');
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;
@@ -202,5 +203,22 @@ describe('in-chat agents generation UI wiring', () => {
         expect(labelSource).toContain('isCompanionAgent(agent)');
         expect(labelSource).toContain("return 'side';");
         expect(indexSource).toContain('getAgentCardPhaseLabel(agent)');
+    });
+
+    test('enables selected post-generation agents on companion outputs', () => {
+        const handlerStart = indexSource.indexOf("$('#ica--bulkEnableOnCompanions').on('click'");
+        const handlerEnd = indexSource.indexOf("$('#ica--bulkDisable').on('click'", handlerStart);
+        const handlerSource = indexSource.slice(handlerStart, handlerEnd);
+
+        expect(settingsSource).toContain('ica--bulkEnableOnCompanions');
+        expect(settingsSource).toContain('On Companions');
+        expect(handlerSource).toContain('for (const id of selectedAgentIds)');
+        expect(handlerSource).toContain('isCompanionAgent(agent)');
+        expect(handlerSource).toContain('isToolAgent(agent)');
+        expect(handlerSource).toContain("['post', 'both'].includes(agent.phase)");
+        expect(handlerSource).toContain('agent.conditions.runOnCompanionOutputs = true;');
+        expect(handlerSource).toContain('lockBundledAgentCustomization(agent);');
+        expect(handlerSource).toContain('await saveAgent(agent);');
+        expect(handlerSource).toContain('exitSelectMode();');
     });
 });

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -221,4 +221,18 @@ describe('in-chat agents generation UI wiring', () => {
         expect(handlerSource).toContain('await saveAgent(agent);');
         expect(handlerSource).toContain('exitSelectMode();');
     });
+
+    test('allows manual agent application to multiple selected targets', () => {
+        const pickerSource = getFunctionSource('pickManualAgentRunTargets');
+        const handlerStart = indexSource.indexOf("card.find('.ica--btn-run-target').on('click'");
+        const handlerEnd = indexSource.indexOf("card.find('.ica--btn-preview-prompt').on('click'", handlerStart);
+        const handlerSource = indexSource.slice(handlerStart, handlerEnd);
+
+        expect(pickerSource).toContain('type="checkbox" name="ica--run-target"');
+        expect(pickerSource).not.toContain('type="radio" name="ica--run-target"');
+        expect(pickerSource).toContain("picker.find('input[name=\"ica--run-target\"]:checked').map((_, input) => String(input.value)).get()");
+        expect(pickerSource).toContain('return selected.map(value => {');
+        expect(handlerSource).toContain('const targets = await pickManualAgentRunTargets(agent);');
+        expect(handlerSource).toContain('await Promise.all(targets.map(target => runAgentOnTarget(agent.id, target)));');
+    });
 });

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -154,6 +154,7 @@ beforeAll(async () => {
         getPromptTransformHistoryForMessage: jest.fn(() => []),
         refreshRegexSnapshotsForAgent: jest.fn(() => 0),
         runAgentOnMessage: jest.fn(),
+        runAgentOnTarget: jest.fn(),
         runTrackerFixOnMessage: jest.fn(),
         syncToolAgentRegistrations: jest.fn(),
         undoPromptTransform: jest.fn(async () => false),
@@ -194,6 +195,7 @@ beforeAll(async () => {
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js', () => ({
         agentHasConnectedCompanionDependencies: jest.fn(() => false),
         collectRecentCompanionResults: jest.fn(() => []),
+        getCompanionResults: jest.fn(() => ({})),
         getLatestValidCompanionMessageIndex: jest.fn(() => -1),
         hasConnectedCompanionAgentCandidates: jest.fn(() => false),
         hasConnectedCompanionAgents: jest.fn(() => false),

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -523,6 +523,34 @@ describe('in-chat agent post-processing runner', () => {
         };
     }
 
+    function createCompanionOutputTransformAgent(overrides = {}) {
+        return {
+            id: overrides.id ?? 'companion-output-transform',
+            name: overrides.name ?? 'Companion Output Transform',
+            phase: 'post',
+            prompt: overrides.prompt ?? 'Rewrite the companion note.',
+            injection: {
+                order: 100,
+                ...(overrides.injection ?? {}),
+            },
+            postProcess: {
+                enabled: false,
+                promptTransformEnabled: true,
+                promptTransformMode: 'rewrite',
+                promptTransformMaxTokens: 8192,
+                promptTransformShowNotifications: false,
+                ...(overrides.postProcess ?? {}),
+            },
+            conditions: {
+                triggerKeywords: [],
+                triggerProbability: 100,
+                generationTypes: ['normal'],
+                runOnCompanionOutputs: true,
+                ...(overrides.conditions ?? {}),
+            },
+        };
+    }
+
     function createPreInterceptAgent(overrides = {}) {
         return {
             id: overrides.id ?? 'agent-pre-intercept',
@@ -2207,6 +2235,87 @@ describe('in-chat agent post-processing runner', () => {
         expect(result.tokenUsage.inputTokens).toBeGreaterThan(0);
         expect(result.tokenUsage.outputTokens).toBeGreaterThan(0);
         expect(chat[0].extra.inChatAgentCompanionResults['token-companion'].tokenUsage).toEqual(result.tokenUsage);
+    });
+
+    test('applies opted-in post passes to companion output', async () => {
+        generateQuietPrompt
+            .mockResolvedValueOnce('Raw companion note')
+            .mockResolvedValueOnce('Rewritten companion note');
+        const companionAgent = createCompanionAgent({ id: 'post-pass-companion' });
+        const transformer = createCompanionOutputTransformAgent();
+        enabledAgents = [companionAgent, transformer];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push({ mes: 'Assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} });
+
+        const result = await companionRunner.runCompanionAgentOnMessage(companionAgent.id, 0);
+
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(2);
+        expect(result?.content).toBe('Rewritten companion note');
+        expect(chat[0].extra.inChatAgentCompanionResults[companionAgent.id].content).toBe('Rewritten companion note');
+    });
+
+    test('keeps the raw companion output when a later post pass fails', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        generateQuietPrompt
+            .mockResolvedValueOnce('Raw companion note')
+            .mockResolvedValueOnce('Partial companion rewrite')
+            .mockRejectedValueOnce(new Error('post pass failed'));
+        const companionAgent = createCompanionAgent({ id: 'failing-post-pass-companion' });
+        const firstTransformer = createCompanionOutputTransformAgent({ id: 'first-companion-transform' });
+        const failingTransformer = createCompanionOutputTransformAgent({
+            id: 'failing-companion-transform',
+            injection: { order: 110 },
+        });
+        enabledAgents = [companionAgent, firstTransformer, failingTransformer];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        try {
+            chat.push({ mes: 'Assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} });
+
+            const result = await companionRunner.runCompanionAgentOnMessage(companionAgent.id, 0);
+
+            expect(generateQuietPrompt).toHaveBeenCalledTimes(3);
+            expect(result?.status).toBe('done');
+            expect(result?.content).toBe('Raw companion note');
+            expect(chat[0].extra.inChatAgentCompanionResults[companionAgent.id].content).toBe('Raw companion note');
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    test('cancels companion post passes without starting later transforms', async () => {
+        let resolveTransform;
+        generateQuietPrompt
+            .mockResolvedValueOnce('Raw companion note')
+            .mockImplementationOnce(async () => await new Promise(resolve => {
+                resolveTransform = resolve;
+            }));
+        const companionAgent = createCompanionAgent({ id: 'cancelled-post-pass-companion' });
+        const firstTransformer = createCompanionOutputTransformAgent({ id: 'first-cancelled-companion-transform' });
+        const secondTransformer = createCompanionOutputTransformAgent({
+            id: 'second-cancelled-companion-transform',
+            injection: { order: 110 },
+        });
+        enabledAgents = [companionAgent, firstTransformer, secondTransformer];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        const { cancelAgentGeneration } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+
+        chat.push({ mes: 'Assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} });
+
+        const running = companionRunner.runCompanionAgentOnMessage(companionAgent.id, 0);
+        await waitFor(() => generateQuietPrompt.mock.calls.length === 2);
+        cancelAgentGeneration();
+        resolveTransform('First transformed note');
+
+        const result = await running;
+
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(2);
+        expect(result?.status).toBe('cancelled');
+        expect(chat[0].extra.inChatAgentCompanionResults[companionAgent.id]).toEqual(expect.objectContaining({
+            status: 'cancelled',
+            content: '',
+        }));
     });
 
     test('stores generated companion notes raw and resolves them once when reused', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -211,6 +211,7 @@ describe('in-chat agent post-processing runner', () => {
                 .replaceAll('{{user}}', 'Traveler')
                 .replaceAll('{{char}}', options.name2Override || 'Assistant')
                 .replaceAll('{{original}}', options.original ?? '')),
+            substituteParamsExtended: jest.fn(value => String(value ?? '')),
             generateQuietPrompt,
             getCurrentChatId: jest.fn(() => currentChatId),
             normalizeContentText: jest.fn(value => String(value ?? '')),
@@ -331,6 +332,7 @@ describe('in-chat agent post-processing runner', () => {
                 const match = String(value ?? '').match(/^\/([\s\S]*)\/([a-z]*)$/i);
                 return match ? new RegExp(match[1], match[2]) : new RegExp(String(value ?? ''));
             }),
+            uuidv4: jest.fn(() => 'test-uuid'),
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({


### PR DESCRIPTION
Implementing the ability for in-chat agents to be used for targets other than chat replies.

Primary additions include: 
1- Gated by an opt-in (`Run this agent's post-passes on companion agent outputs`) plus an optional companion target multi-select (where empty signifies all companions are targeted)
When a targeted companion finishes a note, opted-in agents' prompt passes run first, then their regexes, then the transformed text is stored back into the companion result.
2- Agent Regex on impersonation text:
 The existing "run on impersonation" option   previously applied only prompt passes to the composer after `/impersonate`(including Guided Impersonate). 
It now also applies the agent's regex scripts, and   the checkbox moved out of the prompt-pass-only options so regex-only agents can use it.
3- Manual "Apply to…" target picker:
 Inline agent cards keep the one-click   "Apply to Last Reply" button and gain a crosshair button that opens a picker listing   what exists right now: the last assistant reply, each finished companion note on it,   and the composer text box (when non-empty). 
The chosen target runs through the same   manual-run queue.

Per Claude:

## Technical summary:

- Transforms mutate stored companion content once, at completion, in all four paths
  (single, batch, repair, manual re-run), so every consumer sees the same cleaned text.
  Token usage still reflects the companion's own raw generation.
- Post-pass failure or a cancel mid-pass falls back to the untouched note — a post-pass
  problem never loses the companion result itself.
- New `companion_output` generation-type label gives pass models "companion agent note"
  framing instead of "assistant response", so the pass doesn't treat the note as a chat reply.
- Regex-to-text application mirrors the display path (`AI_OUTPUT` placement, markdown pass
  then raw pass); the companion's own display-time beautifier regex is unchanged.
- The manual-run queue is generalized with a target descriptor
  (`message` / `composer` / `companion`); `runAgentOnMessage` is now a thin wrapper over
  `runAgentOnTarget`, so queueing, cancel revisions, and parallel/sequential modes are
  identical across targets. Manual runs keep the existing "forced" semantics.
- Companion write-back lives in companion-runner and is reached via the registered
  companion runtime bridge, keeping the agent-runner → companion-runner import graph
  one-directional.
- Backward compatible: new fields default off and are filled by `normalizeAgent`;
  existing agents and templates behave exactly as before unless opted in.

## Testing?

- `node --check` and ESLint clean on all touched files.
- Live smoke on a running instance: extension modules load with no new console errors;
  `normalizeAgent` defaults/coercion verified; no-op path verified against a real agent
  store (no opted-in agents → text unchanged); end-to-end
  `runSingleAgentPostPassesOnText` call applied a regex transform to sample text
  ("A note — with an em-dash." → "A note - with an em-dash.").
- Not covered: no automated tests added; a full LLM prompt pass against a live companion
  run was not exercised end-to-end (requires a real generation).

## Anything Else?

- Quick Toggles chips intentionally keep one-click apply only; the target picker lives on full agent cards.

### Pura's Additions
- Hardened canceling agents.
- <img width="898" height="675" alt="image" src="https://github.com/user-attachments/assets/5c97bd3a-6c05-4aed-b445-f5991bf319a5" /> Similar to the robot icon, you can choose to manually apply things to a range of assistant replies manually, and/or the companion notes.
<img width="599" height="1280" alt="image" src="https://github.com/user-attachments/assets/1b0ce757-af39-4214-b61a-48d83a950498" />

