### PR TITLE
fix: Favs not lighting up, scrolling favorites on desktop, validator behavior changes, etc

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -507,6 +507,18 @@
         padding: 3px 10px !important;
     }
 
+    /* The collapsed shell header parks the mode toggle + close button over the
+       right end of this band, and the characters button floats on its left;
+       inset the favorites block so the divider and strip sit cleanly between
+       the flanking controls instead of running underneath them.
+       Left 48px clears the 44px characters button; right 134px clears the
+       82px mode toggle + 36px close button and their edge offsets. */
+    #right-nav-panel.openDrawer #HotSwapWrapper {
+        margin: 0 134px 0 48px !important;
+        min-height: 44px;
+        justify-content: center;
+    }
+
     #right-nav-panel.openDrawer .sb-character-favorites-label {
         font-size: calc(var(--mainFontSize) * 0.66) !important;
         letter-spacing: 0.12em !important;

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -520,26 +520,8 @@
     }
 
     #right-nav-panel.openDrawer .sb-character-favorites-label {
-        font-size: calc(var(--mainFontSize) * 0.66) !important;
-        letter-spacing: 0.12em !important;
-    }
-
-    /* mobile-styles.css flattens the strip to overflow: hidden on mobile,
-       which stops it from being a scroll container — touch panning then has
-       nothing to scroll. Restore the horizontal-rail treatment the other
-       mobile rails use (see .sb-character-create-bar above). */
-    #right-nav-panel.openDrawer #HotSwapWrapper .hotswap {
-        max-height: 28px !important;
-        overflow-x: auto !important;
-        overflow-y: hidden !important;
-        overscroll-behavior-x: contain !important;
-        touch-action: pan-x !important;
-        -webkit-overflow-scrolling: touch !important;
-        scrollbar-width: none !important;
-    }
-
-    #right-nav-panel.openDrawer #HotSwapWrapper .hotswap::-webkit-scrollbar {
-        display: none !important;
+        font-size: calc(var(--mainFontSize) * 0.66);
+        letter-spacing: 0.12em;
     }
 
     #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > small {
@@ -2041,14 +2023,22 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         justify-content: flex-start;
     }
 
+    /* Horizontal-rail treatment like .sb-character-create-bar: the strip must
+       stay a real scroll container or touch panning has nothing to scroll
+       (mobile-styles.css and an earlier revision of this rule flattened it to
+       overflow: hidden). */
     #right-nav-panel.openDrawer #HotSwapWrapper .hotswap {
         min-width: 0;
         max-width: 100%;
-        max-height: 34px;
+        max-height: 28px;
         margin: 0;
-        overflow: hidden;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-x: contain;
+        touch-action: pan-x;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
         white-space: nowrap;
-        text-overflow: ellipsis;
     }
 
     #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > .avatar {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -524,8 +524,22 @@
         letter-spacing: 0.12em !important;
     }
 
+    /* mobile-styles.css flattens the strip to overflow: hidden on mobile,
+       which stops it from being a scroll container — touch panning then has
+       nothing to scroll. Restore the horizontal-rail treatment the other
+       mobile rails use (see .sb-character-create-bar above). */
     #right-nav-panel.openDrawer #HotSwapWrapper .hotswap {
         max-height: 28px !important;
+        overflow-x: auto !important;
+        overflow-y: hidden !important;
+        overscroll-behavior-x: contain !important;
+        touch-action: pan-x !important;
+        -webkit-overflow-scrolling: touch !important;
+        scrollbar-width: none !important;
+    }
+
+    #right-nav-panel.openDrawer #HotSwapWrapper .hotswap::-webkit-scrollbar {
+        display: none !important;
     }
 
     #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > small {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2376,8 +2376,8 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.avatar, .missing-avatar) {
         grid-column: 1;
         grid-row: 1 / -1;
-        align-self: center;
-        justify-self: center;
+        align-self: center !important;
+        justify-self: center !important;
         width: var(--sb-character-list-avatar-size) !important;
         min-width: var(--sb-character-list-avatar-size) !important;
         max-width: var(--sb-character-list-avatar-size) !important;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5348,7 +5348,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 #right-nav-panel .sb-character-editor-controls-row {
-    --sb-character-editor-avatar-size: clamp(96px, 12vw, 132px);
+    --sb-character-editor-avatar-size: clamp(112px, 13vw, 152px);
     width: 100%;
     display: grid;
     grid-template-columns: var(--sb-character-editor-avatar-size) minmax(0, 1fr);
@@ -5835,18 +5835,25 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     width: var(--sb-character-editor-avatar-size) !important;
     min-width: var(--sb-character-editor-avatar-size) !important;
     max-width: var(--sb-character-editor-avatar-size) !important;
-    height: var(--sb-character-editor-avatar-size) !important;
-    min-height: var(--sb-character-editor-avatar-size) !important;
-    max-height: var(--sb-character-editor-avatar-size) !important;
+    /* Portrait box instead of the old square: card art is mostly portrait and
+       the square crop hid most of the image */
+    aspect-ratio: 3 / 4;
+    height: auto !important;
+    min-height: 0 !important;
+    max-height: none !important;
     margin: 0 !important;
     border-width: 3px;
     border-radius: var(--sb-radius-lg, 22px);
     overflow: hidden;
+    /* Letterbox surface for art that isn't 3:4, so `contain` reads as a frame */
+    background: color-mix(in srgb, var(--sb-shell-surface) 62%, transparent);
 }
 
 #right-nav-panel .sb-character-editor-controls-row > #avatar_div_div img {
     width: 100% !important;
     height: 100% !important;
+    /* The whole image stays visible regardless of its aspect ratio */
+    object-fit: contain !important;
 }
 
 #right-nav-panel #avatar_div > #tagList {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2029,6 +2029,7 @@ body.sb-shell-resizing * {
     line-height: 1;
     min-height: 32px;
     padding: 8px 13px;
+    cursor: pointer;
     transition: background var(--sb-transition-fast), color var(--sb-transition-fast), box-shadow var(--sb-transition-fast), transform var(--sb-transition-fast), opacity var(--sb-transition-fast);
     opacity: 0.72;
 }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2158,16 +2158,21 @@ body.sb-shell-resizing * {
 }
 
 #right-nav-panel #CharListButtonAndHotSwaps {
+    /* Natural height: the favorites label sits above the avatar strip, and the
+       old 52px clamp clipped the strip's bottom edge */
     min-height: 52px;
-    max-height: 52px;
+    max-height: none;
     padding: var(--sb-shell-space-sm) var(--sb-shell-panel-padding-inline);
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 76%, transparent);
     overflow: hidden;
 }
 
 #right-nav-panel #HotSwapWrapper {
-    align-items: center;
-    gap: 10px;
+    /* Deliberate two-row layout (label divider, then avatar strip); previously
+       the strip only ended up below the label as a flex-wrap accident */
+    flex-direction: column;
+    align-items: stretch;
+    gap: 5px;
     margin: 0 !important;
     min-height: 0;
     overflow: hidden;
@@ -2175,6 +2180,9 @@ body.sb-shell-resizing * {
 
 #right-nav-panel .sb-character-favorites-label {
     flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
     font-size: var(--sb-type-caption);
     font-weight: var(--sb-weight-title);
     letter-spacing: var(--sb-tracking-kicker);
@@ -2183,11 +2191,25 @@ body.sb-shell-resizing * {
     opacity: 0.72;
 }
 
+#right-nav-panel .sb-character-favorites-label::before,
+#right-nav-panel .sb-character-favorites-label::after {
+    content: '';
+    flex: 1 1 auto;
+    height: 1px;
+    background: color-mix(in srgb, var(--sb-shell-border) 76%, transparent);
+}
+
 #right-nav-panel #HotSwapWrapper .hotswap {
     min-width: 0;
-    flex: 1 1 auto;
+    /* Shrink-to-fit so a short row centers under the label; overflowing rows
+       clamp to full width and scroll */
+    flex: 0 0 auto;
+    align-self: center;
+    max-width: 100%;
+    column-gap: 5px;
     max-height: 36px;
     margin: 0;
+    padding: 1px 2px;
     align-items: center;
     flex-wrap: nowrap;
     overflow-x: auto;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2190,7 +2190,16 @@ body.sb-shell-resizing * {
     margin: 0;
     align-items: center;
     flex-wrap: nowrap;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
+    /* Wheel-driven sideways scroll; a visible scrollbar would eat the 36px row,
+       and smooth behavior makes rapid wheel ticks overwrite each other */
+    scrollbar-width: none;
+    scroll-behavior: auto;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap::-webkit-scrollbar {
+    display: none;
 }
 
 #right-nav-panel #HotSwapWrapper .hotswap > small {
@@ -5786,10 +5795,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     white-space: nowrap;
 }
 
+/* !important: themes (e.g. MoonlitEchoes) pin .menu_button colors with !important,
+   which otherwise flattens the lit state to the idle button color */
 #right-nav-panel .sb-character-editor-side-actions #favorite_button.fav_on {
-    color: var(--active);
-    border-color: color-mix(in srgb, var(--active) 46%, transparent);
-    background: color-mix(in srgb, var(--active) 14%, transparent);
+    color: var(--active) !important;
+    border-color: color-mix(in srgb, var(--active) 46%, transparent) !important;
+    background: color-mix(in srgb, var(--active) 14%, transparent) !important;
 }
 
 #right-nav-panel .sb-character-editor-side-actions #favorite_button:hover {
@@ -6335,10 +6346,11 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     white-space: nowrap;
 }
 
+/* !important: same theme-override guard as the character editor favorite button */
 #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions #group_favorite_button.fav_on {
-    color: var(--active);
-    border-color: color-mix(in srgb, var(--active) 46%, transparent);
-    background: color-mix(in srgb, var(--active) 14%, transparent);
+    color: var(--active) !important;
+    border-color: color-mix(in srgb, var(--active) 46%, transparent) !important;
+    background: color-mix(in srgb, var(--active) 14%, transparent) !important;
 }
 
 #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row label {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2139,6 +2139,12 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     margin: 0;
 }
 
+@media screen and (max-width: 1000px) {
+    body #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.avatar, .missing-avatar) {
+        grid-row: 1 / -1 !important;
+    }
+}
+
 #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.character_select_container, .group_select_container) {
     grid-column: 2 / -1;
     grid-row: 1 / span 2;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2130,11 +2130,11 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     color: var(--color-primary, var(--sb-accent));
 }
 
-#rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > .avatar {
+#rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.avatar, .missing-avatar) {
     grid-column: 1;
     grid-row: 1 / span 2;
-    align-self: center;
-    justify-self: center;
+    align-self: center !important;
+    justify-self: center !important;
     flex: 0 0 var(--avatar-base-width);
     margin: 0;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260622b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260711b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260711c" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260622b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711c">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260622b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260712a" media="(max-width: 768px)">

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711d">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260622b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260711a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -47,10 +47,10 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260711c" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260712a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260621a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260711a" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260711b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -89,6 +89,7 @@ class CharacterContextMenu {
 
         if (!mergeResponse.ok) {
             mergeResponse.json().then(json => toastr.error(`Character not saved. Error: ${json.message}. Field: ${json.error}`));
+            return;
         }
 
         const element = document.getElementById(`CharID${characterId}`);

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -366,9 +366,9 @@ export async function favsToHotswap() {
     const entities = getEntitiesList({ doFilter: false });
     const container = $('#right-nav-panel .hotswap');
 
-    // Hard limit is required because even if all hotswaps don't fit the screen, their images would still be loaded
-    // 25 is roughly calculated as the maximum number of favs that can fit an ultrawide monitor with the default theme
-    const FAVS_LIMIT = 25;
+    // The bar scrolls sideways and avatars are lazy-loaded thumbnails, so the old
+    // fits-on-one-screen cap of 25 no longer applies; this is just a sanity bound.
+    const FAVS_LIMIT = 250;
     const favs = entities.filter(x => x.item.fav || x.item.fav == 'true').slice(0, FAVS_LIMIT);
 
     //helpful instruction message if no characters are favorited
@@ -791,6 +791,20 @@ export function initRossMods() {
     });
 
     $('#api_button').on('click', () => checkStatusDebounced());
+
+    // Mouse wheel scrolls the favorites hotswap bar sideways.
+    // Native listener because jQuery cannot register non-passive wheel handlers.
+    const hotswapBar = document.querySelector('#HotSwapWrapper .hotswap');
+    hotswapBar?.addEventListener('wheel', (event) => {
+        if (hotswapBar.scrollWidth <= hotswapBar.clientWidth) return;
+        // Leave trackpad horizontal swipes to native handling
+        if (Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;
+        event.preventDefault();
+        // deltaMode 1 = lines (Firefox); convert to roughly one avatar per line
+        const step = event.deltaMode === 1 ? event.deltaY * 34 : event.deltaY;
+        // 'instant' so rapid wheel ticks accumulate instead of restarting a smooth animation
+        hotswapBar.scrollTo({ left: hotswapBar.scrollLeft + step, behavior: 'instant' });
+    }, { passive: false });
 
     //toggle pin class when lock toggle clicked
     $(RPanelPin).on('click', function () {

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -796,6 +796,7 @@ export function initRossMods() {
     // Native listener because jQuery cannot register non-passive wheel handlers.
     const hotswapBar = document.querySelector('#HotSwapWrapper .hotswap');
     hotswapBar?.addEventListener('wheel', (event) => {
+        if (event.ctrlKey || event.metaKey) return;
         if (hotswapBar.scrollWidth <= hotswapBar.clientWidth) return;
         // Leave trackpad horizontal swipes to native handling
         if (Math.abs(event.deltaX) >= Math.abs(event.deltaY)) return;

--- a/src/validator/TavernCardValidator.js
+++ b/src/validator/TavernCardValidator.js
@@ -35,13 +35,29 @@ export class TavernCardValidator {
         if (this.validateV1()) {
             return 1;
         }
+        const v1Error = this.#lastValidationError;
 
         if (this.validateV2()) {
+            this.#lastValidationError = null;
             return 2;
         }
+        const v2Error = this.#lastValidationError;
 
         if (this.validateV3()) {
+            this.#lastValidationError = null;
             return 3;
+        }
+        const v3Error = this.#lastValidationError;
+
+        // Report the error from the spec the card declares, otherwise the
+        // last validator tried masks the real failure (e.g. a v2 card with a
+        // missing data field would be reported as a 'spec' mismatch by v3).
+        if (this.card?.spec === 'chara_card_v2') {
+            this.#lastValidationError = v2Error;
+        } else if (this.card?.spec === 'chara_card_v3') {
+            this.#lastValidationError = v3Error;
+        } else {
+            this.#lastValidationError = v1Error;
         }
 
         return false;

--- a/tests/favorites-hotswap.e2e.js
+++ b/tests/favorites-hotswap.e2e.js
@@ -1,0 +1,58 @@
+/* global document, HTMLElement, WheelEvent */
+import { expect, test } from '@playwright/test';
+import { openQuietChatForSmoke } from './chat-scroll-regression-helpers.js';
+
+test.describe('favorites hotswap scrolling', () => {
+    test.beforeEach(async ({ page }) => {
+        await openQuietChatForSmoke(page, { selectCharacter: false });
+    });
+
+    test('scrolls vertical wheel input sideways without cancelling browser zoom gestures', async ({ page }) => {
+        const result = await page.evaluate(() => {
+            const hotswapBar = document.querySelector('#HotSwapWrapper .hotswap');
+
+            if (!(hotswapBar instanceof HTMLElement)) {
+                return null;
+            }
+
+            Object.defineProperties(hotswapBar, {
+                clientWidth: { configurable: true, value: 100 },
+                scrollWidth: { configurable: true, value: 200 },
+            });
+
+            let scrollLeft = null;
+            Object.defineProperty(hotswapBar, 'scrollTo', {
+                configurable: true,
+                value: options => {
+                    scrollLeft = options.left;
+                },
+            });
+
+            const dispatchWheel = options => {
+                const event = new WheelEvent('wheel', {
+                    bubbles: true,
+                    cancelable: true,
+                    deltaY: 80,
+                    ...options,
+                });
+                hotswapBar.dispatchEvent(event);
+
+                return event.defaultPrevented;
+            };
+
+            return {
+                ctrlWheelPrevented: dispatchWheel({ ctrlKey: true }),
+                metaWheelPrevented: dispatchWheel({ metaKey: true }),
+                verticalWheelPrevented: dispatchWheel({}),
+                scrollLeft,
+            };
+        });
+
+        expect(result).toEqual({
+            ctrlWheelPrevented: false,
+            metaWheelPrevented: false,
+            verticalWheelPrevented: true,
+            scrollLeft: 80,
+        });
+    });
+});

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -38,12 +38,14 @@ function getMediaQueryPxValues(cssSource) {
 // border rules without affecting desktop.
 // sillybunny-paper-theme.css starts at 55: the phone-only paper texture and
 // chrome adjustment sheet is budgeted from introduction.
+// sillybunny-theme.css raised 158 -> 161: the mobile character list needs to
+// override upstream !important avatar alignment rules for missing avatars.
 const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
     'sillybunny-mobile-shell.css': 677,
     'sillybunny-paper-theme.css': 55,
     'sillybunny-tabs.css': 386,
     'sillybunny-chat-styles.css': 225,
-    'sillybunny-theme.css': 158,
+    'sillybunny-theme.css': 161,
 });
 
 const FORK_DISTINCT_BREAKPOINT_BUDGET = 18;

--- a/tests/sillybunny-accent-profiles.test.js
+++ b/tests/sillybunny-accent-profiles.test.js
@@ -57,7 +57,7 @@ describe('SillyBunny accent color profiles', () => {
         expect(indexSource).toContain('id="sb-accent-profiles-empty"');
         expect(indexSource).toContain('class="inline-drawer-toggle sb-accent-profiles-toggle"');
         expect(indexSource).toContain('class="inline-drawer-content sb-accent-profiles-content"');
-        expect(indexSource).toContain('css/sillybunny-theme.css?v=20260621a');
+        expect(indexSource).toContain('css/sillybunny-theme.css?v=');
         expect(powerUserSource).toContain('const SB_ACCENT_PROFILES_DRAWER_KEY = \'SBAccentProfilesDrawerExpanded\';');
         expect(powerUserSource).toContain('function bindSbAccentProfilesDrawerPersistence()');
         expect(powerUserSource).toContain('accountStorage.getItem(SB_ACCENT_PROFILES_DRAWER_KEY)');


### PR DESCRIPTION
This PR focuses on ~~three~~ ~~six~~ ~~seven~~ eight (added by Pura) things:

1- Making sure the card spec validator errors correctly on benign actions (current state was that the error was card spec V3's no matter what error was actually occurring)
2-  If a bulk favorite action was performed, even on failed card validation checks (like the above point fixes), the previous behavior would mark `is_fav` anyway, even if it didn't save. This makes the failure clear at least.
3- The hotswap bar actually scrolls now with favorites populating it. If you've got more than it can display, that is. There used to be a 25 fav limit. Now that's 250.
4- Hotswap bar centering and cleanup
5- Editor Avatar preview - image is now always going to show the entire character image instead of just a cropped variant
6- Favorites strip vs. mode toggle/close button - CSS to ensure the favorites bar and close/mode switch don't overlap. Also, the mode toggle pills have the cursor change to a pointer.
7- Fixing scrolling of said favorites on mobile after the fixes above.
8- Centers icons on the character drawer no matter what, so the damn avatars don't go to one edge or another randomly.

Code review done:
- Scrolling over a long Favorites bar no longer disables Ctrl/Command zoom.
- Normal mouse-wheel scrolling still moves the Favorites bar sideways.
- Fixed the two CI failures caused by the CSS change and stylesheet cache refresh.
- Added an automated browser test so this zoom issue stays fixed.