### PR TITLE
fix(ios): add exception to viewport fix on message box

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -119,17 +119,9 @@ function isMobileShellPanelEditable(element) {
 function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {
     let resetScheduled = false;
 
-    // SillyBunny: while the chat composer is held above the iOS keyboard
-    // (sb-ios-composer-keyboard-inset-active, see getComposerKeyboardInset in
-    // sillybunny-tabs.js), resetting the document scroll cannot hide the
-    // focused caret, so Safari's force-scroll to reveal it must be snapped
-    // back even mid-edit instead of sticking until blur.
-    const isComposerHeldAboveKeyboard = () => document.documentElement.classList.contains('sb-ios-composer-keyboard-inset-active');
-
     const shouldSuspendDocumentScrollReset = () => suspendWhileEditing
         && isEditableFocusTarget(document.activeElement)
-        && !isMobileShellPanelEditable(document.activeElement)
-        && !isComposerHeldAboveKeyboard();
+        && !isMobileShellPanelEditable(document.activeElement);
 
     const resetDocumentScroll = () => {
         if (shouldSuspendDocumentScrollReset()) {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2510,84 +2510,6 @@ function isVisualViewportKeyboardOpen(layoutViewport = getLayoutViewportSize(), 
     return keyboardHeight > 80 || visualViewportSize.top > 2;
 }
 
-const MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX = 8;
-const MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS = 700;
-const MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX = 80;
-
-let sbLastIOSKeyboardHeight = 0;
-let sbComposerKeyboardPreShiftDeadline = 0;
-let sbComposerKeyboardSettleTimer = 0;
-
-/**
- * SillyBunny: iOS Safari reveals a focused caret hidden behind the software
- * keyboard by panning the visual viewport and force-scrolling the document,
- * which pushes the fixed shell off screen (the composer-at-top escape).
- * Instead of chasing that pan, give up the keyboard's height while the chat
- * composer is focused: the shell keeps its stable layout top but shrinks so
- * the composer sits above the keyboard and Safari has nothing to reveal. The
- * last measured keyboard height pre-shrinks the shell right after focus,
- * before the keyboard finishes animating, so the reveal never triggers.
- */
-function getComposerKeyboardInset(layoutViewport, visualViewportSize) {
-    if (!isIOSWebKitPlatform() || !isMobileViewport()) {
-        return 0;
-    }
-
-    const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);
-    if (keyboardHeight > MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX) {
-        sbLastIOSKeyboardHeight = keyboardHeight;
-    }
-
-    if (!isChatComposerEditableElement(document.activeElement)) {
-        return 0;
-    }
-
-    const withinPreShiftWindow = Date.now() < sbComposerKeyboardPreShiftDeadline;
-
-    if (isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
-        // Safari already panned the visual viewport (e.g. the first focus of a
-        // session, before any keyboard height is known). Shrinking now would
-        // push the composer to the top of the panned slice with a void below;
-        // keep the stable layout and let the clamped pan frame the composer.
-        if (visualViewportSize.top > MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX) {
-            return 0;
-        }
-
-        // Hold the pre-shift height through the opening animation so interim
-        // resize events cannot bounce the shell; settle on the measured height.
-        return withinPreShiftWindow ? Math.max(keyboardHeight, sbLastIOSKeyboardHeight) : keyboardHeight;
-    }
-
-    // Keyboard not open yet: pre-shrink with the remembered height in the
-    // window right after composer focus so the shell is already short when
-    // the keyboard arrives and the caret never sits behind it.
-    return withinPreShiftWindow ? sbLastIOSKeyboardHeight : 0;
-}
-
-function handleComposerKeyboardFocusIn(event) {
-    if (!isIOSWebKitPlatform() || !isMobileViewport()) {
-        return;
-    }
-
-    if (isChatComposerEditableElement(event.target)) {
-        sbComposerKeyboardPreShiftDeadline = Date.now() + MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS;
-        window.clearTimeout(sbComposerKeyboardSettleTimer);
-        // Re-sync after the pre-shift window closes so the shell settles on
-        // the measured keyboard height even if no viewport events fire.
-        sbComposerKeyboardSettleTimer = window.setTimeout(queueMobileViewportStateSync, MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS + 50);
-    }
-
-    queueMobileViewportStateSync();
-}
-
-function handleMobileKeyboardFocusOut() {
-    if (!isIOSWebKitPlatform() || !isMobileViewport()) {
-        return;
-    }
-
-    queueMobileViewportStateSync();
-}
-
 function syncIOSKeyboardBottomInset() {
     const root = document.documentElement;
     let bottomInset = 0;
@@ -2615,15 +2537,6 @@ function syncIOSKeyboardBottomInset() {
 function getShellViewportSize() {
     const layoutViewport = getLayoutViewportSize();
     const visualViewportSize = getVisualViewportSize(layoutViewport);
-
-    // SillyBunny: composer edits keep the stable layout top but give up the
-    // keyboard's height so the focused composer sits above the keyboard and
-    // Safari never pans or force-scrolls the document to reveal the caret.
-    const composerKeyboardInset = getComposerKeyboardInset(layoutViewport, visualViewportSize);
-    if (composerKeyboardInset > 0) {
-        const height = Math.max(0, layoutViewport.height - composerKeyboardInset);
-        return { ...layoutViewport, height, bottom: height };
-    }
 
     // SillyBunny: iOS keyboard edits inside shell panels or the chat composer
     // should not feed Safari visualViewport jitter back into shell geometry.
@@ -2655,12 +2568,6 @@ function syncShellViewportBounds() {
     // SillyBunny: iOS Safari shifts the visual viewport while the keyboard opens;
     // keyboard edit paths intentionally keep the stable layout top.
     setRootViewportProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
-
-    // SillyBunny: while the composer is held above the iOS keyboard the
-    // document scroll anchor may run mid-edit (see browser-fixes.js), because
-    // resetting the document scroll can no longer hide the focused caret.
-    const composerKeyboardInset = getComposerKeyboardInset(getLayoutViewportSize(), getVisualViewportSize());
-    root.classList.toggle('sb-ios-composer-keyboard-inset-active', composerKeyboardInset > 0);
 }
 
 function getMobileFocusedInputScroller(target) {
@@ -16588,13 +16495,6 @@ function initAll() {
     if (isIOSWebKitPlatform()) {
         document.addEventListener('focusin', syncIOSKeyboardBottomInset);
         document.addEventListener('focusout', syncIOSKeyboardBottomInset);
-
-        // SillyBunny: pre-shrink the shell before the iOS keyboard finishes
-        // opening on composer focus, and re-sync shell bounds whenever keyboard
-        // focus moves so stable-viewport decisions never linger on stale focus
-        // state (see getComposerKeyboardInset).
-        document.addEventListener('focusin', handleComposerKeyboardFocusIn);
-        document.addEventListener('focusout', handleMobileKeyboardFocusOut);
     }
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -487,12 +487,10 @@ describe('mobile shell lifecycle wiring', () => {
     test('settles mobile viewport reset without reapplying the fixed-position workaround', () => {
         expect(browserFixesSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
         expect(browserFixesSource).toContain('function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {');
-        expect(browserFixesSource).toContain('const isComposerHeldAboveKeyboard = () => document.documentElement.classList.contains(\'sb-ios-composer-keyboard-inset-active\');');
         expect(browserFixesSource).toContain('function isMobileShellPanelEditable(element) {');
         expect(browserFixesSource).toContain('const shouldSuspendDocumentScrollReset = () => suspendWhileEditing');
         expect(browserFixesSource).toContain('&& isEditableFocusTarget(document.activeElement)');
-        expect(browserFixesSource).toContain('&& !isMobileShellPanelEditable(document.activeElement)');
-        expect(browserFixesSource).toContain('&& !isComposerHeldAboveKeyboard();');
+        expect(browserFixesSource).toContain('&& !isMobileShellPanelEditable(document.activeElement);');
         expect(browserFixesSource).toContain('if (shouldSuspendDocumentScrollReset()) {');
         expect(browserFixesSource).toContain('if (resetScheduled || shouldSuspendDocumentScrollReset()) {');
         expect(browserFixesSource).toContain('document.addEventListener(\'focusout\', scheduleDocumentScrollReset, true);');
@@ -605,39 +603,15 @@ describe('mobile shell lifecycle wiring', () => {
         );
     });
 
-    test('holds the focused composer above the iOS keyboard instead of letting Safari reveal the caret', () => {
-        const getComposerKeyboardInsetSource = getFunctionSource('getComposerKeyboardInset');
+    test('keeps the iOS composer on stable viewport bounds without keyboard inset resizing', () => {
         const getShellViewportSizeSource = getFunctionSource('getShellViewportSize');
-        const handleComposerKeyboardFocusInSource = getFunctionSource('handleComposerKeyboardFocusIn');
-        const syncShellViewportBoundsSource = getFunctionSource('syncShellViewportBounds');
 
-        // The shell gives up the keyboard's height during composer edits while
-        // keeping the stable layout top, so the caret never sits behind the
-        // keyboard and Safari has no reason to pan or force-scroll the document.
-        expect(getComposerKeyboardInsetSource).toContain('if (!isIOSWebKitPlatform() || !isMobileViewport()) {');
-        expect(getComposerKeyboardInsetSource).toContain('const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);');
-        expect(getComposerKeyboardInsetSource).toContain('sbLastIOSKeyboardHeight = keyboardHeight;');
-        expect(getComposerKeyboardInsetSource).toContain('if (!isChatComposerEditableElement(document.activeElement)) {');
-        expect(getShellViewportSizeSource).toContain('const composerKeyboardInset = getComposerKeyboardInset(layoutViewport, visualViewportSize);');
-        expect(getShellViewportSizeSource).toContain('const height = Math.max(0, layoutViewport.height - composerKeyboardInset);');
-        expect(getShellViewportSizeSource).toContain('return { ...layoutViewport, height, bottom: height };');
-
-        // If Safari already panned the visual viewport, shrinking would push the
-        // composer to the top of the panned slice with a void below it (the
-        // escape this fix removes) - keep the stable layout in that case.
-        expect(getComposerKeyboardInsetSource).toContain('if (visualViewportSize.top > MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX) {');
-
-        // The remembered keyboard height pre-shrinks the shell on focus, before
-        // the keyboard finishes opening, so the reveal never triggers at all.
-        expect(getComposerKeyboardInsetSource).toContain('return withinPreShiftWindow ? sbLastIOSKeyboardHeight : 0;');
-        expect(handleComposerKeyboardFocusInSource).toContain('sbComposerKeyboardPreShiftDeadline = Date.now() + MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS;');
-        expect(handleComposerKeyboardFocusInSource).toContain('queueMobileViewportStateSync();');
-        expect(tabsSource).toContain('document.addEventListener(\'focusin\', handleComposerKeyboardFocusIn);');
-        expect(tabsSource).toContain('document.addEventListener(\'focusout\', handleMobileKeyboardFocusOut);');
-
-        // browser-fixes.js reads this class to re-arm the document scroll
-        // anchor mid-edit while the composer is held clear of the keyboard.
-        expect(syncShellViewportBoundsSource).toContain('root.classList.toggle(\'sb-ios-composer-keyboard-inset-active\', composerKeyboardInset > 0);');
+        expect(getShellViewportSizeSource).toContain('if (shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize)) {');
+        expect(getShellViewportSizeSource).toContain('return layoutViewport;');
+        expect(tabsSource).not.toContain('function getComposerKeyboardInset(');
+        expect(tabsSource).not.toContain('handleComposerKeyboardFocusIn');
+        expect(tabsSource).not.toContain('sb-ios-composer-keyboard-inset-active');
+        expect(browserFixesSource).not.toContain('isComposerHeldAboveKeyboard');
     });
 
     test('routes mobile viewport sync planning through the lifecycle seam', () => {


### PR DESCRIPTION
This PR https://github.com/platberlitz/SillyBunny/pull/658 resolved the viewport constantly moving up in iOS WebKit. However, an exception must be made so that the message bar you use to chat doesn't keep jumping up and doing the same fix that must be done on other areas like the menu.

In essence, this is supposed to keep the previous behaviour for the message box only in iOS WebKit.

## Fix
- Stopped the iPhone chat box from jumping upward when the keyboard opens.
- Kept the keyboard fix working in menus and settings.
- Added a test to prevent the issue returning.