### PR TITLE
fix: Viewport scrolling offscreen in-depth

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2710,8 +2710,8 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
         bottom: auto !important;
         box-sizing: border-box !important;
-        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
     }
 }
 
@@ -2776,6 +2776,14 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         --sb-bottom-chat-mobile-select-height: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
         --sb-bottom-chat-mobile-persona-size: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
         --sb-bottom-chat-mobile-radius: 0px;
+        /* Keep vertical drags on the band between #chat and the composer from
+           becoming visual-viewport pans; its only owned gesture is the
+           horizontal secondary action rail. */
+        touch-action: pan-x;
+    }
+
+    #sb-bottom-chat-secondary-row {
+        touch-action: pan-x;
     }
 
     #chat {

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260712a" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260714a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/scripts/autocomplete/AutoComplete.js
+++ b/public/scripts/autocomplete/AutoComplete.js
@@ -71,6 +71,7 @@ export class AutoComplete {
     /**@type {function}*/ updatePositionDebounced;
     /**@type {function}*/ updateDetailsPositionDebounced;
     /**@type {function}*/ updateFloatingPositionDebounced;
+    /**@type {() => void}*/ windowResizeHandler;
 
     /**@type {(item:AutoCompleteOption)=>any}*/ onSelect;
 
@@ -165,7 +166,18 @@ export class AutoComplete {
         if (isFloating) {
             textarea.addEventListener('scroll', () => this.updateFloatingPositionDebounced());
         }
-        window.addEventListener('resize', () => this.updatePositionDebounced());
+        // Character/editor surfaces replace their textareas in place. Retire
+        // the resize callback once its input leaves the document so viewport
+        // changes cannot keep positioning a detached autocomplete forever.
+        this.windowResizeHandler = () => {
+            if (!this.getLayer()) {
+                window.removeEventListener('resize', this.windowResizeHandler);
+                this.hide();
+                return;
+            }
+            this.updatePositionDebounced();
+        };
+        window.addEventListener('resize', this.windowResizeHandler);
     }
 
     /**
@@ -506,6 +518,8 @@ export class AutoComplete {
      */
     render() {
         if (!this.isActive) return this.domWrap.remove();
+        const layer = this.getLayer();
+        if (!layer) return this.hide();
         if (this.isReplaceable) {
             this.dom.innerHTML = '';
             const frag = document.createDocumentFragment();
@@ -522,7 +536,7 @@ export class AutoComplete {
             }
             this.dom.append(frag);
             this.updatePosition();
-            this.getLayer().append(this.domWrap);
+            layer.append(this.domWrap);
         } else {
             this.domWrap.remove();
         }
@@ -535,17 +549,19 @@ export class AutoComplete {
     renderDetails() {
         if (!this.isActive) return this.detailsWrap.remove();
         if (!this.isShowingDetails && this.isReplaceable) return this.detailsWrap.remove();
+        const layer = this.getLayer();
+        if (!layer) return this.hide();
         this.detailsDom.innerHTML = '';
         this.detailsDom.append(this.selectedItem?.renderDetails() ?? 'NO ITEM');
-        this.getLayer().append(this.detailsWrap);
+        layer.append(this.detailsWrap);
         this.updateDetailsPositionDebounced();
     }
 
     /**
-     * @returns {HTMLElement} closest ancestor dialog or body
+     * @returns {HTMLElement|null} closest ancestor dialog or body
      */
     getLayer() {
-        return this.textarea.closest('dialog, body');
+        return this.textarea?.isConnected ? this.textarea.closest('dialog, body') : null;
     }
 
 
@@ -553,13 +569,17 @@ export class AutoComplete {
      * Update position of DOM.
      */
     updatePosition() {
+        const layer = this.getLayer();
+        if (!layer) {
+            return this.hide();
+        }
         if (this.isFloating) {
-            this.updateFloatingPosition();
+            this.updateFloatingPosition(layer);
         } else {
             const rect = {};
             rect[AUTOCOMPLETE_WIDTH.INPUT] = this.textarea.getBoundingClientRect();
             rect[AUTOCOMPLETE_WIDTH.CHAT] = document.querySelector('#sheld').getBoundingClientRect();
-            rect[AUTOCOMPLETE_WIDTH.FULL] = this.getLayer().getBoundingClientRect();
+            rect[AUTOCOMPLETE_WIDTH.FULL] = layer.getBoundingClientRect();
             this.domWrap.style.setProperty('--bottom', `${window.innerHeight - rect[AUTOCOMPLETE_WIDTH.INPUT].top}px`);
             this.dom.style.setProperty('--bottom', `${window.innerHeight - rect[AUTOCOMPLETE_WIDTH.INPUT].top}px`);
             this.domWrap.style.bottom = `${window.innerHeight - rect[AUTOCOMPLETE_WIDTH.INPUT].top}px`;
@@ -572,21 +592,24 @@ export class AutoComplete {
                 this.domWrap.style.setProperty('--rightOffset', `calc(100vw - min(99vw, ${rect[power_user.stscript.autocomplete.width.right].right}px)`);
             }
         }
-        this.updateDetailsPosition();
+        this.updateDetailsPosition(layer);
     }
 
     /**
      * Update position of details DOM.
      */
-    updateDetailsPosition() {
+    updateDetailsPosition(layer = this.getLayer()) {
+        if (!layer) {
+            return this.hide();
+        }
         if (this.isShowingDetails || !this.isReplaceable) {
             if (this.isFloating) {
-                this.updateFloatingDetailsPosition();
+                this.updateFloatingDetailsPosition(null, layer);
             } else {
                 const rect = {};
                 rect[AUTOCOMPLETE_WIDTH.INPUT] = this.textarea.getBoundingClientRect();
                 rect[AUTOCOMPLETE_WIDTH.CHAT] = document.querySelector('#sheld').getBoundingClientRect();
-                rect[AUTOCOMPLETE_WIDTH.FULL] = this.getLayer().getBoundingClientRect();
+                rect[AUTOCOMPLETE_WIDTH.FULL] = layer.getBoundingClientRect();
                 if (this.isReplaceable) {
                     this.detailsWrap.classList.remove('full');
                     const selRect = this.selectedItem.dom.children[0].getBoundingClientRect();
@@ -609,10 +632,13 @@ export class AutoComplete {
     /**
      * Update position of floating autocomplete.
      */
-    updateFloatingPosition() {
+    updateFloatingPosition(layer = this.getLayer()) {
+        if (!layer) {
+            return this.hide();
+        }
         const location = this.getCursorPosition();
         const rect = this.textarea.getBoundingClientRect();
-        const layerRect = this.getLayer().getBoundingClientRect();
+        const layerRect = layer.getBoundingClientRect();
         // cursor is out of view -> hide
         if (location.bottom < rect.top || location.top > rect.bottom || location.left < rect.left || location.left > rect.right) {
             return this.hide();
@@ -632,10 +658,13 @@ export class AutoComplete {
         }
     }
 
-    updateFloatingDetailsPosition(location = null) {
+    updateFloatingDetailsPosition(location = null, layer = this.getLayer()) {
+        if (!layer) {
+            return this.hide();
+        }
         if (!location) location = this.getCursorPosition();
         const rect = this.textarea.getBoundingClientRect();
-        const layerRect = this.getLayer().getBoundingClientRect();
+        const layerRect = layer.getBoundingClientRect();
         if (location.bottom < rect.top || location.top > rect.bottom || location.left < rect.left || location.left > rect.right) {
             return this.hide();
         }

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1896,6 +1896,9 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
 /* ── Slide-out Tracker Panel ────────────────────────── */
 
 .ica--tpanel {
+    --ica--tpanel-viewport-height: var(--sb-shell-viewport-height, 100dvh);
+    --ica--tpanel-viewport-top: var(--sb-shell-viewport-top, 0px);
+    --ica--tpanel-sheet-height: min(70dvh, 560px, var(--ica--tpanel-viewport-height));
     position: fixed;
     /* Above the mobile shell's modal layer (--sb-z-modal-content: 3100), below toasts. */
     z-index: var(--sb-z-popout, 4000);
@@ -1907,7 +1910,7 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 92%, #000);
     -webkit-backdrop-filter: blur(calc(var(--blurStrength, 10) * 1px));
     backdrop-filter: blur(calc(var(--blurStrength, 10) * 1px));
-    transition: transform 0.25s ease;
+    transition: -webkit-clip-path 0.25s ease, clip-path 0.25s ease;
     overflow-y: auto;
     overscroll-behavior: contain;
     contain: layout style;
@@ -1921,10 +1924,10 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
 
 .ica--tpanel[data-edge="right"],
 .ica--tpanel[data-edge="left"] {
-    top: 0;
-    bottom: 0;
+    top: var(--ica--tpanel-viewport-top);
+    bottom: auto;
     width: min(420px, 94vw);
-    height: 100dvh;
+    height: var(--ica--tpanel-viewport-height);
 }
 
 .ica--tpanel[data-edge="right"] {
@@ -1932,7 +1935,8 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     left: auto;
     border-left-width: 1px;
     padding-right: calc(12px + env(safe-area-inset-right, 0px));
-    transform: translateX(100%);
+    -webkit-clip-path: inset(0 0 0 100%);
+    clip-path: inset(0 0 0 100%);
 }
 
 .ica--tpanel[data-edge="left"] {
@@ -1940,7 +1944,8 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     right: auto;
     border-right-width: 1px;
     padding-left: calc(12px + env(safe-area-inset-left, 0px));
-    transform: translateX(-100%);
+    -webkit-clip-path: inset(0 100% 0 0);
+    clip-path: inset(0 100% 0 0);
 }
 
 .ica--tpanel[data-edge="top"],
@@ -1948,42 +1953,43 @@ dialog.ica--textarea-fullscreen-backdrop::backdrop {
     left: 0;
     right: 0;
     width: 100%;
-    height: min(70dvh, 560px);
+    height: var(--ica--tpanel-sheet-height);
 }
 
 .ica--tpanel[data-edge="top"] {
-    top: 0;
+    top: var(--ica--tpanel-viewport-top);
     bottom: auto;
     border-bottom-width: 1px;
     padding-top: calc(12px + env(safe-area-inset-top, 0px));
-    transform: translateY(-100%);
+    -webkit-clip-path: inset(0 0 100% 0);
+    clip-path: inset(0 0 100% 0);
 }
 
 .ica--tpanel[data-edge="bottom"] {
-    bottom: 0;
-    top: auto;
+    /* The transformed zero-height <html> is the fixed-position containing block,
+       so bottom: 0 would place this sheet above the viewport. Use measured shell
+       coordinates for both normal and keyboard-shifted visual viewports. */
+    top: calc(var(--ica--tpanel-viewport-top) + var(--ica--tpanel-viewport-height) - var(--ica--tpanel-sheet-height));
+    bottom: auto;
     border-top-width: 1px;
     padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
-    transform: translateY(100%);
+    -webkit-clip-path: inset(100% 0 0 0);
+    clip-path: inset(100% 0 0 0);
 }
 
 .ica--tpanel:not(.is-open) {
     visibility: hidden;
     pointer-events: none;
     /* Delay hiding until the close slide finishes so the backdrop blur leaves in lockstep. */
-    transition: transform 0.25s ease, visibility 0s linear 0.25s;
+    transition: -webkit-clip-path 0.25s ease, clip-path 0.25s ease, visibility 0s linear 0.25s;
 }
 
-/* Must out-rank the per-edge closed transforms above (same class+attr specificity,
-   later source order would otherwise keep the panel off-screen while open). */
 .ica--tpanel[data-edge="right"].is-open,
-.ica--tpanel[data-edge="left"].is-open {
-    transform: translateX(0);
-}
-
+.ica--tpanel[data-edge="left"].is-open,
 .ica--tpanel[data-edge="top"].is-open,
 .ica--tpanel[data-edge="bottom"].is-open {
-    transform: translateY(0);
+    -webkit-clip-path: inset(0);
+    clip-path: inset(0);
 }
 
 .ica--tpanel-header {

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/ContextMenu.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/ContextMenu.js
@@ -2,6 +2,9 @@ import { QuickReply } from '../../QuickReply.js';
 import { QuickReplySet } from '../../QuickReplySet.js';
 import { MenuHeader } from './MenuHeader.js';
 import { MenuItem } from './MenuItem.js';
+// Constrain Quick Reply menus to the visual viewport so
+// long/user-positioned menus cannot make actions unreachable on mobile.
+import { clamp, constrainMenuSize, getMenuViewportBounds, syncMenuOverflow } from './MenuViewport.js';
 
 export class ContextMenu {
     /**@type {MenuItem[]}*/ itemList = [];
@@ -9,6 +12,8 @@ export class ContextMenu {
 
     /**@type {HTMLElement}*/ root;
     /**@type {HTMLElement}*/ menu;
+
+    /**@type {function|null}*/ viewportResizeHandler = null;
 
 
     constructor(/**@type {QuickReply}*/qr) {
@@ -102,15 +107,50 @@ export class ContextMenu {
     }
 
 
+    place(clientX, clientY) {
+        if (!this.menu?.isConnected) {
+            return;
+        }
+
+        const viewport = getMenuViewportBounds();
+        constrainMenuSize(this.menu, viewport);
+
+        const measuredRect = this.menu.getBoundingClientRect();
+        const menuWidth = Math.min(measuredRect.width, viewport.width);
+        const menuHeight = Math.min(measuredRect.height, viewport.height);
+        const left = clamp(clientX, viewport.left, Math.max(viewport.left, viewport.right - menuWidth));
+        const top = clamp(clientY - menuHeight, viewport.top, Math.max(viewport.top, viewport.bottom - menuHeight));
+
+        this.menu.style.left = `${Math.round(left)}px`;
+        this.menu.style.top = `${Math.round(top)}px`;
+        this.menu.style.right = 'auto';
+        this.menu.style.bottom = 'auto';
+        syncMenuOverflow(this.menu);
+        this.menu.style.visibility = 'visible';
+    }
+
+
     show({ clientX, clientY }) {
         if (this.isActive) return;
         this.isActive = true;
         this.render();
-        this.menu.style.bottom = `${window.innerHeight - clientY}px`;
-        this.menu.style.left = `${clientX}px`;
+        this.menu.style.visibility = 'hidden';
         document.body.append(this.root);
+        this.place(clientX, clientY);
+
+        this.viewportResizeHandler = () => this.place(clientX, clientY);
+        window.addEventListener('resize', this.viewportResizeHandler, { passive: true });
+        window.visualViewport?.addEventListener('resize', this.viewportResizeHandler, { passive: true });
+        window.visualViewport?.addEventListener('scroll', this.viewportResizeHandler, { passive: true });
     }
     hide() {
+        this.itemList.forEach(item => item.collapse?.());
+        if (this.viewportResizeHandler) {
+            window.removeEventListener('resize', this.viewportResizeHandler);
+            window.visualViewport?.removeEventListener('resize', this.viewportResizeHandler);
+            window.visualViewport?.removeEventListener('scroll', this.viewportResizeHandler);
+            this.viewportResizeHandler = null;
+        }
         if (this.root) {
             this.root.remove();
         }

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
@@ -64,6 +64,8 @@ export class MenuItem {
                     item.append(lbl);
                 }
                 if (this.childList.length > 0) {
+                    // Nested menus are portal-positioned by SubMenu;
+                    // defer closing while the pointer crosses into that overlay.
                     item.classList.add('ctx-has-children');
                     const sub = new SubMenu(this.childList);
                     this.subMenu = sub;
@@ -77,7 +79,7 @@ export class MenuItem {
                         item.append(trigger);
                     }
                     item.addEventListener('mouseover', () => sub.show(item));
-                    item.addEventListener('mouseleave', () => sub.hide());
+                    item.addEventListener('mouseleave', event => sub.handlePointerLeave(event));
                 }
             }
         }
@@ -95,10 +97,11 @@ export class MenuItem {
         this.subMenu?.hide();
     }
     toggle() {
+        // Touch activation must mirror hover expansion on mobile.
         if (this.subMenu.isActive) {
-            this.expand();
-        } else {
             this.collapse();
+        } else {
+            this.expand();
         }
     }
 }

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
@@ -78,7 +78,7 @@ export class MenuItem {
                         });
                         item.append(trigger);
                     }
-                    item.addEventListener('mouseover', () => sub.show(item));
+                    item.addEventListener('pointerenter', event => this.expandFromHover(event));
                     item.addEventListener('mouseleave', event => sub.handlePointerLeave(event));
                 }
             }
@@ -93,11 +93,15 @@ export class MenuItem {
             this.onExpand();
         }
     }
+    expandFromHover(event) {
+        if (event.pointerType === 'mouse') {
+            this.expand();
+        }
+    }
     collapse() {
         this.subMenu?.hide();
     }
     toggle() {
-        // Touch activation must mirror hover expansion on mobile.
         if (this.subMenu.isActive) {
             this.collapse();
         } else {

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuViewport.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuViewport.js
@@ -1,0 +1,42 @@
+const VIEWPORT_MARGIN = 5;
+
+export function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+export function getMenuViewportBounds() {
+    const viewport = window.visualViewport;
+    const offsetLeft = viewport?.offsetLeft ?? 0;
+    const offsetTop = viewport?.offsetTop ?? 0;
+    const width = viewport?.width ?? window.innerWidth;
+    const height = viewport?.height ?? window.innerHeight;
+
+    return {
+        left: offsetLeft + VIEWPORT_MARGIN,
+        top: offsetTop + VIEWPORT_MARGIN,
+        right: offsetLeft + width - VIEWPORT_MARGIN,
+        bottom: offsetTop + height - VIEWPORT_MARGIN,
+        width: Math.max(0, width - (VIEWPORT_MARGIN * 2)),
+        height: Math.max(0, height - (VIEWPORT_MARGIN * 2)),
+    };
+}
+
+export function constrainMenuSize(menu, viewport) {
+    menu.style.width = 'max-content';
+    menu.style.maxWidth = `${viewport.width}px`;
+    menu.style.maxHeight = `${viewport.height}px`;
+    menu.style.boxSizing = 'border-box';
+}
+
+export function syncMenuOverflow(menu) {
+    const overflowsHorizontally = menu.scrollWidth > menu.clientWidth + 1;
+    const overflowsVertically = menu.scrollHeight > menu.clientHeight + 1;
+
+    if (!overflowsHorizontally && !overflowsVertically) {
+        menu.style.overflow = 'visible';
+        return;
+    }
+
+    menu.style.overflowX = overflowsHorizontally ? 'auto' : 'hidden';
+    menu.style.overflowY = overflowsVertically ? 'auto' : 'hidden';
+}

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/SubMenu.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/SubMenu.js
@@ -94,6 +94,16 @@ export class SubMenu {
         this.root.style.transform = '';
 
         const parentRect = this.parent.getBoundingClientRect();
+        const scrollParentRect = this.scrollParent?.getBoundingClientRect();
+        if (scrollParentRect
+            && (parentRect.right <= scrollParentRect.left
+                || parentRect.left >= scrollParentRect.right
+                || parentRect.bottom <= scrollParentRect.top
+                || parentRect.top >= scrollParentRect.bottom)) {
+            this.hide();
+            return;
+        }
+
         const layerRect = this.layer.getBoundingClientRect();
         const initialRect = this.root.getBoundingClientRect();
         const menuWidth = Math.min(initialRect.width, viewport.width);
@@ -107,6 +117,7 @@ export class SubMenu {
         this.root.style.top = `${Math.round(top - layerRect.top)}px`;
         syncMenuOverflow(this.root);
         this.root.style.visibility = 'visible';
+        this.itemList.forEach(item => item.subMenu?.place());
     }
 
     show(/**@type {HTMLElement}*/parent) {
@@ -118,13 +129,12 @@ export class SubMenu {
         this.render();
         this.root.style.visibility = 'hidden';
         this.layer.append(this.root);
-        requestAnimationFrame(() => this.place());
-
         this.viewportResizeHandler = () => this.place();
         window.addEventListener('resize', this.viewportResizeHandler, { passive: true });
         window.visualViewport?.addEventListener('resize', this.viewportResizeHandler, { passive: true });
         window.visualViewport?.addEventListener('scroll', this.viewportResizeHandler, { passive: true });
         this.scrollParent?.addEventListener('scroll', this.viewportResizeHandler, { passive: true });
+        this.place();
     }
     hide() {
         this.cancelHide();

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/SubMenu.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/SubMenu.js
@@ -2,11 +2,21 @@
  * @typedef {import('./MenuItem.js').MenuItem} MenuItem
  */
 
+// Nested Quick Reply menus render in the blocker layer
+// so a viewport-sized scrolling parent cannot clip a flipped submenu.
+import { clamp, constrainMenuSize, getMenuViewportBounds, syncMenuOverflow } from './MenuViewport.js';
+
 export class SubMenu {
     /**@type {MenuItem[]}*/ itemList = [];
     /**@type {Boolean}*/ isActive = false;
 
     /**@type {HTMLElement}*/ root;
+
+    /**@type {HTMLElement|null}*/ parent = null;
+    /**@type {HTMLElement|null}*/ layer = null;
+    /**@type {HTMLElement|null}*/ scrollParent = null;
+    /**@type {function|null}*/ viewportResizeHandler = null;
+    /**@type {number|null}*/ hideTimer = null;
 
 
     constructor(/**@type {MenuItem[]}*/items) {
@@ -21,35 +31,123 @@ export class SubMenu {
                 menu.classList.add('ctx-menu');
                 menu.classList.add('ctx-sub-menu');
                 this.itemList.forEach(it => menu.append(it.render()));
+                menu.addEventListener('mouseenter', () => this.cancelHide());
+                menu.addEventListener('mouseleave', event => this.handlePointerLeave(event));
             }
         }
         return this.root;
     }
 
 
-    show(/**@type {HTMLElement}*/parent) {
-        if (this.isActive) return;
-        this.isActive = true;
-        this.render();
-        parent.append(this.root);
-        requestAnimationFrame(() => {
-            const rect = this.root.getBoundingClientRect();
-            console.log(window.innerHeight, rect);
-            if (rect.bottom > window.innerHeight - 5) {
-                this.root.style.top = `${window.innerHeight - 5 - rect.bottom}px`;
-            }
-            if (rect.right > window.innerWidth - 5) {
-                this.root.style.left = 'unset';
-                this.root.style.right = '100%';
+    cancelHide() {
+        if (this.hideTimer !== null) {
+            window.clearTimeout(this.hideTimer);
+            this.hideTimer = null;
+        }
+    }
+
+    containsMenuTarget(target) {
+        if (!(target instanceof Element)) {
+            return false;
+        }
+
+        if (this.root?.contains(target)) {
+            return true;
+        }
+
+        return this.itemList.some(item => item.subMenu?.containsMenuTarget(target));
+    }
+
+    isMenuTreeHovered() {
+        return Boolean(this.root?.matches(':hover'))
+            || this.itemList.some(item => item.subMenu?.isMenuTreeHovered());
+    }
+
+    handlePointerLeave(event) {
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Element
+            && (this.parent?.contains(nextTarget) || this.containsMenuTarget(nextTarget))) {
+            return;
+        }
+
+        this.cancelHide();
+        this.hideTimer = window.setTimeout(() => {
+            this.hideTimer = null;
+            if (!this.parent?.matches(':hover') && !this.isMenuTreeHovered()) {
+                this.hide();
             }
         });
     }
+
+
+    place() {
+        if (!this.isActive || !this.root?.isConnected || !this.parent?.isConnected || !this.layer?.isConnected) {
+            return;
+        }
+
+        const viewport = getMenuViewportBounds();
+        constrainMenuSize(this.root, viewport);
+        this.root.style.position = 'absolute';
+        this.root.style.top = '0';
+        this.root.style.left = '0';
+        this.root.style.right = 'auto';
+        this.root.style.transform = '';
+
+        const parentRect = this.parent.getBoundingClientRect();
+        const layerRect = this.layer.getBoundingClientRect();
+        const initialRect = this.root.getBoundingClientRect();
+        const menuWidth = Math.min(initialRect.width, viewport.width);
+        const menuHeight = Math.min(initialRect.height, viewport.height);
+        const fitsToRight = parentRect.right + menuWidth <= viewport.right;
+        const preferredLeft = fitsToRight ? parentRect.right : parentRect.left - menuWidth;
+        const left = clamp(preferredLeft, viewport.left, Math.max(viewport.left, viewport.right - menuWidth));
+        const top = clamp(parentRect.top, viewport.top, Math.max(viewport.top, viewport.bottom - menuHeight));
+
+        this.root.style.left = `${Math.round(left - layerRect.left)}px`;
+        this.root.style.top = `${Math.round(top - layerRect.top)}px`;
+        syncMenuOverflow(this.root);
+        this.root.style.visibility = 'visible';
+    }
+
+    show(/**@type {HTMLElement}*/parent) {
+        if (this.isActive) return;
+        this.isActive = true;
+        this.parent = parent;
+        this.layer = parent.closest('.ctx-blocker') ?? document.body;
+        this.scrollParent = parent.closest('.ctx-menu');
+        this.render();
+        this.root.style.visibility = 'hidden';
+        this.layer.append(this.root);
+        requestAnimationFrame(() => this.place());
+
+        this.viewportResizeHandler = () => this.place();
+        window.addEventListener('resize', this.viewportResizeHandler, { passive: true });
+        window.visualViewport?.addEventListener('resize', this.viewportResizeHandler, { passive: true });
+        window.visualViewport?.addEventListener('scroll', this.viewportResizeHandler, { passive: true });
+        this.scrollParent?.addEventListener('scroll', this.viewportResizeHandler, { passive: true });
+    }
     hide() {
+        this.cancelHide();
+        if (this.viewportResizeHandler) {
+            window.removeEventListener('resize', this.viewportResizeHandler);
+            window.visualViewport?.removeEventListener('resize', this.viewportResizeHandler);
+            window.visualViewport?.removeEventListener('scroll', this.viewportResizeHandler);
+            this.scrollParent?.removeEventListener('scroll', this.viewportResizeHandler);
+            this.viewportResizeHandler = null;
+        }
+        this.itemList.forEach(item => item.collapse?.());
         if (this.root) {
             this.root.remove();
+            this.root.style.position = '';
             this.root.style.top = '';
             this.root.style.left = '';
+            this.root.style.right = '';
+            this.root.style.transform = '';
+            this.root.style.visibility = '';
         }
+        this.parent = null;
+        this.layer = null;
+        this.scrollParent = null;
         this.isActive = false;
     }
     toggle(/**@type {HTMLElement}*/parent) {

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -181,6 +181,12 @@
 .ctx-menu .ctx-item .qr--hidden {
   display: none;
 }
+/* Allow long Quick Reply labels to wrap inside the
+   viewport-constrained menu instead of widening the document. */
+.ctx-menu .qr--button-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .list-group .list-group-item.ctx-header {
   font-weight: bold;
   cursor: default;

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -812,12 +812,6 @@ const MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR = [
     '.ica--tpanel-handle',
 ].join(', ');
 
-const MOBILE_DOCUMENT_PAN_OPEN_DRAWER_SELECTOR = [
-    '#left-nav-panel.openDrawer',
-    '#right-nav-panel.openDrawer',
-    '#user-settings-block.openDrawer',
-].join(', ');
-
 const MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX = 3;
 const SCROLLABLE_OVERFLOW_VALUES = new Set(['auto', 'scroll', 'overlay']);
 
@@ -950,12 +944,19 @@ function canElementScrollForGesture(element, delta, { requireAvailableScrollInDi
         : scrollTop < maxScrollTop - MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX;
 }
 
-function closestScrollableElementForGesture(target, delta, { requireAvailableScrollInDirection = false } = {}) {
+function closestScrollableElementForGesture(target, delta, {
+    requireAvailableScrollInDirection = false,
+    boundary = null,
+} = {}) {
     let element = target;
 
     while (element && typeof element === 'object') {
         if (canElementScrollForGesture(element, delta, { requireAvailableScrollInDirection })) {
             return element;
+        }
+
+        if (element === boundary) {
+            break;
         }
 
         element = getParentElementLike(element);
@@ -989,18 +990,31 @@ export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) 
     const editableElement = closestMatchingElement(target, MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR);
     if (editableElement) {
         const isScrollableEditable = elementMatchesSelector(editableElement, 'textarea, [contenteditable="true"]');
-        if (isScrollableEditable) {
-            if (gestureDelta && canElementScrollForGesture(editableElement, gestureDelta, { requireAvailableScrollInDirection: true })) {
-                return false;
-            }
+        if (isScrollableEditable && gestureDelta && canElementScrollForGesture(editableElement, gestureDelta, { requireAvailableScrollInDirection: true })) {
+            return false;
         }
+
+        const ancestorScrollElement = guardedElement
+            ? closestScrollableElementForGesture(getParentElementLike(editableElement), gestureDelta, {
+                requireAvailableScrollInDirection: true,
+                boundary: guardedElement,
+            })
+            : null;
+        if (ancestorScrollElement && (!isHorizontalGesture(gestureDelta) || elementMatchesSelector(ancestorScrollElement, MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR))) {
+            return false;
+        }
+
         return true;
     }
 
-    const scrollElement = closestScrollableElementForGesture(target, gestureDelta, { requireAvailableScrollInDirection: true });
+    const scrollElement = guardedElement
+        ? closestScrollableElementForGesture(target, gestureDelta, {
+            requireAvailableScrollInDirection: true,
+            boundary: guardedElement,
+        })
+        : null;
     if (closestMatchingElement(target, MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR)) {
-        const openDrawerElement = closestMatchingElement(target, MOBILE_DOCUMENT_PAN_OPEN_DRAWER_SELECTOR);
-        if (openDrawerElement && scrollElement && !isHorizontalGesture(gestureDelta)) {
+        if (scrollElement && (!isHorizontalGesture(gestureDelta) || elementMatchesSelector(scrollElement, MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR))) {
             return false;
         }
 

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -792,15 +792,6 @@ const MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR = [
     '.select2-results__options',
 ].join(', ');
 
-const MOBILE_DOCUMENT_PAN_OPEN_MENU_SELECTOR = [
-    '#left-nav-panel.openDrawer',
-    '#right-nav-panel.openDrawer',
-    '#user-settings-block.openDrawer',
-    '.sb-shell-root.openDrawer',
-    '#ica--tracker-panel.is-open',
-    '.ica--tpanel.is-open',
-].join(', ');
-
 const MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR = [
     'input',
     'textarea',
@@ -809,12 +800,22 @@ const MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR = [
 ].join(', ');
 
 const MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR = [
+    'button',
+    '[role="button"]',
+    '.menu_button',
+    '.interactable',
     '#dialogue_popup_controls',
     '.popup-controls',
     '.popup-button-close',
     '.select2-selection',
     '#ica--tracker-panel-handle',
     '.ica--tpanel-handle',
+].join(', ');
+
+const MOBILE_DOCUMENT_PAN_OPEN_DRAWER_SELECTOR = [
+    '#left-nav-panel.openDrawer',
+    '#right-nav-panel.openDrawer',
+    '#user-settings-block.openDrawer',
 ].join(', ');
 
 const MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX = 3;
@@ -919,8 +920,8 @@ function canElementScrollForGesture(element, delta, { requireAvailableScrollInDi
     const absX = Math.abs(delta.x);
     const absY = Math.abs(delta.y);
     const wantsHorizontalScroll = absX > absY;
-    const canScrollX = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth) > 1 && canElementScrollOnAxis(element, 'x');
-    const canScrollY = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight) > 1 && canElementScrollOnAxis(element, 'y');
+    const canScrollX = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth) > MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX && canElementScrollOnAxis(element, 'x');
+    const canScrollY = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight) > MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX && canElementScrollOnAxis(element, 'y');
 
     if (!requireAvailableScrollInDirection) {
         return wantsHorizontalScroll ? canScrollX : canScrollY;
@@ -933,7 +934,9 @@ function canElementScrollForGesture(element, delta, { requireAvailableScrollInDi
 
         const scrollLeft = normalizeNumber(element.scrollLeft);
         const maxScrollLeft = normalizeNumber(element.scrollWidth) - normalizeNumber(element.clientWidth);
-        return delta.x > 0 ? scrollLeft > 0 : scrollLeft < maxScrollLeft - 1;
+        return delta.x > 0
+            ? scrollLeft > MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX
+            : scrollLeft < maxScrollLeft - MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX;
     }
 
     if (!canScrollY) {
@@ -942,7 +945,9 @@ function canElementScrollForGesture(element, delta, { requireAvailableScrollInDi
 
     const scrollTop = normalizeNumber(element.scrollTop);
     const maxScrollTop = normalizeNumber(element.scrollHeight) - normalizeNumber(element.clientHeight);
-    return delta.y > 0 ? scrollTop > 0 : scrollTop < maxScrollTop - 1;
+    return delta.y > 0
+        ? scrollTop > MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX
+        : scrollTop < maxScrollTop - MOBILE_DOCUMENT_PAN_MIN_GESTURE_PX;
 }
 
 function closestScrollableElementForGesture(target, delta, { requireAvailableScrollInDirection = false } = {}) {
@@ -980,15 +985,11 @@ export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) 
         return false;
     }
 
-    if (closestMatchingElement(target, MOBILE_DOCUMENT_PAN_OPEN_MENU_SELECTOR)) {
-        return false;
-    }
-
+    const gestureDelta = getGestureDelta(event, touchStart);
     const editableElement = closestMatchingElement(target, MOBILE_DOCUMENT_PAN_EDITABLE_SELECTOR);
     if (editableElement) {
         const isScrollableEditable = elementMatchesSelector(editableElement, 'textarea, [contenteditable="true"]');
         if (isScrollableEditable) {
-            const gestureDelta = getGestureDelta(event, touchStart);
             if (gestureDelta && canElementScrollForGesture(editableElement, gestureDelta, { requireAvailableScrollInDirection: true })) {
                 return false;
             }
@@ -996,12 +997,16 @@ export function shouldBlockMobileDocumentPan(event, { touchStart = null } = {}) 
         return true;
     }
 
+    const scrollElement = closestScrollableElementForGesture(target, gestureDelta, { requireAvailableScrollInDirection: true });
     if (closestMatchingElement(target, MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR)) {
+        const openDrawerElement = closestMatchingElement(target, MOBILE_DOCUMENT_PAN_OPEN_DRAWER_SELECTOR);
+        if (openDrawerElement && scrollElement && !isHorizontalGesture(gestureDelta)) {
+            return false;
+        }
+
         return true;
     }
 
-    const gestureDelta = getGestureDelta(event, touchStart);
-    const scrollElement = closestScrollableElementForGesture(target, gestureDelta, { requireAvailableScrollInDirection: true });
     if (scrollElement) {
         if (isHorizontalGesture(gestureDelta)) {
             return !elementMatchesSelector(scrollElement, MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR);

--- a/public/scripts/moving-ui-viewport.js
+++ b/public/scripts/moving-ui-viewport.js
@@ -1,0 +1,134 @@
+const MOVING_UI_VIEWPORT_TOLERANCE_PX = 1;
+const MOVING_UI_BOUND_PROPERTIES = ['width', 'height', 'left', 'top', 'right', 'bottom'];
+
+function parsePixelValue(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmedValue = value.trim();
+    if (!/^-?\d+(?:\.\d+)?(?:px)?$/.test(trimmedValue)) {
+        return null;
+    }
+
+    return Number.parseFloat(trimmedValue);
+}
+
+function normalizeViewportDimension(value) {
+    const numericValue = Number(value);
+    return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
+}
+
+function getUsableElementBounds(elementBounds) {
+    if (!elementBounds) {
+        return null;
+    }
+
+    const bounds = Object.fromEntries(MOVING_UI_BOUND_PROPERTIES.map(property => [property, Number(elementBounds[property])]));
+    if (MOVING_UI_BOUND_PROPERTIES.some(property => !Number.isFinite(bounds[property])) || bounds.width <= 0 || bounds.height <= 0) {
+        return null;
+    }
+
+    return bounds;
+}
+
+function getStateBounds(state, viewportWidth, viewportHeight) {
+    const width = parsePixelValue(state?.width);
+    const height = parsePixelValue(state?.height);
+    const right = parsePixelValue(state?.right);
+    const bottom = parsePixelValue(state?.bottom);
+    let left = parsePixelValue(state?.left);
+    let top = parsePixelValue(state?.top);
+
+    if (left === null && right !== null && width !== null) {
+        left = viewportWidth - right - width;
+    }
+
+    if (top === null && bottom !== null && height !== null) {
+        top = viewportHeight - bottom - height;
+    }
+
+    if ([left, top, width, height].some(value => value === null) || width <= 0 || height <= 0) {
+        return null;
+    }
+
+    return {
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+    };
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function roundBound(value) {
+    return Math.round(value);
+}
+
+function hasMeaningfulStateChange(state, nextBounds) {
+    return MOVING_UI_BOUND_PROPERTIES.some(property => {
+        const currentValue = parsePixelValue(state?.[property]);
+        return currentValue === null || Math.abs(currentValue - nextBounds[property]) > MOVING_UI_VIEWPORT_TOLERANCE_PX;
+    });
+}
+
+/**
+ * Resolves persisted MovingUI geometry into a fully viewport-contained state.
+ * Rendered bounds take precedence because CSS min/max rules can make stored
+ * dimensions differ from the box that actually contributes document overflow.
+ *
+ * @param {object} state Persisted MovingUI state.
+ * @param {object} options Viewport and optional rendered geometry.
+ * @param {number} options.viewportWidth Layout viewport width.
+ * @param {number} options.viewportHeight Layout viewport height.
+ * @param {object|null} [options.elementBounds=null] Current rendered bounds.
+ * @returns {{state: object, changed: boolean, canContain: boolean}}
+ */
+export function resolveMovingUIViewportState(state, {
+    viewportWidth,
+    viewportHeight,
+    elementBounds = null,
+} = {}) {
+    const sourceState = state && typeof state === 'object' ? state : {};
+    const safeViewportWidth = normalizeViewportDimension(viewportWidth);
+    const safeViewportHeight = normalizeViewportDimension(viewportHeight);
+
+    if (!safeViewportWidth || !safeViewportHeight) {
+        return { state: sourceState, changed: false, canContain: false };
+    }
+
+    const bounds = getUsableElementBounds(elementBounds)
+        ?? getStateBounds(sourceState, safeViewportWidth, safeViewportHeight);
+    if (!bounds) {
+        return { state: sourceState, changed: false, canContain: false };
+    }
+
+    const width = roundBound(Math.min(bounds.width, safeViewportWidth));
+    const height = roundBound(Math.min(bounds.height, safeViewportHeight));
+    const left = roundBound(clamp(bounds.left, 0, Math.max(0, safeViewportWidth - width)));
+    const top = roundBound(clamp(bounds.top, 0, Math.max(0, safeViewportHeight - height)));
+    const nextBounds = {
+        width,
+        height,
+        left,
+        top,
+        right: roundBound(Math.max(0, safeViewportWidth - left - width)),
+        bottom: roundBound(Math.max(0, safeViewportHeight - top - height)),
+    };
+    const changed = hasMeaningfulStateChange(sourceState, nextBounds);
+
+    return {
+        state: changed ? { ...sourceState, ...nextBounds } : sourceState,
+        changed,
+        canContain: true,
+    };
+}

--- a/public/scripts/moving-ui-viewport.js
+++ b/public/scripts/moving-ui-viewport.js
@@ -74,11 +74,38 @@ function roundBound(value) {
     return Math.round(value);
 }
 
-function hasMeaningfulStateChange(state, nextBounds) {
-    return MOVING_UI_BOUND_PROPERTIES.some(property => {
-        const currentValue = parsePixelValue(state?.[property]);
-        return currentValue === null || Math.abs(currentValue - nextBounds[property]) > MOVING_UI_VIEWPORT_TOLERANCE_PX;
-    });
+function isBoundsOutOfViewport(bounds, viewportWidth, viewportHeight) {
+    return bounds.left < -MOVING_UI_VIEWPORT_TOLERANCE_PX
+        || bounds.top < -MOVING_UI_VIEWPORT_TOLERANCE_PX
+        || bounds.right > viewportWidth + MOVING_UI_VIEWPORT_TOLERANCE_PX
+        || bounds.bottom > viewportHeight + MOVING_UI_VIEWPORT_TOLERANCE_PX;
+}
+
+function getContainmentUpdates(state, bounds, nextBounds, viewportWidth, viewportHeight) {
+    /** @type {Record<string, number>} */
+    const updates = {};
+    const horizontalOverflow = bounds.left < -MOVING_UI_VIEWPORT_TOLERANCE_PX
+        || bounds.right > viewportWidth + MOVING_UI_VIEWPORT_TOLERANCE_PX;
+    const verticalOverflow = bounds.top < -MOVING_UI_VIEWPORT_TOLERANCE_PX
+        || bounds.bottom > viewportHeight + MOVING_UI_VIEWPORT_TOLERANCE_PX;
+
+    if (horizontalOverflow) {
+        if (bounds.width > viewportWidth + MOVING_UI_VIEWPORT_TOLERANCE_PX || parsePixelValue(state?.width) !== null) {
+            updates.width = nextBounds.width;
+        }
+        updates.left = nextBounds.left;
+        updates.right = nextBounds.right;
+    }
+
+    if (verticalOverflow) {
+        if (bounds.height > viewportHeight + MOVING_UI_VIEWPORT_TOLERANCE_PX || parsePixelValue(state?.height) !== null) {
+            updates.height = nextBounds.height;
+        }
+        updates.top = nextBounds.top;
+        updates.bottom = nextBounds.bottom;
+    }
+
+    return updates;
 }
 
 /**
@@ -91,7 +118,7 @@ function hasMeaningfulStateChange(state, nextBounds) {
  * @param {number} options.viewportWidth Layout viewport width.
  * @param {number} options.viewportHeight Layout viewport height.
  * @param {object|null} [options.elementBounds=null] Current rendered bounds.
- * @returns {{state: object, changed: boolean, canContain: boolean}}
+ * @returns {{state: object, updates: object, changed: boolean, canContain: boolean}}
  */
 export function resolveMovingUIViewportState(state, {
     viewportWidth,
@@ -103,13 +130,17 @@ export function resolveMovingUIViewportState(state, {
     const safeViewportHeight = normalizeViewportDimension(viewportHeight);
 
     if (!safeViewportWidth || !safeViewportHeight) {
-        return { state: sourceState, changed: false, canContain: false };
+        return { state: sourceState, updates: {}, changed: false, canContain: false };
     }
 
     const bounds = getUsableElementBounds(elementBounds)
         ?? getStateBounds(sourceState, safeViewportWidth, safeViewportHeight);
     if (!bounds) {
-        return { state: sourceState, changed: false, canContain: false };
+        return { state: sourceState, updates: {}, changed: false, canContain: false };
+    }
+
+    if (!isBoundsOutOfViewport(bounds, safeViewportWidth, safeViewportHeight)) {
+        return { state: sourceState, updates: {}, changed: false, canContain: true };
     }
 
     const width = roundBound(Math.min(bounds.width, safeViewportWidth));
@@ -124,11 +155,48 @@ export function resolveMovingUIViewportState(state, {
         right: roundBound(Math.max(0, safeViewportWidth - left - width)),
         bottom: roundBound(Math.max(0, safeViewportHeight - top - height)),
     };
-    const changed = hasMeaningfulStateChange(sourceState, nextBounds);
+    const updates = Object.fromEntries(Object.entries(
+        getContainmentUpdates(sourceState, bounds, nextBounds, safeViewportWidth, safeViewportHeight),
+    ).filter(([property, value]) => {
+        const currentValue = parsePixelValue(sourceState[property]);
+        return currentValue === null || Math.abs(currentValue - value) > MOVING_UI_VIEWPORT_TOLERANCE_PX;
+    }));
+    const changed = Object.keys(updates).length > 0;
 
     return {
-        state: changed ? { ...sourceState, ...nextBounds } : sourceState,
+        state: changed ? { ...sourceState, ...updates } : sourceState,
+        updates,
         changed,
         canContain: true,
     };
+}
+
+/**
+ * Scales only persisted pixel geometry, preserving responsive and absent values.
+ * @param {object} state Persisted MovingUI state.
+ * @param {object} options Axis scale factors.
+ * @param {number} options.scaleX Horizontal scale factor.
+ * @param {number} options.scaleY Vertical scale factor.
+ * @returns {object}
+ */
+export function scaleMovingUIViewportState(state, { scaleX, scaleY } = {}) {
+    const sourceState = state && typeof state === 'object' ? state : {};
+    const scales = {
+        width: Number(scaleX),
+        left: Number(scaleX),
+        right: Number(scaleX),
+        height: Number(scaleY),
+        top: Number(scaleY),
+        bottom: Number(scaleY),
+    };
+    const updates = {};
+
+    for (const [property, scale] of Object.entries(scales)) {
+        const value = parsePixelValue(sourceState[property]);
+        if (value !== null && Number.isFinite(scale) && scale > 0) {
+            updates[property] = String(roundBound(value * scale));
+        }
+    }
+
+    return { ...sourceState, ...updates };
 }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -77,6 +77,7 @@ import { setSlashCommandParserSettingsGetter } from './slash-commands/SlashComma
 import { persona_description_positions as _persona_description_positions } from './personas.js';
 import { generateCustomCssWithAI, resolveCustomCssAIProfile } from './sillybunny-custom-css-ai.js';
 import { populateConnectionProfileSelect } from './extensions/in-chat-agents/profile-utils.js';
+import { resolveMovingUIViewportState } from './moving-ui-viewport.js';
 
 export const toastPositionClasses = [
     'toast-top-left',
@@ -2656,58 +2657,10 @@ function applyMovingUIStateStyles(element, state) {
     }
 }
 
-function parseMovingUIStatePixel(value) {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return value;
-    }
-
-    if (typeof value !== 'string') {
-        return null;
-    }
-
-    const trimmedValue = value.trim();
-    if (!/^-?\d+(?:\.\d+)?(?:px)?$/.test(trimmedValue)) {
-        return null;
-    }
-
-    return Number.parseFloat(trimmedValue);
-}
-
 function getMovingUIViewportSize() {
     return {
         width: window.innerWidth || document.documentElement.clientWidth || 0,
         height: window.innerHeight || document.documentElement.clientHeight || 0,
-    };
-}
-
-function getMovingUIStateBounds(state) {
-    const { width: viewportWidth, height: viewportHeight } = getMovingUIViewportSize();
-    const width = parseMovingUIStatePixel(state?.width);
-    const height = parseMovingUIStatePixel(state?.height);
-    const right = parseMovingUIStatePixel(state?.right);
-    const bottom = parseMovingUIStatePixel(state?.bottom);
-    let left = parseMovingUIStatePixel(state?.left);
-    let top = parseMovingUIStatePixel(state?.top);
-
-    if (left === null && right !== null && width !== null) {
-        left = viewportWidth - right - width;
-    }
-
-    if (top === null && bottom !== null && height !== null) {
-        top = viewportHeight - bottom - height;
-    }
-
-    if (left === null || top === null || width === null || height === null) {
-        return null;
-    }
-
-    return {
-        left,
-        top,
-        right: left + width,
-        bottom: top + height,
-        width,
-        height,
     };
 }
 
@@ -2746,7 +2699,30 @@ function isMovingUIStateOutOfViewport(element, state) {
         return isMovingUIBoundsOutOfViewport(elementBounds);
     }
 
-    return isMovingUIBoundsOutOfViewport(getMovingUIStateBounds(state));
+    const { width: viewportWidth, height: viewportHeight } = getMovingUIViewportSize();
+    const resolution = resolveMovingUIViewportState(state, { viewportWidth, viewportHeight });
+    return resolution.canContain && resolution.changed;
+}
+
+function containMovingUIElement(element, state) {
+    const { width: viewportWidth, height: viewportHeight } = getMovingUIViewportSize();
+    const resolution = resolveMovingUIViewportState(state, {
+        viewportWidth,
+        viewportHeight,
+        elementBounds: getMovingUIElementBounds(element),
+    });
+
+    if (resolution.changed) {
+        Object.assign(state, resolution.state);
+        for (const property of movingUIPixelStyles) {
+            applyMovingUIStateStyle(element, property, resolution.state[property]);
+        }
+    }
+
+    return {
+        changed: resolution.changed,
+        remainsOutOfViewport: isMovingUIStateOutOfViewport(element, state),
+    };
 }
 
 function syncMovingUIOffscreenWarning(showWarning) {
@@ -2762,6 +2738,7 @@ export function loadMovingUIState() {
         && power_user.movingUI === true) {
         console.debug('loading movingUI state');
         let hasOffscreenPanel = false;
+        let didContainPanel = false;
         for (var elmntName of Object.keys(power_user.movingUIState)) {
             var elmntState = power_user.movingUIState[elmntName];
             try {
@@ -2772,8 +2749,11 @@ export function loadMovingUIState() {
                     if (elmnt.length) {
                         console.debug(`loading state for ${targetName} from ${elmntName}`);
                         applyMovingUIStateStyles(elmnt[0], elmntState);
-                        // SillyBunny: make bad persisted panel geometry recoverable from Settings.
-                        hasOffscreenPanel = isMovingUIStateOutOfViewport(elmnt[0], elmntState) || hasOffscreenPanel;
+                        // Persisted geometry must never enlarge the document or
+                        // leave a panel unreachable after a viewport/monitor change.
+                        const containment = containMovingUIElement(elmnt[0], elmntState);
+                        didContainPanel = containment.changed || didContainPanel;
+                        hasOffscreenPanel = containment.remainsOutOfViewport || hasOffscreenPanel;
                         applied = true;
                     }
                 }
@@ -2785,6 +2765,9 @@ export function loadMovingUIState() {
             }
         }
         syncMovingUIOffscreenWarning(hasOffscreenPanel);
+        if (didContainPanel) {
+            saveSettingsDebounced();
+        }
     } else {
         console.debug('skipping movingUI state load');
         syncMovingUIOffscreenWarning(false);
@@ -4064,6 +4047,7 @@ jQuery(async () => {
         const scaleX = parseFloat(Number(window.innerWidth / coreTruthWinWidth).toFixed(4));
 
         if (Object.keys(power_user.movingUIState).length > 0) {
+            let hasOffscreenPanel = false;
             for (var elmntName of Object.keys(power_user.movingUIState)) {
                 var elmntState = power_user.movingUIState[elmntName];
                 var oldHeight = elmntState.height;
@@ -4095,23 +4079,27 @@ jQuery(async () => {
                         applyMovingUIStateStyle(element, 'height', newHeight);
                         applyMovingUIStateStyle(element, 'width', newWidth);
                         applyMovingUIStateStyle(element, 'inset', `${newTop}px ${newRight}px ${newBottom}px ${newLeft}px`);
+                        Object.assign(elmntState, {
+                            height: newHeight,
+                            width: newWidth,
+                            top: newTop,
+                            bottom: newBottom,
+                            left: newLeft,
+                            right: newRight,
+                        });
+                        const containment = containMovingUIElement(element, elmntState);
+                        hasOffscreenPanel = containment.remainsOutOfViewport || hasOffscreenPanel;
                         applied = true;
                     }
 
-                    if (applied) {
-                        power_user.movingUIState[elmntName].height = newHeight;
-                        power_user.movingUIState[elmntName].width = newWidth;
-                        power_user.movingUIState[elmntName].top = newTop;
-                        power_user.movingUIState[elmntName].bottom = newBottom;
-                        power_user.movingUIState[elmntName].left = newLeft;
-                        power_user.movingUIState[elmntName].right = newRight;
-                    } else {
+                    if (!applied) {
                         console.log(`skipping ${elmntName} because it doesn't exist in the DOM`);
                     }
                 } catch (err) {
                     console.log(`error occurred while processing ${elmntName}: ${err}`);
                 }
             }
+            syncMovingUIOffscreenWarning(hasOffscreenPanel);
         } else {
             console.debug('aborting MUI reset', Object.keys(power_user.movingUIState).length);
         }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -77,7 +77,7 @@ import { setSlashCommandParserSettingsGetter } from './slash-commands/SlashComma
 import { persona_description_positions as _persona_description_positions } from './personas.js';
 import { generateCustomCssWithAI, resolveCustomCssAIProfile } from './sillybunny-custom-css-ai.js';
 import { populateConnectionProfileSelect } from './extensions/in-chat-agents/profile-utils.js';
-import { resolveMovingUIViewportState } from './moving-ui-viewport.js';
+import { resolveMovingUIViewportState, scaleMovingUIViewportState } from './moving-ui-viewport.js';
 
 export const toastPositionClasses = [
     'toast-top-left',
@@ -2714,15 +2714,12 @@ function containMovingUIElement(element, state) {
 
     if (resolution.changed) {
         Object.assign(state, resolution.state);
-        for (const property of movingUIPixelStyles) {
+        for (const property of Object.keys(resolution.updates)) {
             applyMovingUIStateStyle(element, property, resolution.state[property]);
         }
     }
 
-    return {
-        changed: resolution.changed,
-        remainsOutOfViewport: isMovingUIStateOutOfViewport(element, state),
-    };
+    return resolution.changed;
 }
 
 function syncMovingUIOffscreenWarning(showWarning) {
@@ -2743,6 +2740,8 @@ export function loadMovingUIState() {
             var elmntState = power_user.movingUIState[elmntName];
             try {
                 const targetNames = elmntName === 'nav-panel-shared-size' ? ['left-nav-panel', 'right-nav-panel'] : [elmntName];
+                const targetElements = [];
+                let sharedStateChanged = false;
                 let applied = false;
                 for (const targetName of targetNames) {
                     var elmnt = $('#' + $.escapeSelector(targetName));
@@ -2751,12 +2750,19 @@ export function loadMovingUIState() {
                         applyMovingUIStateStyles(elmnt[0], elmntState);
                         // Persisted geometry must never enlarge the document or
                         // leave a panel unreachable after a viewport/monitor change.
-                        const containment = containMovingUIElement(elmnt[0], elmntState);
-                        didContainPanel = containment.changed || didContainPanel;
-                        hasOffscreenPanel = containment.remainsOutOfViewport || hasOffscreenPanel;
+                        const didContainTarget = containMovingUIElement(elmnt[0], elmntState);
+                        didContainPanel = didContainTarget || didContainPanel;
+                        sharedStateChanged = didContainTarget || sharedStateChanged;
+                        targetElements.push(elmnt[0]);
                         applied = true;
                     }
                 }
+                if (sharedStateChanged && targetElements.length > 1) {
+                    targetElements.forEach(element => applyMovingUIStateStyles(element, elmntState));
+                }
+                targetElements.forEach(element => {
+                    hasOffscreenPanel = isMovingUIStateOutOfViewport(element, elmntState) || hasOffscreenPanel;
+                });
                 if (!applied) {
                     console.debug(`skipping ${elmntName} because it doesn't exist in the DOM`);
                 }
@@ -4050,23 +4056,12 @@ jQuery(async () => {
             let hasOffscreenPanel = false;
             for (var elmntName of Object.keys(power_user.movingUIState)) {
                 var elmntState = power_user.movingUIState[elmntName];
-                var oldHeight = elmntState.height;
-                var oldWidth = elmntState.width;
-                var oldLeft = elmntState.left;
-                var oldTop = elmntState.top;
-                var oldBottom = elmntState.bottom;
-                var oldRight = elmntState.right;
-                var newHeight, newWidth, newTop, newBottom, newLeft, newRight;
-
-                newHeight = Number(oldHeight * scaleY).toFixed(0);
-                newWidth = Number(oldWidth * scaleX).toFixed(0);
-                newLeft = Number(oldLeft * scaleX).toFixed(0);
-                newTop = Number(oldTop * scaleY).toFixed(0);
-                newBottom = Number(oldBottom * scaleY).toFixed(0);
-                newRight = Number(oldRight * scaleX).toFixed(0);
                 try {
                     const targetNames = elmntName === 'nav-panel-shared-size' ? ['left-nav-panel', 'right-nav-panel'] : [elmntName];
+                    const targetElements = [];
+                    let sharedStateChanged = false;
                     let applied = false;
+                    Object.assign(elmntState, scaleMovingUIViewportState(elmntState, { scaleX, scaleY }));
 
                     for (const targetName of targetNames) {
                         const elmnt = $('#' + $.escapeSelector(targetName));
@@ -4074,23 +4069,21 @@ jQuery(async () => {
                             continue;
                         }
 
-                        console.log(`scaling ${targetName} by ${scaleX}x${scaleY} to ${newWidth}x${newHeight}`);
+                        console.log(`scaling ${targetName} by ${scaleX}x${scaleY} to ${elmntState.width}x${elmntState.height}`);
                         const element = elmnt[0];
-                        applyMovingUIStateStyle(element, 'height', newHeight);
-                        applyMovingUIStateStyle(element, 'width', newWidth);
-                        applyMovingUIStateStyle(element, 'inset', `${newTop}px ${newRight}px ${newBottom}px ${newLeft}px`);
-                        Object.assign(elmntState, {
-                            height: newHeight,
-                            width: newWidth,
-                            top: newTop,
-                            bottom: newBottom,
-                            left: newLeft,
-                            right: newRight,
-                        });
-                        const containment = containMovingUIElement(element, elmntState);
-                        hasOffscreenPanel = containment.remainsOutOfViewport || hasOffscreenPanel;
+                        applyMovingUIStateStyles(element, elmntState);
+                        const didContainTarget = containMovingUIElement(element, elmntState);
+                        sharedStateChanged = didContainTarget || sharedStateChanged;
+                        targetElements.push(element);
                         applied = true;
                     }
+
+                    if (sharedStateChanged && targetElements.length > 1) {
+                        targetElements.forEach(element => applyMovingUIStateStyles(element, elmntState));
+                    }
+                    targetElements.forEach(element => {
+                        hasOffscreenPanel = isMovingUIStateOutOfViewport(element, elmntState) || hasOffscreenPanel;
+                    });
 
                     if (!applied) {
                         console.log(`skipping ${elmntName} because it doesn't exist in the DOM`);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2747,16 +2747,28 @@ function getMobilePopupDialogForKeyboard(element) {
 }
 
 function clearMobilePopupKeyboardShift(dialog) {
-    if (!(dialog instanceof HTMLElement) || !dialog.dataset.sbKeyboardShift) {
+    if (!(dialog instanceof HTMLElement)) {
         return;
     }
 
+    const scroller = dialog.querySelector('[data-sb-keyboard-max-height]');
+    if (scroller instanceof HTMLElement) {
+        const previousMaxHeight = scroller.dataset.sbKeyboardMaxHeight;
+        if (previousMaxHeight) {
+            scroller.style.maxHeight = previousMaxHeight;
+        } else {
+            scroller.style.removeProperty('max-height');
+        }
+        delete scroller.dataset.sbKeyboardMaxHeight;
+    }
+
+    delete dialog.dataset.sbKeyboardAdjusted;
     delete dialog.dataset.sbKeyboardShift;
     dialog.style.removeProperty('transform');
 }
 
 function clearAllMobilePopupKeyboardShifts(except = null) {
-    for (const dialog of document.querySelectorAll('dialog.popup[data-sb-keyboard-shift]')) {
+    for (const dialog of document.querySelectorAll('dialog.popup[data-sb-keyboard-adjusted], dialog.popup[data-sb-keyboard-shift]')) {
         if (dialog !== except) {
             clearMobilePopupKeyboardShift(dialog);
         }
@@ -2797,9 +2809,14 @@ function syncMobilePopupKeyboardShift() {
     // visualViewport tracks the keyboard: top grows and height shrinks as the
     // keyboard rises, so (top + height) is the bottom of the visible area.
     const viewportBottom = viewportSize.top + viewportSize.height;
-    const scroller = activeElement.closest('.popup-content');
+    const scroller = activeElement.closest('.popup-body, .popup-content');
 
     if (scroller instanceof HTMLElement) {
+        const availableHeight = Math.max(0, viewportSize.height - (MOBILE_POPUP_KEYBOARD_CLEARANCE_PX * 2));
+        scroller.dataset.sbKeyboardMaxHeight = scroller.style.maxHeight;
+        scroller.style.maxHeight = `${availableHeight}px`;
+        dialog.dataset.sbKeyboardAdjusted = 'true';
+
         const scrollOverflow = activeElement.getBoundingClientRect().bottom + MOBILE_POPUP_KEYBOARD_CLEARANCE_PX - viewportBottom;
         if (scrollOverflow > 0) {
             scroller.scrollTop += scrollOverflow;
@@ -2820,6 +2837,7 @@ function syncMobilePopupKeyboardShift() {
         return;
     }
 
+    dialog.dataset.sbKeyboardAdjusted = 'true';
     dialog.dataset.sbKeyboardShift = String(shift);
     dialog.style.transform = `translateY(-${shift}px)`;
 }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2762,9 +2762,20 @@ function clearMobilePopupKeyboardShift(dialog) {
         delete scroller.dataset.sbKeyboardMaxHeight;
     }
 
+    if (dialog.dataset.sbKeyboardShift !== undefined) {
+        const previousTransform = dialog.dataset.sbKeyboardTransform;
+        const previousTransformPriority = dialog.dataset.sbKeyboardTransformPriority;
+        if (previousTransform) {
+            dialog.style.setProperty('transform', previousTransform, previousTransformPriority);
+        } else {
+            dialog.style.removeProperty('transform');
+        }
+    }
+
     delete dialog.dataset.sbKeyboardAdjusted;
     delete dialog.dataset.sbKeyboardShift;
-    dialog.style.removeProperty('transform');
+    delete dialog.dataset.sbKeyboardTransform;
+    delete dialog.dataset.sbKeyboardTransformPriority;
 }
 
 function clearAllMobilePopupKeyboardShifts(except = null) {
@@ -2839,7 +2850,11 @@ function syncMobilePopupKeyboardShift() {
 
     dialog.dataset.sbKeyboardAdjusted = 'true';
     dialog.dataset.sbKeyboardShift = String(shift);
-    dialog.style.transform = `translateY(-${shift}px)`;
+    dialog.dataset.sbKeyboardTransform = dialog.style.transform;
+    dialog.dataset.sbKeyboardTransformPriority = dialog.style.getPropertyPriority('transform');
+    const computedTransform = dialog.style.transform || window.getComputedStyle(dialog).transform;
+    const baseTransform = computedTransform && computedTransform !== 'none' ? ` ${computedTransform}` : '';
+    dialog.style.setProperty('transform', `translateY(-${shift}px)${baseTransform}`, 'important');
 }
 
 let sbMobilePopupKeyboardSyncTimer = 0;

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -101,6 +101,8 @@ describe('mobile popup keyboard shift wiring', () => {
 
         expect(helperSource).toContain('const viewportBottom = viewportSize.top + viewportSize.height;');
         expect(helperSource).toMatch(/if \(!isVisualViewportKeyboardOpen\(layoutViewport, viewportSize\)\) \{/);
+        expect(helperSource).toContain('activeElement.closest(\'.popup-body, .popup-content\')');
+        expect(helperSource).toContain('scroller.style.maxHeight = `${availableHeight}px`;');
         expect(helperSource).toContain('scroller.scrollTop += scrollOverflow;');
         expect(helperSource).toContain('dialog.style.transform = `translateY(-${shift}px)`;');
     });
@@ -114,6 +116,7 @@ describe('mobile popup keyboard shift wiring', () => {
         expect(tabsSource).toContain('function clearMobilePopupKeyboardShift(');
         expect(tabsSource).toContain('function clearAllMobilePopupKeyboardShifts(');
         expect(tabsSource).toMatch(/dialog\.style\.removeProperty\('transform'\)/);
+        expect(tabsSource).toContain('scroller.style.removeProperty(\'max-height\');');
         expect(tabsSource).toContain('delete dialog.dataset.sbKeyboardShift;');
     });
 

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -104,7 +104,7 @@ describe('mobile popup keyboard shift wiring', () => {
         expect(helperSource).toContain('activeElement.closest(\'.popup-body, .popup-content\')');
         expect(helperSource).toContain('scroller.style.maxHeight = `${availableHeight}px`;');
         expect(helperSource).toContain('scroller.scrollTop += scrollOverflow;');
-        expect(helperSource).toContain('dialog.style.transform = `translateY(-${shift}px)`;');
+        expect(helperSource).toContain('dialog.style.setProperty(\'transform\', `translateY(-${shift}px)${baseTransform}`, \'important\');');
     });
 
     test('clamps the shift so the dialog top stays inside the visible viewport', () => {
@@ -115,6 +115,10 @@ describe('mobile popup keyboard shift wiring', () => {
     test('clears the shift when focus leaves or the keyboard closes', () => {
         expect(tabsSource).toContain('function clearMobilePopupKeyboardShift(');
         expect(tabsSource).toContain('function clearAllMobilePopupKeyboardShifts(');
+        expect(tabsSource).toContain('if (dialog.dataset.sbKeyboardShift !== undefined) {');
+        expect(tabsSource).toContain('dialog.dataset.sbKeyboardTransform = dialog.style.transform;');
+        expect(tabsSource).toContain('dialog.dataset.sbKeyboardTransformPriority = dialog.style.getPropertyPriority(\'transform\');');
+        expect(tabsSource).toContain('dialog.style.setProperty(\'transform\', previousTransform, previousTransformPriority);');
         expect(tabsSource).toMatch(/dialog\.style\.removeProperty\('transform'\)/);
         expect(tabsSource).toContain('scroller.style.removeProperty(\'max-height\');');
         expect(tabsSource).toContain('delete dialog.dataset.sbKeyboardShift;');

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -369,7 +369,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(railHorizontalMove.event, { touchStart: railHorizontalMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(railAtStartEdgeMove.event, { touchStart: railAtStartEdgeMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(railVerticalMove.event, { touchStart: railVerticalMove.touchStart })).toBe(true);
-        expect(shouldBlockMobileDocumentPan(railControlMove.event, { touchStart: railControlMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(railControlMove.event, { touchStart: railControlMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(incidentalComposerGapMove.event, { touchStart: incidentalComposerGapMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(incidentalComposerControlMove.event, { touchStart: incidentalComposerControlMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(companionHandleHorizontalMove.event, { touchStart: companionHandleHorizontalMove.touchStart })).toBe(true);
@@ -393,8 +393,8 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(legacyDialogInputMove.event, { touchStart: legacyDialogInputMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(legacyDialogButtonMove.event, { touchStart: legacyDialogButtonMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(genericPopupBodyMove.event, { touchStart: genericPopupBodyMove.touchStart })).toBe(false);
-        expect(shouldBlockMobileDocumentPan(genericPopupInputMove.event, { touchStart: genericPopupInputMove.touchStart })).toBe(true);
-        expect(shouldBlockMobileDocumentPan(genericPopupButtonMove.event, { touchStart: genericPopupButtonMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(genericPopupInputMove.event, { touchStart: genericPopupInputMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(genericPopupButtonMove.event, { touchStart: genericPopupButtonMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(characterDrawerMove.event, { touchStart: characterDrawerMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(shellNavHorizontalMove.event, { touchStart: shellNavHorizontalMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(shellNavHorizontalAtStartEdgeMove.event, { touchStart: shellNavHorizontalAtStartEdgeMove.touchStart })).toBe(true);
@@ -402,7 +402,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
     });
 
-    test('allows owned scrolling but blocks control drags and edge overscroll in open mobile drawers', () => {
+    test('allows owned scrolling from controls while blocking edge overscroll in mobile drawers', () => {
         const createMenuRoot = rootSelector => createElementStub({
             matches: selector => selectorListIncludes(selector, rootSelector) || selectorListIncludes(selector, `${rootSelector}.openDrawer`),
             scrollHeight: 1600,
@@ -438,9 +438,28 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(workspaceScrollMove.event, { touchStart: workspaceScrollMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(workspaceAtTopPullDownMove.event, { touchStart: workspaceAtTopPullDownMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(connectionProfileActionMove.event, { touchStart: connectionProfileActionMove.touchStart })).toBe(true);
-        expect(shouldBlockMobileDocumentPan(customizeSelectMove.event, { touchStart: customizeSelectMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(customizeSelectMove.event, { touchStart: customizeSelectMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(characterAtTopPullDownMove.event, { touchStart: characterAtTopPullDownMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(closedWorkspaceAtTopPullDownMove.event, { touchStart: closedWorkspaceAtTopPullDownMove.touchStart })).toBe(true);
+    });
+
+    test('does not hand guarded control gestures to a scroll owner outside the guard', () => {
+        const documentScroller = createElementStub({
+            scrollHeight: 2000,
+            clientHeight: 800,
+            scrollTop: 200,
+        });
+        const guardedSurface = createElementStub({
+            parentElement: documentScroller,
+            matches: selector => selectorListIncludes(selector, '#send_form'),
+        });
+        const button = createElementStub({
+            parentElement: guardedSurface,
+            matches: selector => selectorListIncludes(selector, 'button'),
+        });
+        const move = createTouchMove(button, { y: -40 });
+
+        expect(shouldBlockMobileDocumentPan(move.event, { touchStart: move.touchStart })).toBe(true);
     });
 
     test('imports the mobile shell lifecycle seam into the shell adapter', () => {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
+import { parse } from '@adobe/css-tools';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -102,6 +103,12 @@ function getFunctionSource(name) {
 }
 
 describe('mobile shell lifecycle wiring', () => {
+    test('keeps the trailing mobile chat hardening parseable', () => {
+        expect(() => parse(mobileShellCssSource, { source: 'sillybunny-mobile-shell.css' })).not.toThrow();
+        expect(mobileShellCssSource).toMatch(/#sb-bottom-chat-bar\s*\{[^}]*touch-action:\s*pan-x;/);
+        expect(mobileShellCssSource).toMatch(/#sb-bottom-chat-secondary-row\s*\{[^}]*touch-action:\s*pan-x;/);
+    });
+
     test('blocks mobile document panning from fixed chrome and scroll edges', () => {
         expect(browserFixesSource).toContain('blockDocumentPanFromShellGaps');
         expect(browserFixesSource).toContain('captureDocumentPanStart');
@@ -168,6 +175,21 @@ describe('mobile shell lifecycle wiring', () => {
         });
         const quickReplyButton = createElementStub({ parentElement: quickReplyRail });
         const quickReplyStartButton = createElementStub({ parentElement: quickReplyRailAtStart });
+        const quickReplyControl = createElementStub({
+            parentElement: quickReplyRail,
+            matches: selector => selectorListIncludes(selector, '.interactable'),
+        });
+        const incidentalComposerRail = createElementStub({
+            parentElement: composerChrome,
+            matches: selector => selectorListIncludes(selector, '#leftSendForm'),
+            scrollWidth: 57,
+            clientWidth: 55,
+        });
+        const incidentalComposerGap = createElementStub({ parentElement: incidentalComposerRail });
+        const incidentalComposerControl = createElementStub({
+            parentElement: incidentalComposerRail,
+            matches: selector => selectorListIncludes(selector, '.interactable'),
+        });
         const sendFormButton = createElementStub({ parentElement: sendFormChrome });
         const genericButton = createElementStub({
             matches: selector => selectorListIncludes(selector, 'button'),
@@ -299,6 +321,9 @@ describe('mobile shell lifecycle wiring', () => {
         const railHorizontalMove = createTouchMove(quickReplyButton, { x: 40, y: 2 });
         const railAtStartEdgeMove = createTouchMove(quickReplyStartButton, { x: 40, y: 2 });
         const railVerticalMove = createTouchMove(quickReplyButton, { x: 2, y: -40 });
+        const railControlMove = createTouchMove(quickReplyControl, { x: -40, y: 2 });
+        const incidentalComposerGapMove = createTouchMove(incidentalComposerGap, { x: -40, y: 2 });
+        const incidentalComposerControlMove = createTouchMove(incidentalComposerControl, { x: -40, y: 2 });
         const companionHandleHorizontalMove = createTouchMove(companionHandle, { x: -40, y: 1 });
         const companionHandleVerticalMove = createTouchMove(companionHandle, { x: 1, y: 40 });
         const companionPanelVerticalMove = createTouchMove(companionPanelBody, { x: 1, y: -40 });
@@ -344,6 +369,9 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(railHorizontalMove.event, { touchStart: railHorizontalMove.touchStart })).toBe(false);
         expect(shouldBlockMobileDocumentPan(railAtStartEdgeMove.event, { touchStart: railAtStartEdgeMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(railVerticalMove.event, { touchStart: railVerticalMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(railControlMove.event, { touchStart: railControlMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(incidentalComposerGapMove.event, { touchStart: incidentalComposerGapMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(incidentalComposerControlMove.event, { touchStart: incidentalComposerControlMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(companionHandleHorizontalMove.event, { touchStart: companionHandleHorizontalMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(companionHandleVerticalMove.event, { touchStart: companionHandleVerticalMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(companionPanelVerticalMove.event, { touchStart: companionPanelVerticalMove.touchStart })).toBe(false);
@@ -374,7 +402,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
     });
 
-    test('relaxes document pan guards inside open mobile shell menus', () => {
+    test('allows owned scrolling but blocks control drags and edge overscroll in open mobile drawers', () => {
         const createMenuRoot = rootSelector => createElementStub({
             matches: selector => selectorListIncludes(selector, rootSelector) || selectorListIncludes(selector, `${rootSelector}.openDrawer`),
             scrollHeight: 1600,
@@ -388,7 +416,11 @@ describe('mobile shell lifecycle wiring', () => {
             scrollHeight: 1600,
             clientHeight: 600,
         });
-        const workspaceButton = createElementStub({ parentElement: workspaceRoot });
+        const workspaceButton = createElementStub({
+            parentElement: workspaceRoot,
+            matches: selector => selectorListIncludes(selector, 'button'),
+        });
+        const connectionProfileAction = createElementStub({ parentElement: workspaceRoot });
         const customizeSelect = createElementStub({
             parentElement: customizeRoot,
             matches: selector => selector.includes('select'),
@@ -396,14 +428,18 @@ describe('mobile shell lifecycle wiring', () => {
         const characterCard = createElementStub({ parentElement: characterRoot });
         const closedWorkspaceButton = createElementStub({ parentElement: closedWorkspaceRoot });
 
+        const workspaceScrollMove = createTouchMove(workspaceButton, { x: 1, y: -40 });
         const workspaceAtTopPullDownMove = createTouchMove(workspaceButton, { x: 1, y: 40 });
+        const connectionProfileActionMove = createTouchMove(connectionProfileAction, { x: 40, y: 1 });
         const customizeSelectMove = createTouchMove(customizeSelect, { x: 1, y: -40 });
         const characterAtTopPullDownMove = createTouchMove(characterCard, { x: 1, y: 40 });
         const closedWorkspaceAtTopPullDownMove = createTouchMove(closedWorkspaceButton, { x: 1, y: 40 });
 
-        expect(shouldBlockMobileDocumentPan(workspaceAtTopPullDownMove.event, { touchStart: workspaceAtTopPullDownMove.touchStart })).toBe(false);
-        expect(shouldBlockMobileDocumentPan(customizeSelectMove.event, { touchStart: customizeSelectMove.touchStart })).toBe(false);
-        expect(shouldBlockMobileDocumentPan(characterAtTopPullDownMove.event, { touchStart: characterAtTopPullDownMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(workspaceScrollMove.event, { touchStart: workspaceScrollMove.touchStart })).toBe(false);
+        expect(shouldBlockMobileDocumentPan(workspaceAtTopPullDownMove.event, { touchStart: workspaceAtTopPullDownMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(connectionProfileActionMove.event, { touchStart: connectionProfileActionMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(customizeSelectMove.event, { touchStart: customizeSelectMove.touchStart })).toBe(true);
+        expect(shouldBlockMobileDocumentPan(characterAtTopPullDownMove.event, { touchStart: characterAtTopPullDownMove.touchStart })).toBe(true);
         expect(shouldBlockMobileDocumentPan(closedWorkspaceAtTopPullDownMove.event, { touchStart: closedWorkspaceAtTopPullDownMove.touchStart })).toBe(true);
     });
 

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -1,4 +1,4 @@
-/* global document, window */
+/* global document, getComputedStyle, localStorage, requestAnimationFrame, window */
 import { expect, test } from '@playwright/test';
 import { openQuietChatForSmoke, waitForAnimationFrames } from './chat-scroll-regression-helpers.js';
 
@@ -10,6 +10,22 @@ import { openQuietChatForSmoke, waitForAnimationFrames } from './chat-scroll-reg
 test.describe.configure({ mode: 'serial' });
 
 const IPHONE_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const VIEWPORT_SURFACE_SELECTOR = [
+    '#left-nav-panel.openDrawer',
+    '#right-nav-panel.openDrawer',
+    '#user-settings-block.openDrawer',
+    '#sb-mobile-nav.sb-nav-open',
+    '#sb-mobile-chat-tools.sb-chat-tools-open',
+    '#sb-universal-search.is-open .sb-universal-search-panel',
+    '#sb-persona-picker',
+    '.options-content',
+    '#extensionsMenu',
+    '.ica--tpanel.is-open',
+    'dialog[open]',
+    '#shadow_popup #dialogue_popup',
+    '.autoComplete-wrap',
+    '.ctx-menu',
+].join(', ');
 const IPAD_USER_AGENT = 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 const MOBILE_SHELL_NAV_OPEN_GRACE_MS = 450;
 
@@ -75,11 +91,14 @@ function getComposerViewportFit(page) {
     });
 }
 
-function getHorizontalOverflow(page) {
+function getDocumentOverflow(page) {
     return page.evaluate(() => {
         const root = document.documentElement;
 
-        return root.scrollWidth - root.clientWidth;
+        return {
+            horizontal: root.scrollWidth - root.clientWidth,
+            vertical: root.scrollHeight - root.clientHeight,
+        };
     });
 }
 
@@ -87,8 +106,47 @@ function getIsMobileShellViewport(page) {
     return page.evaluate(() => window.SillyBunnyShell.isMobileViewport());
 }
 
-async function expectNoHorizontalOverflow(page) {
-    await expect.poll(() => getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+async function expectNoDocumentOverflow(page) {
+    await expect.poll(async () => {
+        const overflow = await getDocumentOverflow(page);
+        const escapedSurfaces = await page.evaluate((selector) => {
+            const viewport = window.visualViewport;
+            const viewportBounds = {
+                left: viewport?.offsetLeft ?? 0,
+                top: viewport?.offsetTop ?? 0,
+                right: (viewport?.offsetLeft ?? 0) + (viewport?.width ?? window.innerWidth),
+                bottom: (viewport?.offsetTop ?? 0) + (viewport?.height ?? window.innerHeight),
+            };
+
+            return Array.from(document.querySelectorAll(selector)).flatMap((element) => {
+                const style = getComputedStyle(element);
+                const rect = element.getBoundingClientRect();
+                if (style.display === 'none'
+                    || style.visibility === 'hidden'
+                    || style.visibility === 'collapse'
+                    || Number(style.opacity) === 0
+                    || rect.width <= 1
+                    || rect.height <= 1) {
+                    return [];
+                }
+
+                const escaped = rect.left < viewportBounds.left - 1
+                    || rect.top < viewportBounds.top - 1
+                    || rect.right > viewportBounds.right + 1
+                    || rect.bottom > viewportBounds.bottom + 1;
+                return escaped ? [{
+                    surface: element.id || element.className || element.tagName,
+                    rect: [rect.left, rect.top, rect.right, rect.bottom],
+                    viewport: Object.values(viewportBounds),
+                }] : [];
+            });
+        }, VIEWPORT_SURFACE_SELECTOR);
+        const violations = [];
+        if (overflow.horizontal > 1) violations.push({ documentHorizontalOverflow: overflow.horizontal });
+        if (overflow.vertical > 1) violations.push({ documentVerticalOverflow: overflow.vertical });
+        violations.push(...escapedSurfaces);
+        return JSON.stringify(violations);
+    }).toBe('[]');
 }
 
 async function waitForNavOpenGrace(page) {
@@ -141,6 +199,12 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await waitForAnimationFrames(page, 3);
     });
 
+    test('primary chat starts without off-canvas document overflow', async ({ page }) => {
+        const overflow = await getDocumentOverflow(page);
+        expect(overflow.horizontal).toBeLessThanOrEqual(1);
+        expect(overflow.vertical).toBeLessThanOrEqual(1);
+    });
+
     test('left drawer open and close honor the mobile viewport bound contract', async ({ page }, testInfo) => {
         await openLeftShell(page);
 
@@ -186,7 +250,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             boxSizing: '',
         });
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
     });
 
     test('hamburger nav keeps hidden, aria-hidden, and inert in agreement', async ({ page }, testInfo) => {
@@ -230,7 +294,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             buttonOpenClass: false,
         });
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
     });
 
     test('opening each overlay closes competing mobile surfaces', async ({ page }, testInfo) => {
@@ -275,7 +339,346 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             characterPanelOpen: true,
         });
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
+    });
+
+    test('every primary chat surface stays inside the document viewport', async ({ page }) => {
+        const detachedAutocompleteErrors = [];
+        page.on('pageerror', error => {
+            if (error.message.includes('Cannot read properties of null (reading \'getBoundingClientRect\')')) {
+                detachedAutocompleteErrors.push(error.message);
+            }
+        });
+        const checkpoint = async (label) => {
+            await test.step(label, async () => {
+                await waitForAnimationFrames(page, 2);
+                await expectNoDocumentOverflow(page);
+            });
+        };
+        const closeOpenShell = () => page.evaluate(() => {
+            document.querySelector('.sb-shell-root.openDrawer .sb-shell-close')?.click();
+        });
+
+        for (const tabId of ['presets', 'api', 'sampling', 'advanced-formatting', 'agents']) {
+            await page.evaluate(tab => window.SillyBunnyShell.openTab('left', tab), tabId);
+            await checkpoint(`Workspace · ${tabId}`);
+        }
+        const textareaFullscreenToggle = page.locator('#left-nav-panel .ica--textarea-fullscreen-toggle').first();
+        await expect(textareaFullscreenToggle).toBeVisible();
+        await textareaFullscreenToggle.click();
+        await expect(page.locator('dialog.ica--textarea-fullscreen-backdrop[open]')).toBeVisible();
+        await checkpoint('Agents textarea · fullscreen');
+        await page.keyboard.press('Escape');
+        await expect(page.locator('dialog.ica--textarea-fullscreen-backdrop')).toHaveCount(0);
+        await checkpoint('Agents textarea · restored');
+        await closeOpenShell();
+        await checkpoint('Workspace · closed');
+
+        for (const tabId of ['settings', 'extensions', 'background', 'server', 'console-logs']) {
+            await page.evaluate(tab => window.SillyBunnyShell.openTab('right', tab), tabId);
+            await checkpoint(`Customize · ${tabId}`);
+        }
+        await closeOpenShell();
+        await checkpoint('Customize · closed');
+
+        for (const tabId of ['characters', 'groups', 'editor', 'world-info', 'persona', 'import']) {
+            await page.evaluate(tab => window.SillyBunnyShell.openTab('characters', tab), tabId);
+            await checkpoint(`Characters · ${tabId}`);
+        }
+        await page.evaluate(() => window.SillyBunnyShell.closeCharacters());
+        await checkpoint('Characters · closed');
+        await page.evaluate(async () => {
+            const { AutoComplete } = await import('/scripts/autocomplete/AutoComplete.js');
+            const detachedTextarea = document.createElement('textarea');
+            document.body.append(detachedTextarea);
+            new AutoComplete(detachedTextarea, () => false, async () => null, true);
+            detachedTextarea.remove();
+            window.dispatchEvent(new Event('resize'));
+            await new Promise(resolve => setTimeout(resolve, 30));
+        });
+        expect(detachedAutocompleteErrors).toEqual([]);
+
+        await clickHamburgerProgrammatically(page);
+        await checkpoint('Mobile nav · open');
+        await page.evaluate(() => document.querySelector('#sb-mobile-nav .sb-mobile-panel-close')?.click());
+        await checkpoint('Mobile nav · closed');
+
+        await page.evaluate(() => window.SillyBunnyShell.openChatTools());
+        await checkpoint('Chat tools · open');
+        await page.evaluate(() => document.querySelector('#sb-mobile-chat-tools .sb-mobile-panel-close')?.click());
+        await checkpoint('Chat tools · closed');
+
+        await page.evaluate(() => window.SillyBunnyShell.openGlobalSearch());
+        await checkpoint('Global search · open');
+        await page.keyboard.press('Escape');
+        await checkpoint('Global search · closed');
+
+        await page.evaluate(() => document.getElementById('sb-persona-bubble')?.click());
+        await checkpoint('Persona picker · open');
+        await page.evaluate(() => document.getElementById('sb-persona-bubble')?.click());
+        await checkpoint('Persona picker · closed');
+
+        for (const buttonId of ['options_button', 'extensionsMenuButton']) {
+            await page.evaluate(id => document.getElementById(id)?.click(), buttonId);
+            await checkpoint(`${buttonId} · open`);
+            await page.evaluate(id => document.getElementById(id)?.click(), buttonId);
+            await checkpoint(`${buttonId} · closed`);
+        }
+
+        const contextMenuBounds = await page.evaluate(async () => {
+            const { ContextMenu } = await import('/scripts/extensions/quick-reply/src/ui/ctx/ContextMenu.js');
+            const childQuickReply = {
+                icon: '',
+                showLabel: true,
+                label: 'A long contextual quick reply that must remain reachable',
+                title: '',
+                message: '',
+                contextList: [],
+                isHidden: false,
+            };
+            const set = {
+                name: 'Context actions',
+                qrList: [childQuickReply],
+                execute() {},
+            };
+            const menu = new ContextMenu({
+                icon: '',
+                showLabel: true,
+                label: 'Root',
+                title: '',
+                message: '',
+                contextList: [{ set, isChained: false }],
+            });
+
+            menu.show({ clientX: window.innerWidth - 1, clientY: window.innerHeight / 2 });
+            await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+            const rect = menu.menu.getBoundingClientRect();
+            const bounds = {
+                left: rect.left,
+                top: rect.top,
+                right: rect.right,
+                bottom: rect.bottom,
+                viewportWidth: window.innerWidth,
+                viewportHeight: window.innerHeight,
+            };
+            menu.hide();
+            return bounds;
+        });
+        expect(contextMenuBounds.left).toBeGreaterThanOrEqual(4);
+        expect(contextMenuBounds.top).toBeGreaterThanOrEqual(4);
+        expect(contextMenuBounds.right).toBeLessThanOrEqual(contextMenuBounds.viewportWidth - 4);
+        expect(contextMenuBounds.bottom).toBeLessThanOrEqual(contextMenuBounds.viewportHeight - 4);
+        await checkpoint('Quick Reply context menu · closed');
+
+        const composer = page.locator('#send_textarea');
+        const originalComposerValue = await composer.inputValue();
+        try {
+            await composer.fill('');
+            await composer.pressSequentially('/');
+            const autocomplete = page.locator('.autoComplete-wrap');
+            await expect(autocomplete).toBeVisible();
+            const autocompleteBounds = await autocomplete.boundingBox();
+            expect(autocompleteBounds).not.toBeNull();
+            expect(autocompleteBounds.x).toBeGreaterThanOrEqual(-1);
+            expect(autocompleteBounds.y).toBeGreaterThanOrEqual(-1);
+            expect(autocompleteBounds.x + autocompleteBounds.width).toBeLessThanOrEqual(391);
+            expect(autocompleteBounds.y + autocompleteBounds.height).toBeLessThanOrEqual(845);
+            await checkpoint('Composer autocomplete · open');
+        } finally {
+            await composer.fill(originalComposerValue);
+            await page.keyboard.press('Escape');
+        }
+        await checkpoint('Composer autocomplete · closed');
+
+        const companionHandleStorageKey = 'ica--tracker-panel-handle-top-v2';
+        const storedCompanionHandlePosition = await page.evaluate(key => localStorage.getItem(key), companionHandleStorageKey);
+        try {
+            for (const edge of ['right', 'left', 'top', 'bottom']) {
+                await page.evaluate(async ({ key, panelEdge }) => {
+                    localStorage.setItem(key, JSON.stringify({ edge: panelEdge, fraction: 0.5 }));
+                    const panel = await import('/scripts/extensions/in-chat-agents/companion/companion-panel.js');
+                    panel.openCompanionPanel();
+                }, { key: companionHandleStorageKey, panelEdge: edge });
+                await checkpoint(`Companion panel · ${edge} · open`);
+                await page.evaluate(async () => {
+                    const panel = await import('/scripts/extensions/in-chat-agents/companion/companion-panel.js');
+                    panel.closeCompanionPanel();
+                });
+                await checkpoint(`Companion panel · ${edge} · closed`);
+            }
+        } finally {
+            await page.evaluate(async ({ key, storedValue }) => {
+                const panel = await import('/scripts/extensions/in-chat-agents/companion/companion-panel.js');
+                panel.closeCompanionPanel();
+                if (storedValue === null) {
+                    localStorage.removeItem(key);
+                } else {
+                    localStorage.setItem(key, storedValue);
+                }
+            }, { key: companionHandleStorageKey, storedValue: storedCompanionHandlePosition });
+        }
+
+        await page.evaluate(async () => {
+            const { Popup, POPUP_TYPE } = await import('/scripts/popup.js');
+            const popup = new Popup('<p>Viewport containment regression</p>', POPUP_TYPE.CONFIRM);
+            window.__viewportContainmentPopup = popup;
+            void popup.show();
+        });
+        await checkpoint('Generic popup · open');
+        await page.evaluate(async () => {
+            await window.__viewportContainmentPopup?.completeCancelled();
+            delete window.__viewportContainmentPopup;
+        });
+        await checkpoint('Generic popup · closed');
+
+        await page.evaluate(async () => {
+            const { callPopup } = await import('/script.js');
+            window.__viewportContainmentLegacyPopup = callPopup('<p>Legacy viewport containment regression</p>', 'confirm');
+        });
+        await expect(page.locator('#shadow_popup')).toBeVisible();
+        const legacyPopupBounds = await page.locator('#dialogue_popup').boundingBox();
+        expect(legacyPopupBounds).not.toBeNull();
+        expect(legacyPopupBounds.x).toBeGreaterThanOrEqual(-1);
+        expect(legacyPopupBounds.y).toBeGreaterThanOrEqual(-1);
+        expect(legacyPopupBounds.x + legacyPopupBounds.width).toBeLessThanOrEqual(391);
+        expect(legacyPopupBounds.y + legacyPopupBounds.height).toBeLessThanOrEqual(845);
+        await checkpoint('Legacy popup · open');
+        await page.locator('#dialogue_popup_cancel').click();
+        await page.evaluate(async () => {
+            await window.__viewportContainmentLegacyPopup;
+            delete window.__viewportContainmentLegacyPopup;
+        });
+        await checkpoint('Legacy popup · closed');
+    });
+
+    test('nested Quick Reply menus stay reachable through viewport changes', async ({ page }) => {
+        await page.evaluate(async () => {
+            const { ContextMenu } = await import('/scripts/extensions/quick-reply/src/ui/ctx/ContextMenu.js');
+            const leafQuickReply = {
+                icon: '',
+                showLabel: true,
+                label: 'Unbroken_nested_action_'.repeat(24),
+                title: '',
+                message: '',
+                contextList: [],
+                isHidden: false,
+            };
+            const nestedSet = {
+                name: 'Nested actions',
+                qrList: [leafQuickReply],
+                execute() {},
+            };
+            const parentQuickReply = {
+                icon: '',
+                showLabel: true,
+                label: 'Nested actions',
+                title: '',
+                message: '',
+                contextList: [{ set: nestedSet, isChained: false }],
+                isHidden: false,
+            };
+            const fillerQuickReplies = Array.from({ length: 30 }, (_, index) => ({
+                icon: '',
+                showLabel: true,
+                label: `Filler action ${index + 1}`,
+                title: '',
+                message: '',
+                contextList: [],
+                isHidden: false,
+            }));
+            const rootSet = {
+                name: 'Root actions',
+                qrList: [parentQuickReply, ...fillerQuickReplies],
+                execute() {},
+            };
+            const menu = new ContextMenu({
+                icon: '',
+                showLabel: true,
+                label: 'Root',
+                title: '',
+                message: '',
+                contextList: [{ set: rootSet, isChained: false }],
+            });
+
+            menu.show({ clientX: window.innerWidth - 1, clientY: window.innerHeight - 1 });
+            window.__viewportContainmentContextMenu = menu;
+        });
+
+        const parentItem = page.locator('.ctx-menu:not(.ctx-sub-menu) > .ctx-has-children').first();
+        await parentItem.locator('.ctx-expander').evaluate(element => element.click());
+        await expect(page.locator('.ctx-sub-menu')).toBeVisible();
+
+        const expectMenusContained = async () => {
+            await waitForAnimationFrames(page, 2);
+            const bounds = await page.locator('.ctx-menu').evaluateAll(menus => menus.map(menu => {
+                const rect = menu.getBoundingClientRect();
+                const hitTarget = document.elementFromPoint(
+                    Math.min(window.innerWidth - 1, Math.max(0, rect.left + (rect.width / 2))),
+                    Math.min(window.innerHeight - 1, Math.max(0, rect.top + (rect.height / 2))),
+                );
+                return {
+                    className: menu.className,
+                    style: menu.getAttribute('style'),
+                    left: rect.left,
+                    top: rect.top,
+                    right: rect.right,
+                    bottom: rect.bottom,
+                    viewportWidth: window.innerWidth,
+                    viewportHeight: window.innerHeight,
+                    visualViewportWidth: window.visualViewport?.width ?? null,
+                    hitTestVisible: menu.classList.contains('ctx-sub-menu')
+                        ? Boolean(hitTarget && menu.contains(hitTarget))
+                        : Boolean(hitTarget?.closest('.ctx-menu')),
+                };
+            }));
+
+            expect(bounds.length).toBeGreaterThan(1);
+            for (const rect of bounds) {
+                const diagnostic = JSON.stringify(rect);
+                expect(rect.left, diagnostic).toBeGreaterThanOrEqual(4);
+                expect(rect.top, diagnostic).toBeGreaterThanOrEqual(4);
+                expect(rect.right, diagnostic).toBeLessThanOrEqual(rect.viewportWidth - 4);
+                expect(rect.bottom, diagnostic).toBeLessThanOrEqual(rect.viewportHeight - 4);
+                expect(rect.hitTestVisible, diagnostic).toBe(true);
+            }
+            await expectNoDocumentOverflow(page);
+        };
+
+        try {
+            await test.step('initial tall menu and nested submenu', async () => {
+                await expectMenusContained();
+                await page.locator('.ctx-sub-menu .ctx-item').first().hover();
+                await expect(page.locator('.ctx-sub-menu')).toBeVisible();
+            });
+            await test.step('visual viewport scroll repositions open menus', async () => {
+                const submenuPlacementCount = await page.evaluate(() => {
+                    const rootMenu = window.__viewportContainmentContextMenu;
+                    const subMenu = rootMenu.itemList.find(item => item.subMenu)?.subMenu;
+                    const originalPlace = subMenu.place.bind(subMenu);
+                    let placementCount = 0;
+                    subMenu.place = () => {
+                        placementCount += 1;
+                        return originalPlace();
+                    };
+                    document.querySelector('.ctx-menu:not(.ctx-sub-menu)').style.left = '2000px';
+                    window.visualViewport?.dispatchEvent(new window.Event('scroll'));
+                    return placementCount;
+                });
+                expect(submenuPlacementCount).toBeGreaterThan(0);
+                await expectMenusContained();
+            });
+            await test.step('resize viewport', () => page.setViewportSize({ width: 320, height: 568 }));
+            await test.step('keep nested submenu open', async () => {
+                await expect(page.locator('.ctx-sub-menu')).toBeVisible();
+            });
+            await test.step('assert resized menu containment', () => expectMenusContained());
+        } finally {
+            await page.evaluate(() => {
+                window.__viewportContainmentContextMenu?.hide();
+                delete window.__viewportContainmentContextMenu;
+            });
+        }
+        await expect(page.locator('.ctx-menu')).toHaveCount(0);
     });
 
     test('keyboard-style viewport shrink re-syncs open drawer bounds and recovers', async ({ page }) => {
@@ -329,7 +732,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             return bounds?.isOpen === false && bounds?.isViewportBound === false;
         }).toBe(true);
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
     });
 
     test('composer stays on screen through keyboard-style viewport shrink', async ({ page }, testInfo) => {
@@ -353,7 +756,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             return fit !== null && fit.bottom <= fit.viewportHeight + 1;
         }).toBe(true);
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
     });
 });
 
@@ -393,7 +796,7 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
         expect(composerBox.x).toBeGreaterThanOrEqual(-1);
         expect(composerBox.x + composerBox.width).toBeLessThanOrEqual(321);
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
     });
 });
 
@@ -424,7 +827,7 @@ test.describe('mobile shell smoke at tablet 768x1024', () => {
             leftShellOpen: false,
         });
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
     });
 });
 
@@ -460,6 +863,162 @@ test.describe('compact desktop smoke at 820x1180', () => {
             return overlayState.chatToolsOpen;
         }).toBe(false);
 
-        await expectNoHorizontalOverflow(page);
+        await expectNoDocumentOverflow(page);
+    });
+});
+
+test.describe('desktop MovingUI containment at 1264x800', () => {
+    test.use({ viewport: { width: 1264, height: 800 } });
+
+    test('clamps an active panel drag at every viewport edge', async ({ page }) => {
+        await openQuietChatForSmoke(page, { selectCharacter: false });
+        await page.evaluate(() => window.SillyBunnyShell.openTab('left', 'presets'));
+        await waitForAnimationFrames(page, 2);
+
+        const original = await page.evaluate(async () => {
+            const powerUserModule = await import('/scripts/power-user.js');
+            const { dragElement } = await import('/scripts/RossAscends-mods.js');
+            const leftPanel = document.getElementById('left-nav-panel');
+            const rightPanel = document.getElementById('right-nav-panel');
+            const snapshot = {
+                movingUI: powerUserModule.power_user.movingUI,
+                movingUIState: powerUserModule.power_user.movingUIState,
+                leftStyle: leftPanel.style.cssText,
+                rightStyle: rightPanel.style.cssText,
+                hadMovingUIClass: document.body.classList.contains('movingUI'),
+            };
+
+            powerUserModule.power_user.movingUI = true;
+            powerUserModule.power_user.movingUIState = {};
+            document.body.classList.add('movingUI');
+            leftPanel.style.setProperty('position', 'fixed', 'important');
+            leftPanel.style.setProperty('inset', 'auto', 'important');
+            leftPanel.style.setProperty('left', '100px', 'important');
+            leftPanel.style.setProperty('top', '100px', 'important');
+            leftPanel.style.setProperty('width', '400px', 'important');
+            leftPanel.style.setProperty('height', '500px', 'important');
+            dragElement(window.$(leftPanel));
+            return snapshot;
+        });
+
+        const dragBeyond = async (targetX, targetY) => {
+            const header = page.locator('#left-nav-panelheader').first();
+            const box = await header.boundingBox();
+            expect(box).not.toBeNull();
+            await page.mouse.move(box.x + (box.width / 2), box.y + (box.height / 2));
+            await page.mouse.down();
+            await page.mouse.move(targetX, targetY, { steps: 2 });
+            await page.mouse.up();
+            await waitForAnimationFrames(page, 2);
+        };
+        const getBounds = () => page.evaluate(() => {
+            const rect = document.getElementById('left-nav-panel').getBoundingClientRect();
+            return {
+                left: rect.left,
+                top: rect.top,
+                right: rect.right,
+                bottom: rect.bottom,
+                viewportWidth: window.innerWidth,
+                viewportHeight: window.innerHeight,
+                rootScrollWidth: document.documentElement.scrollWidth,
+                rootScrollHeight: document.documentElement.scrollHeight,
+            };
+        });
+        const expectContained = (bounds) => {
+            expect(bounds.left).toBeGreaterThanOrEqual(-1);
+            expect(bounds.top).toBeGreaterThanOrEqual(-1);
+            expect(bounds.right).toBeLessThanOrEqual(bounds.viewportWidth + 1);
+            expect(bounds.bottom).toBeLessThanOrEqual(bounds.viewportHeight + 1);
+            expect(bounds.rootScrollWidth).toBe(bounds.viewportWidth);
+            expect(bounds.rootScrollHeight).toBe(bounds.viewportHeight);
+        };
+
+        try {
+            await dragBeyond(2000, 1600);
+            expectContained(await getBounds());
+            await dragBeyond(-800, -600);
+            expectContained(await getBounds());
+        } finally {
+            await page.evaluate(async (snapshot) => {
+                const module = await import('/scripts/power-user.js');
+                const leftPanel = document.getElementById('left-nav-panel');
+                const rightPanel = document.getElementById('right-nav-panel');
+                module.power_user.movingUI = snapshot.movingUI;
+                module.power_user.movingUIState = snapshot.movingUIState;
+                document.body.classList.toggle('movingUI', snapshot.hadMovingUIClass);
+                leftPanel.style.cssText = snapshot.leftStyle;
+                rightPanel.style.cssText = snapshot.rightStyle;
+                document.querySelector('#left-nav-panel .sb-shell-close')?.click();
+            }, original);
+        }
+    });
+
+    test('contains corrupt persisted panel geometry before it can enlarge the document', async ({ page }) => {
+        await openQuietChatForSmoke(page, { selectCharacter: false });
+        await page.evaluate(() => window.SillyBunnyShell.openTab('left', 'presets'));
+        await waitForAnimationFrames(page, 2);
+
+        const snapshot = await page.evaluate(async () => {
+            const module = await import('/scripts/power-user.js');
+            const leftPanel = document.getElementById('left-nav-panel');
+            const rightPanel = document.getElementById('right-nav-panel');
+            const warning = document.getElementById('movingUIOffscreenWarning');
+            const original = {
+                movingUI: module.power_user.movingUI,
+                movingUIState: module.power_user.movingUIState,
+                leftStyle: leftPanel.style.cssText,
+                rightStyle: rightPanel.style.cssText,
+                warningClass: warning?.className ?? '',
+            };
+
+            try {
+                module.power_user.movingUI = true;
+                module.power_user.movingUIState = {
+                    'nav-panel-shared-size': {
+                        position: 'fixed',
+                        width: 600,
+                        height: 500,
+                        left: 1800,
+                        top: 100,
+                        right: -1136,
+                        bottom: 200,
+                    },
+                };
+
+                module.loadMovingUIState();
+                await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+                const rect = leftPanel.getBoundingClientRect();
+                return {
+                    viewportWidth: window.innerWidth,
+                    rootScrollWidth: document.documentElement.scrollWidth,
+                    rect: {
+                        left: rect.left,
+                        right: rect.right,
+                        width: rect.width,
+                    },
+                    state: { ...module.power_user.movingUIState['nav-panel-shared-size'] },
+                    warningVisible: !warning?.classList.contains('displayNone'),
+                };
+            } finally {
+                module.power_user.movingUI = original.movingUI;
+                module.power_user.movingUIState = original.movingUIState;
+                leftPanel.style.cssText = original.leftStyle;
+                rightPanel.style.cssText = original.rightStyle;
+                if (warning) {
+                    warning.className = original.warningClass;
+                }
+                document.querySelector('#left-nav-panel .sb-shell-close')?.click();
+            }
+        });
+
+        expect(snapshot.rootScrollWidth).toBe(snapshot.viewportWidth);
+        expect(snapshot.rect.left).toBeGreaterThanOrEqual(-1);
+        expect(snapshot.rect.right).toBeLessThanOrEqual(snapshot.viewportWidth + 1);
+        expect(snapshot.state.left).toBeGreaterThanOrEqual(0);
+        expect(snapshot.state.left + snapshot.state.width).toBe(snapshot.viewportWidth);
+        expect(snapshot.state.right).toBe(0);
+        expect(snapshot.warningVisible).toBe(false);
+        await expectNoDocumentOverflow(page);
     });
 });

--- a/tests/moving-ui-viewport.test.js
+++ b/tests/moving-ui-viewport.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { resolveMovingUIViewportState } from '../public/scripts/moving-ui-viewport.js';
+
+describe('MovingUI viewport containment', () => {
+    test('pulls a persisted panel back inside the viewport without changing its size', () => {
+        const result = resolveMovingUIViewportState({
+            position: 'fixed',
+            width: 600,
+            height: 500,
+            left: 1800,
+            top: 100,
+            right: -1136,
+            bottom: 200,
+            margin: 'unset',
+        }, {
+            viewportWidth: 1264,
+            viewportHeight: 800,
+        });
+
+        expect(result).toMatchObject({
+            changed: true,
+            canContain: true,
+            state: {
+                position: 'fixed',
+                width: 600,
+                height: 500,
+                left: 664,
+                top: 100,
+                right: 0,
+                bottom: 200,
+                margin: 'unset',
+            },
+        });
+    });
+
+    test('clamps negative coordinates and panels larger than the viewport', () => {
+        const result = resolveMovingUIViewportState({
+            width: '1600px',
+            height: '900px',
+            left: '-240px',
+            top: '-80px',
+            right: '-96px',
+            bottom: '-20px',
+        }, {
+            viewportWidth: 1280,
+            viewportHeight: 720,
+        });
+
+        expect(result.state).toMatchObject({
+            width: 1280,
+            height: 720,
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        });
+    });
+
+    test('resolves right and bottom anchored legacy state before containing it', () => {
+        const result = resolveMovingUIViewportState({
+            width: 400,
+            height: 300,
+            right: -100,
+            bottom: -50,
+        }, {
+            viewportWidth: 1000,
+            viewportHeight: 700,
+        });
+
+        expect(result.state).toMatchObject({
+            width: 400,
+            height: 300,
+            left: 600,
+            top: 400,
+            right: 0,
+            bottom: 0,
+        });
+    });
+
+    test('uses rendered bounds when CSS changes the persisted dimensions', () => {
+        const result = resolveMovingUIViewportState({
+            width: 900,
+            height: 700,
+            left: 500,
+            top: 300,
+            right: -400,
+            bottom: -300,
+        }, {
+            viewportWidth: 1000,
+            viewportHeight: 700,
+            elementBounds: {
+                left: 500,
+                top: 300,
+                right: 1250,
+                bottom: 650,
+                width: 750,
+                height: 350,
+            },
+        });
+
+        expect(result.state).toMatchObject({
+            width: 750,
+            height: 350,
+            left: 250,
+            top: 300,
+            right: 0,
+            bottom: 50,
+        });
+    });
+
+    test('leaves incomplete hidden-panel state alone when no bounds can be resolved', () => {
+        const state = { left: 2000, top: 100, margin: 'unset' };
+
+        expect(resolveMovingUIViewportState(state, {
+            viewportWidth: 1280,
+            viewportHeight: 720,
+        })).toEqual({
+            state,
+            changed: false,
+            canContain: false,
+        });
+    });
+
+    test('is stable once state is already contained', () => {
+        const state = {
+            width: 600,
+            height: 500,
+            left: 664,
+            top: 100,
+            right: 0,
+            bottom: 200,
+        };
+
+        expect(resolveMovingUIViewportState(state, {
+            viewportWidth: 1264,
+            viewportHeight: 800,
+        })).toEqual({
+            state,
+            changed: false,
+            canContain: true,
+        });
+    });
+});

--- a/tests/moving-ui-viewport.test.js
+++ b/tests/moving-ui-viewport.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { resolveMovingUIViewportState } from '../public/scripts/moving-ui-viewport.js';
+import { resolveMovingUIViewportState, scaleMovingUIViewportState } from '../public/scripts/moving-ui-viewport.js';
 
 describe('MovingUI viewport containment', () => {
     test('pulls a persisted panel back inside the viewport without changing its size', () => {
@@ -21,6 +21,10 @@ describe('MovingUI viewport containment', () => {
         expect(result).toMatchObject({
             changed: true,
             canContain: true,
+            updates: {
+                left: 664,
+                right: 0,
+            },
             state: {
                 position: 'fixed',
                 width: 600,
@@ -47,13 +51,17 @@ describe('MovingUI viewport containment', () => {
             viewportHeight: 720,
         });
 
-        expect(result.state).toMatchObject({
-            width: 1280,
-            height: 720,
-            left: 0,
-            top: 0,
-            right: 0,
-            bottom: 0,
+        expect(result).toMatchObject({
+            changed: true,
+            canContain: true,
+            updates: {
+                width: 1280,
+                height: 720,
+                left: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+            },
         });
     });
 
@@ -68,13 +76,15 @@ describe('MovingUI viewport containment', () => {
             viewportHeight: 700,
         });
 
-        expect(result.state).toMatchObject({
-            width: 400,
-            height: 300,
-            left: 600,
-            top: 400,
-            right: 0,
-            bottom: 0,
+        expect(result).toMatchObject({
+            changed: true,
+            canContain: true,
+            updates: {
+                left: 600,
+                top: 400,
+                right: 0,
+                bottom: 0,
+            },
         });
     });
 
@@ -99,13 +109,22 @@ describe('MovingUI viewport containment', () => {
             },
         });
 
-        expect(result.state).toMatchObject({
-            width: 750,
-            height: 350,
-            left: 250,
-            top: 300,
-            right: 0,
-            bottom: 50,
+        expect(result).toMatchObject({
+            changed: true,
+            canContain: true,
+            updates: {
+                width: 750,
+                left: 250,
+                right: 0,
+            },
+            state: {
+                width: 750,
+                height: 700,
+                left: 250,
+                top: 300,
+                right: 0,
+                bottom: -300,
+            },
         });
     });
 
@@ -117,6 +136,7 @@ describe('MovingUI viewport containment', () => {
             viewportHeight: 720,
         })).toEqual({
             state,
+            updates: {},
             changed: false,
             canContain: false,
         });
@@ -137,8 +157,127 @@ describe('MovingUI viewport containment', () => {
             viewportHeight: 800,
         })).toEqual({
             state,
+            updates: {},
             changed: false,
             canContain: true,
         });
+    });
+
+    test('does not freeze responsive dimensions when rendered bounds are already contained', () => {
+        const state = {
+            width: 'var(--sheldWidth)',
+            left: 100,
+            top: 60,
+            right: 100,
+            bottom: 60,
+        };
+
+        expect(resolveMovingUIViewportState(state, {
+            viewportWidth: 1200,
+            viewportHeight: 800,
+            elementBounds: {
+                left: 100,
+                top: 60,
+                right: 1100,
+                bottom: 740,
+                width: 1000,
+                height: 680,
+            },
+        })).toEqual({
+            state,
+            updates: {},
+            changed: false,
+            canContain: true,
+        });
+    });
+
+    test('moves drag-only state without adding fixed dimensions', () => {
+        const result = resolveMovingUIViewportState({
+            left: 900,
+            top: 80,
+            right: -300,
+            bottom: 120,
+        }, {
+            viewportWidth: 1200,
+            viewportHeight: 800,
+            elementBounds: {
+                left: 900,
+                top: 80,
+                right: 1500,
+                bottom: 680,
+                width: 600,
+                height: 600,
+            },
+        });
+
+        expect(result).toMatchObject({
+            changed: true,
+            canContain: true,
+            updates: {
+                left: 600,
+                right: 0,
+            },
+        });
+        expect(result.state).not.toHaveProperty('width');
+        expect(result.state).not.toHaveProperty('height');
+    });
+
+    test('does not repeatedly rewrite contained state when CSS keeps the rendered box oversized', () => {
+        const state = {
+            width: 1000,
+            height: 700,
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        };
+
+        expect(resolveMovingUIViewportState(state, {
+            viewportWidth: 1000,
+            viewportHeight: 700,
+            elementBounds: {
+                left: 0,
+                top: 0,
+                right: 1200,
+                bottom: 700,
+                width: 1200,
+                height: 700,
+            },
+        })).toEqual({
+            state,
+            updates: {},
+            changed: false,
+            canContain: true,
+        });
+    });
+});
+
+describe('MovingUI viewport scaling', () => {
+    test('scales pixel geometry while preserving responsive and absent dimensions', () => {
+        expect(scaleMovingUIViewportState({
+            width: 'var(--sheldWidth)',
+            left: '100px',
+            top: 50,
+            right: 20,
+            bottom: 30,
+        }, {
+            scaleX: 0.5,
+            scaleY: 2,
+        })).toEqual({
+            width: 'var(--sheldWidth)',
+            left: '50',
+            top: '100',
+            right: '10',
+            bottom: '60',
+        });
+    });
+
+    test('ignores invalid scale factors instead of persisting invalid geometry', () => {
+        const state = { width: 600, height: 500, left: 100, top: 50 };
+
+        expect(scaleMovingUIViewportState(state, {
+            scaleX: Number.NaN,
+            scaleY: 0,
+        })).toEqual(state);
     });
 });

--- a/tests/quick-reply-context-menu.test.js
+++ b/tests/quick-reply-context-menu.test.js
@@ -1,0 +1,157 @@
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+import { MenuItem } from '../public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js';
+import { SubMenu } from '../public/scripts/extensions/quick-reply/src/ui/ctx/SubMenu.js';
+
+let originalWindow;
+
+beforeEach(() => {
+    originalWindow = globalThis.window;
+    globalThis.window = {
+        innerWidth: 1000,
+        innerHeight: 800,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    };
+});
+
+afterEach(() => {
+    if (originalWindow === undefined) {
+        delete globalThis.window;
+    } else {
+        globalThis.window = originalWindow;
+    }
+});
+
+describe('Quick Reply context menu activation', () => {
+    test('toggles an active desktop-hover submenu closed on click', () => {
+        const item = new MenuItem(null, true, 'Nested', null, {}, null, [{}]);
+        const hide = jest.fn();
+        item.subMenu = {
+            isActive: true,
+            hide,
+            show: jest.fn(),
+        };
+
+        item.toggle();
+
+        expect(hide).toHaveBeenCalledTimes(1);
+    });
+
+    test('expands from mouse hover and ignores touch pointer entry', () => {
+        const item = new MenuItem(null, true, 'Nested', null, {}, null, [{}]);
+        const show = jest.fn();
+        item.root = {};
+        item.subMenu = {
+            isActive: false,
+            hide: jest.fn(),
+            show,
+        };
+        item.onExpand = jest.fn();
+
+        item.expandFromHover({ pointerType: 'touch' });
+
+        expect(show).not.toHaveBeenCalled();
+        expect(item.onExpand).not.toHaveBeenCalled();
+
+        item.expandFromHover({ pointerType: 'mouse' });
+
+        expect(show).toHaveBeenCalledWith(item.root);
+        expect(item.onExpand).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('Quick Reply portaled submenu placement', () => {
+    test('hides a submenu after its trigger scrolls outside the parent menu', () => {
+        const submenu = new SubMenu([]);
+        const remove = jest.fn();
+        submenu.isActive = true;
+        submenu.parent = {
+            isConnected: true,
+            getBoundingClientRect: () => ({ left: 20, right: 220, top: 600, bottom: 640 }),
+        };
+        submenu.layer = { isConnected: true };
+        submenu.scrollParent = {
+            getBoundingClientRect: () => ({ left: 0, right: 500, top: 0, bottom: 500 }),
+        };
+        submenu.root = {
+            isConnected: true,
+            remove,
+            style: {},
+        };
+
+        submenu.place();
+
+        expect(remove).toHaveBeenCalledTimes(1);
+        expect(submenu.isActive).toBe(false);
+    });
+
+    test('cleans listeners when initial placement hides the submenu', () => {
+        const submenu = new SubMenu([]);
+        const layer = {
+            isConnected: true,
+            append: jest.fn(),
+        };
+        const scrollParent = {
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            getBoundingClientRect: () => ({ left: 0, right: 500, top: 0, bottom: 500 }),
+        };
+        const closestElements = new Map([
+            ['.ctx-blocker', layer],
+            ['.ctx-menu', scrollParent],
+        ]);
+        submenu.parent = null;
+        submenu.root = {
+            isConnected: true,
+            remove: jest.fn(),
+            style: {},
+        };
+        const parent = {
+            isConnected: true,
+            closest: selector => closestElements.get(selector),
+            getBoundingClientRect: () => ({ left: 20, right: 220, top: 600, bottom: 640 }),
+        };
+
+        submenu.show(parent);
+
+        expect(globalThis.window.addEventListener).toHaveBeenCalledTimes(1);
+        expect(globalThis.window.removeEventListener).toHaveBeenCalledTimes(1);
+        expect(scrollParent.addEventListener).toHaveBeenCalledTimes(1);
+        expect(scrollParent.removeEventListener).toHaveBeenCalledTimes(1);
+        expect(submenu.viewportResizeHandler).toBeNull();
+        expect(submenu.isActive).toBe(false);
+    });
+
+    test('repositions active descendants after the parent submenu moves', () => {
+        const placeDescendant = jest.fn();
+        const submenu = new SubMenu([{ subMenu: { place: placeDescendant } }]);
+        submenu.isActive = true;
+        submenu.parent = {
+            isConnected: true,
+            getBoundingClientRect: () => ({ left: 100, right: 200, top: 100, bottom: 140 }),
+        };
+        submenu.layer = {
+            isConnected: true,
+            getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        };
+        submenu.scrollParent = {
+            getBoundingClientRect: () => ({ left: 0, right: 500, top: 0, bottom: 500 }),
+        };
+        submenu.root = {
+            isConnected: true,
+            clientHeight: 200,
+            clientWidth: 200,
+            scrollHeight: 200,
+            scrollWidth: 200,
+            style: {},
+            getBoundingClientRect: () => ({ width: 200, height: 200 }),
+        };
+
+        submenu.place();
+
+        expect(placeDescendant).toHaveBeenCalledTimes(1);
+        expect(submenu.root.style.visibility).toBe('visible');
+    });
+});


### PR DESCRIPTION
I let Sol take a crack at fixing every single instance of viewport escapes happening across sillybunny, it worked for like 3 hours and tested everything to ensure no more viewport escapes. Feel free to test on local branches, but this one's bulletproof. I think.

## Code Review
- Fixed floating panels getting stuck off-screen or losing responsive sizing.
- Fixed mobile scrolling when swiping over buttons, inputs, menus, and drawers.
- Prevented popup keyboard adjustments from breaking existing positioning.
- Fixed nested Quick Reply menus opening, closing, and following scrolling correctly.
- Added regression tests covering these issues.