### PR TITLE
fix(mobile): allow horizontal sliding

### DIFF
--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -788,6 +788,9 @@ const MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR = [
     '#sb-bottom-chat-secondary-row',
     '.sb-bottom-chat-secondary-row',
     '#sb-persona-picker',
+    '.group_speaker_list',
+    '.ica--agent-tabs',
+    '.ica--template-pill-row',
     '.sb-shell-nav',
     '.select2-results__options',
 ].join(', ');

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -792,6 +792,18 @@ const MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR = [
     '.ica--agent-tabs',
     '.ica--template-pill-row',
     '.sb-shell-nav',
+    '.sb-settings-tabs-nav',
+    '.sb-conversation-channel-tabs',
+    '.sb-conversation-quick-actions',
+    '.sb-character-create-bar',
+    '#HotSwapWrapper .hotswap',
+    '#right-nav-panel .rm_tag_controls',
+    '#completion_prompt_manager .completion_prompt_manager_prompt > span:nth-child(3)',
+    '.popup.horizontal_scrolling_dialogue_popup .popup-content',
+    '.mes_text pre code',
+    '.mes_reasoning pre code',
+    '.img_enlarged_holder',
+    '.img_enlarged_container pre code',
     '.select2-results__options',
 ].join(', ');
 

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -402,11 +402,23 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
     });
 
-    test('allows horizontal scrolling within group and agent rails', () => {
+    test('allows horizontal scrolling within designated mobile rails', () => {
         for (const [rootSelector, railSelector] of [
             ['#sheld', '.group_speaker_list'],
             ['#left-nav-panel', '.ica--agent-tabs'],
             ['.popup', '.ica--template-pill-row'],
+            ['#user-settings-block', '.sb-settings-tabs-nav'],
+            ['#sheld', '.sb-conversation-channel-tabs'],
+            ['#sheld', '.sb-conversation-quick-actions'],
+            ['#right-nav-panel', '.sb-character-create-bar'],
+            ['#right-nav-panel', '#HotSwapWrapper .hotswap'],
+            ['#right-nav-panel', '#right-nav-panel .rm_tag_controls'],
+            ['#left-nav-panel', '#completion_prompt_manager .completion_prompt_manager_prompt > span:nth-child(3)'],
+            ['.popup', '.popup.horizontal_scrolling_dialogue_popup .popup-content'],
+            ['#chat', '.mes_text pre code'],
+            ['#chat', '.mes_reasoning pre code'],
+            ['.popup', '.img_enlarged_holder'],
+            ['.popup', '.img_enlarged_container pre code'],
         ]) {
             const root = createElementStub({
                 matches: selector => selectorListIncludes(selector, rootSelector),
@@ -433,10 +445,12 @@ describe('mobile shell lifecycle wiring', () => {
                 matches: selector => selectorListIncludes(selector, 'button'),
             });
             const inwardMove = createTouchMove(control, { x: -40, y: 2 });
+            const railGapMove = createTouchMove(rail, { x: -40, y: 2 });
             const outwardMove = createTouchMove(controlAtStart, { x: 40, y: 2 });
             const verticalMove = createTouchMove(control, { x: 2, y: -40 });
 
             expect(shouldBlockMobileDocumentPan(inwardMove.event, { touchStart: inwardMove.touchStart })).toBe(false);
+            expect(shouldBlockMobileDocumentPan(railGapMove.event, { touchStart: railGapMove.touchStart })).toBe(false);
             expect(shouldBlockMobileDocumentPan(outwardMove.event, { touchStart: outwardMove.touchStart })).toBe(true);
             expect(shouldBlockMobileDocumentPan(verticalMove.event, { touchStart: verticalMove.touchStart })).toBe(true);
         }

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -402,6 +402,46 @@ describe('mobile shell lifecycle wiring', () => {
         expect(shouldBlockMobileDocumentPan(nonCancelableMove.event, { touchStart: nonCancelableMove.touchStart })).toBe(false);
     });
 
+    test('allows horizontal scrolling within group and agent rails', () => {
+        for (const [rootSelector, railSelector] of [
+            ['#sheld', '.group_speaker_list'],
+            ['#left-nav-panel', '.ica--agent-tabs'],
+            ['.popup', '.ica--template-pill-row'],
+        ]) {
+            const root = createElementStub({
+                matches: selector => selectorListIncludes(selector, rootSelector),
+            });
+            const rail = createElementStub({
+                parentElement: root,
+                matches: selector => selectorListIncludes(selector, railSelector),
+                scrollWidth: 600,
+                clientWidth: 240,
+                scrollLeft: 120,
+            });
+            const railAtStart = createElementStub({
+                parentElement: root,
+                matches: selector => selectorListIncludes(selector, railSelector),
+                scrollWidth: 600,
+                clientWidth: 240,
+            });
+            const control = createElementStub({
+                parentElement: rail,
+                matches: selector => selectorListIncludes(selector, 'button'),
+            });
+            const controlAtStart = createElementStub({
+                parentElement: railAtStart,
+                matches: selector => selectorListIncludes(selector, 'button'),
+            });
+            const inwardMove = createTouchMove(control, { x: -40, y: 2 });
+            const outwardMove = createTouchMove(controlAtStart, { x: 40, y: 2 });
+            const verticalMove = createTouchMove(control, { x: 2, y: -40 });
+
+            expect(shouldBlockMobileDocumentPan(inwardMove.event, { touchStart: inwardMove.touchStart })).toBe(false);
+            expect(shouldBlockMobileDocumentPan(outwardMove.event, { touchStart: outwardMove.touchStart })).toBe(true);
+            expect(shouldBlockMobileDocumentPan(verticalMove.event, { touchStart: verticalMove.touchStart })).toBe(true);
+        }
+    });
+
     test('allows owned scrolling from controls while blocking edge overscroll in mobile drawers', () => {
         const createMenuRoot = rootSelector => createElementStub({
             matches: selector => selectorListIncludes(selector, rootSelector) || selectorListIncludes(selector, `${rootSelector}.openDrawer`),


### PR DESCRIPTION
Stated in https://github.com/platberlitz/SillyBunny/issues/669, sliding horizontally to pick group chat characters doesn't appear to work at all. It's stuck. I have noticed this as well on the Agents tab where I can't slide horizontally. It seems to be disabled somehow.

This PR addresses both Android and iOS.

Tested personally and works.