### PR TITLE
fix: favorites save errors, lit fav state, and scrollable hotswap bar

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2190,7 +2190,16 @@ body.sb-shell-resizing * {
     margin: 0;
     align-items: center;
     flex-wrap: nowrap;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
+    /* Wheel-driven sideways scroll; a visible scrollbar would eat the 36px row,
+       and smooth behavior makes rapid wheel ticks overwrite each other */
+    scrollbar-width: none;
+    scroll-behavior: auto;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap::-webkit-scrollbar {
+    display: none;
 }
 
 #right-nav-panel #HotSwapWrapper .hotswap > small {
@@ -5786,10 +5795,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     white-space: nowrap;
 }
 
+/* !important: themes (e.g. MoonlitEchoes) pin .menu_button colors with !important,
+   which otherwise flattens the lit state to the idle button color */
 #right-nav-panel .sb-character-editor-side-actions #favorite_button.fav_on {
-    color: var(--active);
-    border-color: color-mix(in srgb, var(--active) 46%, transparent);
-    background: color-mix(in srgb, var(--active) 14%, transparent);
+    color: var(--active) !important;
+    border-color: color-mix(in srgb, var(--active) 46%, transparent) !important;
+    background: color-mix(in srgb, var(--active) 14%, transparent) !important;
 }
 
 #right-nav-panel .sb-character-editor-side-actions #favorite_button:hover {
@@ -6335,10 +6346,11 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     white-space: nowrap;
 }
 
+/* !important: same theme-override guard as the character editor favorite button */
 #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions #group_favorite_button.fav_on {
-    color: var(--active);
-    border-color: color-mix(in srgb, var(--active) 46%, transparent);
-    background: color-mix(in srgb, var(--active) 14%, transparent);
+    color: var(--active) !important;
+    border-color: color-mix(in srgb, var(--active) 46%, transparent) !important;
+    background: color-mix(in srgb, var(--active) 14%, transparent) !important;
 }
 
 #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row label {

--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260622b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -89,6 +89,7 @@ class CharacterContextMenu {
 
         if (!mergeResponse.ok) {
             mergeResponse.json().then(json => toastr.error(`Character not saved. Error: ${json.message}. Field: ${json.error}`));
+            return;
         }
 
         const element = document.getElementById(`CharID${characterId}`);

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -366,9 +366,9 @@ export async function favsToHotswap() {
     const entities = getEntitiesList({ doFilter: false });
     const container = $('#right-nav-panel .hotswap');
 
-    // Hard limit is required because even if all hotswaps don't fit the screen, their images would still be loaded
-    // 25 is roughly calculated as the maximum number of favs that can fit an ultrawide monitor with the default theme
-    const FAVS_LIMIT = 25;
+    // The bar scrolls sideways and avatars are lazy-loaded thumbnails, so the old
+    // fits-on-one-screen cap of 25 no longer applies; this is just a sanity bound.
+    const FAVS_LIMIT = 250;
     const favs = entities.filter(x => x.item.fav || x.item.fav == 'true').slice(0, FAVS_LIMIT);
 
     //helpful instruction message if no characters are favorited
@@ -791,6 +791,20 @@ export function initRossMods() {
     });
 
     $('#api_button').on('click', () => checkStatusDebounced());
+
+    // Mouse wheel scrolls the favorites hotswap bar sideways.
+    // Native listener because jQuery cannot register non-passive wheel handlers.
+    const hotswapBar = document.querySelector('#HotSwapWrapper .hotswap');
+    hotswapBar?.addEventListener('wheel', (event) => {
+        if (hotswapBar.scrollWidth <= hotswapBar.clientWidth) return;
+        // Leave trackpad horizontal swipes to native handling
+        if (Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;
+        event.preventDefault();
+        // deltaMode 1 = lines (Firefox); convert to roughly one avatar per line
+        const step = event.deltaMode === 1 ? event.deltaY * 34 : event.deltaY;
+        // 'instant' so rapid wheel ticks accumulate instead of restarting a smooth animation
+        hotswapBar.scrollTo({ left: hotswapBar.scrollLeft + step, behavior: 'instant' });
+    }, { passive: false });
 
     //toggle pin class when lock toggle clicked
     $(RPanelPin).on('click', function () {

--- a/src/validator/TavernCardValidator.js
+++ b/src/validator/TavernCardValidator.js
@@ -35,13 +35,29 @@ export class TavernCardValidator {
         if (this.validateV1()) {
             return 1;
         }
+        const v1Error = this.#lastValidationError;
 
         if (this.validateV2()) {
+            this.#lastValidationError = null;
             return 2;
         }
+        const v2Error = this.#lastValidationError;
 
         if (this.validateV3()) {
+            this.#lastValidationError = null;
             return 3;
+        }
+        const v3Error = this.#lastValidationError;
+
+        // Report the error from the spec the card declares, otherwise the
+        // last validator tried masks the real failure (e.g. a v2 card with a
+        // missing data field would be reported as a 'spec' mismatch by v3).
+        if (this.card?.spec === 'chara_card_v2') {
+            this.#lastValidationError = v2Error;
+        } else if (this.card?.spec === 'chara_card_v3') {
+            this.#lastValidationError = v3Error;
+        } else {
+            this.#lastValidationError = v1Error;
         }
 
         return false;


### PR DESCRIPTION
## What?

Fixes the chain of bugs that made favoriting characters appear broken:

- `TavernCardValidator` now reports the validation error from the spec the card actually declares, instead of whichever spec branch was tried last (a v2 card missing `character_version` used to surface as a meaningless `Field: spec` error from the v3 branch).
- The bulk-edit favorite flow no longer flips the `is_fav` UI state when the `/api/characters/merge-attributes` save fails — previously the list showed a favorite that was never persisted.
- The favorites hotswap bar scrolls sideways with the mouse wheel, its favorite cap is raised from 25 to 250, and the character/group editor FAV buttons now visibly light up under themes that pin `.menu_button` colors with `!important`.

## Why?

Any card with a spec-conformance gap (e.g. missing `character_version`) failed **every** save — including simple favorite toggles, since `merge-attributes` re-validates the whole card — and the masked error (`Field: spec`) pointed users at the wrong cause. On top of that, two UI bugs made the feature look broken even when saves succeeded: the fav icon never lit under themes that pin `.menu_button` colors (e.g. MoonlitEchoes), and favorites past 25 silently never appeared in the hotswap bar.

## How?

- **Validator** (`src/validator/TavernCardValidator.js`): `validate()` captures each branch's error as it tries V1 → V2 → V3, clears the stale error on success, and on total failure picks the error matching `card.spec`.
- **Bulk edit** (`public/scripts/BulkEditOverlay.js`): early `return` after the error toast.
- **Hotswap bar** (`RossAscends-mods.js`, `sillybunny-tabs.css`): native non-passive `wheel` listener translating vertical wheel to horizontal scroll — `scrollTo(..., behavior: 'instant')` because smooth scrolling makes rapid ticks overwrite each other; trackpad horizontal swipes are left to native handling. `overflow-x: auto` with the scrollbar hidden so the 36px row keeps its height. `FAVS_LIMIT` 25 → 250 is safe because the bar scrolls and avatars are lazy-loaded thumbnails.
- **Fav button styling** (`sillybunny-tabs.css`): `!important` on the two-ID `.fav_on` rules, since theme-level `.menu_button { color: ... !important }` otherwise wins the cascade and renders `fav_on` pixel-identical to `fav_off`. Cache-bust param bumped per repo convention.

## Testing?

- Live verification on a running instance: favoriting a previously-failing card persists and the FAV button lights up under MoonlitEchoes; wheel scrolling moves the hotswap bar in both directions and clamps at the ends.
- Validator fix verified by feeding deficient v2/v3 cards: errors now name the real missing field (e.g. `data.character_version`) instead of `spec`.
- 144 card chunks from a personal library re-validated through the patched validator: all pass.
- Not covered: no automated tests were added; Firefox `deltaMode === 1` wheel handling is untested (converted at ~34px/line).

## Screenshots

None attached — changes were verified live in a browser session (fav button lit state, error toast wording, bar scrolling). Can add before/after captures on request.

## Anything Else?

- Root cause of the failing saves was non-conformant cards produced by an external pipeline; those card files were repaired on the user side (not part of this repo). This PR makes SillyBunny diagnose such cards correctly and keeps the UI honest about failed saves.
- `FAVS_LIMIT = 250` is a sanity bound, not a layout constraint anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)