### PR TITLE
fix(ios): includes backwards compatibility of viewport fix for old iOS versions

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -1,6 +1,6 @@
 import { getParsedUA, isMobile } from './RossAscends-mods.js';
 import { shouldBlockMobileDocumentPan } from './mobile-shell-lifecycle/index.js';
-import { isIOSWebKitPlatform } from './mobile-send-button.js';
+import { isIOSWebKitPlatform, isLegacyIOSWebKitPlatform } from './mobile-send-button.js';
 
 const isFirefox = () => /firefox/i.test(navigator.userAgent);
 
@@ -119,9 +119,15 @@ function isMobileShellPanelEditable(element) {
 function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {
     let resetScheduled = false;
 
+    // SillyBunny: the legacy shell inset keeps the caret visible, so old iOS
+    // force-scroll can be anchored immediately instead of waiting for blur.
+    const isComposerHeldAboveKeyboard = () => isLegacyIOSWebKitPlatform()
+        && document.documentElement.classList.contains('sb-ios-composer-keyboard-inset-active');
+
     const shouldSuspendDocumentScrollReset = () => suspendWhileEditing
         && isEditableFocusTarget(document.activeElement)
-        && !isMobileShellPanelEditable(document.activeElement);
+        && !isMobileShellPanelEditable(document.activeElement)
+        && !isComposerHeldAboveKeyboard();
 
     const resetDocumentScroll = () => {
         if (shouldSuspendDocumentScrollReset()) {

--- a/public/scripts/mobile-send-button.js
+++ b/public/scripts/mobile-send-button.js
@@ -1,4 +1,5 @@
 const IOS_SYNTHETIC_CLICK_SUPPRESS_MS = 2500;
+const IOS_STABLE_COMPOSER_VIEWPORT_MAJOR = 26;
 
 /**
  * Detects iOS Safari/WebKit surfaces, including iPadOS desktop-mode Safari.
@@ -12,6 +13,22 @@ export function isIOSWebKitPlatform(navigatorRef = globalThis.navigator) {
 
     const platform = String(navigatorRef.platform || '');
     return /iPad|iPhone|iPod/.test(platform) || (platform === 'MacIntel' && Number(navigatorRef.maxTouchPoints) > 1);
+}
+
+/**
+ * Detects known iOS versions that need the legacy composer keyboard inset.
+ * Unknown versions retain the modern stable viewport behavior.
+ * @param {Navigator} [navigatorRef] Navigator-like object
+ * @returns {boolean}
+ */
+export function isLegacyIOSWebKitPlatform(navigatorRef = globalThis.navigator) {
+    if (!isIOSWebKitPlatform(navigatorRef)) {
+        return false;
+    }
+
+    const match = String(navigatorRef.userAgent || '').match(/\bCPU(?: iPhone)? OS (\d+)(?:[_\s]|$)/i);
+    const majorVersion = Number(match?.[1]);
+    return Number.isInteger(majorVersion) && majorVersion < IOS_STABLE_COMPOSER_VIEWPORT_MAJOR;
 }
 
 /**

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -3,7 +3,7 @@ import {
     createMobileShellLifecycle,
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
 } from './mobile-shell-lifecycle/index.js';
-import { isIOSWebKitPlatform } from './mobile-send-button.js';
+import { isIOSWebKitPlatform, isLegacyIOSWebKitPlatform } from './mobile-send-button.js';
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
 import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { hasServerReturnedAfterRestart } from './server-restart-monitor.js';
@@ -2505,9 +2505,73 @@ function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
     return isMobileShellPanelEditableElement(activeElement) || isChatComposerEditableElement(activeElement) || hasOpenMobileShellDrawer();
 }
 
+const MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX = 8;
+const MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS = 700;
+const MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX = 80;
+
+let sbLastIOSKeyboardHeight = 0;
+let sbComposerKeyboardPreShiftDeadline = 0;
+let sbComposerKeyboardSettleTimer = 0;
+
 function isVisualViewportKeyboardOpen(layoutViewport = getLayoutViewportSize(), visualViewportSize = getVisualViewportSize(layoutViewport)) {
     const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);
-    return keyboardHeight > 80 || visualViewportSize.top > 2;
+    return keyboardHeight > MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX || visualViewportSize.top > 2;
+}
+
+/**
+ * SillyBunny: old iOS versions can force-scroll the document to reveal the
+ * composer caret. Shrink the stable shell by the keyboard height before that
+ * reveal while preserving the modern viewport behavior on iOS 26 and newer.
+ */
+function getComposerKeyboardInset(layoutViewport, visualViewportSize) {
+    if (!isLegacyIOSWebKitPlatform() || !isMobileViewport()) {
+        return 0;
+    }
+
+    const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);
+    if (keyboardHeight > MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX) {
+        sbLastIOSKeyboardHeight = keyboardHeight;
+    }
+
+    if (!isChatComposerEditableElement(document.activeElement)) {
+        return 0;
+    }
+
+    const withinPreShiftWindow = Date.now() < sbComposerKeyboardPreShiftDeadline;
+
+    if (isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
+        // Do not shrink after Safari has already panned, which would recreate
+        // the empty space below the escaped composer.
+        if (visualViewportSize.top > MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX) {
+            return 0;
+        }
+
+        return withinPreShiftWindow ? Math.max(keyboardHeight, sbLastIOSKeyboardHeight) : keyboardHeight;
+    }
+
+    return withinPreShiftWindow ? sbLastIOSKeyboardHeight : 0;
+}
+
+function handleComposerKeyboardFocusIn(event) {
+    if (!isLegacyIOSWebKitPlatform() || !isMobileViewport()) {
+        return;
+    }
+
+    if (isChatComposerEditableElement(event.target)) {
+        sbComposerKeyboardPreShiftDeadline = Date.now() + MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS;
+        window.clearTimeout(sbComposerKeyboardSettleTimer);
+        sbComposerKeyboardSettleTimer = window.setTimeout(queueMobileViewportStateSync, MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS + 50);
+    }
+
+    queueMobileViewportStateSync();
+}
+
+function handleMobileKeyboardFocusOut() {
+    if (!isLegacyIOSWebKitPlatform() || !isMobileViewport()) {
+        return;
+    }
+
+    queueMobileViewportStateSync();
 }
 
 function syncIOSKeyboardBottomInset() {
@@ -2537,6 +2601,12 @@ function syncIOSKeyboardBottomInset() {
 function getShellViewportSize() {
     const layoutViewport = getLayoutViewportSize();
     const visualViewportSize = getVisualViewportSize(layoutViewport);
+
+    const composerKeyboardInset = getComposerKeyboardInset(layoutViewport, visualViewportSize);
+    if (composerKeyboardInset > 0) {
+        const height = Math.max(0, layoutViewport.height - composerKeyboardInset);
+        return { ...layoutViewport, height, bottom: height };
+    }
 
     // SillyBunny: iOS keyboard edits inside shell panels or the chat composer
     // should not feed Safari visualViewport jitter back into shell geometry.
@@ -2568,6 +2638,11 @@ function syncShellViewportBounds() {
     // SillyBunny: iOS Safari shifts the visual viewport while the keyboard opens;
     // keyboard edit paths intentionally keep the stable layout top.
     setRootViewportProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
+
+    // SillyBunny: browser-fixes.js may reset document scroll mid-edit once the
+    // legacy shell has moved the focused composer above the keyboard.
+    const composerKeyboardInset = getComposerKeyboardInset(getLayoutViewportSize(), getVisualViewportSize());
+    root.classList.toggle('sb-ios-composer-keyboard-inset-active', composerKeyboardInset > 0);
 }
 
 function getMobileFocusedInputScroller(target) {
@@ -16532,6 +16607,11 @@ function initAll() {
     if (isIOSWebKitPlatform()) {
         document.addEventListener('focusin', syncIOSKeyboardBottomInset);
         document.addEventListener('focusout', syncIOSKeyboardBottomInset);
+    }
+
+    if (isLegacyIOSWebKitPlatform()) {
+        document.addEventListener('focusin', handleComposerKeyboardFocusIn);
+        document.addEventListener('focusout', handleMobileKeyboardFocusOut);
     }
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings

--- a/tests/mobile-send-button.test.js
+++ b/tests/mobile-send-button.test.js
@@ -1,6 +1,7 @@
 import {
     bindIOSFastTapSendButton,
     isIOSWebKitPlatform,
+    isLegacyIOSWebKitPlatform,
     touchEndedInsideElement,
 } from '../public/scripts/mobile-send-button.js';
 
@@ -18,6 +19,39 @@ describe('mobile send button helpers', () => {
         expect(isIOSWebKitPlatform({ platform: 'MacIntel', maxTouchPoints: 5 })).toBe(true);
         expect(isIOSWebKitPlatform({ platform: 'MacIntel', maxTouchPoints: 0 })).toBe(false);
         expect(isIOSWebKitPlatform({ platform: 'Linux x86_64', maxTouchPoints: 1 })).toBe(false);
+    });
+
+    test('uses the legacy composer viewport only for known iOS versions before 26', () => {
+        expect(isLegacyIOSWebKitPlatform({
+            platform: 'iPhone',
+            maxTouchPoints: 1,
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X)',
+        })).toBe(true);
+        expect(isLegacyIOSWebKitPlatform({
+            platform: 'iPad',
+            maxTouchPoints: 5,
+            userAgent: 'Mozilla/5.0 (iPad; CPU OS 18_5 like Mac OS X)',
+        })).toBe(true);
+        expect(isLegacyIOSWebKitPlatform({
+            platform: 'iPhone',
+            maxTouchPoints: 1,
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X)',
+        })).toBe(false);
+        expect(isLegacyIOSWebKitPlatform({
+            platform: 'iPhone',
+            maxTouchPoints: 1,
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 27_0 like Mac OS X)',
+        })).toBe(false);
+        expect(isLegacyIOSWebKitPlatform({
+            platform: 'Linux x86_64',
+            maxTouchPoints: 1,
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X)',
+        })).toBe(false);
+        expect(isLegacyIOSWebKitPlatform({
+            platform: 'MacIntel',
+            maxTouchPoints: 5,
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        })).toBe(false);
     });
 
     test('checks whether a touch ended inside the send button', () => {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -594,12 +594,14 @@ describe('mobile shell lifecycle wiring', () => {
     });
 
     test('settles mobile viewport reset without reapplying the fixed-position workaround', () => {
-        expect(browserFixesSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
+        expect(browserFixesSource).toContain('import { isIOSWebKitPlatform, isLegacyIOSWebKitPlatform } from \'./mobile-send-button.js\';');
         expect(browserFixesSource).toContain('function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {');
         expect(browserFixesSource).toContain('function isMobileShellPanelEditable(element) {');
         expect(browserFixesSource).toContain('const shouldSuspendDocumentScrollReset = () => suspendWhileEditing');
         expect(browserFixesSource).toContain('&& isEditableFocusTarget(document.activeElement)');
-        expect(browserFixesSource).toContain('&& !isMobileShellPanelEditable(document.activeElement);');
+        expect(browserFixesSource).toContain('&& !isMobileShellPanelEditable(document.activeElement)');
+        expect(browserFixesSource).toContain('const isComposerHeldAboveKeyboard = () => isLegacyIOSWebKitPlatform()');
+        expect(browserFixesSource).toContain('&& !isComposerHeldAboveKeyboard();');
         expect(browserFixesSource).toContain('if (shouldSuspendDocumentScrollReset()) {');
         expect(browserFixesSource).toContain('if (resetScheduled || shouldSuspendDocumentScrollReset()) {');
         expect(browserFixesSource).toContain('document.addEventListener(\'focusout\', scheduleDocumentScrollReset, true);');
@@ -674,7 +676,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsSource).toContain('function getShellViewportSize(');
         expect(tabsSource).toContain('function getVisualViewportSize(');
         expect(tabsSource).toContain('function shouldUseStableIOSPanelViewport(');
-        expect(tabsSource).toContain('import { isIOSWebKitPlatform } from \'./mobile-send-button.js\';');
+        expect(tabsSource).toContain('import { isIOSWebKitPlatform, isLegacyIOSWebKitPlatform } from \'./mobile-send-button.js\';');
         expect(tabsSource).toContain('function isChatComposerEditableElement(');
         expect(tabsSource).toContain('function hasOpenMobileShellDrawer(');
         expect(tabsSource).toContain('!isIOSWebKitPlatform() || !isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)');
@@ -712,15 +714,26 @@ describe('mobile shell lifecycle wiring', () => {
         );
     });
 
-    test('keeps the iOS composer on stable viewport bounds without keyboard inset resizing', () => {
+    test('uses keyboard inset resizing only for legacy iOS composer edits', () => {
+        const getComposerKeyboardInsetSource = getFunctionSource('getComposerKeyboardInset');
         const getShellViewportSizeSource = getFunctionSource('getShellViewportSize');
+        const handleComposerKeyboardFocusInSource = getFunctionSource('handleComposerKeyboardFocusIn');
+        const syncShellViewportBoundsSource = getFunctionSource('syncShellViewportBounds');
 
+        expect(getComposerKeyboardInsetSource).toContain('if (!isLegacyIOSWebKitPlatform() || !isMobileViewport()) {');
+        expect(getComposerKeyboardInsetSource).toContain('const keyboardHeight = Math.max(0, layoutViewport.height - visualViewportSize.height);');
+        expect(getComposerKeyboardInsetSource).toContain('sbLastIOSKeyboardHeight = keyboardHeight;');
+        expect(getComposerKeyboardInsetSource).toContain('if (visualViewportSize.top > MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX) {');
+        expect(getComposerKeyboardInsetSource).toContain('return withinPreShiftWindow ? sbLastIOSKeyboardHeight : 0;');
+        expect(handleComposerKeyboardFocusInSource).toContain('sbComposerKeyboardPreShiftDeadline = Date.now() + MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS;');
         expect(getShellViewportSizeSource).toContain('if (shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize)) {');
         expect(getShellViewportSizeSource).toContain('return layoutViewport;');
-        expect(tabsSource).not.toContain('function getComposerKeyboardInset(');
-        expect(tabsSource).not.toContain('handleComposerKeyboardFocusIn');
-        expect(tabsSource).not.toContain('sb-ios-composer-keyboard-inset-active');
-        expect(browserFixesSource).not.toContain('isComposerHeldAboveKeyboard');
+        expect(getShellViewportSizeSource).toContain('const composerKeyboardInset = getComposerKeyboardInset(layoutViewport, visualViewportSize);');
+        expect(getShellViewportSizeSource).toContain('return { ...layoutViewport, height, bottom: height };');
+        expect(syncShellViewportBoundsSource).toContain('root.classList.toggle(\'sb-ios-composer-keyboard-inset-active\', composerKeyboardInset > 0);');
+        expect(tabsSource).toContain('if (isLegacyIOSWebKitPlatform()) {');
+        expect(tabsSource).toContain('document.addEventListener(\'focusin\', handleComposerKeyboardFocusIn);');
+        expect(tabsSource).toContain('document.addEventListener(\'focusout\', handleMobileKeyboardFocusOut);');
     });
 
     test('routes mobile viewport sync planning through the lifecycle seam', () => {


### PR DESCRIPTION
The PR https://github.com/platberlitz/SillyBunny/pull/664 resolved the viewport escaping in the input text box for iOS 26/27, but the same problem remains in iOS 18.

## Fix
- The newer iOS fix unintentionally removed behavior still needed by iOS 18.
- On iOS 18, opening the keyboard could push the message box to the top of the screen.
- The older keyboard-handling fix was restored only for iOS versions before 26.
- iOS 26/27 keep the newer behavior, avoiding regressions.