### PR TITLE
feat: Card sorting option based on newest additions (for real)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
         "open": "^10.2.0",
         "png-chunk-text": "^1.0.0",
         "png-chunks-extract": "^1.0.0",
+        "proper-lockfile": "^4.1.2",
         "proxy-agent": "^6.5.0",
         "rate-limiter-flexible": "^5.0.5",
         "response-time": "^2.3.4",
@@ -1226,6 +1227,8 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
     "protobufjs": ["protobufjs@6.11.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -1271,6 +1274,8 @@
     "response-time": ["response-time@2.3.4", "", { "dependencies": { "depd": "~2.0.0", "on-headers": "~1.1.0" } }, "sha512-fiyq1RvW5/Br6iAtT8jN1XrNY8WPu2+yEypLbaijWry8WDZmn12azG9p/+c+qpEebURLlQmqCB8BNSu7ji+xQQ=="],
 
     "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
 
@@ -1318,7 +1323,7 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sillytavern-transformers": ["sillytavern-transformers@2.14.6", "", { "dependencies": { "@huggingface/jinja": "^0.1.0", "jimp": "^0.22.10", "onnxruntime-web": "1.14.0" } }, "sha512-Tpu3lcDfa3vQB/wRgF+7ZG8ZNtYygT6vEQs9+4BpXLghVanx6ic7rBSxmTxx9Sm90G1P3W8mxoVkzfs8KAvMiA=="],
 
@@ -1620,6 +1625,8 @@
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "formdata-node/web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
@@ -1705,6 +1712,8 @@
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
                 "open": "^10.2.0",
                 "png-chunk-text": "^1.0.0",
                 "png-chunks-extract": "^1.0.0",
+                "proper-lockfile": "^4.1.2",
                 "proxy-agent": "^6.5.0",
                 "rate-limiter-flexible": "^5.0.5",
                 "response-time": "^2.3.4",
@@ -7631,6 +7632,23 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
         },
+        "node_modules/proper-lockfile": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+            "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "retry": "^0.12.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "node_modules/proper-lockfile/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
         "node_modules/protobufjs": {
             "version": "6.11.4",
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
@@ -8047,6 +8065,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "open": "^10.2.0",
         "png-chunk-text": "^1.0.0",
         "png-chunks-extract": "^1.0.0",
+        "proper-lockfile": "^4.1.2",
         "proxy-agent": "^6.5.0",
         "rate-limiter-flexible": "^5.0.5",
         "response-time": "^2.3.4",

--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -38,6 +38,7 @@ declare global {
         avatar_url?: string;
         hideMutedSprites?: boolean;
         fav?: boolean;
+        date_added?: number;
         date_last_chat?: MessageTimestamp;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -7117,6 +7117,7 @@
                                     <option data-field="name" data-order="desc" data-i18n="Z-A">Z-A</option>
                                     <option data-field="create_date" data-order="desc" data-i18n="Newest">Newest</option>
                                     <option data-field="create_date" data-order="asc" data-i18n="Oldest">Oldest</option>
+                                    <option data-field="date_added" data-order="desc" data-i18n="Date added">Date added</option>
                                     <option data-field="fav" data-order="desc" data-rule="boolean" data-i18n="Favorites">Favorites</option>
                                     <option data-field="date_last_chat" data-order="desc" data-i18n="Recent">Recent</option>
                                     <option data-field="chat_size" data-order="desc" data-i18n="Most chats">Most chats</option>

--- a/public/scripts/char-data.js
+++ b/public/scripts/char-data.js
@@ -114,6 +114,7 @@
  * @property {number} talkativeness - talkativeness
  * @property {boolean|string} fav - fav
  * @property {string} create_date - create_date
+ * @property {number} date_added - local date-added timestamp
  * @property {v2CharData} data - v2 data extension
  * // Non-standard extensions added by the ST server (not part of the original data)
  * @property {string} chat - name of the current chat file chat

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -25,6 +25,7 @@ import { getChatInfo } from './chats.js';
 import { ByafParser } from '../byaf.js';
 import { CharXParser, persistCharXAssets } from '../charx.js';
 import { getSuspiciousEmptyCharacterDefinitionFields } from '../character-save-guard.js';
+import { createEntityDateAdded, ensureEntityDateAdded, prepareEntityDateAddedMove, reconcileEntityDateAdded, removeEntityDateAdded } from '../entity-date-added.js';
 import {
     clearChatRecoveryState,
     createCharacterChatTarget,
@@ -48,6 +49,9 @@ const BULK_MERGE_CONCURRENCY = 8;
 const EXTENSION_UNSET_VALUE = '__@@UNSET@@__';
 const forbiddenAvatarRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
 const CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE = 'allow_empty_definition_save';
+const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.characters);
+const getCharacterDateAddedFallback = stat => [stat.ctimeMs, stat.birthtimeMs, stat.mtimeMs]
+    .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
 
 class DiskCache {
     /**
@@ -229,9 +233,10 @@ async function readCharacterData(inputFile, inputFormat = 'png') {
  * @param {string} outputFile - Target image file name
  * @param {import('express').Request} request - Express request obejct
  * @param {Crop|undefined} crop - Crop parameters
+ * @param {boolean} [preserveDateAdded] - Preserve preassigned metadata for rename operations
  * @returns {Promise<boolean>} - True if the operation was successful
  */
-async function writeCharacterData(inputFile, data, outputFile, request, crop = undefined) {
+async function writeCharacterData(inputFile, data, outputFile, request, crop = undefined, preserveDateAdded = false) {
     try {
         // Reset the cache
         for (const key of memoryCache.keys()) {
@@ -268,9 +273,27 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
 
         // Get the chunks
         const outputImage = write(inputImage, data);
-        const outputImagePath = path.join(request.user.directories.characters, `${outputFile}.png`);
+        const outputImageName = `${outputFile}.png`;
+        const outputImagePath = path.join(request.user.directories.characters, outputImageName);
+        const operationTime = Date.now();
+        const fileExists = fs.existsSync(outputImagePath);
+        const migrationFallback = fileExists ? getCharacterDateAddedFallback(fs.statSync(outputImagePath)) : operationTime;
 
+        if (fileExists) {
+            ensureEntityDateAdded(getEntityDateAddedRoot(request.user.directories), 'characters', outputImageName, migrationFallback, operationTime);
+        }
         tryWriteFileSync(outputImagePath, outputImage);
+        if (!fileExists) {
+            try {
+                if (preserveDateAdded) {
+                    ensureEntityDateAdded(getEntityDateAddedRoot(request.user.directories), 'characters', outputImageName, operationTime, operationTime);
+                } else {
+                    createEntityDateAdded(getEntityDateAddedRoot(request.user.directories), 'characters', outputImageName, operationTime);
+                }
+            } catch (metadataError) {
+                console.error('Could not record date-added metadata after creating a character.', metadataError);
+            }
+        }
         return true;
     } catch (err) {
         console.error(err);
@@ -336,7 +359,10 @@ async function mergeCharacterUpdate(avatarPath, avatar, updateData, request, sho
     }
 
     const targetImg = avatar.replace('.png', '');
-    await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request);
+    const writeSucceeded = await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request);
+    if (!writeSucceeded) {
+        return { ok: false, error: 'Failed to write character data.' };
+    }
     return { ok: true };
 }
 
@@ -477,9 +503,10 @@ const toShallow = (character) => {
  * @param  {import('../users.js').UserDirectoryList} directories User directories
  * @param  {object} options Options for the character processing
  * @param  {boolean} options.shallow If true, only return the core character's metadata
+ * @param  {fs.Stats} [options.fileStat] Preloaded character file metadata
  * @return {Promise<object>}     A Promise that resolves when the character processing is done.
  */
-const processCharacter = async (item, directories, { shallow }) => {
+const processCharacter = async (item, directories, { shallow, fileStat }) => {
     try {
         const imgFile = path.join(directories.characters, item);
         const imgData = await readCharacterData(imgFile);
@@ -489,8 +516,8 @@ const processCharacter = async (item, directories, { shallow }) => {
         jsonObject.avatar = item;
         const character = jsonObject;
         character.json_data = imgData;
-        const charStat = fs.statSync(path.join(directories.characters, item));
-        character.date_added = charStat.ctimeMs;
+        const charStat = fileStat ?? fs.statSync(path.join(directories.characters, item));
+        character.date_added = getCharacterDateAddedFallback(charStat);
         character.create_date = jsonObject.create_date || new Date(Math.round(charStat.ctimeMs)).toISOString();
         const chatsDirectory = path.join(directories.chats, item.replace('.png', ''));
 
@@ -1134,11 +1161,28 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
     const newAvatarName = `${newInternalName}.png`;
 
     const oldAvatarPath = path.join(request.user.directories.characters, oldAvatarName);
+    const newAvatarPath = path.join(request.user.directories.characters, newAvatarName);
 
     const oldChatsPath = path.join(request.user.directories.chats, oldInternalName);
     const newChatsPath = path.join(request.user.directories.chats, newInternalName);
+    const dateAddedRoot = getEntityDateAddedRoot(request.user.directories);
+    let dateAddedMoved = false;
+    let chatsCopied = false;
+    let oldDateAdded;
+    let operationTime;
 
     try {
+        operationTime = Date.now();
+        oldDateAdded = ensureEntityDateAdded(
+            dateAddedRoot,
+            'characters',
+            oldAvatarName,
+            getCharacterDateAddedFallback(fs.statSync(oldAvatarPath)),
+            operationTime,
+        );
+        prepareEntityDateAddedMove(dateAddedRoot, 'characters', oldAvatarName, newAvatarName, oldDateAdded, operationTime);
+        dateAddedMoved = true;
+
         // Read old file, replace name int it
         const rawOldData = await readCharacterData(oldAvatarPath);
         if (rawOldData === undefined) throw new Error('Failed to read character file');
@@ -1149,20 +1193,49 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
         const newData = JSON.stringify(oldData);
 
         // Write data to new location
-        await writeCharacterData(oldAvatarPath, newData, newInternalName, request);
+        const writeSucceeded = await writeCharacterData(oldAvatarPath, newData, newInternalName, request, undefined, true);
+        if (!writeSucceeded) {
+            throw new Error('Failed to write renamed character data.');
+        }
 
         // Rename chats folder
         if (fs.existsSync(oldChatsPath) && !fs.existsSync(newChatsPath)) {
             fs.cpSync(oldChatsPath, newChatsPath, { recursive: true });
+            chatsCopied = true;
             fs.rmSync(oldChatsPath, { recursive: true, force: true });
         }
 
         // Remove the old character file
         fs.unlinkSync(oldAvatarPath);
+        try {
+            removeEntityDateAdded(dateAddedRoot, 'characters', oldAvatarName);
+        } catch (metadataError) {
+            console.error('Could not remove stale date-added metadata after character rename.', metadataError);
+        }
 
         // Return new avatar name to ST
         return response.send({ avatar: newAvatarName });
     } catch (err) {
+        if (dateAddedMoved && fs.existsSync(oldAvatarPath)) {
+            let chatsRestored = true;
+            if (chatsCopied) {
+                try {
+                    fs.cpSync(newChatsPath, oldChatsPath, { recursive: true });
+                    fs.rmSync(newChatsPath, { recursive: true, force: true });
+                } catch (rollbackError) {
+                    chatsRestored = false;
+                    console.error('Could not restore chats after a failed character rename.', rollbackError);
+                }
+            }
+            if (chatsRestored) {
+                try {
+                    fs.rmSync(newAvatarPath, { force: true });
+                    removeEntityDateAdded(dateAddedRoot, 'characters', newAvatarName, operationTime);
+                } catch (rollbackError) {
+                    console.error('Could not clean up date-added metadata after a failed character rename.', rollbackError);
+                }
+            }
+        }
         console.error(err);
         return response.sendStatus(500);
     }
@@ -1212,15 +1285,17 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
     let targetFile = (request.body.avatar_url).replace('.png', '');
 
     try {
+        let writeSucceeded;
         if (!request.file) {
-            await writeCharacterData(avatarPath, char, targetFile, request);
+            writeSucceeded = await writeCharacterData(avatarPath, char, targetFile, request);
         } else {
             const crop = tryParse(request.query.crop);
             const newAvatarPath = path.join(request.file.destination, request.file.filename);
             invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
-            await writeCharacterData(newAvatarPath, char, targetFile, request, crop);
+            writeSucceeded = await writeCharacterData(newAvatarPath, char, targetFile, request, crop);
             fs.unlinkSync(newAvatarPath);
         }
+        if (!writeSucceeded) throw new Error('Failed to write character data.');
 
         return response.sendStatus(200);
     } catch (err) {
@@ -1254,10 +1329,11 @@ router.post('/edit-avatar', validateAvatarUrlMiddleware, async function (request
 
         const crop = tryParse(request.query.crop);
         const fileName = request.body.avatar_url.replace('.png', '');
-        await writeCharacterData(uploadPath, data, fileName, request, crop);
+        const writeSucceeded = await writeCharacterData(uploadPath, data, fileName, request, crop);
 
         // Remove uploaded temp file
         fs.unlinkSync(uploadPath);
+        if (!writeSucceeded) throw new Error('Failed to write character avatar data.');
 
         // Reset thumbnail cache
         invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
@@ -1312,7 +1388,8 @@ router.post('/edit-attribute', validateAvatarUrlMiddleware, async function (requ
         char.data[request.body.field] = request.body.value;
         let newCharJSON = JSON.stringify(char);
         const targetFile = (request.body.avatar_url).replace('.png', '');
-        await writeCharacterData(avatarPath, newCharJSON, targetFile, request);
+        const writeSucceeded = await writeCharacterData(avatarPath, newCharJSON, targetFile, request);
+        if (!writeSucceeded) throw new Error('Failed to write character data.');
         return response.sendStatus(200);
     } catch (err) {
         console.error('An error occurred, character edit invalidated.', err);
@@ -1466,7 +1543,21 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
         }
     }
 
-    fs.unlinkSync(avatarPath);
+    try {
+        fs.unlinkSync(avatarPath);
+    } catch (error) {
+        console.error('Could not delete character.', error);
+        return response.sendStatus(500);
+    }
+    try {
+        removeEntityDateAdded(
+            getEntityDateAddedRoot(request.user.directories),
+            'characters',
+            request.body.avatar_url,
+        );
+    } catch (metadataError) {
+        console.error('Could not remove date-added metadata after character deletion.', metadataError);
+    }
     invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
 
     return response.sendStatus(200);
@@ -1527,8 +1618,29 @@ router.post('/all', async function (request, response) {
     try {
         const files = fs.readdirSync(request.user.directories.characters);
         const pngFiles = files.filter(file => file.endsWith('.png'));
-        const processingPromises = pngFiles.map(file => processCharacter(file, request.user.directories, { shallow: useShallowCharacters }));
+        const fileStats = new Map();
+        const dateAddedEntries = pngFiles.map(file => {
+            try {
+                const fileStat = fs.statSync(path.join(request.user.directories.characters, file));
+                fileStats.set(file, fileStat);
+                return { id: file, fallback: getCharacterDateAddedFallback(fileStat) };
+            } catch {
+                return null;
+            }
+        }).filter(Boolean);
+        const dateAddedByFile = reconcileEntityDateAdded(
+            getEntityDateAddedRoot(request.user.directories),
+            'characters',
+            dateAddedEntries,
+        );
+        const processingPromises = pngFiles.map(file => processCharacter(file, request.user.directories, {
+            shallow: useShallowCharacters,
+            fileStat: fileStats.get(file),
+        }));
         const data = (await Promise.all(processingPromises)).filter(c => c.name);
+        for (const character of data) {
+            character.date_added = dateAddedByFile.get(character.avatar);
+        }
         return response.send(data);
     } catch (err) {
         console.error(err);
@@ -1548,6 +1660,24 @@ router.post('/get', validateAvatarUrlMiddleware, async function (request, respon
         }
 
         const data = await processCharacter(item, request.user.directories, { shallow: false });
+        let fileStat;
+        try {
+            fileStat = fs.statSync(filePath);
+        } catch (error) {
+            if (error?.code === 'ENOENT') {
+                return response.sendStatus(404);
+            }
+            throw error;
+        }
+        const dateAddedByFile = reconcileEntityDateAdded(
+            getEntityDateAddedRoot(request.user.directories),
+            'characters',
+            [{ id: item, fallback: getCharacterDateAddedFallback(fileStat) }],
+        );
+        data.date_added = dateAddedByFile.get(item);
+        if (data.date_added === undefined) {
+            return response.sendStatus(404);
+        }
 
         return response.send(data);
     } catch (err) {
@@ -1725,7 +1855,15 @@ router.post('/duplicate', validateAvatarUrlMiddleware, async function (request, 
             suffix++;
         }
 
-        fs.copyFileSync(filename, newFilename);
+        const operationTime = Date.now();
+        const dateAddedRoot = getEntityDateAddedRoot(request.user.directories);
+        const newAvatarName = path.basename(newFilename);
+        fs.copyFileSync(filename, newFilename, fs.constants.COPYFILE_EXCL);
+        try {
+            createEntityDateAdded(dateAddedRoot, 'characters', newAvatarName, operationTime);
+        } catch (metadataError) {
+            console.error('Could not record date-added metadata after duplicating a character.', metadataError);
+        }
         console.info(`${filename} was copied to ${newFilename}`);
         response.send({ path: path.parse(newFilename).base });
     } catch (error) {

--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -9,10 +9,14 @@ import { default as writeFileAtomic } from 'write-file-atomic';
 import { color, getConfigValue, tryParse, tryWriteFileSync } from '../util.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 import { clearChatRecoveryState, createGroupChatTarget, markChatDeleted, runChatRecoveryBestEffort } from '../chat-recovery.js';
+import { createEntityDateAdded, ensureEntityDateAdded, reconcileEntityDateAdded, removeEntityDateAdded } from '../entity-date-added.js';
 
 export const router = express.Router();
 const isChatBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
 const maxTotalChatBackups = Number(getConfigValue('backups.chat.maxTotalBackups', 25, 'number'));
+const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.groups);
+const getGroupDateAddedFallback = stat => [stat.birthtimeMs, stat.ctimeMs, stat.mtimeMs]
+    .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
 
 /**
  * Warns if group data contains deprecated metadata keys and removes them.
@@ -41,6 +45,25 @@ export async function migrateGroupChatsMetadataFormat(userDirectories) {
             const backupPath = path.join(userDirs.backups, '_group_metadata_update');
             const groupFiles = await fsPromises.readdir(userDirs.groups, { withFileTypes: true });
             const groupChatFiles = await fsPromises.readdir(userDirs.groupChats, { withFileTypes: true });
+            // Capture addition dates before metadata migration rewrites group files.
+            reconcileEntityDateAdded(
+                getEntityDateAddedRoot(userDirs),
+                'groups',
+                groupFiles
+                    .filter(groupFile => groupFile.isFile() && path.extname(groupFile.name) === '.json')
+                    .map(groupFile => ({
+                        groupFile,
+                        filePath: path.join(userDirs.groups, groupFile.name),
+                    }))
+                    .map(({ groupFile, filePath }) => {
+                        try {
+                            return { id: groupFile.name, fallback: getGroupDateAddedFallback(fs.statSync(filePath)) };
+                        } catch {
+                            return null;
+                        }
+                    })
+                    .filter(Boolean),
+            );
             for (const groupFile of groupFiles) {
                 try {
                     const isJsonFile = groupFile.isFile() && path.extname(groupFile.name) === '.json';
@@ -123,14 +146,29 @@ router.post('/all', (request, response) => {
     const files = fs.readdirSync(request.user.directories.groups).filter(x => path.extname(x) === '.json');
     const chats = fs.readdirSync(request.user.directories.groupChats).filter(x => path.extname(x) === '.jsonl');
     const chatFileSet = new Set(chats);
+    const groupStats = new Map();
+    const dateAddedEntries = files.map(file => {
+        try {
+            const fileStat = fs.statSync(path.join(request.user.directories.groups, file));
+            groupStats.set(file, fileStat);
+            return { id: file, fallback: getGroupDateAddedFallback(fileStat) };
+        } catch {
+            return null;
+        }
+    }).filter(Boolean);
+    const dateAddedByFile = reconcileEntityDateAdded(
+        getEntityDateAddedRoot(request.user.directories),
+        'groups',
+        dateAddedEntries,
+    );
 
     files.forEach(function (file) {
         try {
             const filePath = path.join(request.user.directories.groups, file);
             const fileContents = fs.readFileSync(filePath, 'utf8');
             const group = JSON.parse(fileContents);
-            const groupStat = fs.statSync(filePath);
-            group.date_added = groupStat.birthtimeMs;
+            const groupStat = groupStats.get(file) ?? fs.statSync(filePath);
+            group.date_added = dateAddedByFile.get(file);
             group.create_date = new Date(groupStat.birthtimeMs).toISOString();
 
             let chat_size = 0;
@@ -214,7 +252,15 @@ router.post('/create', (request, response) => {
         fs.mkdirSync(request.user.directories.groups);
     }
 
+    const operationTime = Date.now();
+    const dateAddedRoot = getEntityDateAddedRoot(request.user.directories);
+    const fileName = path.basename(pathToFile);
     tryWriteFileSync(pathToFile, fileData);
+    try {
+        createEntityDateAdded(dateAddedRoot, 'groups', fileName, operationTime);
+    } catch (metadataError) {
+        console.error('Could not record date-added metadata after creating a group.', metadataError);
+    }
     return response.send(groupMetadata);
 });
 
@@ -226,8 +272,29 @@ router.post('/edit', getFileNameValidationFunction('id'), (request, response) =>
     const id = request.body.id;
     const pathToFile = path.join(request.user.directories.groups, sanitize(`${id}.json`));
     const fileData = JSON.stringify(request.body, null, 4);
+    const operationTime = Date.now();
+    const fileExists = fs.existsSync(pathToFile);
+    const migrationFallback = fileExists ? getGroupDateAddedFallback(fs.statSync(pathToFile)) : operationTime;
+    const dateAddedRoot = getEntityDateAddedRoot(request.user.directories);
+    const fileName = path.basename(pathToFile);
 
-    tryWriteFileSync(pathToFile, fileData);
+    if (fileExists) {
+        ensureEntityDateAdded(
+            dateAddedRoot,
+            'groups',
+            fileName,
+            migrationFallback,
+            operationTime,
+        );
+        tryWriteFileSync(pathToFile, fileData);
+    } else {
+        tryWriteFileSync(pathToFile, fileData);
+        try {
+            createEntityDateAdded(dateAddedRoot, 'groups', fileName, operationTime);
+        } catch (metadataError) {
+            console.error('Could not record date-added metadata after creating a group.', metadataError);
+        }
+    }
     return response.send({ ok: true });
 });
 
@@ -238,6 +305,8 @@ router.post('/delete', getFileNameValidationFunction('id'), async (request, resp
 
     const id = request.body.id;
     const pathToGroup = path.join(request.user.directories.groups, sanitize(`${id}.json`));
+    const dateAddedRoot = getEntityDateAddedRoot(request.user.directories);
+    const groupFileName = path.basename(pathToGroup);
 
     try {
         // Delete group chats
@@ -273,6 +342,11 @@ router.post('/delete', getFileNameValidationFunction('id'), async (request, resp
         }
         if (fs.existsSync(pathToGroup)) {
             fs.unlinkSync(pathToGroup);
+        }
+        try {
+            removeEntityDateAdded(dateAddedRoot, 'groups', groupFileName);
+        } catch (metadataError) {
+            console.error('Could not remove date-added metadata after group deletion.', metadataError);
         }
         for (const recoveryTarget of recoveryTargets) {
             runChatRecoveryBestEffort(

--- a/src/endpoints/users-private.js
+++ b/src/endpoints/users-private.js
@@ -13,9 +13,10 @@ import { SETTINGS_FILE, USER_DIRECTORY_TEMPLATE } from '../constants.js';
 import { checkForNewContent, CONTENT_TYPES } from './content-manager.js';
 import { SECRETS_FILE } from './secrets.js';
 import { color, Cache, getConfigValue, ensureDirectory, normalizeZipEntryPath } from '../util.js';
+import { ENTITY_DATE_ADDED_FILE, importEntityDateAdded } from '../entity-date-added.js';
 
 const RESET_CACHE = new Cache(5 * 60 * 1000);
-const IMPORTABLE_ROOT_FILES = [SETTINGS_FILE, SECRETS_FILE];
+const IMPORTABLE_ROOT_FILES = [SETTINGS_FILE, SECRETS_FILE, ENTITY_DATE_ADDED_FILE];
 const IMPORTABLE_TOP_LEVEL_DIRECTORIES = [...new Set(
     Object.values(USER_DIRECTORY_TEMPLATE)
         .filter(Boolean)
@@ -225,6 +226,7 @@ async function copyDirectoryTree(sourceDirectory, destinationDirectory, {
 
 async function copyAllowedFolderContents(sourceRoot, targetRoot) {
     let copiedEntries = 0;
+    let importedEntityDateAdded;
     const protectedRoots = new Set([await getStableRealPath(targetRoot)]);
     const visitedDirectories = new Set();
 
@@ -236,6 +238,11 @@ async function copyAllowedFolderContents(sourceRoot, targetRoot) {
 
         const destinationPath = path.join(targetRoot, relativePath);
         const stats = await fsPromises.stat(sourcePath);
+
+        if (relativePath === ENTITY_DATE_ADDED_FILE && stats.isFile()) {
+            importedEntityDateAdded = await fsPromises.readFile(sourcePath);
+            continue;
+        }
 
         if (stats.isDirectory()) {
             const copiedFiles = await copyDirectoryTree(sourcePath, destinationPath, {
@@ -256,6 +263,15 @@ async function copyAllowedFolderContents(sourceRoot, targetRoot) {
         ensureDirectory(path.dirname(destinationPath));
         await fsPromises.copyFile(sourcePath, destinationPath);
         copiedEntries++;
+    }
+
+    if (importedEntityDateAdded !== undefined) {
+        try {
+            importEntityDateAdded(targetRoot, importedEntityDateAdded);
+            copiedEntries++;
+        } catch (error) {
+            console.warn('Could not import date-added metadata. Imported entities will be indexed locally.', error);
+        }
     }
 
     if (copiedEntries === 0) {
@@ -533,6 +549,7 @@ async function importZipContents(zipFilePath, targetRoot) {
             }
 
             let importedFiles = 0;
+            let importedEntityDateAdded;
             let completed = false;
 
             const finalize = (finalError = null) => {
@@ -542,8 +559,18 @@ async function importZipContents(zipFilePath, targetRoot) {
 
                 completed = true;
 
-                if (finalError) {
-                    reject(finalError);
+                const completionError = finalError;
+                if (!completionError && importedEntityDateAdded !== undefined) {
+                    try {
+                        importEntityDateAdded(targetRoot, importedEntityDateAdded);
+                    } catch (error) {
+                        importedFiles--;
+                        console.warn('Could not import date-added metadata. Imported entities will be indexed locally.', error);
+                    }
+                }
+
+                if (completionError) {
+                    reject(completionError);
                 } else if (importedFiles === 0) {
                     reject(new Error('That ZIP did not contain any importable SillyTavern files.'));
                 } else {
@@ -584,6 +611,18 @@ async function importZipContents(zipFilePath, targetRoot) {
 
                     const destinationPath = path.join(targetRoot, relativePath);
                     ensureDirectory(path.dirname(destinationPath));
+
+                    if (relativePath === ENTITY_DATE_ADDED_FILE) {
+                        const chunks = [];
+                        readStream.on('data', chunk => chunks.push(chunk));
+                        readStream.once('error', finalize);
+                        readStream.once('end', () => {
+                            importedEntityDateAdded = Buffer.concat(chunks);
+                            importedFiles++;
+                            zipfile.readEntry();
+                        });
+                        return;
+                    }
 
                     pipeline(readStream, fs.createWriteStream(destinationPath))
                         .then(() => {

--- a/src/entity-date-added.js
+++ b/src/entity-date-added.js
@@ -1,0 +1,331 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import lockfile from 'proper-lockfile';
+import { tryWriteFileSync } from './util.js';
+
+export const ENTITY_DATE_ADDED_FILE = 'entity-date-added.json';
+const STORE_VERSION = 1;
+const ENTITY_TYPES = new Set(['characters', 'groups']);
+const LOCK_FILENAME = `${ENTITY_DATE_ADDED_FILE}.lock`;
+const LOCK_RETRY_DELAY_MS = 25;
+const LOCK_RETRY_LIMIT = 200;
+
+function createScope() {
+    return {
+        initialized: false,
+        entries: {},
+        deleted: {},
+    };
+}
+
+function createStore() {
+    return {
+        version: STORE_VERSION,
+        characters: createScope(),
+        groups: createScope(),
+    };
+}
+
+function isValidTimestamp(value) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function normalizeTimestamp(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function getScope(store, entityType) {
+    if (!ENTITY_TYPES.has(entityType)) {
+        throw new TypeError(`Unsupported entity date-added type: ${entityType}`);
+    }
+
+    return store[entityType];
+}
+
+function normalizeStore(value) {
+    if (!value || typeof value !== 'object' || value.version !== STORE_VERSION) {
+        throw new Error('Unsupported entity date-added metadata format.');
+    }
+
+    const store = createStore();
+    for (const entityType of ENTITY_TYPES) {
+        const sourceScope = value[entityType];
+        if (!sourceScope || typeof sourceScope !== 'object') {
+            continue;
+        }
+
+        store[entityType].initialized = sourceScope.initialized === true;
+        if (!sourceScope.entries || typeof sourceScope.entries !== 'object' || Array.isArray(sourceScope.entries)) {
+            continue;
+        }
+
+        for (const [id, timestamp] of Object.entries(sourceScope.entries)) {
+            const normalizedTimestamp = Number(timestamp);
+            if (id && Number.isFinite(normalizedTimestamp) && normalizedTimestamp > 0) {
+                store[entityType].entries[id] = normalizedTimestamp;
+            }
+        }
+
+        if (!sourceScope.deleted || typeof sourceScope.deleted !== 'object' || Array.isArray(sourceScope.deleted)) {
+            continue;
+        }
+
+        for (const [id, timestamp] of Object.entries(sourceScope.deleted)) {
+            const normalizedTimestamp = Number(timestamp);
+            if (id && !Object.hasOwn(store[entityType].entries, id) && Number.isFinite(normalizedTimestamp) && normalizedTimestamp > 0) {
+                store[entityType].deleted[id] = normalizedTimestamp;
+            }
+        }
+    }
+
+    return store;
+}
+
+function readStore(userRoot) {
+    if (typeof userRoot !== 'string' || !userRoot) {
+        throw new TypeError('A user root is required for entity date-added metadata.');
+    }
+
+    const filePath = path.join(userRoot, ENTITY_DATE_ADDED_FILE);
+    if (!fs.existsSync(filePath)) {
+        return { filePath, store: createStore(), writable: true };
+    }
+
+    try {
+        const store = normalizeStore(JSON.parse(fs.readFileSync(filePath, 'utf8')));
+        return { filePath, store, writable: true };
+    } catch (error) {
+        const corruptPath = `${filePath}.corrupt-${Date.now()}-${process.pid}`;
+        try {
+            fs.renameSync(filePath, corruptPath);
+            console.error(`Could not read entity date-added metadata at ${filePath}. The corrupt file was moved to ${corruptPath}.`, error);
+            return { filePath, store: createStore(), writable: true };
+        } catch (backupError) {
+            throw new Error(`Could not preserve corrupt entity date-added metadata at ${filePath}.`, { cause: backupError });
+        }
+    }
+}
+
+function withStoreLock(userRoot, callback) {
+    fs.mkdirSync(userRoot, { recursive: true });
+    const lockPath = path.join(userRoot, LOCK_FILENAME);
+    let release;
+
+    for (let attempt = 0; attempt <= LOCK_RETRY_LIMIT; attempt++) {
+        try {
+            release = lockfile.lockSync(userRoot, {
+                lockfilePath: lockPath,
+                realpath: false,
+                stale: 30_000,
+                update: 10_000,
+            });
+            break;
+        } catch (error) {
+            if (error?.code !== 'ELOCKED' || attempt === LOCK_RETRY_LIMIT) {
+                throw error;
+            }
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, LOCK_RETRY_DELAY_MS);
+        }
+    }
+
+    try {
+        return callback();
+    } finally {
+        release?.();
+    }
+}
+
+function updateStore(userRoot, entityType, callback) {
+    return withStoreLock(userRoot, () => {
+        const state = readStore(userRoot);
+        const scope = getScope(state.store, entityType);
+        const before = JSON.stringify(state.store);
+        const result = callback(scope);
+
+        if (state.writable && before !== JSON.stringify(state.store)) {
+            tryWriteFileSync(state.filePath, `${JSON.stringify(state.store, null, 4)}\n`, 'utf8');
+        }
+
+        return result;
+    });
+}
+
+/**
+ * Reconciles persisted date-added metadata with the entities currently on disk.
+ * The first reconciliation migrates filesystem timestamps; later discoveries use discovery time.
+ * @param {string} userRoot User data root.
+ * @param {'characters'|'groups'} entityType Entity collection to reconcile.
+ * @param {{id: string, fallback: number}[]} entities Current entity IDs and migration timestamps.
+ * @param {number} [now] Discovery timestamp.
+ * @returns {Map<string, number>} Date-added timestamps keyed by entity ID.
+ */
+export function reconcileEntityDateAdded(userRoot, entityType, entities, now = Date.now()) {
+    if (!Array.isArray(entities)) {
+        throw new TypeError('Entity date-added reconciliation requires an entity array.');
+    }
+
+    const discoveredAt = normalizeTimestamp(now, Date.now());
+    return updateStore(userRoot, entityType, (scope) => {
+        const result = new Map();
+        const isMigration = !scope.initialized;
+
+        for (const entity of entities) {
+            if (!entity || typeof entity.id !== 'string' || !entity.id) {
+                throw new TypeError('Entity date-added reconciliation requires non-empty string IDs.');
+            }
+
+            let timestamp = scope.entries[entity.id];
+            if (!isValidTimestamp(timestamp)) {
+                const deletedAt = scope.deleted[entity.id];
+                const fallback = normalizeTimestamp(entity.fallback, 0);
+                if (isValidTimestamp(deletedAt) && fallback <= deletedAt) {
+                    continue;
+                }
+
+                delete scope.deleted[entity.id];
+                timestamp = isMigration
+                    ? normalizeTimestamp(fallback, discoveredAt)
+                    : discoveredAt;
+                scope.entries[entity.id] = timestamp;
+            }
+            result.set(entity.id, timestamp);
+        }
+
+        scope.initialized = true;
+        return result;
+    });
+}
+
+/**
+ * Gets or assigns an immutable local date-added timestamp for an entity.
+ * @param {string} userRoot User data root.
+ * @param {'characters'|'groups'} entityType Entity collection.
+ * @param {string} id Entity ID.
+ * @param {number} fallback Filesystem timestamp used during initial migration.
+ * @param {number} [now] Timestamp used for entities discovered after migration.
+ * @returns {number} Persisted date-added timestamp.
+ */
+export function ensureEntityDateAdded(userRoot, entityType, id, fallback, now = Date.now()) {
+    if (typeof id !== 'string' || !id) {
+        throw new TypeError('Entity date-added metadata requires a non-empty string ID.');
+    }
+
+    const discoveredAt = normalizeTimestamp(now, Date.now());
+    return updateStore(userRoot, entityType, (scope) => {
+        let timestamp = scope.entries[id];
+        if (!isValidTimestamp(timestamp)) {
+            timestamp = scope.initialized
+                ? discoveredAt
+                : normalizeTimestamp(fallback, discoveredAt);
+            scope.entries[id] = timestamp;
+        }
+        delete scope.deleted[id];
+        return timestamp;
+    });
+}
+
+/**
+ * Assigns a new immutable date-added timestamp after an entity file is created.
+ * @param {string} userRoot User data root.
+ * @param {'characters'|'groups'} entityType Entity collection.
+ * @param {string} id Entity ID.
+ * @param {number} [now] Creation timestamp.
+ * @returns {number} Persisted date-added timestamp.
+ */
+export function createEntityDateAdded(userRoot, entityType, id, now = Date.now()) {
+    if (typeof id !== 'string' || !id) {
+        throw new TypeError('Entity date-added metadata requires a non-empty string ID.');
+    }
+
+    const timestamp = normalizeTimestamp(now, Date.now());
+    return updateStore(userRoot, entityType, (scope) => {
+        scope.entries[id] = timestamp;
+        delete scope.deleted[id];
+        return timestamp;
+    });
+}
+
+/**
+ * Prepares a rename by assigning the original date-added timestamp to the new ID.
+ * @param {string} userRoot User data root.
+ * @param {'characters'|'groups'} entityType Entity collection.
+ * @param {string} oldId Previous entity ID.
+ * @param {string} newId New entity ID.
+ * @param {number} fallback Filesystem timestamp used if the old ID was not indexed.
+ * @param {number} [now] Discovery timestamp used after migration.
+ * @returns {number} Date-added timestamp assigned to the new ID.
+ */
+export function prepareEntityDateAddedMove(userRoot, entityType, oldId, newId, fallback, now = Date.now()) {
+    if (typeof oldId !== 'string' || !oldId || typeof newId !== 'string' || !newId) {
+        throw new TypeError('Entity date-added moves require non-empty string IDs.');
+    }
+
+    const discoveredAt = normalizeTimestamp(now, Date.now());
+    return updateStore(userRoot, entityType, (scope) => {
+        const timestamp = isValidTimestamp(scope.entries[oldId])
+            ? scope.entries[oldId]
+            : normalizeTimestamp(fallback, discoveredAt);
+
+        scope.entries[newId] = timestamp;
+        delete scope.deleted[newId];
+        return timestamp;
+    });
+}
+
+/**
+ * Removes an entity's persisted date-added timestamp.
+ * @param {string} userRoot User data root.
+ * @param {'characters'|'groups'} entityType Entity collection.
+ * @param {string} id Entity ID.
+ * @param {number} [now] Deletion timestamp.
+ * @returns {number|undefined} Removed date-added timestamp.
+ */
+export function removeEntityDateAdded(userRoot, entityType, id, now = Date.now()) {
+    if (typeof id !== 'string' || !id) {
+        throw new TypeError('Entity date-added removal requires a non-empty string ID.');
+    }
+
+    const deletedAt = normalizeTimestamp(now, Date.now());
+    return updateStore(userRoot, entityType, (scope) => {
+        const timestamp = scope.entries[id];
+        delete scope.entries[id];
+        scope.deleted[id] = deletedAt;
+        return isValidTimestamp(timestamp) ? timestamp : undefined;
+    });
+}
+
+/**
+ * Merges metadata from an account import without dropping concurrent local additions.
+ * @param {string} userRoot User data root.
+ * @param {string|Buffer|object} value Imported metadata.
+ */
+export function importEntityDateAdded(userRoot, value) {
+    const parsed = typeof value === 'string' || Buffer.isBuffer(value)
+        ? JSON.parse(value.toString())
+        : value;
+    const importedStore = normalizeStore(parsed);
+
+    withStoreLock(userRoot, () => {
+        const state = readStore(userRoot);
+        for (const entityType of ENTITY_TYPES) {
+            const currentScope = state.store[entityType];
+            const importedScope = importedStore[entityType];
+
+            for (const [id, timestamp] of Object.entries(currentScope.entries)) {
+                if (!Object.hasOwn(importedScope.entries, id)) {
+                    importedScope.entries[id] = timestamp;
+                    delete importedScope.deleted[id];
+                }
+            }
+            for (const [id, timestamp] of Object.entries(currentScope.deleted)) {
+                if (!Object.hasOwn(importedScope.entries, id) && !Object.hasOwn(importedScope.deleted, id)) {
+                    importedScope.deleted[id] = timestamp;
+                }
+            }
+            importedScope.initialized ||= currentScope.initialized;
+        }
+
+        tryWriteFileSync(state.filePath, `${JSON.stringify(importedStore, null, 4)}\n`, 'utf8');
+    });
+}

--- a/tests/entity-date-added-endpoints.test.js
+++ b/tests/entity-date-added-endpoints.test.js
@@ -1,0 +1,308 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const originalWorkingDirectory = process.cwd();
+const diskCacheEnvironmentKey = 'SILLYTAVERN_PERFORMANCE_USEDISKCACHE';
+const originalDiskCacheSetting = process.env[diskCacheEnvironmentKey];
+process.env[diskCacheEnvironmentKey] = 'false';
+process.chdir(repoRoot);
+setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
+
+const { router: charactersRouter } = await import('../src/endpoints/characters.js');
+const { migrateGroupChatsMetadataFormat, router: groupsRouter } = await import('../src/endpoints/groups.js');
+
+describe('entity date added endpoints', () => {
+    let baseUrl;
+    let directories;
+    let server;
+    let tempRoot;
+
+    beforeAll(async () => {
+        const app = express();
+        app.use(express.json({ limit: '10mb' }));
+        app.use((request, _response, next) => {
+            request.user = {
+                profile: { handle: 'date-added-test-user' },
+                directories,
+            };
+            next();
+        });
+        app.use('/api/characters', charactersRouter);
+        app.use('/api/groups', groupsRouter);
+
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-date-added-endpoints-'));
+        directories = {
+            root: tempRoot,
+            backups: path.join(tempRoot, 'backups'),
+            chats: path.join(tempRoot, 'chats'),
+            characters: path.join(tempRoot, 'characters'),
+            groupChats: path.join(tempRoot, 'group chats'),
+            groups: path.join(tempRoot, 'groups'),
+            thumbnailsAvatar: path.join(tempRoot, 'thumbnails', 'avatar'),
+            worlds: path.join(tempRoot, 'worlds'),
+        };
+        for (const directory of Object.values(directories)) {
+            fs.mkdirSync(directory, { recursive: true });
+        }
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+        if (server) {
+            await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        }
+        if (originalDiskCacheSetting === undefined) {
+            delete process.env[diskCacheEnvironmentKey];
+        } else {
+            process.env[diskCacheEnvironmentKey] = originalDiskCacheSetting;
+        }
+        process.chdir(originalWorkingDirectory);
+    });
+
+    test('preserves character addition time across edits and renames while treating copies as new', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        const createResponse = await postJson('/api/characters/create', {
+            ch_name: 'Alice',
+            file_name: 'Alice',
+        });
+        expect(createResponse.status).toBe(200);
+        expect(await createResponse.text()).toBe('Alice.png');
+
+        const [created] = await getCharacters();
+        const originalDateAdded = created.date_added;
+
+        await delay();
+        const editResponse = await postJson('/api/characters/edit', {
+            avatar_url: 'Alice.png',
+            ch_name: 'Alice',
+            chat: created.chat,
+            create_date: created.create_date,
+            json_data: created.json_data,
+        });
+        expect(editResponse.status).toBe(200);
+
+        const [edited] = await getCharacters();
+        expect(edited.date_added).toBe(originalDateAdded);
+
+        await delay();
+        const renameResponse = await postJson('/api/characters/rename', {
+            avatar_url: 'Alice.png',
+            new_name: 'Alicia',
+        });
+        expect(renameResponse.status).toBe(200);
+        const renamedAvatar = (await renameResponse.json()).avatar;
+        const renamed = (await getCharacters()).find(character => character.avatar === renamedAvatar);
+        expect(renamed.date_added).toBe(originalDateAdded);
+
+        await delay();
+        const duplicateResponse = await postJson('/api/characters/duplicate', { avatar_url: renamedAvatar });
+        expect(duplicateResponse.status).toBe(200);
+        const duplicateAvatar = (await duplicateResponse.json()).path;
+        const duplicated = (await getCharacters()).find(character => character.avatar === duplicateAvatar);
+        expect(duplicated.date_added).toBeGreaterThan(originalDateAdded);
+
+        const deleteResponse = await postJson('/api/characters/delete', {
+            avatar_url: renamedAvatar,
+            delete_chats: false,
+        });
+        expect(deleteResponse.status).toBe(200);
+
+        await delay();
+        const recreateResponse = await postJson('/api/characters/create', {
+            ch_name: 'Alicia',
+            file_name: path.parse(renamedAvatar).name,
+        });
+        expect(recreateResponse.status).toBe(200);
+        const recreated = (await getCharacters()).find(character => character.avatar === renamedAvatar);
+        expect(recreated.date_added).toBeGreaterThan(originalDateAdded);
+    });
+
+    test('restores character chats when a rename cannot remove the old avatar', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        const createResponse = await postJson('/api/characters/create', {
+            ch_name: 'Alice',
+            file_name: 'Alice',
+        });
+        expect(createResponse.status).toBe(200);
+        const [created] = await getCharacters();
+        const oldAvatarPath = path.join(directories.characters, 'Alice.png');
+        const newAvatarPath = path.join(directories.characters, 'Alicia.png');
+        const oldChatsPath = path.join(directories.chats, 'Alice');
+        const newChatsPath = path.join(directories.chats, 'Alicia');
+        fs.mkdirSync(oldChatsPath, { recursive: true });
+        fs.writeFileSync(path.join(oldChatsPath, 'Chat.jsonl'), '{}\n');
+        const unlinkSync = fs.unlinkSync.bind(fs);
+        jest.spyOn(fs, 'unlinkSync').mockImplementation(filePath => {
+            if (path.resolve(String(filePath)) === path.resolve(oldAvatarPath)) {
+                const error = new Error('The old avatar is locked.');
+                error.code = 'EBUSY';
+                throw error;
+            }
+            return unlinkSync(filePath);
+        });
+
+        const renameResponse = await postJson('/api/characters/rename', {
+            avatar_url: 'Alice.png',
+            new_name: 'Alicia',
+        });
+
+        expect(renameResponse.status).toBe(500);
+        expect(fs.existsSync(oldAvatarPath)).toBe(true);
+        expect(fs.existsSync(newAvatarPath)).toBe(false);
+        expect(fs.existsSync(path.join(oldChatsPath, 'Chat.jsonl'))).toBe(true);
+        expect(fs.existsSync(newChatsPath)).toBe(false);
+        const [restored] = await getCharacters();
+        expect(restored.avatar).toBe('Alice.png');
+        expect(restored.date_added).toBe(created.date_added);
+    });
+
+    test('restores a complete chat snapshot after partial rename cleanup', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const createResponse = await postJson('/api/characters/create', {
+            ch_name: 'Alice',
+            file_name: 'Alice',
+        });
+        expect(createResponse.status).toBe(200);
+        const oldAvatarPath = path.join(directories.characters, 'Alice.png');
+        const newAvatarPath = path.join(directories.characters, 'Alicia.png');
+        const oldChatsPath = path.join(directories.chats, 'Alice');
+        const newChatsPath = path.join(directories.chats, 'Alicia');
+        fs.mkdirSync(oldChatsPath, { recursive: true });
+        fs.writeFileSync(path.join(oldChatsPath, 'First.jsonl'), '{}\n');
+        fs.writeFileSync(path.join(oldChatsPath, 'Second.jsonl'), '{}\n');
+        const rmSync = fs.rmSync.bind(fs);
+        let removalFailed = false;
+        jest.spyOn(fs, 'rmSync').mockImplementation((targetPath, options) => {
+            if (!removalFailed && path.resolve(String(targetPath)) === path.resolve(oldChatsPath)) {
+                removalFailed = true;
+                rmSync(path.join(oldChatsPath, 'First.jsonl'), { force: true });
+                const error = new Error('Chat directory cleanup was interrupted.');
+                error.code = 'EBUSY';
+                throw error;
+            }
+            return rmSync(targetPath, options);
+        });
+
+        const renameResponse = await postJson('/api/characters/rename', {
+            avatar_url: 'Alice.png',
+            new_name: 'Alicia',
+        });
+
+        expect(renameResponse.status).toBe(500);
+        expect(fs.existsSync(oldAvatarPath)).toBe(true);
+        expect(fs.existsSync(newAvatarPath)).toBe(false);
+        expect(fs.existsSync(path.join(oldChatsPath, 'First.jsonl'))).toBe(true);
+        expect(fs.existsSync(path.join(oldChatsPath, 'Second.jsonl'))).toBe(true);
+        expect(fs.existsSync(newChatsPath)).toBe(false);
+    });
+
+    test('preserves group addition time across atomic edits', async () => {
+        const createResponse = await postJson('/api/groups/create', {
+            name: 'Test Group',
+            members: [],
+        });
+        expect(createResponse.status).toBe(200);
+        const createdGroup = await createResponse.json();
+        const [listedGroup] = await getGroups();
+        const originalDateAdded = listedGroup.date_added;
+
+        await delay();
+        const editResponse = await postJson('/api/groups/edit', {
+            ...createdGroup,
+            name: 'Updated Group',
+        });
+        expect(editResponse.status).toBe(200);
+
+        const [editedGroup] = await getGroups();
+        expect(editedGroup.name).toBe('Updated Group');
+        expect(editedGroup.date_added).toBe(originalDateAdded);
+    });
+
+    test('freezes group addition time before startup metadata migrations rewrite files', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const groupPath = path.join(directories.groups, 'legacy-group.json');
+        const unstatableGroupPath = path.join(directories.groups, 'unstatable-group.json');
+        fs.writeFileSync(groupPath, JSON.stringify({
+            id: 'legacy-group',
+            name: 'Legacy Group',
+            members: [],
+            chats: [],
+            chat_id: '',
+            chat_metadata: {},
+            past_metadata: {},
+        }));
+        fs.writeFileSync(unstatableGroupPath, JSON.stringify({
+            id: 'unstatable-group',
+            name: 'Unstatable Group',
+            members: [],
+            chats: [],
+            chat_id: '',
+        }));
+        const initialStat = fs.statSync(groupPath);
+        const expectedDateAdded = [initialStat.birthtimeMs, initialStat.ctimeMs, initialStat.mtimeMs]
+            .find(timestamp => Number.isFinite(timestamp) && timestamp > 0);
+        const statSync = fs.statSync.bind(fs);
+        jest.spyOn(fs, 'statSync').mockImplementation(filePath => {
+            if (path.resolve(String(filePath)) === path.resolve(unstatableGroupPath)) {
+                const error = new Error('File disappeared during startup migration.');
+                error.code = 'ENOENT';
+                throw error;
+            }
+            return statSync(filePath);
+        });
+
+        await delay();
+        await migrateGroupChatsMetadataFormat([directories]);
+
+        const migratedGroup = (await getGroups()).find(group => group.id === 'legacy-group');
+        expect(migratedGroup.date_added).toBe(expectedDateAdded);
+        const migratedData = JSON.parse(fs.readFileSync(groupPath, 'utf8'));
+        expect(migratedData).not.toHaveProperty('chat_metadata');
+        expect(migratedData).not.toHaveProperty('past_metadata');
+    });
+
+    function postJson(resource, body = {}) {
+        return fetch(`${baseUrl}${resource}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+    }
+
+    async function getCharacters() {
+        const response = await postJson('/api/characters/all');
+        expect(response.status).toBe(200);
+        return response.json();
+    }
+
+    async function getGroups() {
+        const response = await postJson('/api/groups/all');
+        expect(response.status).toBe(200);
+        return response.json();
+    }
+
+    function delay() {
+        return new Promise(resolve => setTimeout(resolve, 25));
+    }
+});

--- a/tests/entity-date-added.test.js
+++ b/tests/entity-date-added.test.js
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+    createEntityDateAdded,
+    ENTITY_DATE_ADDED_FILE,
+    ensureEntityDateAdded,
+    importEntityDateAdded,
+    prepareEntityDateAddedMove,
+    reconcileEntityDateAdded,
+    removeEntityDateAdded,
+} from '../src/entity-date-added.js';
+
+const tempDirectories = [];
+
+function createUserRoot() {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-date-added-'));
+    tempDirectories.push(directory);
+    return directory;
+}
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    for (const directory of tempDirectories.splice(0)) {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+describe('entity date added metadata', () => {
+    test('migrates filesystem timestamps once and preserves them across later saves', () => {
+        const userRoot = createUserRoot();
+        const migrated = reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 1_000 },
+        ], 5_000);
+
+        expect(migrated.get('Alice.png')).toBe(1_000);
+        expect(ensureEntityDateAdded(userRoot, 'characters', 'Alice.png', 9_000, 10_000)).toBe(1_000);
+        expect(reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 12_000 },
+        ], 15_000).get('Alice.png')).toBe(1_000);
+    });
+
+    test('uses discovery time for files first seen after migration', () => {
+        const userRoot = createUserRoot();
+        reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 1_000 },
+        ], 5_000);
+
+        const dates = reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 6_000 },
+            { id: 'Bob.png', fallback: 2_000 },
+        ], 7_000);
+
+        expect(dates.get('Alice.png')).toBe(1_000);
+        expect(dates.get('Bob.png')).toBe(7_000);
+    });
+
+    test('preserves timestamps across renames and resets them after deletion', () => {
+        const userRoot = createUserRoot();
+        reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 1_000 },
+        ], 5_000);
+
+        expect(prepareEntityDateAddedMove(userRoot, 'characters', 'Alice.png', 'Alicia.png', 6_000, 7_000)).toBe(1_000);
+        removeEntityDateAdded(userRoot, 'characters', 'Alice.png', 7_000);
+        expect(reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alicia.png', fallback: 8_000 },
+        ], 9_000).get('Alicia.png')).toBe(1_000);
+
+        removeEntityDateAdded(userRoot, 'characters', 'Alicia.png');
+        expect(ensureEntityDateAdded(userRoot, 'characters', 'Alicia.png', 10_000, 11_000)).toBe(11_000);
+    });
+
+    test('tracks character and group dates independently', () => {
+        const userRoot = createUserRoot();
+
+        reconcileEntityDateAdded(userRoot, 'characters', [{ id: 'Shared', fallback: 1_000 }], 3_000);
+        reconcileEntityDateAdded(userRoot, 'groups', [{ id: 'Shared', fallback: 2_000 }], 4_000);
+
+        expect(ensureEntityDateAdded(userRoot, 'characters', 'Shared', 5_000, 6_000)).toBe(1_000);
+        expect(ensureEntityDateAdded(userRoot, 'groups', 'Shared', 7_000, 8_000)).toBe(2_000);
+    });
+
+    test('retains unseen identities until an explicit lifecycle deletion', () => {
+        const userRoot = createUserRoot();
+        reconcileEntityDateAdded(userRoot, 'characters', [{ id: 'Alice.png', fallback: 1_000 }], 2_000);
+
+        reconcileEntityDateAdded(userRoot, 'characters', [], 3_000);
+
+        expect(ensureEntityDateAdded(userRoot, 'characters', 'Alice.png', 4_000, 5_000)).toBe(1_000);
+    });
+
+    test('does not resurrect a deleted identity from a stale directory snapshot', () => {
+        const userRoot = createUserRoot();
+        reconcileEntityDateAdded(userRoot, 'characters', [{ id: 'Alice.png', fallback: 1_000 }], 2_000);
+
+        removeEntityDateAdded(userRoot, 'characters', 'Alice.png', 3_000);
+        const staleDates = reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 1_000 },
+        ], 4_000);
+
+        expect(staleDates.has('Alice.png')).toBe(false);
+        expect(createEntityDateAdded(userRoot, 'characters', 'Alice.png', 5_000)).toBe(5_000);
+    });
+
+    test('merges imported metadata without dropping concurrent local entries', () => {
+        const userRoot = createUserRoot();
+        reconcileEntityDateAdded(userRoot, 'characters', [{ id: 'Local.png', fallback: 1_000 }], 2_000);
+
+        importEntityDateAdded(userRoot, {
+            version: 1,
+            characters: {
+                initialized: true,
+                entries: { 'Imported.png': 3_000 },
+                deleted: {},
+            },
+            groups: {
+                initialized: false,
+                entries: {},
+                deleted: {},
+            },
+        });
+
+        const dates = reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Local.png', fallback: 4_000 },
+            { id: 'Imported.png', fallback: 5_000 },
+        ], 6_000);
+        expect(dates.get('Local.png')).toBe(1_000);
+        expect(dates.get('Imported.png')).toBe(3_000);
+    });
+
+    test('recovers a stale interprocess lock', () => {
+        const userRoot = createUserRoot();
+        const lockPath = path.join(userRoot, `${ENTITY_DATE_ADDED_FILE}.lock`);
+        fs.mkdirSync(lockPath);
+        const staleTime = new Date(Date.now() - 60_000);
+        fs.utimesSync(lockPath, staleTime, staleTime);
+
+        expect(createEntityDateAdded(userRoot, 'characters', 'Alice.png', 1_000)).toBe(1_000);
+        expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    test('serializes updates from separate processes', async () => {
+        const userRoot = createUserRoot();
+        const moduleUrl = new URL('../src/entity-date-added.js', import.meta.url).href;
+        reconcileEntityDateAdded(userRoot, 'characters', [], 1_000);
+
+        await Promise.all([
+            runChild(`import { ensureEntityDateAdded } from ${JSON.stringify(moduleUrl)}; ensureEntityDateAdded(${JSON.stringify(userRoot)}, 'characters', 'Alice.png', 2_000, 2_000);`),
+            runChild(`import { ensureEntityDateAdded } from ${JSON.stringify(moduleUrl)}; ensureEntityDateAdded(${JSON.stringify(userRoot)}, 'characters', 'Bob.png', 3_000, 3_000);`),
+        ]);
+
+        const dates = reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 4_000 },
+            { id: 'Bob.png', fallback: 5_000 },
+        ], 6_000);
+        expect(dates.get('Alice.png')).toBe(2_000);
+        expect(dates.get('Bob.png')).toBe(3_000);
+    });
+
+    test('backs up corrupt metadata before rebuilding it', () => {
+        const userRoot = createUserRoot();
+        fs.writeFileSync(path.join(userRoot, ENTITY_DATE_ADDED_FILE), '{not json');
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const dates = reconcileEntityDateAdded(userRoot, 'characters', [
+            { id: 'Alice.png', fallback: 1_000 },
+        ], 2_000);
+
+        expect(dates.get('Alice.png')).toBe(1_000);
+        expect(fs.readdirSync(userRoot).some(file => file.startsWith(`${ENTITY_DATE_ADDED_FILE}.corrupt-`))).toBe(true);
+        expect(() => JSON.parse(fs.readFileSync(path.join(userRoot, ENTITY_DATE_ADDED_FILE), 'utf8'))).not.toThrow();
+    });
+});
+
+function runChild(script) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, ['--input-type=module', '--eval', script], {
+            stdio: ['ignore', 'ignore', 'pipe'],
+        });
+        let errorOutput = '';
+        child.stderr.setEncoding('utf8');
+        child.stderr.on('data', chunk => errorOutput += chunk);
+        child.on('error', reject);
+        child.on('exit', code => code === 0 ? resolve() : reject(new Error(errorOutput || `Child exited with code ${code}.`)));
+    });
+}


### PR DESCRIPTION
Currently, `Newest` doesn't actually mean newest. It depends on the card's modification timestamp.
I've added an option so that the date the card was refreshed/added locally is what is used for sorting. Leaves the existing behavior untouched while at it.
