### PR TITLE
fix(continue): continue button also works when thinking is interrupted

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -127,7 +127,7 @@ import {
 } from './scripts/openai.js';
 import {
     extractOocBlocksForDisplay,
-    hasTextOrArrayPayload,
+    hasPromptPayload,
     shouldRetainContextAtDepth,
     restoreOocBlocksForDisplay,
     stripHtmlTagsFromContext,
@@ -3799,19 +3799,6 @@ function notifyCardScriptStripped(messageElement, messageId) {
 }
 
 /**
- * Checks whether a prompt message still carries non-text payload after OOC text is removed.
- * @param {object} chatItem Message history item.
- * @returns {boolean} True if the prompt item should remain in context.
- */
-function hasPromptPayload(chatItem) {
-    return hasTextOrArrayPayload(chatItem?.mes, [
-        chatItem?.extra?.media,
-        chatItem?.extra?.files,
-        chatItem?.extra?.tool_invocations,
-    ]);
-}
-
-/**
  * Creates an Image element for the given API/model icon.
  * The image references the matching SVG file from `/img/` and includes a tooltip with API and model info.
  * The caller is responsible for appending the image to the DOM and optionally calling `SVGInject` on it.
@@ -7070,7 +7057,11 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         const variant = worldInfoMessageVariants.get(chatItem.index);
         return variant && !hasPromptPayload(chatItem) && hasPromptPayload({ ...chatItem, mes: variant.worldInfo });
     });
-    coreChat = coreChat.filter(hasPromptPayload);
+    // SillyBunny: preserve an interrupted reasoning-only prefix when continuing.
+    coreChat = coreChat.filter((chatItem, index) => hasPromptPayload(
+        chatItem,
+        isContinue && index === coreChat.length - 1,
+    ));
 
     const promptReasoning = new PromptReasoning();
     for (let i = coreChat.length - 1; i >= 0; i--) {

--- a/public/scripts/ooc-blocks.js
+++ b/public/scripts/ooc-blocks.js
@@ -197,3 +197,17 @@ export function hasTextOrArrayPayload(text, payloads = []) {
     return String(text ?? '').trim().length > 0
         || payloads.some(payload => Array.isArray(payload) && payload.length > 0);
 }
+
+/**
+ * Checks whether a prompt message still carries payload after OOC text is removed.
+ * @param {object} chatItem Message history item.
+ * @param {boolean} [includeReasoning=false] Whether reasoning can retain the message.
+ * @returns {boolean} True if the prompt item should remain in context.
+ */
+export function hasPromptPayload(chatItem, includeReasoning = false) {
+    return hasTextOrArrayPayload(chatItem?.mes, [
+        chatItem?.extra?.media,
+        chatItem?.extra?.files,
+        chatItem?.extra?.tool_invocations,
+    ]) || (includeReasoning && String(chatItem?.extra?.reasoning ?? '').trim().length > 0);
+}

--- a/tests/ooc-blocks.test.js
+++ b/tests/ooc-blocks.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect } from '@jest/globals';
 
 import {
     extractOocBlocksForDisplay,
+    hasPromptPayload,
     hasTextOrArrayPayload,
     normalizeContextRetentionDepth,
     renderOocBlock,
@@ -64,6 +65,21 @@ describe('OOC block handling', () => {
         expect(hasTextOrArrayPayload('', [[], [{ id: 'tool-call' }]])).toBe(true);
         expect(hasTextOrArrayPayload(stripOocBlocksFromContext('((note only))'), [])).toBe(false);
         expect(hasTextOrArrayPayload('', [[], undefined])).toBe(false);
+    });
+
+    test('keeps reasoning-only prompt messages only for continuation', () => {
+        const message = { mes: '', extra: { reasoning: 'partial reasoning' } };
+
+        expect(hasPromptPayload(message)).toBe(false);
+        expect(hasPromptPayload(message, true)).toBe(true);
+        expect(hasPromptPayload({ mes: '', extra: { reasoning: '   ' } }, true)).toBe(false);
+    });
+
+    test('keeps non-text prompt payloads without continuation reasoning', () => {
+        expect(hasPromptPayload({ mes: '', extra: { media: [{ url: 'image.png' }] } })).toBe(true);
+        expect(hasPromptPayload({ mes: '', extra: { files: [{ name: 'file.txt' }] } })).toBe(true);
+        expect(hasPromptPayload({ mes: '', extra: { tool_invocations: [{ id: 'tool-call' }] } })).toBe(true);
+        expect(hasPromptPayload({ mes: '' })).toBe(false);
     });
 
     test('normalizes context retention depth with -1 as preserve-all default', () => {


### PR DESCRIPTION
Sometmes your internet goes down or there's an upstream error that causes the thinking to be interrupted. Trying to continue makes the LLM act as though the thinking never happened and starts over again.

This PR allows Continue to work even on interrupted thinking blocks.

## Fix
- Found that interrupted “thinking” was being discarded when pressing Continue.
- Changed Continue to preserve and resume the unfinished thinking.
- Kept normal messages and unrelated hidden content behaving as before.
- Added tests covering interrupted thinking and other message types.