### PR TITLE
fix(mobile): remove icon overlap on message box

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -82,7 +82,7 @@
         grid-template-rows: minmax(var(--sb-mobile-composer-input-height), auto) !important;
         grid-template-areas: 'tools input action' !important;
         align-items: center !important;
-        gap: 0 4px !important;
+        gap: 0 clamp(10px, 3vw, 14px) !important;
         min-height: calc(var(--sb-mobile-composer-input-height) + 4px) !important;
         padding: 2px 4px !important;
         box-sizing: border-box !important;
@@ -96,7 +96,7 @@
         --sb-composer-action-icon-size: clamp(9px, calc(11px * var(--sb-bottom-bar-scale, 1)), 16px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));
         --sb-composer-right-rail-width: calc(var(--sb-composer-action-size) + var(--sb-composer-send-width) + 2px);
-        gap: 0 3px !important;
+        gap: 0 clamp(10px, 3vw, 14px) !important;
     }
 
     #leftSendForm {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2810,7 +2810,7 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         --sb-composer-action-icon-size: clamp(10px, calc(12px * var(--sb-bottom-bar-scale, 1)), 17px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));
         --sb-composer-right-rail-width: calc(var(--sb-composer-action-size) + var(--sb-composer-send-width) + 2px);
-        gap: 0 3px !important;
+        gap: 0 clamp(10px, 3vw, 14px) !important;
         min-height: calc(var(--sb-mobile-composer-input-height) + 3px) !important;
         padding: 1px 4px !important;
     }

--- a/tests/mobile-composer-spacing.e2e.js
+++ b/tests/mobile-composer-spacing.e2e.js
@@ -1,0 +1,57 @@
+/* global document, getComputedStyle */
+import { expect, test } from '@playwright/test';
+import { openQuietChatForSmoke, waitForAnimationFrames } from './chat-scroll-regression-helpers.js';
+
+const IPHONE_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+function getComposerSpacing(page) {
+    return page.evaluate(() => {
+        const composer = document.getElementById('nonQRFormItems');
+        const textareaRect = document.getElementById('send_textarea')?.getBoundingClientRect();
+        const getVisibleControlRects = id => Array.from(document.getElementById(id)?.children ?? [])
+            .map(element => element.getBoundingClientRect())
+            .filter(rect => rect.width > 0 && rect.height > 0);
+        const leftControlRects = getVisibleControlRects('leftSendForm');
+        const rightControlRects = getVisibleControlRects('rightSendForm');
+
+        if (!composer || !textareaRect || leftControlRects.length === 0 || rightControlRects.length === 0) {
+            return null;
+        }
+
+        return {
+            columnGap: Number.parseFloat(getComputedStyle(composer).columnGap),
+            leftClearance: textareaRect.left - Math.max(...leftControlRects.map(rect => rect.right)),
+            rightClearance: Math.min(...rightControlRects.map(rect => rect.left)) - textareaRect.right,
+        };
+    });
+}
+
+test.describe('mobile composer spacing at 320x568', () => {
+    test.use({
+        viewport: { width: 320, height: 568 },
+        isMobile: true,
+        hasTouch: true,
+        userAgent: IPHONE_USER_AGENT,
+    });
+
+    test('normal and compact modes keep the action rails clear of the textarea', async ({ page }) => {
+        await openQuietChatForSmoke(page, { selectCharacter: false });
+
+        await page.evaluate(() => {
+            document.documentElement.style.setProperty('--sb-bottom-bar-scale', '1.5');
+            document.getElementById('send_but')?.classList.remove('displayNone');
+        });
+
+        for (const compactMode of ['false', 'true']) {
+            await page.evaluate(mode => document.documentElement.setAttribute('data-sb-compact-mode', mode), compactMode);
+            await waitForAnimationFrames(page, 2);
+
+            const spacing = await getComposerSpacing(page);
+
+            expect(spacing).not.toBeNull();
+            expect(spacing.columnGap).toBeGreaterThanOrEqual(10);
+            expect(spacing.leftClearance).toBeGreaterThanOrEqual(6);
+            expect(spacing.rightClearance).toBeGreaterThanOrEqual(6);
+        }
+    });
+});

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -75,6 +75,26 @@ function getComposerViewportFit(page) {
     });
 }
 
+function getComposerControlGaps(page) {
+    return page.evaluate(() => {
+        const textareaRect = document.getElementById('send_textarea')?.getBoundingClientRect();
+        const visibleControlRects = id => Array.from(document.getElementById(id)?.children ?? [])
+            .map(element => element.getBoundingClientRect())
+            .filter(rect => rect.width > 0 && rect.height > 0);
+        const leftControlRects = visibleControlRects('leftSendForm');
+        const rightControlRects = visibleControlRects('rightSendForm');
+
+        if (!textareaRect || leftControlRects.length === 0 || rightControlRects.length === 0) {
+            return null;
+        }
+
+        return {
+            left: textareaRect.left - Math.max(...leftControlRects.map(rect => rect.right)),
+            right: Math.min(...rightControlRects.map(rect => rect.left)) - textareaRect.right,
+        };
+    });
+}
+
 function getHorizontalOverflow(page) {
     return page.evaluate(() => {
         const root = document.documentElement;
@@ -365,17 +385,32 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
         userAgent: IPHONE_USER_AGENT,
     });
 
-    test('composer fits and the send target keeps its current floor', async ({ page }) => {
+    test('composer controls clear the textarea and keep the current send target floor', async ({ page }) => {
         await openQuietChatForSmoke(page, { selectCharacter: false });
 
         // Compact mode and connection state come from the linked user profile;
         // normalize both so this measures the stylesheet contract, not the
         // profile. The displayNone class on #send_but is only a connection
-        // visibility gate (RossAscends-mods.js), not a sizing rule.
+        // visibility gate (RossAscends-mods.js), not a sizing rule. The optional
+        // tracker panel is fixed off-canvas, outside the composer contract.
         await page.evaluate(() => {
-            document.documentElement.setAttribute('data-sb-compact-mode', 'false');
+            document.documentElement.style.setProperty('--sb-bottom-bar-scale', '1.5');
             document.getElementById('send_but')?.classList.remove('displayNone');
+            document.getElementById('ica--tracker-panel')?.remove();
         });
+
+        for (const compactMode of ['true', 'false']) {
+            await page.evaluate(mode => document.documentElement.setAttribute('data-sb-compact-mode', mode), compactMode);
+            await waitForAnimationFrames(page, 2);
+
+            const controlGaps = await getComposerControlGaps(page);
+
+            expect(controlGaps).not.toBeNull();
+            expect(controlGaps.left).toBeGreaterThanOrEqual(6);
+            expect(controlGaps.right).toBeGreaterThanOrEqual(6);
+        }
+
+        await page.evaluate(() => document.documentElement.style.setProperty('--sb-bottom-bar-scale', '1'));
         await waitForAnimationFrames(page, 2);
 
         const sendButtonBox = await page.locator('#send_but').boundingBox();

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -75,26 +75,6 @@ function getComposerViewportFit(page) {
     });
 }
 
-function getComposerControlGaps(page) {
-    return page.evaluate(() => {
-        const textareaRect = document.getElementById('send_textarea')?.getBoundingClientRect();
-        const visibleControlRects = id => Array.from(document.getElementById(id)?.children ?? [])
-            .map(element => element.getBoundingClientRect())
-            .filter(rect => rect.width > 0 && rect.height > 0);
-        const leftControlRects = visibleControlRects('leftSendForm');
-        const rightControlRects = visibleControlRects('rightSendForm');
-
-        if (!textareaRect || leftControlRects.length === 0 || rightControlRects.length === 0) {
-            return null;
-        }
-
-        return {
-            left: textareaRect.left - Math.max(...leftControlRects.map(rect => rect.right)),
-            right: Math.min(...rightControlRects.map(rect => rect.left)) - textareaRect.right,
-        };
-    });
-}
-
 function getHorizontalOverflow(page) {
     return page.evaluate(() => {
         const root = document.documentElement;
@@ -385,32 +365,17 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
         userAgent: IPHONE_USER_AGENT,
     });
 
-    test('composer controls clear the textarea and keep the current send target floor', async ({ page }) => {
+    test('composer fits and the send target keeps its current floor', async ({ page }) => {
         await openQuietChatForSmoke(page, { selectCharacter: false });
 
         // Compact mode and connection state come from the linked user profile;
         // normalize both so this measures the stylesheet contract, not the
         // profile. The displayNone class on #send_but is only a connection
-        // visibility gate (RossAscends-mods.js), not a sizing rule. The optional
-        // tracker panel is fixed off-canvas, outside the composer contract.
+        // visibility gate (RossAscends-mods.js), not a sizing rule.
         await page.evaluate(() => {
-            document.documentElement.style.setProperty('--sb-bottom-bar-scale', '1.5');
+            document.documentElement.setAttribute('data-sb-compact-mode', 'false');
             document.getElementById('send_but')?.classList.remove('displayNone');
-            document.getElementById('ica--tracker-panel')?.remove();
         });
-
-        for (const compactMode of ['true', 'false']) {
-            await page.evaluate(mode => document.documentElement.setAttribute('data-sb-compact-mode', mode), compactMode);
-            await waitForAnimationFrames(page, 2);
-
-            const controlGaps = await getComposerControlGaps(page);
-
-            expect(controlGaps).not.toBeNull();
-            expect(controlGaps.left).toBeGreaterThanOrEqual(6);
-            expect(controlGaps.right).toBeGreaterThanOrEqual(6);
-        }
-
-        await page.evaluate(() => document.documentElement.style.setProperty('--sb-bottom-bar-scale', '1'));
         await waitForAnimationFrames(page, 2);
 
         const sendButtonBox = await page.locator('#send_but').boundingBox();


### PR DESCRIPTION
In mobile, icons always seem to overlap on the message box. This PR addresses that.

## Fix
- Added more space between the message box and the icons on both sides.
- Kept all existing icons visible and functional.
- Added a test to prevent the overlap from returning.

### Before
<img width="1179" height="195" alt="image" src="https://github.com/user-attachments/assets/6d23c92d-18dd-4c0e-a6f5-3b400accaded" />

### After
<img width="1179" height="307" alt="image" src="https://github.com/user-attachments/assets/b0840d4c-43db-4be4-8c6b-34ba5689290e" />
