### PR TITLE
chore: add the new GPT 5.6 variants, Sonnet 5, remove deprecated models

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3124,6 +3124,7 @@
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
+                                        <option value="claude-sonnet-5">claude-sonnet-5</option>
                                         <option value="claude-fable-5">claude-fable-5</option><!-- SillyBunny: claude-fable-5 support -->
                                         <option value="claude-opus-4-8">claude-opus-4-8</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
@@ -3137,19 +3138,6 @@
                                         <option value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001</option>
                                         <option value="claude-opus-4-1">claude-opus-4-1</option>
                                         <option value="claude-opus-4-1-20250805">claude-opus-4-1-20250805</option>
-                                        <option value="claude-opus-4-0">claude-opus-4-0</option>
-                                        <option value="claude-opus-4-20250514">claude-opus-4-20250514</option>
-                                        <option value="claude-sonnet-4-0">claude-sonnet-4-0</option>
-                                        <option value="claude-sonnet-4-20250514">claude-sonnet-4-20250514</option>
-                                        <option value="claude-3-7-sonnet-latest">claude-3-7-sonnet-latest</option>
-                                        <option value="claude-3-7-sonnet-20250219">claude-3-7-sonnet-20250219</option>
-                                        <option value="claude-3-5-sonnet-latest">claude-3-5-sonnet-latest</option>
-                                        <option value="claude-3-5-sonnet-20241022">claude-3-5-sonnet-20241022</option>
-                                        <option value="claude-3-5-sonnet-20240620">claude-3-5-sonnet-20240620</option>
-                                        <option value="claude-3-5-haiku-latest">claude-3-5-haiku-latest</option>
-                                        <option value="claude-3-5-haiku-20241022">claude-3-5-haiku-20241022</option>
-                                        <option value="claude-3-opus-20240229">claude-3-opus-20240229</option>
-                                        <option value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
                                     </optgroup>
                                     <optgroup id="claude_other_models" label="From API"></optgroup>
                                 </select>
@@ -3261,10 +3249,6 @@
                                         <option value="jamba-mini">jamba-mini</option>
                                         <option value="jamba-large">jamba-large</option>
                                     </optgroup>
-                                    <optgroup label="Jamba 1.7">
-                                        <option value="jamba-1.7-mini">jamba-1.7-mini</option>
-                                        <option value="jamba-1.7-large">jamba-1.7-large</option>
-                                    </optgroup>
                                     <optgroup id="ai21_other_models" label="From API"></optgroup>
                                 </select>
                             </div>
@@ -3287,58 +3271,15 @@
                                 <select id="model_google_select">
                                     <optgroup label="Gemini 3.1">
                                         <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
-                                        <option value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
-                                        <option value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
                                     </optgroup>
                                     <optgroup label="Gemini 3.0">
-                                        <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
-                                        <option value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
                                         <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
                                     </optgroup>
                                     <optgroup label="Gemini 2.5">
                                         <option value="gemini-2.5-pro">gemini-2.5-pro</option>
-                                        <option value="gemini-2.5-pro-preview-06-05">gemini-2.5-pro-preview-06-05</option>
-                                        <option value="gemini-2.5-pro-preview-05-06">gemini-2.5-pro-preview-05-06</option>
-                                        <option value="gemini-2.5-pro-preview-03-25">gemini-2.5-pro-preview-03-25</option>
                                         <option value="gemini-2.5-flash">gemini-2.5-flash</option>
-                                        <option value="gemini-2.5-flash-preview-09-2025">gemini-2.5-flash-preview-09-2025</option>
-                                        <option value="gemini-2.5-flash-preview-05-20">gemini-2.5-flash-preview-05-20</option>
                                         <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
-                                        <option value="gemini-2.5-flash-lite-preview-09-2025">gemini-2.5-flash-lite-preview-09-2025</option>
-                                        <option value="gemini-2.5-flash-lite-preview-06-17">gemini-2.5-flash-lite-preview-06-17</option>
                                         <option value="gemini-2.5-flash-image">gemini-2.5-flash-image</option>
-                                        <option value="gemini-2.5-flash-image-preview">gemini-2.5-flash-image-preview</option>
-                                    </optgroup>
-                                    <optgroup label="Gemini 2.0">
-                                        <option value="gemini-2.0-pro-exp-02-05">gemini-2.0-pro-exp-02-05 → 2.5-exp-03-25</option>
-                                        <option value="gemini-2.0-pro-exp">gemini-2.0-pro-exp → 2.5-exp-03-25</option>
-                                        <option value="gemini-exp-1206">gemini-exp-1206 → 2.5-exp-03-25</option>
-                                        <option value="gemini-2.0-flash-001">gemini-2.0-flash-001</option>
-                                        <option value="gemini-2.0-flash-exp-image-generation">gemini-2.0-flash-exp-image-generation</option>
-                                        <option value="gemini-2.0-flash-preview-image-generation">gemini-2.0-flash-preview-image-generation</option>
-                                        <option value="gemini-2.0-flash-exp">gemini-2.0-flash-exp</option>
-                                        <option value="gemini-2.0-flash">gemini-2.0-flash</option>
-                                        <option value="gemini-2.0-flash-thinking-exp-01-21">gemini-2.0-flash-thinking-exp-01-21 → 2.5-flash-preview-05-20</option>
-                                        <option value="gemini-2.0-flash-thinking-exp-1219">gemini-2.0-flash-thinking-exp-1219 → 2.5-flash-preview-05-20</option>
-                                        <option value="gemini-2.0-flash-thinking-exp">gemini-2.0-flash-thinking-exp → 2.5-flash-preview-05-20</option>
-                                        <option value="gemini-2.0-flash-lite-001">gemini-2.0-flash-lite-001</option>
-                                        <option value="gemini-2.0-flash-lite-preview-02-05">gemini-2.0-flash-lite-preview-02-05</option>
-                                        <option value="gemini-2.0-flash-lite-preview">gemini-2.0-flash-lite-preview</option>
-                                        <option value="gemini-2.0-flash-lite">gemini-2.0-flash-lite</option>
-                                    </optgroup>
-                                    <optgroup label="Gemma">
-                                        <option value="gemma-3n-e4b-it">gemma-3n-e4b-it</option>
-                                        <option value="gemma-3n-e2b-it">gemma-3n-e2b-it</option>
-                                        <option value="gemma-3-27b-it">gemma-3-27b-it</option>
-                                        <option value="gemma-3-12b-it">gemma-3-12b-it</option>
-                                        <option value="gemma-3-4b-it">gemma-3-4b-it</option>
-                                        <option value="gemma-3-1b-it">gemma-3-1b-it</option>
-                                    </optgroup>
-                                    <optgroup label="LearnLM">
-                                        <option value="learnlm-2.0-flash-experimental">learnlm-2.0-flash-experimental</option>
-                                    </optgroup>
-                                    <optgroup label="Robotics-ER">
-                                        <option value="gemini-robotics-er-1.5-preview">gemini-robotics-er-1.5-preview</option>
                                     </optgroup>
                                     <optgroup id="google_other_models" label="Other"></optgroup>
                                 </select>
@@ -3482,14 +3423,6 @@
                                         <option value="gemini-2.5-flash">gemini-2.5-flash</option>
                                         <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
                                         <option value="gemini-2.5-flash-image">gemini-2.5-flash-image</option>
-                                        <option value="gemini-2.5-flash-image-preview">gemini-2.5-flash-image-preview</option>
-                                    </optgroup>
-                                    <optgroup label="Gemini 2.0">
-                                        <option value="gemini-2.0-flash-exp" data-mode="full">gemini-2.0-flash-exp</option>
-                                        <option value="gemini-2.0-flash-preview-image-generation" data-mode="full">gemini-2.0-flash-preview-image-generation</option>
-                                        <option value="gemini-2.0-flash">gemini-2.0-flash</option>
-                                        <option value="gemini-2.0-flash-001">gemini-2.0-flash-001</option>
-                                        <option value="gemini-2.0-flash-lite-001">gemini-2.0-flash-lite-001</option>
                                     </optgroup>
                                     <optgroup id="vertexai_other_models" label="From API"></optgroup>
                                 </select>
@@ -3523,16 +3456,9 @@
                             <h4 data-i18n="Groq Model">Groq Model</h4>
                             <select id="model_groq_select">
                                 <option value="qwen/qwen3-32b">qwen/qwen3-32b</option>
-                                <option value="deepseek-r1-distill-llama-70b">deepseek-r1-distill-llama-70b</option>
-                                <option value="gemma2-9b-it">gemma2-9b-it</option>
                                 <option value="meta-llama/llama-4-scout-17b-16e-instruct">meta-llama/llama-4-scout-17b-16e-instruct</option>
-                                <option value="meta-llama/llama-4-maverick-17b-128e-instruct">meta-llama/llama-4-maverick-17b-128e-instruct</option>
                                 <option value="llama-3.1-8b-instant">llama-3.1-8b-instant</option>
                                 <option value="llama-3.3-70b-versatile">llama-3.3-70b-versatile </option>
-                                <option value="llama-guard-3-8b">llama-guard-3-8b</option>
-                                <option value="llama3-70b-8192">llama3-70b-8192</option>
-                                <option value="llama3-8b-8192">llama3-8b-8192</option>
-                                <option value="mistral-saba-24b">mistral-saba-24b</option>
                             </select>
                         </div>
                         <div id="siliconflow_form" data-source="siliconflow">
@@ -3575,7 +3501,6 @@
                                 <option value="MiniMax-M2.5">MiniMax-M2.5</option>
                                 <option value="MiniMax-M2.5-highspeed">MiniMax-M2.5-highspeed</option>
                                 <option value="MiniMax-M2">MiniMax-M2</option>
-                                <option value="MiniMax-M1">MiniMax-M1</option>
                                 <option value="M2-her">M2-her</option>
                             </select>
                         </div>
@@ -3717,8 +3642,6 @@
                                 <h4 data-i18n="DeepSeek Model">DeepSeek Model</h4>
                                 <select id="model_deepseek_select">
                                     <option value="deepseek-chat">deepseek-chat</option>
-                                    <option value="deepseek-v4">deepseek-v4</option>
-                                    <option value="deepseek-coder">deepseek-coder</option>
                                     <option value="deepseek-reasoner">deepseek-reasoner</option>
                                 </select>
                             </div>
@@ -3775,12 +3698,8 @@
                                 <optgroup label="Perplexity Sonar Models">
                                     <option value="sonar">sonar</option>
                                     <option value="sonar-pro">sonar-pro</option>
-                                    <option value="sonar-reasoning">sonar-reasoning</option>
                                     <option value="sonar-reasoning-pro">sonar-reasoning-pro</option>
                                     <option value="sonar-deep-research">sonar-deep-research</option>
-                                </optgroup>
-                                <optgroup label="Offline Models">
-                                    <option value="r1-1776">r1-1776</option>
                                 </optgroup>
                                 <optgroup id="perplexity_other_models" label="From API"></optgroup>
                             </select>
@@ -3802,16 +3721,8 @@
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <select id="model_cohere_select">
                                     <optgroup label="Stable">
-                                        <option value="c4ai-aya-23-8b">c4ai-aya-23-8b</option>
-                                        <option value="c4ai-aya-23">c4ai-aya-23</option>
-                                        <option value="c4ai-aya-expanse-8b">c4ai-aya-expanse-8b</option>
                                         <option value="c4ai-aya-expanse-32b">c4ai-aya-expanse-32b</option>
-                                        <option value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                                         <option value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
-                                        <option value="command-light">command-light</option>
-                                        <option value="command">command</option>
-                                        <option value="command-r">command-r</option>
-                                        <option value="command-r-plus">command-r-plus</option>
                                         <option value="command-r-08-2024">command-r-08-2024</option>
                                         <option value="command-r-plus-08-2024">command-r-plus-08-2024</option>
                                         <option value="command-r7b-12-2024">command-r7b-12-2024</option>
@@ -3970,16 +3881,12 @@
                             </div>
                             <h4 data-i18n="Moonshot AI Model">Moonshot AI Model</h4>
                             <select id="model_moonshot_select">
-                                <option value="kimi-k2-0711-preview">kimi-k2-0711-preview</option>
                                 <option value="moonshot-v1-8k">moonshot-v1-8k</option>
                                 <option value="moonshot-v1-32k">moonshot-v1-32k</option>
                                 <option value="moonshot-v1-128k">moonshot-v1-128k</option>
-                                <option value="moonshot-v1-auto">moonshot-v1-auto</option>
-                                <option value="kimi-latest">kimi-latest</option>
                                 <option value="moonshot-v1-8k-vision-preview">moonshot-v1-8k-vision-preview</option>
                                 <option value="moonshot-v1-32k-vision-preview">moonshot-v1-32k-vision-preview</option>
                                 <option value="moonshot-v1-128k-vision-preview">moonshot-v1-128k-vision-preview</option>
-                                <option value="kimi-thinking-preview">kimi-thinking-preview</option>
                             </select>
                         </div>
                         <div id="zai_form" data-source="zai">

--- a/public/index.html
+++ b/public/index.html
@@ -2990,11 +2990,16 @@
                             <div>
                                 <h4 data-i18n="Model ID">Model ID</h4>
                                 <div class="flex-container">
-                                    <input id="openai_model_id" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: gpt-5.5" placeholder="Example: gpt-5.5">
+                                    <input id="openai_model_id" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: gpt-5.6-sol" placeholder="Example: gpt-5.6-sol">
                                 </div>
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <div id="openai_model_picker">
                                     <select id="model_openai_select">
+                                        <optgroup label="GPT-5.6">
+                                            <option value="gpt-5.6-sol">gpt-5.6-sol</option>
+                                            <option value="gpt-5.6-terra">gpt-5.6-terra</option>
+                                            <option value="gpt-5.6-luna">gpt-5.6-luna</option>
+                                        </optgroup>
                                         <optgroup label="GPT-5.5">
                                             <option value="gpt-5.5">gpt-5.5</option>
                                             <option value="gpt-5.5-2026-04-23">gpt-5.5-2026-04-23</option>
@@ -3035,7 +3040,6 @@
                                             <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
                                             <option value="gpt-4o-2024-08-06">gpt-4o-2024-08-06</option>
                                             <option value="gpt-4o-2024-05-13">gpt-4o-2024-05-13</option>
-                                            <option value="chatgpt-4o-latest">chatgpt-4o-latest</option>
                                         </optgroup>
                                         <optgroup label="GPT-4o mini">
                                             <option value="gpt-4o-mini">gpt-4o-mini</option>
@@ -3052,10 +3056,6 @@
                                         <optgroup label="o1">
                                             <option value="o1">o1</option>
                                             <option value="o1-2024-12-17">o1-2024-12-17</option>
-                                            <option value="o1-mini">o1-mini</option>
-                                            <option value="o1-mini-2024-09-12">o1-mini-2024-09-12</option>
-                                            <option value="o1-preview">o1-preview</option>
-                                            <option value="o1-preview-2024-09-12">o1-preview-2024-09-12</option>
                                         </optgroup>
                                         <optgroup label="o3">
                                             <option value="o3">o3</option>
@@ -3067,19 +3067,12 @@
                                             <option value="o4-mini">o4-mini</option>
                                             <option value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
                                         </optgroup>
-                                        <optgroup label="GPT-4.5">
-                                            <option value="gpt-4.5-preview">gpt-4.5-preview</option>
-                                            <option value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
-                                        </optgroup>
                                         <optgroup label="GPT-4 Turbo and GPT-4">
                                             <option value="gpt-4-turbo">gpt-4-turbo</option>
                                             <option value="gpt-4-turbo-2024-04-09">gpt-4-turbo-2024-04-09</option>
-                                            <option value="gpt-4-turbo-preview">gpt-4-turbo-preview</option>
-                                            <option value="gpt-4-0125-preview">gpt-4-0125-preview (2024)</option>
                                             <option value="gpt-4-1106-preview">gpt-4-1106-preview (2023)</option>
                                             <option value="gpt-4">gpt-4</option>
                                             <option value="gpt-4-0613">gpt-4-0613 (2023)</option>
-                                            <option value="gpt-4-0314">gpt-4-0314 (2023)</option>
                                         </optgroup>
                                         <optgroup label="GPT-3.5 Turbo">
                                             <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>

--- a/public/index.html
+++ b/public/index.html
@@ -2995,6 +2995,7 @@
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <div id="openai_model_picker">
                                     <select id="model_openai_select">
+                                        <!-- SillyBunny: static provider catalogs track current IDs; API-discovered models remain available through dynamic groups. -->
                                         <optgroup label="GPT-5.6">
                                             <option value="gpt-5.6-sol">gpt-5.6-sol</option>
                                             <option value="gpt-5.6-terra">gpt-5.6-terra</option>
@@ -3280,6 +3281,11 @@
                                         <option value="gemini-2.5-flash">gemini-2.5-flash</option>
                                         <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
                                         <option value="gemini-2.5-flash-image">gemini-2.5-flash-image</option>
+                                    </optgroup>
+                                    <!-- SillyBunny: Gemma 4 remains available after the older Gemini API Gemma catalog retired. -->
+                                    <optgroup label="Gemma 4">
+                                        <option value="gemma-4-31b-it">gemma-4-31b-it</option>
+                                        <option value="gemma-4-26b-a4b-it">gemma-4-26b-a4b-it</option>
                                     </optgroup>
                                     <optgroup id="google_other_models" label="Other"></optgroup>
                                 </select>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -51,6 +51,7 @@
                     </label>
                     <select id="caption_multimodal_model" class="flex1 text_pole">
                         <!-- AI/ML API, OpenRouter, Pollinations, NanoGPT, Mistral, xAI, Moonshot are added externally by JavaScript -->
+                        <!-- SillyBunny: keep the static caption catalog to current provider IDs; externally loaded models are unaffected. -->
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
                         <option data-type="openai" value="gpt-5.6-sol">gpt-5.6-sol</option>
@@ -114,6 +115,9 @@
                         <option data-type="google" value="gemini-2.5-flash">gemini-2.5-flash</option>
                         <option data-type="google" value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
                         <option data-type="google" value="gemini-2.5-flash-image">gemini-2.5-flash-image</option>
+                        <!-- SillyBunny: Gemma 4 remains available after the older Gemini API Gemma catalog retired. -->
+                        <option data-type="google" value="gemma-4-31b-it">gemma-4-31b-it</option>
+                        <option data-type="google" value="gemma-4-26b-a4b-it">gemma-4-26b-a4b-it</option>
                         <option data-type="vertexai" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                         <option data-type="vertexai" value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
                         <option data-type="vertexai" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -54,6 +54,9 @@
                         <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
+                        <option data-type="openai" value="gpt-5.6-sol">gpt-5.6-sol</option>
+                        <option data-type="openai" value="gpt-5.6-terra">gpt-5.6-terra</option>
+                        <option data-type="openai" value="gpt-5.6-luna">gpt-5.6-luna</option>
                         <option data-type="openai" value="gpt-5.5">gpt-5.5</option>
                         <option data-type="openai" value="gpt-5.5-2026-04-23">gpt-5.5-2026-04-23</option>
                         <option data-type="openai" value="gpt-5.4">gpt-5.4</option>
@@ -82,20 +85,16 @@
                         <option data-type="openai" value="gpt-4.1-mini-2025-04-14">gpt-4.1-mini-2025-04-14</option>
                         <option data-type="openai" value="gpt-4.1-nano">gpt-4.1-nano</option>
                         <option data-type="openai" value="gpt-4.1-nano-2025-04-14">gpt-4.1-nano-2025-04-14</option>
-                        <option data-type="openai" value="gpt-4-vision-preview">gpt-4-vision-preview</option>
                         <option data-type="openai" value="gpt-4-turbo">gpt-4-turbo</option>
                         <option data-type="openai" value="gpt-4o">gpt-4o</option>
                         <option data-type="openai" value="gpt-4o-mini">gpt-4o-mini</option>
                         <option data-type="openai" value="gpt-4o-mini-2024-07-18">gpt-4o-mini-2024-07-18</option>
-                        <option data-type="openai" value="chatgpt-4o-latest">chatgpt-4o-latest</option>
                         <option data-type="openai" value="o1">o1</option>
                         <option data-type="openai" value="o1-2024-12-17">o1-2024-12-17</option>
                         <option data-type="openai" value="o3">o3</option>
                         <option data-type="openai" value="o3-2025-04-16">o3-2025-04-16</option>
                         <option data-type="openai" value="o4-mini">o4-mini</option>
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
-                        <option data-type="openai" value="gpt-4.5-preview">gpt-4.5-preview</option>
-                        <option data-type="openai" value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
                         <option data-type="anthropic" value="claude-fable-5">claude-fable-5</option>
                         <option data-type="anthropic" value="claude-opus-4-8">claude-opus-4-8</option>
                         <option data-type="anthropic" value="claude-opus-4-7">claude-opus-4-7</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -51,7 +51,6 @@
                     </label>
                     <select id="caption_multimodal_model" class="flex1 text_pole">
                         <!-- AI/ML API, OpenRouter, Pollinations, NanoGPT, Mistral, xAI, Moonshot are added externally by JavaScript -->
-                        <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
                         <option data-type="openai" value="gpt-5.6-sol">gpt-5.6-sol</option>
@@ -95,6 +94,7 @@
                         <option data-type="openai" value="o3-2025-04-16">o3-2025-04-16</option>
                         <option data-type="openai" value="o4-mini">o4-mini</option>
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
+                        <option data-type="anthropic" value="claude-sonnet-5">claude-sonnet-5</option>
                         <option data-type="anthropic" value="claude-fable-5">claude-fable-5</option>
                         <option data-type="anthropic" value="claude-opus-4-8">claude-opus-4-8</option>
                         <option data-type="anthropic" value="claude-opus-4-7">claude-opus-4-7</option>
@@ -108,57 +108,12 @@
                         <option data-type="anthropic" value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001</option>
                         <option data-type="anthropic" value="claude-opus-4-1">claude-opus-4-1</option>
                         <option data-type="anthropic" value="claude-opus-4-1-20250805">claude-opus-4-1-20250805</option>
-                        <option data-type="anthropic" value="claude-opus-4-0">claude-opus-4-0</option>
-                        <option data-type="anthropic" value="claude-opus-4-20250514">claude-opus-4-20250514</option>
-                        <option data-type="anthropic" value="claude-sonnet-4-0">claude-sonnet-4-0</option>
-                        <option data-type="anthropic" value="claude-sonnet-4-20250514">claude-sonnet-4-20250514</option>
-                        <option data-type="anthropic" value="claude-3-7-sonnet-latest">claude-3-7-sonnet-latest</option>
-                        <option data-type="anthropic" value="claude-3-7-sonnet-20250219">claude-3-7-sonnet-20250219</option>
-                        <option data-type="anthropic" value="claude-3-5-sonnet-latest">claude-3-5-sonnet-latest</option>
-                        <option data-type="anthropic" value="claude-3-5-sonnet-20241022">claude-3-5-sonnet-20241022</option>
-                        <option data-type="anthropic" value="claude-3-5-sonnet-20240620">claude-3-5-sonnet-20240620</option>
-                        <option data-type="anthropic" value="claude-3-5-haiku-latest">claude-3-5-haiku-latest</option>
-                        <option data-type="anthropic" value="claude-3-5-haiku-20241022">claude-3-5-haiku-20241022</option>
-                        <option data-type="anthropic" value="claude-3-opus-20240229">claude-3-opus-20240229</option>
-                        <option data-type="anthropic" value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
                         <option data-type="google" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
-                        <option data-type="google" value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
-                        <option data-type="google" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
-                        <option data-type="google" value="gemini-3-pro-preview">gemini-3-pro-preview</option>
-                        <option data-type="google" value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
                         <option data-type="google" value="gemini-3-flash-preview">gemini-3-flash-preview</option>
                         <option data-type="google" value="gemini-2.5-pro">gemini-2.5-pro</option>
-                        <option data-type="google" value="gemini-2.5-pro-preview-06-05">gemini-2.5-pro-preview-06-05</option>
-                        <option data-type="google" value="gemini-2.5-pro-preview-05-06">gemini-2.5-pro-preview-05-06</option>
-                        <option data-type="google" value="gemini-2.5-pro-preview-03-25">gemini-2.5-pro-preview-03-25</option>
                         <option data-type="google" value="gemini-2.5-flash">gemini-2.5-flash</option>
-                        <option data-type="google" value="gemini-2.5-flash-preview-09-2025">gemini-2.5-flash-preview-09-2025</option>
-                        <option data-type="google" value="gemini-2.5-flash-preview-05-20">gemini-2.5-flash-preview-05-20</option>
                         <option data-type="google" value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
-                        <option data-type="google" value="gemini-2.5-flash-lite-preview-09-2025">gemini-2.5-flash-lite-preview-09-2025</option>
-                        <option data-type="google" value="gemini-2.5-flash-lite-preview-06-17">gemini-2.5-flash-lite-preview-06-17</option>
                         <option data-type="google" value="gemini-2.5-flash-image">gemini-2.5-flash-image</option>
-                        <option data-type="google" value="gemini-2.5-flash-image-preview">gemini-2.5-flash-image-preview</option>
-                        <option data-type="google" value="gemini-2.0-pro-exp-02-05">gemini-2.0-pro-exp-02-05 → 2.5-exp-03-25</option>
-                        <option data-type="google" value="gemini-2.0-pro-exp">gemini-2.0-pro-exp → 2.5-exp-03-25</option>
-                        <option data-type="google" value="gemini-exp-1206">gemini-exp-1206 → 2.5-exp-03-25</option>
-                        <option data-type="google" value="gemini-2.0-flash-001">gemini-2.0-flash-001</option>
-                        <option data-type="google" value="gemini-2.0-flash-exp-image-generation">gemini-2.0-flash-exp-image-generation</option>
-                        <option data-type="google" value="gemini-2.0-flash-exp">gemini-2.0-flash-exp</option>
-                        <option data-type="google" value="gemini-2.0-flash">gemini-2.0-flash</option>
-                        <option data-type="google" value="gemini-2.0-flash-thinking-exp-01-21">gemini-2.0-flash-thinking-exp-01-21 → 2.5-flash-preview-5-20</option>
-                        <option data-type="google" value="gemini-2.0-flash-thinking-exp-1219">gemini-2.0-flash-thinking-exp-1219 → 2.5-flash-preview-05-20</option>
-                        <option data-type="google" value="gemini-2.0-flash-thinking-exp">gemini-2.0-flash-thinking-exp → 2.5-flash-preview-05-20</option>
-                        <option data-type="google" value="gemini-2.0-flash-lite-001">gemini-2.0-flash-lite-001</option>
-                        <option data-type="google" value="gemini-2.0-flash-lite-preview-02-05">gemini-2.0-flash-lite-preview-02-05</option>
-                        <option data-type="google" value="gemini-2.0-flash-lite-preview">gemini-2.0-flash-lite-preview</option>
-                        <option data-type="google" value="learnlm-2.0-flash-experimental">learnlm-2.0-flash-experimental</option>
-                        <option data-type="google" value="gemini-robotics-er-1.5-preview">gemini-robotics-er-1.5-preview</option>
-                        <option data-type="google" value="gemma-4-31b-it">gemma-4-31b-it</option>
-                        <option data-type="google" value="gemma-4-26b-a4b-it">gemma-4-26b-a4b-it</option>
-                        <option data-type="google" value="gemma-3-27b-it">gemma-3-27b-it</option>
-                        <option data-type="google" value="gemma-3-12b-it">gemma-3-12b-it</option>
-                        <option data-type="google" value="gemma-3-4b-it">gemma-3-4b-it</option>
                         <option data-type="vertexai" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                         <option data-type="vertexai" value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
                         <option data-type="vertexai" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
@@ -169,11 +124,7 @@
                         <option data-type="vertexai" value="gemini-2.5-flash">gemini-2.5-flash</option>
                         <option data-type="vertexai" value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
                         <option data-type="vertexai" value="gemini-2.5-flash-image">gemini-2.5-flash-image</option>
-                        <option data-type="vertexai" value="gemini-2.5-flash-image-preview">gemini-2.5-flash-image-preview</option>
-                        <option data-type="vertexai" value="gemini-2.0-flash-001">gemini-2.0-flash-001</option>
-                        <option data-type="vertexai" value="gemini-2.0-flash-lite-001">gemini-2.0-flash-lite-001</option>
                         <option data-type="groq" value="meta-llama/llama-4-scout-17b-16e-instruct">meta-llama/llama-4-scout-17b-16e-instruct</option>
-                        <option data-type="groq" value="meta-llama/llama-4-maverick-17b-128e-instruct">meta-llama/llama-4-maverick-17b-128e-instruct</option>
                         <option data-type="ollama" value="ollama_current" data-i18n="currently_selected">[Currently selected]</option>
                         <option data-type="ollama" value="ollama_custom" data-i18n="[Custom model]">[Custom model]</option>
                         <option data-type="ollama" value="bakllava">bakllava</option>

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2099,7 +2099,6 @@ async function loadBflModels() {
     return [
         { value: 'flux-pro-1.1-ultra', text: 'flux-pro-1.1-ultra' },
         { value: 'flux-pro-1.1', text: 'flux-pro-1.1' },
-        { value: 'flux-pro', text: 'flux-pro' },
         { value: 'flux-dev', text: 'flux-dev' },
     ];
 }
@@ -2475,10 +2474,6 @@ async function loadNovelModels() {
             text: 'NAI Diffusion Anime V3',
         },
         {
-            value: 'nai-diffusion-2',
-            text: 'NAI Diffusion Anime V2',
-        },
-        {
             value: 'nai-diffusion-furry-3',
             text: 'NAI Diffusion Furry V3',
         },
@@ -2490,23 +2485,8 @@ async function loadGoogleModels() {
         'imagen-4.0-generate-001',
         'imagen-4.0-ultra-generate-001',
         'imagen-4.0-fast-generate-001',
-        'imagen-4.0-generate-preview-06-06',
-        'imagen-4.0-fast-generate-preview-06-06',
-        'imagen-4.0-ultra-generate-preview-06-06',
-        'imagen-3.0-generate-002',
-        'imagen-3.0-generate-001',
-        'imagen-3.0-fast-generate-001',
-        'imagen-3.0-capability-001',
-        'imagegeneration@006',
-        'imagegeneration@005',
-        'imagegeneration@002',
         'veo-3.1-generate-preview',
         'veo-3.1-fast-generate-preview',
-        'veo-3.0-generate-001',
-        'veo-3.0-fast-generate-001',
-        'veo-2.0-generate-001',
-        'veo-2.0-generate-exp',
-        'veo-2.0-generate-preview',
     ].map(name => ({ value: name, text: name }));
 }
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2096,10 +2096,10 @@ async function loadStabilityModels() {
 async function loadBflModels() {
     $('#sd_bfl_key').toggleClass('success', !!secret_state[SECRET_KEYS.BFL]);
 
-    // SillyBunny: omit BFL's retired unversioned flux-pro alias.
     return [
         { value: 'flux-pro-1.1-ultra', text: 'flux-pro-1.1-ultra' },
         { value: 'flux-pro-1.1', text: 'flux-pro-1.1' },
+        { value: 'flux-pro', text: 'flux-pro' },
         { value: 'flux-dev', text: 'flux-dev' },
     ];
 }
@@ -2454,7 +2454,6 @@ async function loadVladModels() {
 }
 
 async function loadNovelModels() {
-    // SillyBunny: omit NovelAI Diffusion V2 after its provider retirement.
     return [
         {
             value: 'nai-diffusion-4-5-full',
@@ -2477,6 +2476,10 @@ async function loadNovelModels() {
             text: 'NAI Diffusion Anime V3',
         },
         {
+            value: 'nai-diffusion-2',
+            text: 'NAI Diffusion Anime V2',
+        },
+        {
             value: 'nai-diffusion-furry-3',
             text: 'NAI Diffusion Furry V3',
         },
@@ -2484,13 +2487,27 @@ async function loadNovelModels() {
 }
 
 async function loadGoogleModels() {
-    // SillyBunny: keep the Google image catalog to current Imagen and Veo IDs.
     return [
         'imagen-4.0-generate-001',
         'imagen-4.0-ultra-generate-001',
         'imagen-4.0-fast-generate-001',
+        'imagen-4.0-generate-preview-06-06',
+        'imagen-4.0-fast-generate-preview-06-06',
+        'imagen-4.0-ultra-generate-preview-06-06',
+        'imagen-3.0-generate-002',
+        'imagen-3.0-generate-001',
+        'imagen-3.0-fast-generate-001',
+        'imagen-3.0-capability-001',
+        'imagegeneration@006',
+        'imagegeneration@005',
+        'imagegeneration@002',
         'veo-3.1-generate-preview',
         'veo-3.1-fast-generate-preview',
+        'veo-3.0-generate-001',
+        'veo-3.0-fast-generate-001',
+        'veo-2.0-generate-001',
+        'veo-2.0-generate-exp',
+        'veo-2.0-generate-preview',
     ].map(name => ({ value: name, text: name }));
 }
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2096,6 +2096,7 @@ async function loadStabilityModels() {
 async function loadBflModels() {
     $('#sd_bfl_key').toggleClass('success', !!secret_state[SECRET_KEYS.BFL]);
 
+    // SillyBunny: omit BFL's retired unversioned flux-pro alias.
     return [
         { value: 'flux-pro-1.1-ultra', text: 'flux-pro-1.1-ultra' },
         { value: 'flux-pro-1.1', text: 'flux-pro-1.1' },
@@ -2380,6 +2381,7 @@ async function loadDrawthingsModels() {
 }
 
 async function loadOpenAiModels() {
+    // SillyBunny: omit DALL-E 2 and 3 after their OpenAI API retirement.
     return [
         { value: 'gpt-image-2', text: 'gpt-image-2' },
         { value: 'gpt-image-2-2026-04-21', text: 'gpt-image-2-2026-04-21' },
@@ -2452,6 +2454,7 @@ async function loadVladModels() {
 }
 
 async function loadNovelModels() {
+    // SillyBunny: omit NovelAI Diffusion V2 after its provider retirement.
     return [
         {
             value: 'nai-diffusion-4-5-full',
@@ -2481,6 +2484,7 @@ async function loadNovelModels() {
 }
 
 async function loadGoogleModels() {
+    // SillyBunny: keep the Google image catalog to current Imagen and Veo IDs.
     return [
         'imagen-4.0-generate-001',
         'imagen-4.0-ultra-generate-001',

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2388,8 +2388,6 @@ async function loadOpenAiModels() {
         { value: 'gpt-image-1-mini', text: 'gpt-image-1-mini' },
         { value: 'gpt-image-1', text: 'gpt-image-1' },
         { value: 'chatgpt-image-latest', text: 'chatgpt-image-latest' },
-        { value: 'dall-e-3', text: 'dall-e-3' },
-        { value: 'dall-e-2', text: 'dall-e-2' },
         { value: 'sora-2', text: 'sora-2' },
         { value: 'sora-2-pro', text: 'sora-2-pro' },
     ];

--- a/public/scripts/openai-model-capabilities.js
+++ b/public/scripts/openai-model-capabilities.js
@@ -1,0 +1,28 @@
+/**
+ * Removes request parameters that are unsupported by the selected Claude model.
+ *
+ * @param {Record<string, any>} generateData Chat Completion request data
+ * @param {object} [options] Constraint options
+ * @param {boolean} [options.preserveReasoning=false] Keep reasoning fields for native Claude handlers
+ * @returns {Record<string, any>} The request data
+ */
+export function applyClaudeModelParameterConstraints(generateData, { preserveReasoning = false } = {}) {
+    const model = String(generateData?.model ?? '').trim().toLowerCase();
+    const hasRestrictedSampling = /(?:^|[/:])claude-(?:fable|sonnet-5)(?:[-./:]|$)/.test(model);
+
+    if (!hasRestrictedSampling) {
+        return generateData;
+    }
+
+    delete generateData.temperature;
+    delete generateData.top_p;
+    delete generateData.top_k;
+    delete generateData.frequency_penalty;
+    delete generateData.presence_penalty;
+    if (!preserveReasoning) {
+        delete generateData.reasoning_effort;
+        delete generateData.custom_reasoning_param_name;
+    }
+
+    return generateData;
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -98,6 +98,7 @@ import {
     normalizeReverseProxyPreset,
     shouldIncludeSamplingFieldsInPreset,
 } from './openai-preset-utils.js';
+import { applyClaudeModelParameterConstraints } from './openai-model-capabilities.js';
 import { TOOL_CALL_RECURSE_LIMIT_DEFAULT, normalizeToolCallRecurseLimit } from './tool-call-recurse-limit.js';
 import { LINKAPI_ENDPOINT, getLinkApiRequestFormat } from './linkapi-utils.js';
 
@@ -5481,22 +5482,10 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
-    // SillyBunny: Claude Fable and Sonnet 5 models reject sampling parameters with HTTP 400, including via OpenAI-compatible proxies.
-    // Substring match to also catch router ids like 'anthropic/claude-fable-5'.
-    if (/claude-fable/.test(model) || model === 'claude-sonnet-5') {
-        delete generate_data.temperature;
-        delete generate_data.top_p;
-        delete generate_data.top_k;
-        delete generate_data.frequency_penalty;
-        delete generate_data.presence_penalty;
-        // Keep reasoning_effort for the native Claude source (the backend maps it to adaptive thinking);
-        // strip it for proxies, which may translate it into a thinking budget that fable rejects.
-        // LinkAPI routes claude models through the native Claude handler, so it keeps effort too.
-        if (![chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source)) {
-            delete generate_data.reasoning_effort;
-            delete generate_data.custom_reasoning_param_name;
-        }
-    }
+    // SillyBunny: Claude Fable and Sonnet 5 reject sampling parameters, including through provider-prefixed proxy model ids.
+    applyClaudeModelParameterConstraints(generate_data, {
+        preserveReasoning: [chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source),
+    });
 
     if (jsonSchema) {
         generate_data.json_schema = jsonSchema;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5015,8 +5015,14 @@ function getReasoningEffort(settings = null, model = null) {
                     ? reasoning_effort_types.min
                     : reasoning_effort_types.low;
             case reasoning_effort_types.max: {
+                const nativeOpenAISource = [chat_completion_sources.OPENAI, chat_completion_sources.OPENAI_RESPONSES, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source);
+                // SillyBunny: GPT-5.6 exposes max separately from xhigh.
+                if (nativeOpenAISource && /^gpt-5\.6(?:-|$)/.test(model)) {
+                    return reasoning_effort_types.max;
+                }
+
                 // xhigh is supported on OpenAI models after gpt-5.1-codex-max and on xAI grok-4.20-multi-agent
-                const xhighOpenAI = [chat_completion_sources.OPENAI, chat_completion_sources.OPENAI_RESPONSES, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
+                const xhighOpenAI = nativeOpenAISource
                     && /^gpt-5\.([2-9]|\d{2,})/.test(model);
                 const xhighXAI = settings.chat_completion_source === chat_completion_sources.XAI
                     && model.includes('grok-4.20-multi-agent');
@@ -7803,6 +7809,7 @@ function getMaxContextOpenAI(value) {
     if (isMaxContextUnlockedForSource()) {
         return unlocked_max;
     } else if (value.startsWith('gpt-5.4') || value.startsWith('gpt-5.6')) {
+        // SillyBunny: GPT-5.6 has the same one-million-token context tier as GPT-5.4.
         return max_1mil;
     } else if (value.startsWith('gpt-5')) {
         return max_400k;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -7802,7 +7802,7 @@ function onSettingsPresetChange() {
 function getMaxContextOpenAI(value) {
     if (isMaxContextUnlockedForSource()) {
         return unlocked_max;
-    } else if (value.startsWith('gpt-5.4')) {
+    } else if (value.startsWith('gpt-5.4') || value.startsWith('gpt-5.6')) {
         return max_1mil;
     } else if (value.startsWith('gpt-5')) {
         return max_400k;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5475,9 +5475,9 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
-    // SillyBunny: Claude Fable models reject sampling parameters with HTTP 400, including via OpenAI-compatible proxies.
+    // SillyBunny: Claude Fable and Sonnet 5 models reject sampling parameters with HTTP 400, including via OpenAI-compatible proxies.
     // Substring match to also catch router ids like 'anthropic/claude-fable-5'.
-    if (/claude-fable/.test(model)) {
+    if (/claude-fable/.test(model) || model === 'claude-sonnet-5') {
         delete generate_data.temperature;
         delete generate_data.top_p;
         delete generate_data.top_k;
@@ -8477,7 +8477,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
         if (maxContextUnlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^claude-(sonnet-4-(?:[5-9]|\d{2,})|opus-4-(?:[6-9]|\d{2,})|fable)/.test(value)) { // SillyBunny: |fable — claude-fable-5 has a 1M context window
+        } else if (/^claude-(sonnet-5|sonnet-4-(?:[5-9]|\d{2,})|opus-4-(?:[6-9]|\d{2,})|fable)/.test(value)) { // SillyBunny: |fable — claude-fable-5; |sonnet-5 — 1M context window
             $('#openai_max_context').attr('max', max_1mil);
         } else if (/^claude-(3|opus|haiku|sonnet)/.test(value)) {
             $('#openai_max_context').attr('max', max_200k);
@@ -9109,6 +9109,7 @@ export function isImageInliningSupported() {
         // Claude
         'claude-3',
         'claude-fable', // SillyBunny: claude-fable-5 vision support
+        'claude-sonnet-5', // SillyBunny: claude-sonnet-5 vision support
         'claude-opus-4',
         'claude-sonnet-4',
         'claude-haiku-4',

--- a/src/constants.js
+++ b/src/constants.js
@@ -494,6 +494,7 @@ export const OPENAI_REASONING_EFFORT_MODELS = [
     'gpt-5.5',
     'gpt-5.5-2026-04-23',
     'gpt-5.5-pro',
+    // SillyBunny: GPT-5.6 native IDs expose configurable reasoning effort.
     'gpt-5.6-sol',
     'gpt-5.6-terra',
     'gpt-5.6-luna',

--- a/src/constants.js
+++ b/src/constants.js
@@ -494,6 +494,9 @@ export const OPENAI_REASONING_EFFORT_MODELS = [
     'gpt-5.5',
     'gpt-5.5-2026-04-23',
     'gpt-5.5-pro',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
 ];
 
 export const OPENAI_REASONING_EFFORT_MAP = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -343,12 +343,15 @@ async function sendClaudeRequest(request, response) {
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
         // SillyBunny: claude-fable-5 support (substring match also catches router ids like 'anthropic/claude-fable-5')
         const isFableModel = /claude-fable/.test(request.body.model);
-        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || (isFableModel && enableAdaptiveThinking);
-        const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
+        // SillyBunny: claude-sonnet-5 always uses adaptive thinking; never accepts manual thinking, sampling params, or assistant prefill.
+        const isSonnet5 = /^claude-sonnet-5/.test(request.body.model);
+        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || (isFableModel && enableAdaptiveThinking) || isSonnet5;
+        const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel || isSonnet5) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model);
-        const useVerbosity = /^claude-(opus-4-5|opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel;
-        const noPrefillModel = /^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel;
-        const isAdaptiveModel = enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel);
+        const useVerbosity = /^claude-(opus-4-5|opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel || isSonnet5;
+        const noPrefillModel = /^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel || isSonnet5;
+        // Sonnet 5 is always adaptive regardless of enableAdaptiveThinking; other adaptive models require the flag.
+        const isAdaptiveModel = (enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel)) || isSonnet5;
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];
@@ -440,6 +443,13 @@ async function sendClaudeRequest(request, response) {
             delete requestBody.top_k;
         }
 
+        // SillyBunny: claude-sonnet-5 rejects all custom sampling params with HTTP 400.
+        if (isSonnet5) {
+            delete requestBody.temperature;
+            delete requestBody.top_p;
+            delete requestBody.top_k;
+        }
+
         const reasoningEffort = request.body.reasoning_effort;
         const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, isAdaptiveModel);
 
@@ -447,6 +457,10 @@ async function sendClaudeRequest(request, response) {
         if (useThinking && typeof budgetTokens === 'string') {
             fixThinkingPrefill = true;
             requestBody.thinking = { type: 'adaptive' };
+            // SillyBunny: claude-sonnet-5 defaults to omitted; request summarized display when the UI shows reasoning.
+            if (isSonnet5 && request.body.include_reasoning) {
+                requestBody.thinking.display = 'summarized';
+            }
             requestBody.output_config ??= {};
             requestBody.output_config.effort = budgetTokens;
             // top_k is not allowed in adaptive mode
@@ -470,6 +484,9 @@ async function sendClaudeRequest(request, response) {
             delete requestBody.temperature;
             delete requestBody.top_p;
             delete requestBody.top_k;
+        } else if (isSonnet5 && budgetTokens === null) {
+            // SillyBunny: Sonnet 5 enables adaptive thinking by default; explicitly disable when effort is none/auto.
+            requestBody.thinking = { type: 'disabled' };
         }
 
         if ((fixThinkingPrefill || noPrefillModel) && convertedPrompt.messages.length && convertedPrompt.messages[convertedPrompt.messages.length - 1].role === 'assistant') {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -352,6 +352,8 @@ async function sendClaudeRequest(request, response) {
         const noPrefillModel = /^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel || isSonnet5;
         // Sonnet 5 is always adaptive regardless of enableAdaptiveThinking; other adaptive models require the flag.
         const isAdaptiveModel = (enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel)) || isSonnet5;
+        // SillyBunny: older adaptive Claude models reject xhigh and must receive max instead.
+        const supportsXhigh = /^claude-(sonnet-5|opus-4-(?:7|8))/.test(request.body.model) || isFableModel;
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];
@@ -451,7 +453,7 @@ async function sendClaudeRequest(request, response) {
         }
 
         const reasoningEffort = request.body.reasoning_effort;
-        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, isAdaptiveModel);
+        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, isAdaptiveModel, supportsXhigh);
 
         // Adaptive thinking: returns a string effort level (like Gemini 3)
         if (useThinking && typeof budgetTokens === 'string') {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -352,8 +352,8 @@ async function sendClaudeRequest(request, response) {
         const noPrefillModel = /^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel || isSonnet5;
         // Sonnet 5 is always adaptive regardless of enableAdaptiveThinking; other adaptive models require the flag.
         const isAdaptiveModel = (enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel)) || isSonnet5;
-        // SillyBunny: older adaptive Claude models reject xhigh and must receive max instead.
-        const supportsXhigh = /^claude-(sonnet-5|opus-4-(?:7|8))/.test(request.body.model) || isFableModel;
+        // SillyBunny: Sonnet 5 supports xhigh; existing adaptive Claude models keep the max fallback.
+        const supportsXhigh = isSonnet5;
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];

--- a/src/endpoints/google.js
+++ b/src/endpoints/google.js
@@ -470,8 +470,7 @@ router.post('/generate-native-tts', async (request, response) => {
 
 router.post('/generate-image', async (request, response) => {
     try {
-        // SillyBunny: use Imagen 4 after Imagen 3 retirement.
-        const model = request.body.model || 'imagen-4.0-generate-001';
+        const model = request.body.model || 'imagen-3.0-generate-002';
         const { url, headers, apiName } = await getGoogleApiConfig(request, model, 'predict');
 
         // AI Studio is stricter than Vertex AI.

--- a/src/endpoints/google.js
+++ b/src/endpoints/google.js
@@ -273,6 +273,7 @@ router.post('/caption-image', async (request, response) => {
     try {
         const mimeType = request.body.image.split(';')[0].split(':')[1];
         const base64Data = request.body.image.split(',')[1];
+        // SillyBunny: use a current Gemini captioning default after Gemini 2.0 retirement.
         const model = request.body.model || 'gemini-2.5-flash';
         const { url, headers, apiName, safetySettings } = await getGoogleApiConfig(request, model);
 
@@ -469,6 +470,7 @@ router.post('/generate-native-tts', async (request, response) => {
 
 router.post('/generate-image', async (request, response) => {
     try {
+        // SillyBunny: use Imagen 4 after Imagen 3 retirement.
         const model = request.body.model || 'imagen-4.0-generate-001';
         const { url, headers, apiName } = await getGoogleApiConfig(request, model, 'predict');
 

--- a/src/endpoints/google.js
+++ b/src/endpoints/google.js
@@ -273,7 +273,7 @@ router.post('/caption-image', async (request, response) => {
     try {
         const mimeType = request.body.image.split(';')[0].split(':')[1];
         const base64Data = request.body.image.split(',')[1];
-        const model = request.body.model || 'gemini-2.0-flash';
+        const model = request.body.model || 'gemini-2.5-flash';
         const { url, headers, apiName, safetySettings } = await getGoogleApiConfig(request, model);
 
         const body = {
@@ -469,7 +469,7 @@ router.post('/generate-native-tts', async (request, response) => {
 
 router.post('/generate-image', async (request, response) => {
     try {
-        const model = request.body.model || 'imagen-3.0-generate-002';
+        const model = request.body.model || 'imagen-4.0-generate-001';
         const { url, headers, apiName } = await getGoogleApiConfig(request, model, 'predict');
 
         // AI Studio is stricter than Vertex AI.

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1156,8 +1156,9 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
                 return 'medium';
             case REASONING_EFFORT.high:
                 return 'high';
-            case REASONING_EFFORT.max:
             case REASONING_EFFORT.xhigh:
+                return 'xhigh'; // SillyBunny: Sonnet 5 treats xhigh as a distinct effort level, not an alias for max
+            case REASONING_EFFORT.max:
                 return 'max';
         }
         return null;

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1139,9 +1139,10 @@ export function cachingSystemPromptForOpenRouter(messages, ttl = undefined) {
  * @param {string} reasoningEffort Reasoning effort
  * @param {boolean} stream If streaming is enabled
  * @param {boolean} isAdaptiveModel If the model supports adaptive thinking (Opus 4.6+)
+ * @param {boolean} supportsXhigh If the adaptive model accepts the xhigh effort value
  * @returns {number|string|null} Budget tokens, effort string, or null
  */
-export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, isAdaptiveModel) {
+export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, isAdaptiveModel, supportsXhigh = false) {
     // Adaptive thinking for Opus 4.6+: return effort string (like Gemini 3)
     if (isAdaptiveModel) {
         switch (reasoningEffort) {
@@ -1157,7 +1158,8 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
             case REASONING_EFFORT.high:
                 return 'high';
             case REASONING_EFFORT.xhigh:
-                return 'xhigh'; // SillyBunny: Sonnet 5 treats xhigh as a distinct effort level, not an alias for max
+                // SillyBunny: fall back for adaptive Claude models whose API rejects xhigh.
+                return supportsXhigh ? 'xhigh' : 'max';
             case REASONING_EFFORT.max:
                 return 'max';
         }

--- a/tests/claude-sonnet5.test.js
+++ b/tests/claude-sonnet5.test.js
@@ -8,8 +8,6 @@ import { fileURLToPath } from 'node:url';
 import { setConfigFilePath } from '../src/util.js';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
 
-setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
-
 const actualNodeFetch = (await import('node-fetch')).default;
 const nodeFetchMock = jest.fn((url, options) => actualNodeFetch(url, options));
 await jest.unstable_mockModule('node-fetch', () => ({
@@ -46,6 +44,13 @@ describe('Claude Sonnet 5 backend request handling', () => {
     const tempDirs = [];
 
     beforeAll(async () => {
+        const configRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-claude-config-'));
+        const configPath = path.join(configRoot, 'config.yaml');
+        const defaultConfig = fs.readFileSync(fileURLToPath(new URL('../default/config.yaml', import.meta.url)), 'utf8');
+        fs.writeFileSync(configPath, defaultConfig.replace('enableAdaptiveThinking: false', 'enableAdaptiveThinking: true'));
+        tempDirs.push(configRoot);
+        setConfigFilePath(configPath);
+
         const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
 
         const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-claude-sonnet5-'));
@@ -118,6 +123,16 @@ describe('Claude Sonnet 5 backend request handling', () => {
 
         expect(body.thinking).toEqual({ type: 'adaptive' });
         expect(body.output_config?.effort).toBe('xhigh');
+    });
+
+    test('Sonnet 4.6 maps unsupported xhigh effort to max', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ model: 'claude-sonnet-4-6', reasoning_effort: 'xhigh' });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.output_config?.effort).toBe('max');
     });
 
     test('Sonnet 5 with effort=none sends thinking.type disabled and omits sampling params', async () => {

--- a/tests/claude-sonnet5.test.js
+++ b/tests/claude-sonnet5.test.js
@@ -1,0 +1,192 @@
+import { beforeAll, afterAll, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+const actualNodeFetch = (await import('node-fetch')).default;
+const nodeFetchMock = jest.fn((url, options) => actualNodeFetch(url, options));
+await jest.unstable_mockModule('node-fetch', () => ({
+    default: nodeFetchMock,
+}));
+
+function captureClaudePayload() {
+    nodeFetchMock.mockClear();
+    let capturedBody = null;
+    nodeFetchMock.mockImplementation(async (url, options) => {
+        capturedBody = JSON.parse(options?.body ?? '{}');
+        // Return a minimal successful Claude messages response
+        return new Response(JSON.stringify({
+            id: 'msg-test',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'ok' }],
+            model: capturedBody.model,
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 5, output_tokens: 2 },
+        }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        });
+    });
+    return () => capturedBody;
+}
+
+describe('Claude Sonnet 5 backend request handling', () => {
+    /** @type {import('http').Server} */
+    let appServer;
+    /** @type {import('../src/users.js').UserDirectoryList} */
+    let userDirectories;
+    const tempDirs = [];
+
+    beforeAll(async () => {
+        const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
+
+        const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-claude-sonnet5-'));
+        tempDirs.push(userRoot);
+        userDirectories = { root: userRoot, backups: userRoot };
+
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            req.user = { directories: userDirectories };
+            next();
+        });
+        app.use('/api/backends/chat-completions', chatCompletionsRouter);
+
+        await new Promise((resolve) => {
+            appServer = app.listen(3020, '127.0.0.1', resolve);
+        });
+    });
+
+    afterAll(async () => {
+        if (appServer) {
+            await new Promise((resolve, reject) => {
+                appServer.close((err) => err ? reject(err) : resolve());
+            });
+        }
+        for (const dir of tempDirs.splice(0)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+        nodeFetchMock.mockImplementation((url, options) => actualNodeFetch(url, options));
+    });
+
+    function makeRequest(overrides = {}) {
+        return fetch('http://127.0.0.1:3020/api/backends/chat-completions/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                chat_completion_source: CHAT_COMPLETION_SOURCES.CLAUDE,
+                reverse_proxy: 'https://api.anthropic.com',
+                proxy_password: 'test-key',
+                model: 'claude-sonnet-5',
+                stream: false,
+                temperature: 0.8,
+                top_p: 0.9,
+                top_k: 40,
+                max_tokens: 2000,
+                messages: [{ role: 'user', content: 'Hello' }],
+                ...overrides,
+            }),
+        });
+    }
+
+    test('Sonnet 5 with effort=high sends adaptive thinking and omits sampling params', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ reasoning_effort: 'high' });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.output_config?.effort).toBe('high');
+        expect(body.temperature).toBeUndefined();
+        expect(body.top_p).toBeUndefined();
+        expect(body.top_k).toBeUndefined();
+    });
+
+    test('Sonnet 5 with effort=xhigh sends xhigh (not max) as the effort string', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ reasoning_effort: 'xhigh' });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.output_config?.effort).toBe('xhigh');
+    });
+
+    test('Sonnet 5 with effort=none sends thinking.type disabled and omits sampling params', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ reasoning_effort: 'none' });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking).toEqual({ type: 'disabled' });
+        expect(body.output_config).toBeUndefined();
+        expect(body.temperature).toBeUndefined();
+        expect(body.top_p).toBeUndefined();
+        expect(body.top_k).toBeUndefined();
+    });
+
+    test('Sonnet 5 with no reasoning_effort sends thinking.type disabled', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({});
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking).toEqual({ type: 'disabled' });
+    });
+
+    test('Sonnet 5 with include_reasoning adds display:summarized to thinking', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ reasoning_effort: 'high', include_reasoning: true });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking?.type).toBe('adaptive');
+        expect(body.thinking?.display).toBe('summarized');
+    });
+
+    test('Sonnet 5 sampling params are omitted even without reasoning effort', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ reasoning_effort: 'low' });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.temperature).toBeUndefined();
+        expect(body.top_p).toBeUndefined();
+        expect(body.top_k).toBeUndefined();
+    });
+
+    test('Sonnet 5 with web search enabled includes the web_search tool', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ reasoning_effort: 'high', enable_web_search: true });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(Array.isArray(body.tools)).toBe(true);
+        expect(body.tools.some(t => t.type === 'web_search_20250305')).toBe(true);
+    });
+
+    test('Sonnet 5 removes assistant prefill from messages', async () => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({
+            reasoning_effort: 'high',
+            messages: [
+                { role: 'user', content: 'Question' },
+                { role: 'assistant', content: 'Start of answer' },
+            ],
+        });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        const lastMessage = body.messages[body.messages.length - 1];
+        // noPrefillModel: last assistant role must have been converted to user
+        expect(lastMessage.role).not.toBe('assistant');
+    });
+});

--- a/tests/claude-sonnet5.test.js
+++ b/tests/claude-sonnet5.test.js
@@ -135,6 +135,16 @@ describe('Claude Sonnet 5 backend request handling', () => {
         expect(body.output_config?.effort).toBe('max');
     });
 
+    test.each(['claude-opus-4-8', 'claude-fable-5'])('%s does not inherit Sonnet 5 xhigh support', async (model) => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({ model, reasoning_effort: 'xhigh' });
+        expect(res.status).toBe(200);
+        const body = getBody();
+
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.output_config?.effort).toBe('max');
+    });
+
     test('Sonnet 5 with effort=none sends thinking.type disabled and omits sampling params', async () => {
         const getBody = captureClaudePayload();
         const res = await makeRequest({ reasoning_effort: 'none' });

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { applyClaudeModelParameterConstraints } from '../public/scripts/openai-model-capabilities.js';
+
+const openAiSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/openai.js', import.meta.url)), 'utf8');
+
+describe('OpenAI-compatible Claude model capabilities', () => {
+    test('removes unsupported Sonnet 5 parameters from provider-prefixed proxy requests', () => {
+        const payload = {
+            model: 'anthropic/claude-sonnet-5',
+            temperature: 0.8,
+            top_p: 0.9,
+            top_k: 40,
+            frequency_penalty: 0.2,
+            presence_penalty: 0.3,
+            reasoning_effort: 'high',
+            custom_reasoning_param_name: 'reasoning_effort',
+        };
+
+        applyClaudeModelParameterConstraints(payload);
+
+        expect(payload).toEqual({ model: 'anthropic/claude-sonnet-5' });
+    });
+
+    test('preserves native Claude reasoning controls while removing sampling parameters', () => {
+        const payload = {
+            model: 'claude-sonnet-5',
+            temperature: 0.8,
+            top_p: 0.9,
+            top_k: 40,
+            reasoning_effort: 'high',
+            custom_reasoning_param_name: 'reasoning_effort',
+        };
+
+        applyClaudeModelParameterConstraints(payload, { preserveReasoning: true });
+
+        expect(payload).toEqual({
+            model: 'claude-sonnet-5',
+            reasoning_effort: 'high',
+            custom_reasoning_param_name: 'reasoning_effort',
+        });
+    });
+
+    test('applies Claude model constraints while building generation parameters', () => {
+        expect(openAiSource).toContain('import { applyClaudeModelParameterConstraints } from \'./openai-model-capabilities.js\';');
+        expect(openAiSource).toContain('applyClaudeModelParameterConstraints(generate_data, {');
+        expect(openAiSource).toContain('preserveReasoning: [chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source)');
+    });
+});

--- a/tests/openai-static-models.test.js
+++ b/tests/openai-static-models.test.js
@@ -22,6 +22,102 @@ const retiredCaptionModels = [
     'gpt-4-vision-preview',
 ];
 
+// Claude retired IDs removed from both pickers
+const retiredClaudeModels = [
+    'claude-opus-4-0',
+    'claude-opus-4-20250514',
+    'claude-sonnet-4-0',
+    'claude-sonnet-4-20250514',
+    'claude-3-7-sonnet-latest',
+    'claude-3-7-sonnet-20250219',
+    'claude-3-5-sonnet-latest',
+    'claude-3-5-sonnet-20241022',
+    'claude-3-5-sonnet-20240620',
+    'claude-3-5-haiku-latest',
+    'claude-3-5-haiku-20241022',
+    'claude-3-opus-20240229',
+    'claude-3-haiku-20240307',
+];
+
+// Provider IDs retired from the main picker
+const retiredMainPickerOtherModels = [
+    'jamba-1.7-mini',
+    'jamba-1.7-large',
+    'deepseek-r1-distill-llama-70b',
+    'gemma2-9b-it',
+    'meta-llama/llama-4-maverick-17b-128e-instruct',
+    'llama-guard-3-8b',
+    'llama3-70b-8192',
+    'llama3-8b-8192',
+    'mistral-saba-24b',
+    'MiniMax-M1',
+    'deepseek-v4',
+    'deepseek-coder',
+    'sonar-reasoning',
+    'r1-1776',
+    'c4ai-aya-23-8b',
+    'c4ai-aya-23',
+    'c4ai-aya-expanse-8b',
+    'c4ai-aya-vision-8b',
+    'command-light',
+    'command-r',
+    'command-r-plus',
+    'kimi-k2-0711-preview',
+    'moonshot-v1-auto',
+    'kimi-latest',
+    'kimi-thinking-preview',
+];
+
+// IDs removed from Google AI Studio (main google select / data-type="google" caption options).
+// Note: some of these (e.g. gemini-3.1-flash-lite-preview, gemini-3-pro-preview) are legitimately
+// retained in the Vertex sections, so tests must scope checks to the AI Studio selects only.
+const retiredGoogleStudioModels = [
+    'gemini-3.1-flash-lite-preview',
+    'gemini-3.1-flash-image-preview',
+    'gemini-3-pro-preview',
+    'gemini-3-pro-image-preview',
+    'gemini-2.5-pro-preview-03-25',
+    'gemini-2.5-pro-preview-05-06',
+    'gemini-2.5-pro-preview-06-05',
+    'gemini-2.5-flash-preview-05-20',
+    'gemini-2.5-flash-preview-09-2025',
+    'gemini-2.5-flash-lite-preview-06-17',
+    'gemini-2.5-flash-lite-preview-09-2025',
+    'gemini-2.5-flash-image-preview',
+    'gemini-2.0-flash',
+    'gemini-2.0-flash-001',
+    'gemini-2.0-flash-lite',
+    'gemini-2.0-flash-lite-001',
+    'gemini-2.0-flash-lite-preview',
+    'gemini-2.0-flash-lite-preview-02-05',
+    'gemini-2.0-pro-exp',
+    'gemini-2.0-pro-exp-02-05',
+    'gemini-exp-1206',
+    'gemini-2.0-flash-exp',
+    'gemini-2.0-flash-thinking-exp',
+    'gemini-2.0-flash-thinking-exp-01-21',
+    'gemini-2.0-flash-thinking-exp-1219',
+    'gemini-2.0-flash-exp-image-generation',
+    'gemini-2.0-flash-preview-image-generation',
+    'gemini-robotics-er-1.5-preview',
+    'learnlm-2.0-flash-experimental',
+    'gemma-4-31b-it',
+    'gemma-4-26b-a4b-it',
+    'gemma-3-27b-it',
+    'gemma-3-12b-it',
+    'gemma-3-4b-it',
+    'gemma-3-1b-it',
+];
+
+// IDs removed from Vertex AI selects (the Gemini 2.0 batch; 3.x previews are Vertex-only retained)
+const retiredVertexModels = [
+    'gemini-2.0-flash-exp',
+    'gemini-2.0-flash-preview-image-generation',
+    'gemini-2.0-flash',
+    'gemini-2.0-flash-001',
+    'gemini-2.0-flash-lite-001',
+];
+
 function readSource(relativePath) {
     return fs.readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 }
@@ -29,6 +125,10 @@ function readSource(relativePath) {
 function getSelectOptionIds(source, selectId) {
     const select = source.match(new RegExp(`<select id="${selectId}"[^>]*>([\\s\\S]*?)</select>`));
     return [...select[1].matchAll(/<option[^>]*value="([^"]+)"/g)].map((match) => match[1]);
+}
+
+function getDataTypeOptionIds(source, dataType) {
+    return [...source.matchAll(new RegExp(`<option[^>]*data-type="${dataType}"[^>]*value="([^"]+)"`, 'g'))].map(m => m[1]);
 }
 
 test('OpenAI pickers include GPT-5.6 and omit retired native OpenAI models', () => {
@@ -57,4 +157,113 @@ test('GPT-5.6 supports reasoning effort and one-million-token context', () => {
         expect(constants).toContain(`'${model}'`);
     }
     expect(openAiScript).toContain('value.startsWith(\'gpt-5.4\') || value.startsWith(\'gpt-5.6\')');
+});
+
+test('Claude pickers include claude-sonnet-5 and omit all retired Claude IDs', () => {
+    const mainSource = readSource('../public/index.html');
+    const captionSource = readSource('../public/scripts/extensions/caption/settings.html');
+    const mainPicker = getSelectOptionIds(mainSource, 'model_claude_select');
+    const captionPicker = getDataTypeOptionIds(captionSource, 'anthropic');
+
+    expect(mainPicker).toContain('claude-sonnet-5');
+    expect(captionPicker).toContain('claude-sonnet-5');
+    expect(mainPicker).toEqual(expect.not.arrayContaining(retiredClaudeModels));
+    expect(captionPicker).toEqual(expect.not.arrayContaining(retiredClaudeModels));
+});
+
+test('Other provider pickers omit confirmed-retired model IDs', () => {
+    const mainSource = readSource('../public/index.html');
+    const mainPicker = getSelectOptionIds(mainSource, 'model_openai_select');
+    const mainHtml = mainSource; // full source for providers not in model_openai_select
+
+    // AI21, Groq, MiniMax, DeepSeek, Perplexity, Cohere, Moonshot are separate selects;
+    // check raw source since select IDs vary.
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="jamba-1.7-mini"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="jamba-1.7-large"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="deepseek-r1-distill-llama-70b"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="gemma2-9b-it"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="meta-llama/llama-4-maverick-17b-128e-instruct"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="llama-guard-3-8b"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="llama3-70b-8192"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="llama3-8b-8192"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="mistral-saba-24b"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="MiniMax-M1"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="deepseek-v4"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="deepseek-coder"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="sonar-reasoning"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="r1-1776"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="c4ai-aya-23-8b"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="c4ai-aya-23"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="c4ai-aya-expanse-8b"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="c4ai-aya-vision-8b"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="command-light"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="command-r"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="command-r-plus"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="kimi-k2-0711-preview"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="moonshot-v1-auto"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="kimi-latest"'));
+    expect(mainHtml).toEqual(expect.not.stringContaining('value="kimi-thinking-preview"'));
+});
+
+test('Google AI Studio pickers omit all retired Gemini/Gemma models', () => {
+    const mainSource = readSource('../public/index.html');
+    const captionSource = readSource('../public/scripts/extensions/caption/settings.html');
+
+    // Scope to only the AI Studio selects — Vertex legitimately retains some preview IDs.
+    const mainAiStudio = getSelectOptionIds(mainSource, 'model_google_select');
+    const captionAiStudio = getDataTypeOptionIds(captionSource, 'google');
+
+    expect(mainAiStudio).toEqual(expect.not.arrayContaining(retiredGoogleStudioModels));
+    expect(captionAiStudio).toEqual(expect.not.arrayContaining(retiredGoogleStudioModels));
+});
+
+test('Vertex AI pickers omit retired Gemini 2.0 entries', () => {
+    const mainSource = readSource('../public/index.html');
+    const captionSource = readSource('../public/scripts/extensions/caption/settings.html');
+
+    const mainVertex = getSelectOptionIds(mainSource, 'model_vertexai_select');
+    const captionVertex = getDataTypeOptionIds(captionSource, 'vertexai');
+
+    expect(mainVertex).toEqual(expect.not.arrayContaining(retiredVertexModels));
+    expect(captionVertex).toEqual(expect.not.arrayContaining(retiredVertexModels));
+});
+
+test('Caption picker omits retired Cohere and Groq vision models', () => {
+    const captionSource = readSource('../public/scripts/extensions/caption/settings.html');
+
+    expect(captionSource).toEqual(expect.not.stringContaining('value="c4ai-aya-vision-8b"'));
+    expect(captionSource).toEqual(expect.not.stringContaining('value="meta-llama/llama-4-maverick-17b-128e-instruct"'));
+});
+
+test('Stable Diffusion image catalog omits retired models and retains current ones', () => {
+    const source = readSource('../public/scripts/extensions/stable-diffusion/index.js');
+
+    // NovelAI: V2 retired
+    const novelSection = source.match(/async function loadNovelModels\(\)([\s\S]*?)\n}\n/)[1];
+    expect(novelSection).toEqual(expect.not.stringContaining('nai-diffusion-2'));
+    expect(novelSection).toContain('nai-diffusion-4-5-full');
+    expect(novelSection).toContain('nai-diffusion-4-5-curated');
+    expect(novelSection).toContain('nai-diffusion-3');
+    expect(novelSection).toContain('nai-diffusion-furry-3');
+
+    // BFL: flux-pro (unversioned) retired
+    const bflSection = source.match(/async function loadBflModels\(\)([\s\S]*?)\n}\n/)[1];
+    expect(bflSection).toEqual(expect.not.stringContaining("'flux-pro'"));
+    expect(bflSection).toContain('flux-pro-1.1');
+    expect(bflSection).toContain('flux-pro-1.1-ultra');
+    expect(bflSection).toContain('flux-dev');
+
+    // Google: only current Imagen 4 and Veo 3.1 entries
+    const googleSection = source.match(/async function loadGoogleModels\(\)([\s\S]*?)\n}\n/)[1];
+    expect(googleSection).toContain('imagen-4.0-generate-001');
+    expect(googleSection).toContain('imagen-4.0-ultra-generate-001');
+    expect(googleSection).toContain('imagen-4.0-fast-generate-001');
+    expect(googleSection).toContain('veo-3.1-generate-preview');
+    expect(googleSection).toContain('veo-3.1-fast-generate-preview');
+    // Retired entries
+    expect(googleSection).toEqual(expect.not.stringContaining('imagen-3.0'));
+    expect(googleSection).toEqual(expect.not.stringContaining('imagegeneration@'));
+    expect(googleSection).toEqual(expect.not.stringContaining('imagen-4.0-generate-preview'));
+    expect(googleSection).toEqual(expect.not.stringContaining('veo-2.0'));
+    expect(googleSection).toEqual(expect.not.stringContaining('veo-3.0'));
 });

--- a/tests/openai-static-models.test.js
+++ b/tests/openai-static-models.test.js
@@ -207,35 +207,45 @@ test('Caption picker omits retired Cohere and Groq vision models', () => {
     expect(captionSource).toEqual(expect.not.stringContaining('value="meta-llama/llama-4-maverick-17b-128e-instruct"'));
 });
 
-test('Stable Diffusion image catalog omits retired models and retains current ones', () => {
+test('Stable Diffusion image catalog preserves models outside the declared retirements', () => {
     const source = readSource('../public/scripts/extensions/stable-diffusion/index.js');
+    const googleEndpoint = readSource('../src/endpoints/google.js');
 
-    // NovelAI: V2 retired
     const novelSection = source.match(/async function loadNovelModels\(\)([\s\S]*?)\r?\n}\r?\n/)[1];
-    expect(novelSection).toEqual(expect.not.stringContaining('nai-diffusion-2'));
+    expect(novelSection).toContain('nai-diffusion-2');
     expect(novelSection).toContain('nai-diffusion-4-5-full');
     expect(novelSection).toContain('nai-diffusion-4-5-curated');
     expect(novelSection).toContain('nai-diffusion-3');
     expect(novelSection).toContain('nai-diffusion-furry-3');
 
-    // BFL: flux-pro (unversioned) retired
     const bflSection = source.match(/async function loadBflModels\(\)([\s\S]*?)\r?\n}\r?\n/)[1];
-    expect(bflSection).toEqual(expect.not.stringContaining('\'flux-pro\''));
+    expect(bflSection).toContain('{ value: \'flux-pro\', text: \'flux-pro\' }');
     expect(bflSection).toContain('flux-pro-1.1');
     expect(bflSection).toContain('flux-pro-1.1-ultra');
     expect(bflSection).toContain('flux-dev');
 
-    // Google: only current Imagen 4 and Veo 3.1 entries
     const googleSection = source.match(/async function loadGoogleModels\(\)([\s\S]*?)\r?\n}\r?\n/)[1];
-    expect(googleSection).toContain('imagen-4.0-generate-001');
-    expect(googleSection).toContain('imagen-4.0-ultra-generate-001');
-    expect(googleSection).toContain('imagen-4.0-fast-generate-001');
-    expect(googleSection).toContain('veo-3.1-generate-preview');
-    expect(googleSection).toContain('veo-3.1-fast-generate-preview');
-    // Retired entries
-    expect(googleSection).toEqual(expect.not.stringContaining('imagen-3.0'));
-    expect(googleSection).toEqual(expect.not.stringContaining('imagegeneration@'));
-    expect(googleSection).toEqual(expect.not.stringContaining('imagen-4.0-generate-preview'));
-    expect(googleSection).toEqual(expect.not.stringContaining('veo-2.0'));
-    expect(googleSection).toEqual(expect.not.stringContaining('veo-3.0'));
+    const retainedGoogleModels = [
+        'imagen-4.0-generate-preview-06-06',
+        'imagen-4.0-fast-generate-preview-06-06',
+        'imagen-4.0-ultra-generate-preview-06-06',
+        'imagen-3.0-generate-002',
+        'imagen-3.0-generate-001',
+        'imagen-3.0-fast-generate-001',
+        'imagen-3.0-capability-001',
+        'imagegeneration@006',
+        'imagegeneration@005',
+        'imagegeneration@002',
+        'veo-3.0-generate-001',
+        'veo-3.0-fast-generate-001',
+        'veo-2.0-generate-001',
+        'veo-2.0-generate-exp',
+        'veo-2.0-generate-preview',
+    ];
+
+    for (const model of retainedGoogleModels) {
+        expect(googleSection).toContain(model);
+    }
+
+    expect(googleEndpoint).toContain('const model = request.body.model || \'imagen-3.0-generate-002\';');
 });

--- a/tests/openai-static-models.test.js
+++ b/tests/openai-static-models.test.js
@@ -1,0 +1,60 @@
+import { expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const gpt56Models = ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'];
+const retiredMainModels = [
+    'chatgpt-4o-latest',
+    'gpt-4.5-preview',
+    'gpt-4.5-preview-2025-02-27',
+    'o1-preview',
+    'o1-preview-2024-09-12',
+    'o1-mini',
+    'o1-mini-2024-09-12',
+    'gpt-4-turbo-preview',
+    'gpt-4-0125-preview',
+    'gpt-4-0314',
+];
+const retiredCaptionModels = [
+    'chatgpt-4o-latest',
+    'gpt-4.5-preview',
+    'gpt-4.5-preview-2025-02-27',
+    'gpt-4-vision-preview',
+];
+
+function readSource(relativePath) {
+    return fs.readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+}
+
+function getSelectOptionIds(source, selectId) {
+    const select = source.match(new RegExp(`<select id="${selectId}"[^>]*>([\\s\\S]*?)</select>`));
+    return [...select[1].matchAll(/<option[^>]*value="([^"]+)"/g)].map((match) => match[1]);
+}
+
+test('OpenAI pickers include GPT-5.6 and omit retired native OpenAI models', () => {
+    const mainPicker = getSelectOptionIds(readSource('../public/index.html'), 'model_openai_select');
+    const captionPicker = getSelectOptionIds(readSource('../public/scripts/extensions/caption/settings.html'), 'caption_multimodal_model');
+
+    expect(mainPicker).toEqual(expect.arrayContaining(gpt56Models));
+    expect(captionPicker).toEqual(expect.arrayContaining(gpt56Models));
+    expect(mainPicker).toEqual(expect.not.arrayContaining(retiredMainModels));
+    expect(captionPicker).toEqual(expect.not.arrayContaining(retiredCaptionModels));
+});
+
+test('OpenAI image picker omits retired DALL-E models', () => {
+    const source = readSource('../public/scripts/extensions/stable-diffusion/index.js');
+    const modelList = source.match(/async function loadOpenAiModels\(\) \{([\s\S]*?)\n}\n/)[1];
+    const imageModels = [...modelList.matchAll(/\{ value: '([^']+)'/g)].map((match) => match[1]);
+
+    expect(imageModels).toEqual(expect.not.arrayContaining(['dall-e-2', 'dall-e-3']));
+});
+
+test('GPT-5.6 supports reasoning effort and one-million-token context', () => {
+    const constants = readSource('../src/constants.js');
+    const openAiScript = readSource('../public/scripts/openai.js');
+
+    for (const model of gpt56Models) {
+        expect(constants).toContain(`'${model}'`);
+    }
+    expect(openAiScript).toContain('value.startsWith(\'gpt-5.4\') || value.startsWith(\'gpt-5.6\')');
+});

--- a/tests/openai-static-models.test.js
+++ b/tests/openai-static-models.test.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const gpt56Models = ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'];
+const currentGemmaModels = ['gemma-4-31b-it', 'gemma-4-26b-a4b-it'];
 const retiredMainModels = [
     'chatgpt-4o-latest',
     'gpt-4.5-preview',
@@ -39,35 +40,6 @@ const retiredClaudeModels = [
     'claude-3-haiku-20240307',
 ];
 
-// Provider IDs retired from the main picker
-const retiredMainPickerOtherModels = [
-    'jamba-1.7-mini',
-    'jamba-1.7-large',
-    'deepseek-r1-distill-llama-70b',
-    'gemma2-9b-it',
-    'meta-llama/llama-4-maverick-17b-128e-instruct',
-    'llama-guard-3-8b',
-    'llama3-70b-8192',
-    'llama3-8b-8192',
-    'mistral-saba-24b',
-    'MiniMax-M1',
-    'deepseek-v4',
-    'deepseek-coder',
-    'sonar-reasoning',
-    'r1-1776',
-    'c4ai-aya-23-8b',
-    'c4ai-aya-23',
-    'c4ai-aya-expanse-8b',
-    'c4ai-aya-vision-8b',
-    'command-light',
-    'command-r',
-    'command-r-plus',
-    'kimi-k2-0711-preview',
-    'moonshot-v1-auto',
-    'kimi-latest',
-    'kimi-thinking-preview',
-];
-
 // IDs removed from Google AI Studio (main google select / data-type="google" caption options).
 // Note: some of these (e.g. gemini-3.1-flash-lite-preview, gemini-3-pro-preview) are legitimately
 // retained in the Vertex sections, so tests must scope checks to the AI Studio selects only.
@@ -101,8 +73,6 @@ const retiredGoogleStudioModels = [
     'gemini-2.0-flash-preview-image-generation',
     'gemini-robotics-er-1.5-preview',
     'learnlm-2.0-flash-experimental',
-    'gemma-4-31b-it',
-    'gemma-4-26b-a4b-it',
     'gemma-3-27b-it',
     'gemma-3-12b-it',
     'gemma-3-4b-it',
@@ -143,13 +113,13 @@ test('OpenAI pickers include GPT-5.6 and omit retired native OpenAI models', () 
 
 test('OpenAI image picker omits retired DALL-E models', () => {
     const source = readSource('../public/scripts/extensions/stable-diffusion/index.js');
-    const modelList = source.match(/async function loadOpenAiModels\(\) \{([\s\S]*?)\n}\n/)[1];
+    const modelList = source.match(/async function loadOpenAiModels\(\) \{([\s\S]*?)\r?\n}\r?\n/)[1];
     const imageModels = [...modelList.matchAll(/\{ value: '([^']+)'/g)].map((match) => match[1]);
 
     expect(imageModels).toEqual(expect.not.arrayContaining(['dall-e-2', 'dall-e-3']));
 });
 
-test('GPT-5.6 supports reasoning effort and one-million-token context', () => {
+test('GPT-5.6 supports distinct max reasoning effort and one-million-token context', () => {
     const constants = readSource('../src/constants.js');
     const openAiScript = readSource('../public/scripts/openai.js');
 
@@ -157,6 +127,7 @@ test('GPT-5.6 supports reasoning effort and one-million-token context', () => {
         expect(constants).toContain(`'${model}'`);
     }
     expect(openAiScript).toContain('value.startsWith(\'gpt-5.4\') || value.startsWith(\'gpt-5.6\')');
+    expect(openAiScript).toMatch(/case reasoning_effort_types\.max:[\s\S]*?\^gpt-5\\\.6[\s\S]*?return reasoning_effort_types\.max/);
 });
 
 test('Claude pickers include claude-sonnet-5 and omit all retired Claude IDs', () => {
@@ -173,7 +144,6 @@ test('Claude pickers include claude-sonnet-5 and omit all retired Claude IDs', (
 
 test('Other provider pickers omit confirmed-retired model IDs', () => {
     const mainSource = readSource('../public/index.html');
-    const mainPicker = getSelectOptionIds(mainSource, 'model_openai_select');
     const mainHtml = mainSource; // full source for providers not in model_openai_select
 
     // AI21, Groq, MiniMax, DeepSeek, Perplexity, Cohere, Moonshot are separate selects;
@@ -215,6 +185,8 @@ test('Google AI Studio pickers omit all retired Gemini/Gemma models', () => {
 
     expect(mainAiStudio).toEqual(expect.not.arrayContaining(retiredGoogleStudioModels));
     expect(captionAiStudio).toEqual(expect.not.arrayContaining(retiredGoogleStudioModels));
+    expect(mainAiStudio).toEqual(expect.arrayContaining(currentGemmaModels));
+    expect(captionAiStudio).toEqual(expect.arrayContaining(currentGemmaModels));
 });
 
 test('Vertex AI pickers omit retired Gemini 2.0 entries', () => {
@@ -239,7 +211,7 @@ test('Stable Diffusion image catalog omits retired models and retains current on
     const source = readSource('../public/scripts/extensions/stable-diffusion/index.js');
 
     // NovelAI: V2 retired
-    const novelSection = source.match(/async function loadNovelModels\(\)([\s\S]*?)\n}\n/)[1];
+    const novelSection = source.match(/async function loadNovelModels\(\)([\s\S]*?)\r?\n}\r?\n/)[1];
     expect(novelSection).toEqual(expect.not.stringContaining('nai-diffusion-2'));
     expect(novelSection).toContain('nai-diffusion-4-5-full');
     expect(novelSection).toContain('nai-diffusion-4-5-curated');
@@ -247,14 +219,14 @@ test('Stable Diffusion image catalog omits retired models and retains current on
     expect(novelSection).toContain('nai-diffusion-furry-3');
 
     // BFL: flux-pro (unversioned) retired
-    const bflSection = source.match(/async function loadBflModels\(\)([\s\S]*?)\n}\n/)[1];
-    expect(bflSection).toEqual(expect.not.stringContaining("'flux-pro'"));
+    const bflSection = source.match(/async function loadBflModels\(\)([\s\S]*?)\r?\n}\r?\n/)[1];
+    expect(bflSection).toEqual(expect.not.stringContaining('\'flux-pro\''));
     expect(bflSection).toContain('flux-pro-1.1');
     expect(bflSection).toContain('flux-pro-1.1-ultra');
     expect(bflSection).toContain('flux-dev');
 
     // Google: only current Imagen 4 and Veo 3.1 entries
-    const googleSection = source.match(/async function loadGoogleModels\(\)([\s\S]*?)\n}\n/)[1];
+    const googleSection = source.match(/async function loadGoogleModels\(\)([\s\S]*?)\r?\n}\r?\n/)[1];
     expect(googleSection).toContain('imagen-4.0-generate-001');
     expect(googleSection).toContain('imagen-4.0-ultra-generate-001');
     expect(googleSection).toContain('imagen-4.0-fast-generate-001');

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -120,7 +120,7 @@ describe('calculateClaudeBudgetTokens', () => {
 
         test('max returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'max', true, true)).toBe('max'));
 
-        test('xhigh returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true)).toBe('max'));
+        test('xhigh returns "xhigh"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true)).toBe('xhigh'));
     });
 
     describe('traditional model', () => {

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -120,7 +120,10 @@ describe('calculateClaudeBudgetTokens', () => {
 
         test('max returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'max', true, true)).toBe('max'));
 
-        test('xhigh returns "xhigh"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true)).toBe('xhigh'));
+        // SillyBunny: Sonnet 5 accepts xhigh; older adaptive Claude models require max.
+        test('xhigh falls back to "max" when unsupported', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true)).toBe('max'));
+
+        test('xhigh remains "xhigh" when supported', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true, true)).toBe('xhigh'));
     });
 
     describe('traditional model', () => {


### PR DESCRIPTION
Adds GPT 5.6 Sol, Terra, and Luna on the GPT backend. Includes 1M context support.
Adds Sonnet 5 on the Claude backend. Includes reasoning effort fix + 1M context support.

All models removed no longer exist in the following backends nor will they return in the corresponding APIs.

Removes the outdated GPT models:
- chatgpt-4o-latest
- gpt-4.5-preview
- gpt-4.5-preview-2025-02-27
- o1-preview
- o1-preview-2024-09-12
- o1-mini
- o1-mini-2024-09-12
- gpt-4-turbo-preview
- gpt-4-0125-preview
- gpt-4-0314
- gpt-4-vision-preview
- dall-e-2
- dall-e-3

Outdated Claude models:
- claude-opus-4-0/20250514
- claude-sonnet-4-0/20250514
- claude-3-7-sonnet-*
- claude-3-5-sonnet-*
- claude-3-5-haiku-*
- claude-3-opus-20240229
- claude-3-haiku-20240307

AI Studio:
- all Gemini 2.0 and preview aliases removed
- Gemma 3 and LearnLM groups removed

Vertex AI:
- Gemini 2.0 Flash entries removed

Groq:
- deepseek-r1-distill-llama-70b
- gemma2-9b-it
- meta-llama/llama-4-maverick-17b-128e-instruct
- llama-guard-3-8b
- llama3-70b-8192
- llama3-8b-8192
- mistral-saba-24b

AI21:
- Jamba1.7 optgroup

MiniMax: 
- M1

DeepSeek: 
- coder
- v4 (standalone)

Perplexity: 
- sonar-reasoning
- r1-1776

Cohere:
- c4ai-aya-23-8b
- c4ai-aya-23
- c4ai-aya-expanse-8b
- c4ai-aya-vision-8b
- command-light
- command
- command-r
- command-r-plus

Moonshot:
- kimi-k2-0711-preview
- moonshot-v1-auto
- kimi-latest
- kimi-thinking-preview