### PR TITLE
fix: Bun throws EEXIST on mkdir when SillyBunny is installed inside OneDrive

### DIFF
--- a/src/middleware/uploadStorage.js
+++ b/src/middleware/uploadStorage.js
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+
+import multer from 'multer';
+
+function isDirectory(directoryPath) {
+    try {
+        return fs.statSync(directoryPath).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+export function ensureUploadDirectory(uploadsPath) {
+    try {
+        fs.mkdirSync(uploadsPath);
+    } catch (error) {
+        if (error?.code === 'EEXIST' && isDirectory(uploadsPath)) {
+            return;
+        }
+
+        throw error;
+    }
+}
+
+export function createUploadStorage(uploadsPath) {
+    ensureUploadDirectory(uploadsPath);
+
+    return multer.diskStorage({
+        destination: (_request, _file, callback) => callback(null, uploadsPath),
+    });
+}

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -61,6 +61,7 @@ import cacheBuster from './middleware/cacheBuster.js';
 import corsProxyMiddleware from './middleware/corsProxy.js';
 import hostWhitelistMiddleware from './middleware/hostWhitelist.js';
 import userCssMiddleware from './middleware/userCss.js';
+import { createUploadStorage } from './middleware/uploadStorage.js';
 import {
     getVersion,
     color,
@@ -444,8 +445,9 @@ if (cliArgs.enableCorsProxy) {
 
 // File uploads
 const uploadsPath = path.join(cliArgs.dataRoot, UPLOADS_DIRECTORY);
-fs.mkdirSync(uploadsPath, { recursive: true });
-app.use(multer({ dest: uploadsPath, limits: { fieldSize: 500 * 1024 * 1024 } }).single('avatar'));
+// SillyBunny: avoid Bun's recursive mkdir bug on ReadOnly Windows directories.
+const uploadStorage = createUploadStorage(uploadsPath);
+app.use(multer({ storage: uploadStorage, limits: { fieldSize: 500 * 1024 * 1024 } }).single('avatar'));
 app.use(multerMonkeyPatch);
 
 app.get('/version', async function (_, response) {

--- a/tests/upload-storage.test.js
+++ b/tests/upload-storage.test.js
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import multer from 'multer';
+
+import { createUploadStorage, ensureUploadDirectory } from '../src/middleware/uploadStorage.js';
+
+const tempRoots = [];
+
+function createTempRoot() {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-uploads-'));
+    tempRoots.push(tempRoot);
+    return tempRoot;
+}
+
+afterEach(() => {
+    jest.restoreAllMocks();
+
+    for (const tempRoot of tempRoots.splice(0)) {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+});
+
+describe('upload storage', () => {
+    test('creates a missing upload directory', () => {
+        const uploadsPath = path.join(createTempRoot(), '_uploads');
+
+        ensureUploadDirectory(uploadsPath);
+
+        expect(fs.statSync(uploadsPath).isDirectory()).toBe(true);
+    });
+
+    test('accepts an existing directory without a recursive mkdir', () => {
+        const uploadsPath = path.join(createTempRoot(), '_uploads');
+        fs.mkdirSync(uploadsPath);
+        const mkdirSpy = jest.spyOn(fs, 'mkdirSync');
+
+        const storage = createUploadStorage(uploadsPath);
+        const middleware = multer({ storage }).single('avatar');
+
+        expect(middleware).toEqual(expect.any(Function));
+        expect(mkdirSpy).toHaveBeenCalledTimes(1);
+        expect(mkdirSpy).toHaveBeenCalledWith(uploadsPath);
+    });
+
+    test('rejects an existing file at the upload path', () => {
+        const uploadsPath = path.join(createTempRoot(), '_uploads');
+        fs.writeFileSync(uploadsPath, 'not a directory');
+
+        expect(() => ensureUploadDirectory(uploadsPath)).toThrow(expect.objectContaining({ code: 'EEXIST' }));
+    });
+
+    test('rethrows unexpected directory creation errors', () => {
+        const uploadsPath = path.join(createTempRoot(), '_uploads');
+        const expectedError = Object.assign(new Error('permission denied'), { code: 'EPERM' });
+        jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+            throw expectedError;
+        });
+
+        expect(() => ensureUploadDirectory(uploadsPath)).toThrow(expectedError);
+    });
+});


### PR DESCRIPTION
As stated in https://github.com/platberlitz/SillyBunny/issues/673, it seems to refuse to start, and could be an upstream Bun issue. However, it may be possible to mitigate it.

## Fix
- Changed folder creation to avoid Bun’s bug.
- Prevented Multer from repeating the broken operation.
- Kept real folder/permission errors visible.
- Added tests to prevent regression.