### PR TITLE
fix(tts): TTS extension only considers actual quotes

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -713,6 +713,13 @@ async function processTtsQueue() {
         text = text.replace(/~~~.*?~~~/gs, '').trim();
     }
 
+    // SillyBunny: Strip tag markup before quote extraction so wrappers preserve dialogue without narrating attributes.
+    if (extension_settings.tts.narrate_quoted_only) {
+        const partJoiner = (ttsProvider?.separator || ' ... ');
+        text = text.replace(/<.*?>/g, '').trim();
+        text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });
+    }
+
     if (extension_settings.tts.skip_tags) {
         text = text.replace(/<.*?>[\s\S]*?<\/.*?>/g, '').trim();
     }
@@ -731,11 +738,6 @@ async function processTtsQueue() {
         } else {
             console.warn('Invalid regex pattern:', extension_settings.tts.regex_pattern);
         }
-    }
-
-    if (extension_settings.tts.narrate_quoted_only) {
-        const partJoiner = (ttsProvider?.separator || ' ... ');
-        text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });
     }
 
     // Remove embedded images

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -632,6 +632,25 @@ function parseMessageSegments(text) {
     return segments;
 }
 
+// SillyBunny: discard semantic blocks before quote extraction without dropping dialogue wrapped in presentation tags.
+function stripTtsTaggedBlocks(text, { preserveFormatting = false } = {}) {
+    const formattingTags = new Set([
+        'b', 'big', 'em', 'font', 'i', 'mark', 's', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'u',
+    ]);
+    let filteredText = String(text ?? '');
+    let previousText;
+
+    do {
+        previousText = filteredText;
+        filteredText = filteredText.replace(
+            /<([a-z][\w:-]*)\b[^>]*>([\s\S]*?)<\/\1\s*>/gi,
+            (_block, tagName, content) => preserveFormatting && formattingTags.has(tagName.toLowerCase()) ? content : '',
+        );
+    } while (filteredText !== previousText);
+
+    return filteredText;
+}
+
 async function processTtsQueue() {
     // Called each moduleWorker iteration to pull chat messages from queue
     if (currentTtsJob || ttsJobQueue.length <= 0 || audioPaused) {
@@ -716,6 +735,9 @@ async function processTtsQueue() {
     // SillyBunny: Strip tag markup before quote extraction so wrappers preserve dialogue without narrating attributes.
     if (extension_settings.tts.narrate_quoted_only) {
         const partJoiner = (ttsProvider?.separator || ' ... ');
+        if (extension_settings.tts.skip_tags) {
+            text = stripTtsTaggedBlocks(text, { preserveFormatting: true });
+        }
         text = text.replace(/<.*?>/g, '').trim();
         text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });
     }

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -632,6 +632,17 @@ function parseMessageSegments(text) {
     return segments;
 }
 
+// SillyBunny: filter action blocks before quote extraction so quoted actions remain excluded from dialogue-only narration.
+function filterTtsAsterisks(text, { narrateDialoguesOnly = false, passAsterisks = false } = {}) {
+    if (passAsterisks) {
+        return text;
+    }
+
+    return narrateDialoguesOnly
+        ? text.replace(/\*[^*]*?(\*|$)/g, '').trim()
+        : text.replaceAll('*', '').trim();
+}
+
 // SillyBunny: discard semantic blocks before quote extraction without dropping dialogue wrapped in presentation tags.
 function stripTtsTaggedBlocks(text, { preserveFormatting = false } = {}) {
     const formattingTags = new Set([
@@ -732,6 +743,11 @@ async function processTtsQueue() {
         text = text.replace(/~~~.*?~~~/gs, '').trim();
     }
 
+    text = filterTtsAsterisks(text, {
+        narrateDialoguesOnly: extension_settings.tts.narrate_dialogues_only,
+        passAsterisks: extension_settings.tts.pass_asterisks,
+    });
+
     // SillyBunny: Strip tag markup before quote extraction so wrappers preserve dialogue without narrating attributes.
     if (extension_settings.tts.narrate_quoted_only) {
         const partJoiner = (ttsProvider?.separator || ' ... ');
@@ -744,12 +760,6 @@ async function processTtsQueue() {
 
     if (extension_settings.tts.skip_tags) {
         text = text.replace(/<.*?>[\s\S]*?<\/.*?>/g, '').trim();
-    }
-
-    if (!extension_settings.tts.pass_asterisks) {
-        text = extension_settings.tts.narrate_dialogues_only
-            ? text.replace(/\*[^*]*?(\*|$)/g, '').trim() // remove asterisks content
-            : text.replaceAll('*', '').trim(); // remove just the asterisks
     }
 
     if (extension_settings.tts.apply_regex && extension_settings.tts.regex_pattern) {

--- a/tests/tts-quoted-only-filtering.test.js
+++ b/tests/tts-quoted-only-filtering.test.js
@@ -2,25 +2,29 @@ import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
 
-const ttsSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/extensions/tts/index.js', import.meta.url)), 'utf8');
+const ttsSource = (await fs.readFile(fileURLToPath(new URL('../public/scripts/extensions/tts/index.js', import.meta.url)), 'utf8')).replace(/\r\n/g, '\n');
+const stripTtsTaggedBlocksStart = ttsSource.indexOf('function stripTtsTaggedBlocks(');
+const stripTtsTaggedBlocksEnd = ttsSource.indexOf('async function processTtsQueue()', stripTtsTaggedBlocksStart);
+const stripTtsTaggedBlocks = vm.runInNewContext(`(${ttsSource.slice(stripTtsTaggedBlocksStart, stripTtsTaggedBlocksEnd)})`);
 const joinQuotedBlocksStart = ttsSource.indexOf('function joinQuotedBlocks(');
-const joinQuotedBlocksEnd = ttsSource.indexOf('\n\nasync function playFullConversation()', joinQuotedBlocksStart);
+const joinQuotedBlocksEnd = ttsSource.indexOf('async function playFullConversation()', joinQuotedBlocksStart);
 const joinQuotedBlocks = vm.runInNewContext(`(${ttsSource.slice(joinQuotedBlocksStart, joinQuotedBlocksEnd)})`);
 
 describe('TTS quoted-only filtering', () => {
-    test('extracts quoted dialogue before removing tagged blocks', () => {
+    test('filters semantic blocks before extracting quoted dialogue', () => {
         const processTtsQueueBody = ttsSource.slice(
             ttsSource.indexOf('async function processTtsQueue()'),
             ttsSource.indexOf('/**\n * Extract and join quoted blocks'),
         );
         const quotedOnlyIndex = processTtsQueueBody.indexOf('if (extension_settings.tts.narrate_quoted_only)');
-        const skipTagsIndex = processTtsQueueBody.indexOf('if (extension_settings.tts.skip_tags)');
+        const taggedBlockFilterIndex = processTtsQueueBody.indexOf('text = stripTtsTaggedBlocks(text, { preserveFormatting: true });', quotedOnlyIndex);
+        const markupFilterIndex = processTtsQueueBody.indexOf('text = text.replace(/<.*?>/g, \'\').trim();', quotedOnlyIndex);
+        const quoteExtractionIndex = processTtsQueueBody.indexOf('text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });', quotedOnlyIndex);
 
         expect(quotedOnlyIndex).toBeGreaterThanOrEqual(0);
-        expect(skipTagsIndex).toBeGreaterThanOrEqual(0);
-        expect(quotedOnlyIndex).toBeLessThan(skipTagsIndex);
-        expect(processTtsQueueBody.slice(quotedOnlyIndex, skipTagsIndex))
-            .toContain('text = text.replace(/<.*?>/g, \'\').trim();\n        text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });');
+        expect(taggedBlockFilterIndex).toBeGreaterThan(quotedOnlyIndex);
+        expect(markupFilterIndex).toBeGreaterThan(taggedBlockFilterIndex);
+        expect(quoteExtractionIndex).toBeGreaterThan(markupFilterIndex);
     });
 
     test('does not treat quoted font attributes as dialogue', () => {
@@ -29,5 +33,14 @@ describe('TTS quoted-only filtering', () => {
 
         expect(joinQuotedBlocks(textWithoutTagMarkup, { includeQuotes: true }))
             .toBe('"More water. That fire\'s dying. Move, girl, move."');
+    });
+
+    test('drops quoted semantic blocks while preserving dialogue inside formatting wrappers', () => {
+        const taggedDialogue = '<think>"Keep this hidden."</think><font color="#c8a86e">"Speak this aloud."</font>';
+        const filteredText = stripTtsTaggedBlocks(taggedDialogue, { preserveFormatting: true });
+        const textWithoutTagMarkup = filteredText.replace(/<.*?>/g, '').trim();
+
+        expect(joinQuotedBlocks(textWithoutTagMarkup, { includeQuotes: true }))
+            .toBe('"Speak this aloud."');
     });
 });

--- a/tests/tts-quoted-only-filtering.test.js
+++ b/tests/tts-quoted-only-filtering.test.js
@@ -16,15 +16,34 @@ describe('TTS quoted-only filtering', () => {
             ttsSource.indexOf('async function processTtsQueue()'),
             ttsSource.indexOf('/**\n * Extract and join quoted blocks'),
         );
+        const asteriskFilterIndex = processTtsQueueBody.indexOf('text = filterTtsAsterisks(text, {');
         const quotedOnlyIndex = processTtsQueueBody.indexOf('if (extension_settings.tts.narrate_quoted_only)');
         const taggedBlockFilterIndex = processTtsQueueBody.indexOf('text = stripTtsTaggedBlocks(text, { preserveFormatting: true });', quotedOnlyIndex);
         const markupFilterIndex = processTtsQueueBody.indexOf('text = text.replace(/<.*?>/g, \'\').trim();', quotedOnlyIndex);
         const quoteExtractionIndex = processTtsQueueBody.indexOf('text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });', quotedOnlyIndex);
 
+        expect(asteriskFilterIndex).toBeGreaterThanOrEqual(0);
+        expect(asteriskFilterIndex).toBeLessThan(quotedOnlyIndex);
         expect(quotedOnlyIndex).toBeGreaterThanOrEqual(0);
         expect(taggedBlockFilterIndex).toBeGreaterThan(quotedOnlyIndex);
         expect(markupFilterIndex).toBeGreaterThan(taggedBlockFilterIndex);
         expect(quoteExtractionIndex).toBeGreaterThan(markupFilterIndex);
+    });
+
+    test('excludes quoted text inside asterisk actions when both filters are enabled', () => {
+        const filterTtsAsterisksStart = ttsSource.indexOf('function filterTtsAsterisks(');
+        const filterTtsAsterisksEnd = ttsSource.indexOf('// SillyBunny: discard semantic blocks', filterTtsAsterisksStart);
+
+        expect(filterTtsAsterisksStart).toBeGreaterThanOrEqual(0);
+        expect(filterTtsAsterisksEnd).toBeGreaterThan(filterTtsAsterisksStart);
+
+        const filterTtsAsterisks = vm.runInNewContext(`(${ttsSource.slice(filterTtsAsterisksStart, filterTtsAsterisksEnd)})`);
+        const filteredText = filterTtsAsterisks('*"Do not narrate me."*', {
+            narrateDialoguesOnly: true,
+            passAsterisks: false,
+        });
+
+        expect(joinQuotedBlocks(filteredText, { includeQuotes: true })).toBe('');
     });
 
     test('does not treat quoted font attributes as dialogue', () => {

--- a/tests/tts-quoted-only-filtering.test.js
+++ b/tests/tts-quoted-only-filtering.test.js
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const ttsSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/extensions/tts/index.js', import.meta.url)), 'utf8');
+const joinQuotedBlocksStart = ttsSource.indexOf('function joinQuotedBlocks(');
+const joinQuotedBlocksEnd = ttsSource.indexOf('\n\nasync function playFullConversation()', joinQuotedBlocksStart);
+const joinQuotedBlocks = vm.runInNewContext(`(${ttsSource.slice(joinQuotedBlocksStart, joinQuotedBlocksEnd)})`);
+
+describe('TTS quoted-only filtering', () => {
+    test('extracts quoted dialogue before removing tagged blocks', () => {
+        const processTtsQueueBody = ttsSource.slice(
+            ttsSource.indexOf('async function processTtsQueue()'),
+            ttsSource.indexOf('/**\n * Extract and join quoted blocks'),
+        );
+        const quotedOnlyIndex = processTtsQueueBody.indexOf('if (extension_settings.tts.narrate_quoted_only)');
+        const skipTagsIndex = processTtsQueueBody.indexOf('if (extension_settings.tts.skip_tags)');
+
+        expect(quotedOnlyIndex).toBeGreaterThanOrEqual(0);
+        expect(skipTagsIndex).toBeGreaterThanOrEqual(0);
+        expect(quotedOnlyIndex).toBeLessThan(skipTagsIndex);
+        expect(processTtsQueueBody.slice(quotedOnlyIndex, skipTagsIndex))
+            .toContain('text = text.replace(/<.*?>/g, \'\').trim();\n        text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });');
+    });
+
+    test('does not treat quoted font attributes as dialogue', () => {
+        const taggedDialogue = '<font color="#c8a86e">"More water. That fire\'s dying. Move, girl, move."</font>';
+        const textWithoutTagMarkup = taggedDialogue.replace(/<.*?>/g, '').trim();
+
+        expect(joinQuotedBlocks(textWithoutTagMarkup, { includeQuotes: true }))
+            .toBe('"More water. That fire\'s dying. Move, girl, move."');
+    });
+});


### PR DESCRIPTION
In Issue https://github.com/platberlitz/SillyBunny/issues/666, when the the quoted dialogue has font color tags, it ignores what's actually inside.

## Fix
- Fixed TTS so font color tags no longer hide quoted dialogue.
- Prevented HTML attributes like `color="#c8a86e"` from being spoken as dialogue.
- Added tests covering the reported problem.