### PR TITLE
fix(lorebooks): general lorebook bug fixes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -59,7 +59,7 @@ import {
     charUpdatePrimaryWorld,
     charSetAuxWorlds,
 } from './scripts/world-info.js';
-import { buildWorldInfoScanChat } from './scripts/world-info-scan-chat.js';
+import { buildWorldInfoScanChat, substituteWorldInfoGreeting } from './scripts/world-info-scan-chat.js';
 
 import {
     groups,
@@ -6985,9 +6985,13 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     }
 
     // First message in fresh 1-on-1 chat reacts to user/character settings changes
-    if (chat.length) {
-        chat[0].mes = substituteParams(chat[0].mes);
-    }
+    const firstChatMessage = chat[0];
+    const firstMessageVariants = !world_info_include_names && firstChatMessage
+        ? substituteWorldInfoGreeting(firstChatMessage.mes, substituteParams, { char: name2, user: name1 })
+        : undefined;
+    const firstPromptMessage = firstChatMessage
+        ? (firstMessageVariants?.prompt ?? substituteParams(firstChatMessage.mes))
+        : undefined;
 
     // Collect messages with usable content
     const canUseTools = ToolManager.isToolCallingSupported();
@@ -7002,7 +7006,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
     const worldInfoMessageVariants = new Map();
     coreChat = await Promise.all(coreChat.map(async (/** @type {ChatMessage} */ chatItem, index) => {
-        const originalMessage = chatItem.mes;
+        const originalMessage = chatItem === firstChatMessage ? firstPromptMessage : chatItem.mes;
+        const worldInfoSourceMessage = chatItem === firstChatMessage && firstMessageVariants !== undefined
+            ? firstMessageVariants.worldInfo
+            : originalMessage;
         let message = originalMessage;
         let regexType = chatItem.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
         let options = { isPrompt: true, depth: (coreChat.length - index - (isContinue ? 2 : 1)) };
@@ -7020,7 +7027,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         }
 
         let regexedMessage = getRegexedString(message, regexType, options);
-        let worldInfoRegexedMessage = message === originalMessage ? undefined : getRegexedString(originalMessage, regexType, options);
+        let worldInfoRegexedMessage = message === worldInfoSourceMessage ? undefined : getRegexedString(worldInfoSourceMessage, regexType, options);
         const fileContent = await appendFileContent(chatItem, '');
         regexedMessage = fileContent + regexedMessage;
         if (worldInfoRegexedMessage !== undefined) {

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2490,11 +2490,12 @@ export function highlightRegex(regexStr) {
  * @param {object} options - Optional parameters
  * @param {boolean} [options.interactive=false] - Whether to show a confirmation dialog when needing to overwrite an existing data object
  * @param {string} [options.actionName='overwrite'] - The action name to display in the confirmation dialog
- * @param {(existingName:string)=>void} [options.deleteAction=null] - Optional action to execute wen deleting an existing data object on overwrite
+ * @param {(existingName:string)=>void|Promise<void>} [options.deleteAction=null] - Optional action to execute when deleting an existing data object on overwrite
  * @returns {Promise<boolean>} True if the user confirmed the overwrite or there is no overwrite needed, false otherwise
  */
 export async function checkOverwriteExistingData(type, existingNames, name, { interactive = false, actionName = 'Overwrite', deleteAction = null } = {}) {
-    const existing = existingNames.find(x => equalsIgnoreCaseAndAccents(x, name));
+    const existing = existingNames.find(x => x === name)
+        ?? existingNames.find(x => equalsIgnoreCaseAndAccents(x, name));
     if (!existing) {
         return true;
     }
@@ -2509,7 +2510,7 @@ export async function checkOverwriteExistingData(type, existingNames, name, { in
 
     // If there is an action to delete the existing data, do it, as the name might be slightly different so file name would not be the same
     if (deleteAction) {
-        deleteAction(existing);
+        await deleteAction(existing);
     }
 
     return true;

--- a/public/scripts/world-info-batch-helpers.js
+++ b/public/scripts/world-info-batch-helpers.js
@@ -3,25 +3,47 @@
  * Separated from world-info.js for testability.
  */
 
+function normalizeLorebookName(value) {
+    return String(value ?? '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}
+
+/**
+ * Finds a persisted lorebook name, preferring an exact match before equivalent spellings.
+ * @param {string[]} names Persisted lorebook names
+ * @param {string} target Requested lorebook name
+ * @returns {string|undefined} Matching persisted name
+ */
+export function findMatchingLorebookName(names, target) {
+    return names.find(name => name === target)
+        ?? names.find(name => normalizeLorebookName(name) === normalizeLorebookName(target));
+}
+
 /**
  * Detects which characters have embedded lorebooks and whether their book names collide with existing worlds.
  * @param {Array<{chid: number, character: object}>} charList - Characters to check
  * @param {string[]} existingWorldNames - Currently saved world/lorebook names
+ * @param {Map<number, string>} [canonicalNames] Canonical book names keyed by character ID
  * @returns {Array<{chid: number, characterName: string, bookName: string, collision: boolean}>} Candidates with embedded lorebooks
  */
-export function detectEmbeddedLorebookCandidates(charList, existingWorldNames) {
+export function detectEmbeddedLorebookCandidates(charList, existingWorldNames, canonicalNames = new Map()) {
     const result = [];
+    const reservedNames = new Set(existingWorldNames.map(normalizeLorebookName));
     for (const { chid, character } of charList) {
         if (!character?.data?.character_book) {
             continue;
         }
-        const bookName = character.data.character_book.name || `${character.name}'s Lorebook`;
+        const rawBookName = character.data.character_book.name || `${character.name}'s Lorebook`;
+        const bookName = canonicalNames.get(chid) ?? rawBookName;
+        if (!bookName) {
+            continue;
+        }
         result.push({
             chid,
             characterName: character.name,
             bookName,
-            collision: existingWorldNames.includes(bookName),
+            collision: reservedNames.has(normalizeLorebookName(bookName)),
         });
+        reservedNames.add(normalizeLorebookName(bookName));
     }
     return result;
 }

--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -150,3 +150,71 @@ export function serializeCharacterBookKeys(primaryKeys = [], secondaryKeys = [])
         useRegex,
     };
 }
+
+/**
+ * Serializes a native World Info entry into a CharacterBook-format record.
+ *
+ * Mirrors the per-entry output of the server-side character book converter
+ * (src/endpoints/characters.js, convertWorldInfoToCharacterBook) so records
+ * appended to a book's originalData are complete rather than lossy. Legacy
+ * positions (e.g. the string '0') are normalized before choosing the
+ * before_char/after_char label; anything that does not normalize to
+ * `positions.before` serializes as 'after_char', matching server semantics.
+ *
+ * @param {object} entry Native World Info entry
+ * @param {{ before: number, after: number, ANTop: number, ANBottom: number, atDepth: number, EMTop: number, EMBottom: number, outlet: number }} positions World Info position enum
+ * @returns {object} CharacterBook-format entry record
+ */
+export function serializeWorldInfoEntry(entry, positions) {
+    const { keys, secondaryKeys, useRegex } = serializeCharacterBookKeys(entry.key ?? [], entry.keysecondary ?? []);
+    const normalizedPosition = normalizeWorldInfoPosition(entry.position, positions);
+    return {
+        id: entry.uid,
+        keys,
+        secondary_keys: secondaryKeys,
+        comment: entry.comment ?? '',
+        content: entry.content ?? '',
+        constant: entry.constant ?? false,
+        selective: entry.selective ?? false,
+        insertion_order: entry.order ?? 100,
+        enabled: !entry.disable,
+        position: normalizedPosition === positions.before ? 'before_char' : 'after_char',
+        use_regex: useRegex,
+        case_sensitive: entry.caseSensitive ?? null,
+        extensions: {
+            ...entry.extensions,
+            position: normalizedPosition ?? entry.position,
+            exclude_recursion: entry.excludeRecursion ?? false,
+            display_index: entry.displayIndex,
+            probability: entry.probability ?? null,
+            useProbability: entry.useProbability ?? false,
+            depth: entry.depth ?? 4,
+            selectiveLogic: entry.selectiveLogic ?? 0,
+            outlet_name: entry.outletName ?? '',
+            group: entry.group ?? '',
+            group_override: entry.groupOverride ?? false,
+            group_weight: entry.groupWeight ?? null,
+            prevent_recursion: entry.preventRecursion ?? false,
+            delay_until_recursion: entry.delayUntilRecursion ?? false,
+            scan_depth: entry.scanDepth ?? null,
+            match_whole_words: entry.matchWholeWords ?? null,
+            use_group_scoring: entry.useGroupScoring ?? false,
+            case_sensitive: entry.caseSensitive ?? null,
+            automation_id: entry.automationId ?? '',
+            role: entry.role ?? 0,
+            vectorized: entry.vectorized ?? false,
+            sticky: entry.sticky ?? null,
+            cooldown: entry.cooldown ?? null,
+            delay: entry.delay ?? null,
+            match_persona_description: entry.matchPersonaDescription ?? false,
+            match_character_description: entry.matchCharacterDescription ?? false,
+            match_character_personality: entry.matchCharacterPersonality ?? false,
+            match_character_depth_prompt: entry.matchCharacterDepthPrompt ?? false,
+            match_scenario: entry.matchScenario ?? false,
+            match_creator_notes: entry.matchCreatorNotes ?? false,
+            triggers: entry.triggers ?? [],
+            ignore_budget: entry.ignoreBudget ?? false,
+            agent_blacklisted: entry.agentBlacklisted ?? false,
+        },
+    };
+}

--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -77,5 +77,76 @@ export function normalizeWorldInfoPosition(position, positions) {
 export function normalizeCharacterBookPosition(extensionPosition, entryPosition, positions) {
     return normalizeWorldInfoPosition(extensionPosition, positions)
         ?? normalizeWorldInfoPosition(entryPosition, positions)
-        ?? positions.after;
+        ?? positions.before;
+}
+
+/**
+ * Escapes regex delimiter slashes without adding duplicate escaping on repeated conversions.
+ * @param {string} value Raw CharacterBook regex
+ * @returns {string} Regex body safe for slash-delimited storage
+ */
+export function escapeCharacterBookRegex(value) {
+    return String(value).replace(/(\\*)\//g, (_match, backslashes) => {
+        const delimiterEscape = backslashes.length % 2 === 0 ? '\\' : '';
+        return `${backslashes}${delimiterEscape}/`;
+    });
+}
+
+function unescapeCharacterBookRegex(value) {
+    return String(value).replace(/(\\*)\//g, (_match, backslashes) => {
+        const rawBackslashes = backslashes.length % 2 === 1 ? backslashes.slice(0, -1) : backslashes;
+        return `${rawBackslashes}/`;
+    });
+}
+
+function parseWorldInfoRegexKey(value) {
+    const match = String(value).match(/^\/([\s\S]+)\/([gimsuy]*)$/);
+    if (!match) {
+        return null;
+    }
+
+    const body = match[1];
+    for (let index = 0; index < body.length; index++) {
+        if (body[index] !== '/') {
+            continue;
+        }
+        let backslashes = 0;
+        for (let cursor = index - 1; cursor >= 0 && body[cursor] === '\\'; cursor--) {
+            backslashes++;
+        }
+        if (backslashes % 2 === 0) {
+            return null;
+        }
+    }
+
+    try {
+        RegExp(body, match[2]);
+        return match;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Serializes internal slash-delimited keys for CharacterBook storage.
+ * @param {string[]} primaryKeys Primary entry keys
+ * @param {string[]} secondaryKeys Secondary entry keys
+ * @returns {{keys: string[], secondaryKeys: string[], useRegex: boolean}} Serialized keys and regex mode
+ */
+export function serializeCharacterBookKeys(primaryKeys = [], secondaryKeys = []) {
+    const allKeys = [...primaryKeys, ...secondaryKeys];
+    const parsedKeys = allKeys.map(parseWorldInfoRegexKey);
+    const useRegex = allKeys.length > 0 && parsedKeys.every(Boolean);
+    const serializeKey = key => {
+        if (!useRegex) {
+            return key;
+        }
+        const match = parseWorldInfoRegexKey(key);
+        return match?.[2] ? key : unescapeCharacterBookRegex(match?.[1] ?? key);
+    };
+    return {
+        keys: primaryKeys.map(serializeKey),
+        secondaryKeys: secondaryKeys.map(serializeKey),
+        useRegex,
+    };
 }

--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -154,7 +154,7 @@ export function serializeCharacterBookKeys(primaryKeys = [], secondaryKeys = [])
 /**
  * Serializes a native World Info entry into a CharacterBook-format record.
  *
- * Mirrors the per-entry output of the server-side character book converter
+ * Uses the per-entry layout of the server-side character book converter
  * (src/endpoints/characters.js, convertWorldInfoToCharacterBook) so records
  * appended to a book's originalData are complete rather than lossy. Legacy
  * positions (e.g. the string '0') are normalized before choosing the
@@ -163,12 +163,14 @@ export function serializeCharacterBookKeys(primaryKeys = [], secondaryKeys = [])
  *
  * @param {object} entry Native World Info entry
  * @param {{ before: number, after: number, ANTop: number, ANBottom: number, atDepth: number, EMTop: number, EMBottom: number, outlet: number }} positions World Info position enum
+ * @param {object} [originalEntry={}] Existing CharacterBook record whose unknown metadata should be preserved
  * @returns {object} CharacterBook-format entry record
  */
-export function serializeWorldInfoEntry(entry, positions) {
+export function serializeWorldInfoEntry(entry, positions, originalEntry = {}) {
     const { keys, secondaryKeys, useRegex } = serializeCharacterBookKeys(entry.key ?? [], entry.keysecondary ?? []);
     const normalizedPosition = normalizeWorldInfoPosition(entry.position, positions);
-    return {
+    const serializedEntry = {
+        ...originalEntry,
         id: entry.uid,
         keys,
         secondary_keys: secondaryKeys,
@@ -182,6 +184,7 @@ export function serializeWorldInfoEntry(entry, positions) {
         use_regex: useRegex,
         case_sensitive: entry.caseSensitive ?? null,
         extensions: {
+            ...originalEntry.extensions,
             ...entry.extensions,
             position: normalizedPosition ?? entry.position,
             exclude_recursion: entry.excludeRecursion ?? false,
@@ -217,4 +220,12 @@ export function serializeWorldInfoEntry(entry, positions) {
             agent_blacklisted: entry.agentBlacklisted ?? false,
         },
     };
+
+    if (entry.characterFilter === undefined) {
+        delete serializedEntry.character_filter;
+    } else {
+        serializedEntry.character_filter = entry.characterFilter;
+    }
+
+    return serializedEntry;
 }

--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -77,7 +77,7 @@ export function normalizeWorldInfoPosition(position, positions) {
 export function normalizeCharacterBookPosition(extensionPosition, entryPosition, positions) {
     return normalizeWorldInfoPosition(extensionPosition, positions)
         ?? normalizeWorldInfoPosition(entryPosition, positions)
-        ?? positions.before;
+        ?? positions.after;
 }
 
 /**

--- a/public/scripts/world-info-scan-chat.js
+++ b/public/scripts/world-info-scan-chat.js
@@ -21,3 +21,28 @@ export function buildWorldInfoScanChat(chat, supplementalChat, messageVariants, 
         return includeNames ? `${message.name}: ${content}` : content;
     }).reverse();
 }
+
+/**
+ * Expands greeting macros while preserving automatic participant-name macros for World Info scans.
+ * @param {string} message Greeting text
+ * @param {(message: string) => string} substitute Macro substitution function
+ * @param {{char: string, user: string}} names Participant names
+ * @returns {{prompt: string, worldInfo: string}} Prompt and name-excluded World Info variants
+ */
+export function substituteWorldInfoGreeting(message, substitute, names) {
+    const macros = [];
+    const protectedMessage = String(message ?? '').replace(/{{\s*(char|user)\s*}}|<(BOT|CHAR|USER)>/gi, (macro, curlyName, legacyName) => {
+        const placeholder = `__SB_WI_NAME_MACRO_${macros.length}__`;
+        const name = String(curlyName || legacyName).toLowerCase() === 'user' ? 'user' : 'char';
+        macros.push({ macro, name });
+        return placeholder;
+    });
+    const substitutedMessage = substitute(protectedMessage);
+    return macros.reduce((result, item, index) => {
+        const placeholder = `__SB_WI_NAME_MACRO_${index}__`;
+        return {
+            prompt: result.prompt.replace(placeholder, () => names[item.name]),
+            worldInfo: result.worldInfo.replace(placeholder, () => item.macro),
+        };
+    }, { prompt: substitutedMessage, worldInfo: substitutedMessage });
+}

--- a/public/scripts/world-info-scan-core.js
+++ b/public/scripts/world-info-scan-core.js
@@ -72,3 +72,28 @@ export function getWorldInfoGroupNames(group) {
 export function getWorldInfoEntryKey(entry) {
     return `${entry.world}.${entry.uid}`;
 }
+
+/**
+ * Computes the persisted activity window for a World Info timed effect.
+ *
+ * `start` is the chat length when the effect is created. The scanner removes an
+ * effect once `chat.length >= end`, and discards a non-protected effect when
+ * `chat.length <= start` (the chat did not advance, e.g. a swipe). A
+ * non-protected effect of duration `d` created at chat length `N` is therefore
+ * active for scans at chat lengths `N+1` through `N+d` — the extra message in
+ * `end` keeps a duration-1 effect from expiring before it ever applies.
+ * Protected effects (a cooldown started by an ended sticky) already cover the
+ * creating scan via an immediate buffer push, so their persisted window is not
+ * extended: scans `N+1` through `N+d-1` plus the creating scan give `d` total.
+ *
+ * @param {number} chatLength Chat length when the effect is created
+ * @param {number} duration Effect duration in messages
+ * @param {boolean} isProtected Whether the effect survives without the chat advancing
+ * @returns {{ start: number, end: number }} Effect window
+ */
+export function getTimedEffectWindow(chatLength, duration, isProtected) {
+    return {
+        start: chatLength,
+        end: chatLength + Number(duration) + (isProtected ? 0 : 1),
+    };
+}

--- a/public/scripts/world-info-scan-core.js
+++ b/public/scripts/world-info-scan-core.js
@@ -65,35 +65,14 @@ export function getWorldInfoGroupNames(group) {
 }
 
 /**
- * Gets the stable identity used across scan passes.
- * @param {object} entry World Info entry
- * @returns {string} Stable identity
- */
-export function getWorldInfoEntryKey(entry) {
-    return `${entry.world}.${entry.uid}`;
-}
-
-/**
  * Computes the persisted activity window for a World Info timed effect.
- *
- * `start` is the chat length when the effect is created. The scanner removes an
- * effect once `chat.length >= end`, and discards a non-protected effect when
- * `chat.length <= start` (the chat did not advance, e.g. a swipe). A
- * non-protected effect of duration `d` created at chat length `N` is therefore
- * active for scans at chat lengths `N+1` through `N+d` — the extra message in
- * `end` keeps a duration-1 effect from expiring before it ever applies.
- * Protected effects (a cooldown started by an ended sticky) already cover the
- * creating scan via an immediate buffer push, so their persisted window is not
- * extended: scans `N+1` through `N+d-1` plus the creating scan give `d` total.
- *
  * @param {number} chatLength Chat length when the effect is created
  * @param {number} duration Effect duration in messages
- * @param {boolean} isProtected Whether the effect survives without the chat advancing
  * @returns {{ start: number, end: number }} Effect window
  */
-export function getTimedEffectWindow(chatLength, duration, isProtected) {
+export function getTimedEffectWindow(chatLength, duration) {
     return {
         start: chatLength,
-        end: chatLength + Number(duration) + (isProtected ? 0 : 1),
+        end: chatLength + Number(duration),
     };
 }

--- a/public/scripts/world-info-scan-core.js
+++ b/public/scripts/world-info-scan-core.js
@@ -1,0 +1,74 @@
+/**
+ * Normalizes probability fields from native and CharacterBook-shaped entries.
+ * @param {object} entry World Info entry
+ * @returns {object} Entry with native probability fields
+ */
+export function normalizeWorldInfoProbability(entry) {
+    const rawProbability = entry.probability ?? entry.extensions?.probability ?? 100;
+    const probability = Number(rawProbability);
+    return {
+        ...entry,
+        probability: Number.isFinite(probability) ? probability : 100,
+        useProbability: entry.useProbability ?? entry.extensions?.useProbability ?? true,
+    };
+}
+
+/**
+ * Tests whether an entry passes its probability check.
+ * @param {object} entry Normalized World Info entry
+ * @param {() => number} random Random source returning a value in [0, 1)
+ * @param {boolean} isSticky Whether the entry is currently sticky
+ * @returns {boolean} Whether the entry passes
+ */
+export function passesWorldInfoProbability(entry, random = Math.random, isSticky = false) {
+    if (!entry.useProbability || isSticky) {
+        return true;
+    }
+
+    const probability = Number(entry.probability);
+    if (!Number.isFinite(probability) || probability >= 100) {
+        return true;
+    }
+    if (probability <= 0) {
+        return false;
+    }
+
+    return random() * 100 < probability;
+}
+
+/**
+ * Substitutes and trims a World Info key.
+ * @param {unknown} key Raw key
+ * @param {(value: string) => string} substitute Substitution function
+ * @returns {string|null} A usable key, or null when empty
+ */
+export function normalizeWorldInfoKey(key, substitute) {
+    if (typeof key !== 'string') {
+        return null;
+    }
+
+    const normalized = substitute(key)?.trim();
+    return normalized || null;
+}
+
+/**
+ * Parses an entry's comma-separated inclusion groups.
+ * @param {unknown} group Raw group field
+ * @returns {string[]} Trimmed unique group names
+ */
+export function getWorldInfoGroupNames(group) {
+    if (typeof group !== 'string') {
+        return [];
+    }
+
+    return [...new Set(group.split(',').map(value => value.trim()).filter(Boolean))];
+}
+
+/**
+ * Gets the stable identity used across scan passes.
+ * @param {object} entry World Info entry
+ * @returns {string} Stable identity
+ */
+export function getWorldInfoEntryKey(entry) {
+    return `${entry.world}.${entry.uid}`;
+}

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1469,7 +1469,7 @@ function registerWorldInfoSlashCommands() {
                     setWIOriginalDataValue(data, uid, 'enabled', !entry.disable);
                 } else if (field === 'position') {
                     setWIOriginalDataValue(data, uid, 'extensions.position', entry.position);
-                    setWIOriginalDataValue(data, uid, 'position', entry.position === world_info_position.after ? 'after_char' : 'before_char');
+                    setWIOriginalDataValue(data, uid, 'position', entry.position == 0 ? 'before_char' : 'after_char');
                 } else if (originalWIDataKeyMap[field]) {
                     setWIOriginalDataValue(data, uid, originalWIDataKeyMap[field], entry[field]);
                 }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -23,9 +23,9 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
-import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys } from './world-info-character-book.js';
+import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from './world-info-character-book.js';
 import { detectEmbeddedLorebookCandidates, findMatchingLorebookName, getLinkedAuxBooks, isEmbeddedBookLinked } from './world-info-batch-helpers.js';
-import { getWorldInfoEntryKey, getWorldInfoGroupNames, normalizeWorldInfoKey, normalizeWorldInfoProbability, passesWorldInfoProbability } from './world-info-scan-core.js';
+import { getTimedEffectWindow, getWorldInfoEntryKey, getWorldInfoGroupNames, normalizeWorldInfoKey, normalizeWorldInfoProbability, passesWorldInfoProbability } from './world-info-scan-core.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -625,10 +625,11 @@ class WorldInfoTimedEffects {
      * @returns {WITimedEffect} Timed effect for the entry
      */
     #getEntryTimedEffect(type, entry, isProtected) {
+        const { start, end } = getTimedEffectWindow(this.#chat.length, Number(entry[type]), isProtected);
         return {
             hash: this.#getEntryHash(entry),
-            start: this.#chat.length,
-            end: this.#chat.length + Number(entry[type]) + (isProtected ? 0 : 1),
+            start,
+            end,
             protected: !!isProtected,
         };
     }
@@ -4367,9 +4368,15 @@ export function duplicateWorldInfoEntry(data, uid) {
     const entry = createWorldInfoEntry(data.name, data);
     Object.assign(entry, originalData);
     const targetOriginalIndex = data.originalDataUidMap?.[entry.uid];
-    if (sourceOriginalEntry && Number.isInteger(targetOriginalIndex)) {
-        sourceOriginalEntry.id = entry.uid;
-        data.originalData.entries[targetOriginalIndex] = sourceOriginalEntry;
+    if (Number.isInteger(targetOriginalIndex)) {
+        if (sourceOriginalEntry) {
+            sourceOriginalEntry.id = entry.uid;
+            data.originalData.entries[targetOriginalIndex] = sourceOriginalEntry;
+        } else {
+            // No source record to carry over: replace the blank-template record
+            // appended by createWorldInfoEntry with the fully copied entry.
+            data.originalData.entries[targetOriginalIndex] = structuredClone(serializeWorldInfoEntry(entry, world_info_position));
+        }
     }
 
     return entry;
@@ -4500,25 +4507,9 @@ function appendWIOriginalDataEntry(data, entry) {
 
     data.originalDataUidMap ??= {};
     data.originalDataUidMap[entry.uid] = data.originalData.entries.length;
-    data.originalData.entries.push({
-        id: entry.uid,
-        keys: structuredClone(entry.key ?? []),
-        secondary_keys: structuredClone(entry.keysecondary ?? []),
-        comment: entry.comment ?? '',
-        content: entry.content ?? '',
-        constant: entry.constant ?? false,
-        selective: entry.selective ?? false,
-        insertion_order: entry.order ?? 100,
-        enabled: !entry.disable,
-        position: entry.position === world_info_position.before ? 'before_char' : 'after_char',
-        use_regex: false,
-        extensions: {
-            ...entry.extensions,
-            position: entry.position,
-            probability: entry.probability ?? 100,
-            useProbability: entry.useProbability ?? true,
-        },
-    });
+    // Clone: the serialized record aliases live entry objects (extensions, triggers)
+    // and must not track later editor mutations.
+    data.originalData.entries.push(structuredClone(serializeWorldInfoEntry(entry, world_info_position)));
 }
 
 async function _save(name, data) {
@@ -5323,8 +5314,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             };
 
             // Already processed, considered and then skipped entries should still be skipped
-            const entryKey = getWorldInfoEntryKey(entry);
-            if (failedProbabilityChecks.has(entryKey) || allActivatedEntries.has(entryKey)) {
+            if (failedProbabilityChecks.has(entry) || allActivatedEntries.has(getWorldInfoEntryKey(entry))) {
                 continue;
             }
 
@@ -5519,18 +5509,19 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         console.debug(`[WI] Search done. Found ${activatedNow.size} possible entries.`);
 
         // Sort the entries for the probability and the budget limit checks
-        const entryOrder = new Map(sortedEntries.map((entry, index) => [getWorldInfoEntryKey(entry), index]));
-        const newEntries = [...activatedNow]
-            .sort((a, b) => {
-                const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
-                const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
-                const isAConstant = a.constant ? 1 : 0;
-                const isBConstant = b.constant ? 1 : 0;
-                return isBSticky - isASticky
-                    || isBConstant - isAConstant
-                    || (entryOrder.get(getWorldInfoEntryKey(a)) ?? Number.MAX_SAFE_INTEGER) - (entryOrder.get(getWorldInfoEntryKey(b)) ?? Number.MAX_SAFE_INTEGER);
-            });
-
+        let newEntries;
+        if (activatedNow.size > 1) {
+            const sortedEntriesIndex = new Map(sortedEntries.map((entry, index) => [entry, index]));
+            newEntries = [...activatedNow]
+                .sort((a, b) => {
+                    const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
+                    const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
+                    return isBSticky - isASticky
+                        || (sortedEntriesIndex.get(a) ?? -1) - (sortedEntriesIndex.get(b) ?? -1);
+                });
+        } else {
+            newEntries = [...activatedNow];
+        }
 
         let acceptedContent = '';
         const successfulNewEntries = [];
@@ -5559,7 +5550,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                     return true;
                 }
 
-                failedProbabilityChecks.add(getWorldInfoEntryKey(entry));
+                failedProbabilityChecks.add(entry);
                 return false;
             };
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -23,8 +23,9 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
-import { normalizeCharacterBookPosition, normalizeWorldInfoPosition } from './world-info-character-book.js';
-import { detectEmbeddedLorebookCandidates, getLinkedAuxBooks, isEmbeddedBookLinked } from './world-info-batch-helpers.js';
+import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys } from './world-info-character-book.js';
+import { detectEmbeddedLorebookCandidates, findMatchingLorebookName, getLinkedAuxBooks, isEmbeddedBookLinked } from './world-info-batch-helpers.js';
+import { getWorldInfoEntryKey, getWorldInfoGroupNames, normalizeWorldInfoKey, normalizeWorldInfoProbability, passesWorldInfoProbability } from './world-info-scan-core.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -82,7 +83,12 @@ export let world_info_use_group_scoring = false;
 export let world_info_character_strategy = world_info_insertion_strategy.character_first;
 export let world_info_budget_cap = 0;
 export let world_info_max_recursion_steps = 0;
-const saveWorldDebounced = debounce(async (name, data) => await _save(name, data), debounce_timeout.relaxed);
+/** @type {Map<string, {timer: ReturnType<typeof setTimeout>, data: object}>} */
+const pendingWorldInfoSaves = new Map();
+/** @type {Map<string, Promise<void>>} */
+const worldInfoSaveQueues = new Map();
+/** @type {Map<string, Promise<string|null>>} */
+const worldInfoSaveBlocks = new Map();
 const saveSettingsDebounced = debounce(() => {
     Object.assign(world_info, { globalSelect: selected_world_info });
     saveSettings();
@@ -93,6 +99,7 @@ const WORLD_INFO_DESKTOP_SPLIT_QUERY = '(min-width: 961px)';
 let desktopSelectedWorldInfoUid = null;
 let isWorldInfoEditorPopoutRequested = false;
 let isWorldInfoEditorPopoutShellSyncBound = false;
+let worldInfoEditorLoadId = 0;
 
 // Do not optimize. updateEditor is a function that is updated by the displayWorldEntries with new data.
 export const worldInfoFilter = new FilterHelper(() => updateEditor());
@@ -110,6 +117,7 @@ const WORLD_INFO_LIST_VIEW_FILTER_KEY = 'world_info_list_view_filter';
 export const DEFAULT_DEPTH = 4;
 export const DEFAULT_WEIGHT = 100;
 export const MAX_SCAN_DEPTH = 1000;
+const MAX_WORLD_INFO_NAME_BYTES = 234;
 const MAX_COMMENT_LENGTH = 100;
 const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
 let worldInfoListViewFilter = WORLD_INFO_LIST_VIEW_FILTERS.all;
@@ -293,10 +301,6 @@ class WorldInfoBuffer {
      */
     get(entry, scanState) {
         let depth = entry.scanDepth ?? this.getDepth();
-        if (depth <= this.#startDepth) {
-            return '';
-        }
-
         if (depth < 0) {
             console.error(`[WI] Invalid WI scan depth ${depth}. Must be >= 0`);
             return '';
@@ -311,23 +315,25 @@ class WorldInfoBuffer {
         const JOINER = '\n' + MATCHER;
         let result = MATCHER + this.#depthBuffer.slice(this.#startDepth, depth).join(JOINER);
 
-        if (entry.matchPersonaDescription && this.#globalScanData.personaDescription) {
-            result += JOINER + this.#globalScanData.personaDescription;
-        }
-        if (entry.matchCharacterDescription && this.#globalScanData.characterDescription) {
-            result += JOINER + this.#globalScanData.characterDescription;
-        }
-        if (entry.matchCharacterPersonality && this.#globalScanData.characterPersonality) {
-            result += JOINER + this.#globalScanData.characterPersonality;
-        }
-        if (entry.matchCharacterDepthPrompt && this.#globalScanData.characterDepthPrompt) {
-            result += JOINER + this.#globalScanData.characterDepthPrompt;
-        }
-        if (entry.matchScenario && this.#globalScanData.scenario) {
-            result += JOINER + this.#globalScanData.scenario;
-        }
-        if (entry.matchCreatorNotes && this.#globalScanData.creatorNotes) {
-            result += JOINER + this.#globalScanData.creatorNotes;
+        if (depth > 0) {
+            if (entry.matchPersonaDescription && this.#globalScanData.personaDescription) {
+                result += JOINER + this.#globalScanData.personaDescription;
+            }
+            if (entry.matchCharacterDescription && this.#globalScanData.characterDescription) {
+                result += JOINER + this.#globalScanData.characterDescription;
+            }
+            if (entry.matchCharacterPersonality && this.#globalScanData.characterPersonality) {
+                result += JOINER + this.#globalScanData.characterPersonality;
+            }
+            if (entry.matchCharacterDepthPrompt && this.#globalScanData.characterDepthPrompt) {
+                result += JOINER + this.#globalScanData.characterDepthPrompt;
+            }
+            if (entry.matchScenario && this.#globalScanData.scenario) {
+                result += JOINER + this.#globalScanData.scenario;
+            }
+            if (entry.matchCreatorNotes && this.#globalScanData.creatorNotes) {
+                result += JOINER + this.#globalScanData.creatorNotes;
+            }
         }
 
         if (this.#injectBuffer.length > 0) {
@@ -449,8 +455,9 @@ class WorldInfoBuffer {
 
         // Increment score for every key found in the buffer
         if (Array.isArray(entry.key)) {
-            numberOfPrimaryKeys = entry.key.length;
-            for (const key of entry.key) {
+            const normalizedKeys = entry.key.map(key => normalizeWorldInfoKey(key, substituteParams)).filter(Boolean);
+            numberOfPrimaryKeys = normalizedKeys.length;
+            for (const key of normalizedKeys) {
                 if (this.matchKeys(bufferState, key, entry)) {
                     primaryScore++;
                 }
@@ -459,8 +466,9 @@ class WorldInfoBuffer {
 
         // Increment score for every secondary key found in the buffer
         if (Array.isArray(entry.keysecondary)) {
-            numberOfSecondaryKeys = entry.keysecondary.length;
-            for (const key of entry.keysecondary) {
+            const normalizedKeys = entry.keysecondary.map(key => normalizeWorldInfoKey(key, substituteParams)).filter(Boolean);
+            numberOfSecondaryKeys = normalizedKeys.length;
+            for (const key of normalizedKeys) {
                 if (this.matchKeys(bufferState, key, entry)) {
                     secondaryScore++;
                 }
@@ -620,7 +628,7 @@ class WorldInfoTimedEffects {
         return {
             hash: this.#getEntryHash(entry),
             start: this.#chat.length,
-            end: this.#chat.length + Number(entry[type]),
+            end: this.#chat.length + Number(entry[type]) + (isProtected ? 0 : 1),
             protected: !!isProtected,
         };
     }
@@ -910,7 +918,7 @@ export async function getWorldInfoPrompt(chat, maxContext, isDryRun, globalScanD
     const activatedWorldInfo = await checkWorldInfo(chat, maxContext, isDryRun, globalScanData);
     worldInfoBefore = activatedWorldInfo.worldInfoBefore;
     worldInfoAfter = activatedWorldInfo.worldInfoAfter;
-    worldInfoString = worldInfoBefore + worldInfoAfter;
+    worldInfoString = [worldInfoBefore, worldInfoAfter].filter(Boolean).join('\n');
 
     if (!isDryRun && activatedWorldInfo.allActivatedEntries && activatedWorldInfo.allActivatedEntries.size > 0) {
         const arg = Array.from(activatedWorldInfo.allActivatedEntries.values());
@@ -1349,6 +1357,10 @@ function registerWorldInfoSlashCommands() {
             entry.content = content;
         }
 
+        syncWIOriginalDataKeys(data, entry.uid);
+        setWIOriginalDataValue(data, entry.uid, 'comment', entry.comment);
+        setWIOriginalDataValue(data, entry.uid, 'content', entry.content);
+
         await saveWorldInfo(file, data);
         reloadEditor(file);
 
@@ -1451,7 +1463,14 @@ function registerWorldInfoSlashCommands() {
                     entry[field] = value;
                 }
 
-                if (originalWIDataKeyMap[field]) {
+                if (field === 'key' || field === 'keysecondary') {
+                    syncWIOriginalDataKeys(data, uid);
+                } else if (field === 'disable') {
+                    setWIOriginalDataValue(data, uid, 'enabled', !entry.disable);
+                } else if (field === 'position') {
+                    setWIOriginalDataValue(data, uid, 'extensions.position', entry.position);
+                    setWIOriginalDataValue(data, uid, 'position', entry.position === world_info_position.after ? 'after_char' : 'before_char');
+                } else if (originalWIDataKeyMap[field]) {
                     setWIOriginalDataValue(data, uid, originalWIDataKeyMap[field], entry[field]);
                 }
         }
@@ -2031,12 +2050,16 @@ function registerWorldInfoSlashCommands() {
  * @return {Promise<void>} A promise that resolves when the world editor is loaded
  */
 export async function showWorldEditor(name) {
+    const loadId = ++worldInfoEditorLoadId;
     if (!name) {
         await hideWorldEditor();
         return;
     }
 
     const wiData = await loadWorldInfo(name);
+    if (loadId !== worldInfoEditorLoadId) {
+        return;
+    }
     await displayWorldEntries(name, wiData);
 }
 
@@ -2099,6 +2122,7 @@ export async function updateWorldInfoList() {
 }
 
 async function hideWorldEditor() {
+    worldInfoEditorLoadId++;
     desktopSelectedWorldInfoUid = null;
     clearWorldInfoDesktopEditor();
     await displayWorldEntries(null, null);
@@ -2315,6 +2339,9 @@ function addMissingWorldInfoFields(data) {
                 names: [],
                 tags: [],
             };
+        } else {
+            entry.characterFilter.names = Array.isArray(entry.characterFilter.names) ? entry.characterFilter.names : [];
+            entry.characterFilter.tags = Array.isArray(entry.characterFilter.tags) ? entry.characterFilter.tags : [];
         }
     });
 
@@ -2544,16 +2571,9 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
         }
 
         if (world_info.charLore) {
-            world_info.charLore.forEach((charLore, index) => {
-                if (charLore.extraBooks?.includes(name)) {
-                    const tempCharLore = charLore.extraBooks.filter((e) => e !== name);
-                    if (tempCharLore.length === 0) {
-                        world_info.charLore.splice(index, 1);
-                    } else {
-                        charLore.extraBooks = tempCharLore;
-                    }
-                }
-            });
+            world_info.charLore = world_info.charLore
+                .map(charLore => ({ ...charLore, extraBooks: charLore.extraBooks?.filter(book => book !== name) ?? [] }))
+                .filter(charLore => charLore.extraBooks.length > 0);
 
             saveSettingsDebounced();
         }
@@ -2706,9 +2726,12 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
         });
     }
 
-    $('#world_popup_new').off('click').on('click', () => {
+    $('#world_popup_new').off('click').on('click', async () => {
         const entry = createWorldInfoEntry(name, data);
-        if (entry) updateEditor(entry.uid);
+        if (entry) {
+            await saveWorldInfo(name, data, true);
+            updateEditor(entry.uid);
+        }
     });
 
     $('#world_popup_name_button').off('click').on('click', async () => {
@@ -2763,7 +2786,7 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
             if (entry.order === newOrder) continue;
 
             entry.order = newOrder;
-            setWIOriginalDataValue(data, entry.order, 'order', entry.order);
+            setWIOriginalDataValue(data, entry.uid, 'insertion_order', entry.order);
             updated++;
         }
 
@@ -2848,12 +2871,13 @@ export const originalWIDataKeyMap = {
     'excludeRecursion': 'extensions.exclude_recursion',
     'preventRecursion': 'extensions.prevent_recursion',
     'delayUntilRecursion': 'extensions.delay_until_recursion',
-    'selectiveLogic': 'selectiveLogic',
+    'selectiveLogic': 'extensions.selectiveLogic',
     'comment': 'comment',
     'constant': 'constant',
     'order': 'insertion_order',
     'depth': 'extensions.depth',
     'probability': 'extensions.probability',
+    'useProbability': 'extensions.useProbability',
     'position': 'extensions.position',
     'role': 'extensions.role',
     'content': 'content',
@@ -2863,7 +2887,7 @@ export const originalWIDataKeyMap = {
     'selective': 'selective',
     'matchWholeWords': 'extensions.match_whole_words',
     'useGroupScoring': 'extensions.use_group_scoring',
-    'caseSensitive': 'extensions.case_sensitive',
+    'caseSensitive': 'case_sensitive',
     'matchPersonaDescription': 'extensions.match_persona_description',
     'matchCharacterDescription': 'extensions.match_character_description',
     'matchCharacterPersonality': 'extensions.match_character_personality',
@@ -2880,6 +2904,9 @@ export const originalWIDataKeyMap = {
     'delay': 'extensions.delay',
     'triggers': 'extensions.triggers',
     'ignoreBudget': 'extensions.ignore_budget',
+    'outletName': 'extensions.outlet_name',
+    'group': 'extensions.group',
+    'agentBlacklisted': 'extensions.agent_blacklisted',
 };
 
 /** Checks the state of the current search, and adds/removes the search sorting option accordingly */
@@ -2914,7 +2941,8 @@ function verifyWorldInfoSearchSortRule() {
  */
 export function setWIOriginalDataValue(data, uid, key, value) {
     if (data.originalData && Array.isArray(data.originalData.entries)) {
-        let originalEntry = data.originalData.entries.find(x => x.uid === uid);
+        const originalIndex = getWIOriginalDataIndex(data, uid);
+        const originalEntry = originalIndex >= 0 ? data.originalData.entries[originalIndex] : null;
 
         if (!originalEntry) {
             return;
@@ -2932,14 +2960,40 @@ export function setWIOriginalDataValue(data, uid, key, value) {
  */
 export function deleteWIOriginalDataValue(data, uid) {
     if (data.originalData && Array.isArray(data.originalData.entries)) {
-        // Non-strict equality is used here to allow for both string and number comparisons
-        // @eslint-disable-next-line eqeqeq
-        const originalIndex = data.originalData.entries.findIndex(x => x.uid == uid);
+        const originalIndex = getWIOriginalDataIndex(data, uid);
 
         if (originalIndex >= 0) {
             data.originalData.entries.splice(originalIndex, 1);
+            if (data.originalDataUidMap) {
+                delete data.originalDataUidMap[uid];
+                for (const [mappedUid, index] of Object.entries(data.originalDataUidMap)) {
+                    if (index > originalIndex) {
+                        data.originalDataUidMap[mappedUid] = index - 1;
+                    }
+                }
+            }
         }
     }
+}
+
+function getWIOriginalDataIndex(data, uid) {
+    const mappedIndex = data.originalDataUidMap?.[uid];
+    if (Number.isInteger(mappedIndex) && data.originalData?.entries?.[mappedIndex]) {
+        return mappedIndex;
+    }
+    return data.originalData?.entries?.findIndex(x => String(x.id ?? x.uid) === String(uid)) ?? -1;
+}
+
+function syncWIOriginalDataKeys(data, uid) {
+    const entry = data.entries?.[uid];
+    if (!entry) {
+        return;
+    }
+
+    const serialized = serializeCharacterBookKeys(entry.key, entry.keysecondary);
+    setWIOriginalDataValue(data, uid, 'keys', serialized.keys);
+    setWIOriginalDataValue(data, uid, 'secondary_keys', serialized.secondaryKeys);
+    setWIOriginalDataValue(data, uid, 'use_regex', serialized.useRegex);
 }
 
 /** @typedef {import('./utils.js').Select2Option} Select2Option */
@@ -3090,11 +3144,10 @@ export function parseRegexFromString(input) {
  * @param {JQuery<HTMLElement>} params.template - The template element containing the input.
  * @param {object} params.entry - The entry object containing the keys.
  * @param {string} params.entryPropName - The property name of the entry that holds the keys.
- * @param {string} params.originalDataValueName - The name of the original data value to be set.
  * @param {string} params.name - The name of the world info entry.
  * @param {object} params.data - The data object containing entries.
  */
-function enableKeysInputHelper({ template, entry, entryPropName, originalDataValueName, name, data }) {
+function enableKeysInputHelper({ template, entry, entryPropName, name, data }) {
     const isFancyInput = !isMobile() && !power_user.wi_key_input_plaintext;
     const input = isFancyInput ? template.find(`select[name="${entryPropName}"]`) : template.find(`textarea[name="${entryPropName}"]`);
     input.data('uid', entry.uid);
@@ -3144,7 +3197,7 @@ function enableKeysInputHelper({ template, entry, entryPropName, originalDataVal
             if (!skipReset) await resetScrollHeight(this);
             if (!noSave) {
                 data.entries[uid][entryPropName] = keys;
-                setWIOriginalDataValue(data, uid, originalDataValueName, data.entries[uid][entryPropName]);
+                syncWIOriginalDataKeys(data, uid);
                 await saveWorldInfo(name, data);
             }
             $(this).toggleClass('empty', !data.entries[uid][entryPropName].length);
@@ -3184,7 +3237,7 @@ function enableKeysInputHelper({ template, entry, entryPropName, originalDataVal
             if (!skipReset) await resetScrollHeight(this);
             if (!noSave) {
                 data.entries[uid][entryPropName] = splitKeywordsAndRegexes(value);
-                setWIOriginalDataValue(data, uid, originalDataValueName, data.entries[uid][entryPropName]);
+                syncWIOriginalDataKeys(data, uid);
                 await saveWorldInfo(name, data);
                 $(this).toggleClass('empty', !data.entries[uid][entryPropName].length);
             }
@@ -3266,23 +3319,48 @@ function initCharacterFilterSelect2Helper(characterFilter) {
  */
 function fillCharacterAndTagOptionsHelper({ characterFilter, entry }) {
     const characters = getContext().characters;
+    const knownNames = new Set();
     characters.forEach((character) => {
         const option = document.createElement('option');
         const name = character.avatar.replace(/\.[^/.]+$/, '') ?? character.name;
+        knownNames.add(name);
         option.innerText = name;
         option.selected = entry.characterFilter?.names?.includes(name);
         option.setAttribute('data-type', 'character');
         characterFilter.append(option);
     });
+    for (const name of entry.characterFilter?.names ?? []) {
+        if (knownNames.has(name)) {
+            continue;
+        }
+        const option = document.createElement('option');
+        option.innerText = name;
+        option.selected = true;
+        option.setAttribute('data-type', 'character');
+        characterFilter.append(option);
+    }
     const tags = getContext().tags;
+    const knownTags = new Set();
     tags.forEach((tag) => {
         const option = document.createElement('option');
         option.innerText = `[Tag] ${tag.name}`;
         option.selected = entry.characterFilter?.tags?.includes(tag.id);
         option.value = tag.id;
+        knownTags.add(tag.id);
         option.setAttribute('data-type', 'tag');
         characterFilter.append(option);
     });
+    for (const tag of entry.characterFilter?.tags ?? []) {
+        if (knownTags.has(tag)) {
+            continue;
+        }
+        const option = document.createElement('option');
+        option.innerText = `[Tag] ${tag}`;
+        option.value = tag;
+        option.selected = true;
+        option.setAttribute('data-type', 'tag');
+        characterFilter.append(option);
+    }
 }
 
 /**
@@ -3334,8 +3412,9 @@ function handleProbabilityInputHelper({ probabilityInput, data, entry, name }) {
     probabilityInput.data('uid', entry.uid);
     probabilityInput.on('input', async function (_, { noSave = false } = {}) {
         const uid = $(this).data('uid');
+        const isEmpty = $(this).val() === '';
         const value = Number($(this).val());
-        data.entries[uid].probability = !isNaN(value) ? value : null;
+        data.entries[uid].probability = !isEmpty && !isNaN(value) ? value : null;
         if (data.entries[uid].probability !== null) {
             data.entries[uid].probability = Math.min(100, Math.max(0, data.entries[uid].probability));
             if (data.entries[uid].probability !== value) {
@@ -3343,9 +3422,13 @@ function handleProbabilityInputHelper({ probabilityInput, data, entry, name }) {
             }
         }
         setWIOriginalDataValue(data, uid, 'extensions.probability', data.entries[uid].probability);
+        if (!noSave) {
+            data.entries[uid].useProbability = true;
+            setWIOriginalDataValue(data, uid, 'extensions.useProbability', true);
+        }
         !noSave && await saveWorldInfo(name, data);
     });
-    probabilityInput.val(entry.probability).trigger('input', { noSave: true });
+    probabilityInput.val(entry.probability ?? '');
     probabilityInput.css({ width: '100%', maxWidth: 'none' });
 }
 
@@ -3364,6 +3447,7 @@ function handleProbabilityToggleHelper({ probabilityToggle, data, entry, name, p
         const uid = $(this).data('uid');
         const value = $(this).prop('checked');
         data.entries[uid].useProbability = value;
+        setWIOriginalDataValue(data, uid, 'extensions.useProbability', value);
         const probabilityContainerElement = probabilityContainer && typeof probabilityContainer.show === 'function' && probabilityContainer.length
             ? probabilityContainer
             : $(this).closest('.world_entry').find('.probabilityContainer');
@@ -3372,12 +3456,11 @@ function handleProbabilityToggleHelper({ probabilityToggle, data, entry, name, p
         if (value && data.entries[uid].probability === null) {
             data.entries[uid].probability = 100;
         }
-        if (!value) {
-            data.entries[uid].probability = null;
-        }
-        probabilityInput.val(data.entries[uid].probability).trigger('input', { noSave });
+        probabilityInput.val(data.entries[uid].probability ?? '');
     });
-    probabilityToggle.prop('checked', true).trigger('input', { noSave: true });
+    const useProbability = entry.useProbability ?? true;
+    probabilityToggle.prop('checked', useProbability);
+    useProbability ? probabilityContainer?.show() : probabilityContainer?.hide();
     probabilityToggle.parent().hide();
 }
 
@@ -3396,10 +3479,11 @@ function handleBooleanSelectHelper({ selectElem, entry, entryKey, data, name }) 
         const uid = $(this).data('uid');
         const value = $(this).val();
         data.entries[uid][entryKey] = value === 'null' ? null : value === 'true';
-        setWIOriginalDataValue(data, uid, `extensions.${entryKey.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`)}`, data.entries[uid][entryKey]);
+        const originalDataKey = originalWIDataKeyMap[entryKey] ?? `extensions.${entryKey.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`)}`;
+        setWIOriginalDataValue(data, uid, originalDataKey, data.entries[uid][entryKey]);
         !noSave && await saveWorldInfo(name, data);
     });
-    selectElem.val((entry[entryKey] === null || entry[entryKey] === undefined) ? 'null' : entry[entryKey] ? 'true' : 'false').trigger('input', { noSave: true });
+    selectElem.val((entry[entryKey] === null || entry[entryKey] === undefined) ? 'null' : entry[entryKey] ? 'true' : 'false');
 }
 
 /**
@@ -3418,7 +3502,14 @@ function handleNumberInputHelper({ inputElem, entry, entryKey, data, name, min, 
     inputElem.data('uid', entry.uid);
     inputElem.on('input', async function (_, { noSave = false } = {}) {
         const uid = $(this).data('uid');
+        const isEmpty = $(this).val() === '';
         let value = Number($(this).val());
+        if (isEmpty) {
+            data.entries[uid][entryKey] = null;
+            setWIOriginalDataValue(data, uid, `extensions.${entryKey.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`)}`, null);
+            !noSave && await saveWorldInfo(name, data);
+            return;
+        }
         if (clamp) {
             if (value < min) {
                 value = min;
@@ -3432,7 +3523,7 @@ function handleNumberInputHelper({ inputElem, entry, entryKey, data, name, min, 
         setWIOriginalDataValue(data, uid, `extensions.${entryKey.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`)}`, data.entries[uid][entryKey]);
         !noSave && await saveWorldInfo(name, data);
     });
-    inputElem.val(entry[entryKey] ?? (clamp ? min : '')).trigger('input', { noSave: true });
+    inputElem.val(entry[entryKey] ?? '');
 }
 
 /**
@@ -3624,7 +3715,11 @@ export async function getWorldEntry(name, data, entry, options = {}) {
         !noSave && await saveWorldInfo(name, data);
     });
     const roleValue = entry.position === world_info_position.atDepth ? String(entry.role ?? extension_prompt_roles.SYSTEM) : '';
-    headerTemplate.find(`select[name="position"] option[value="${entry.position}"][data-role="${roleValue}"]`).prop('selected', true).trigger('input', { noSave: true });
+    headerTemplate.find(`select[name="position"] option[value="${entry.position}"][data-role="${roleValue}"]`).prop('selected', true);
+    const depthInput = headerTemplate.find('input[name="depth"]');
+    const isAtDepth = entry.position === world_info_position.atDepth;
+    depthInput.prop('disabled', !isAtDepth);
+    depthInput.css('visibility', isAtDepth ? 'visible' : 'hidden');
 
     // Tri-state selector
     handleEntryStateSelectorHelper({
@@ -3730,8 +3825,8 @@ export async function getWorldEntry(name, data, entry, options = {}) {
         editTemplate.find('.world_entry_form_uid_value').text(`(UID: ${entry.uid})`);
 
         // Key inputs
-        const keyInput = enableKeysInputHelper({ template: editTemplate, entry, entryPropName: 'key', originalDataValueName: 'keys', name, data });
-        const keySecondaryInput = enableKeysInputHelper({ template: editTemplate, entry, entryPropName: 'keysecondary', originalDataValueName: 'secondary_keys', name, data });
+        const keyInput = enableKeysInputHelper({ template: editTemplate, entry, entryPropName: 'key', name, data });
+        const keySecondaryInput = enableKeysInputHelper({ template: editTemplate, entry, entryPropName: 'keysecondary', name, data });
         if (!keyInput.isFancy) initScrollHeight(keyInput.control);
         if (!keySecondaryInput.isFancy) initScrollHeight(keySecondaryInput.control);
 
@@ -3768,7 +3863,9 @@ export async function getWorldEntry(name, data, entry, options = {}) {
             !noSave && await saveWorldInfo(name, data);
             value ? commentContainer.show() : commentContainer.hide();
         });
-        commentToggle.prop('checked', true).trigger('input', { noSave: true });
+        const hasMemo = entry.addMemo ?? true;
+        commentToggle.prop('checked', hasMemo);
+        hasMemo ? editorRoot.find('.commentContainer').show() : editorRoot.find('.commentContainer').hide();
         commentToggle.parent().hide();
 
         // Logic AND/NOT
@@ -3779,7 +3876,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
             const uid = $(this).data('uid');
             const value = Number($(this).val());
             data.entries[uid].selectiveLogic = !isNaN(value) ? value : world_info_logic.AND_ANY;
-            setWIOriginalDataValue(data, uid, 'selectiveLogic', data.entries[uid].selectiveLogic);
+            setWIOriginalDataValue(data, uid, 'extensions.selectiveLogic', data.entries[uid].selectiveLogic);
             !noSave && await saveWorldInfo(name, data);
         });
         editTemplate.find(`select[name="entryLogicType"] option[value=${entry.selectiveLogic}]`).prop('selected', true).trigger('input', { noSave: true });
@@ -3800,7 +3897,9 @@ export async function getWorldEntry(name, data, entry, options = {}) {
             keysecondarytextpole.css('height', keyprimaryHeight + 'px');
             value ? keysecondary.show() : keysecondary.hide();
         });
-        selectiveInput.prop('checked', true).trigger('input', { noSave: true });
+        const isSelective = entry.selective ?? false;
+        selectiveInput.prop('checked', isSelective);
+        isSelective ? editTemplate.find('.keysecondary').show() : editTemplate.find('.keysecondary').hide();
         selectiveInput.parent().hide();
 
         // Character filter
@@ -3821,17 +3920,10 @@ export async function getWorldEntry(name, data, entry, options = {}) {
             } else if (value) {
                 Object.assign(data.entries[uid], { characterFilter: { isExclude: true, names: [], tags: [] } });
             }
-            if (data.entries[uid]?.characterFilter?.names?.length > 0) {
-                for (const name of [...data.entries[uid].characterFilter.names]) {
-                    if (!getContext().characters.find(x => x.avatar.replace(/\.[^/.]+$/, '') === name)) {
-                        data.entries[uid].characterFilter.names = data.entries[uid].characterFilter.names.filter(x => x !== name);
-                    }
-                }
-            }
             setWIOriginalDataValue(data, uid, 'character_filter', data.entries[uid].characterFilter);
             !noSave && await saveWorldInfo(name, data);
         });
-        characterExclusionInput.prop('checked', entry.characterFilter?.isExclude ?? false).trigger('input', { noSave: true });
+        characterExclusionInput.prop('checked', entry.characterFilter?.isExclude ?? false);
 
         const characterFilter = editTemplate.find('select[name="characterFilter"]');
         characterFilter.data('uid', entry.uid);
@@ -3895,7 +3987,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
             setWIOriginalDataValue(data, uid, 'extensions.scan_depth', data.entries[uid].scanDepth);
             !noSave && await saveWorldInfo(name, data);
         });
-        scanDepthInput.val(entry.scanDepth ?? null).trigger('input', { noSave: true });
+        scanDepthInput.val(entry.scanDepth ?? '');
 
         // Group
         const groupInput = editTemplate.find('input[name="group"]');
@@ -3925,7 +4017,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
         // Group weight
         handleNumberInputHelper({
             inputElem: editTemplate.find('input[name="groupWeight"]'),
-            entry, entryKey: 'groupWeight', data, name, min: 1, max: 10000, clamp: true,
+            entry, entryKey: 'groupWeight', data, name, min: 1, max: 999999, clamp: true,
         });
 
         // Sticky, cooldown, delay
@@ -3963,12 +4055,14 @@ export async function getWorldEntry(name, data, entry, options = {}) {
         delayUntilRecursionInput.prop('checked', entry.delayUntilRecursion).trigger('input', { noSave: true });
         delayUntilRecursionLevelInput.on('input', async function (_, { noSave = false } = {}) {
             const uid = $(this).data('uid');
-            const content = $(this).val();
+            const content = String($(this).val());
+            const numericLevel = Number(content);
             const value = content === '' ? (typeof data.entries[uid].delayUntilRecursion === 'boolean' ? data.entries[uid].delayUntilRecursion : true)
-                : content === 1 ? true
-                    : !isNaN(Number(content)) ? Number(content)
+                : numericLevel === 1 ? true
+                    : Number.isInteger(numericLevel) && numericLevel > 1 ? numericLevel
                         : false;
             data.entries[uid].delayUntilRecursion = value;
+            delayUntilRecursionInput.prop('checked', Boolean(value));
             setWIOriginalDataValue(data, uid, 'extensions.delay_until_recursion', data.entries[uid].delayUntilRecursion);
             !noSave && await saveWorldInfo(name, data);
         });
@@ -4264,10 +4358,19 @@ export function duplicateWorldInfoEntry(data, uid) {
     // Exclude uid and gather the rest of the properties
     const originalData = structuredClone(data.entries[uid]);
     delete originalData.uid;
+    const sourceOriginalIndex = getWIOriginalDataIndex(data, uid);
+    const sourceOriginalEntry = sourceOriginalIndex >= 0
+        ? structuredClone(data.originalData.entries[sourceOriginalIndex])
+        : null;
 
     // Create new entry and copy over data
     const entry = createWorldInfoEntry(data.name, data);
     Object.assign(entry, originalData);
+    const targetOriginalIndex = data.originalDataUidMap?.[entry.uid];
+    if (sourceOriginalEntry && Number.isInteger(targetOriginalIndex)) {
+        sourceOriginalEntry.id = entry.uid;
+        data.originalData.entries[targetOriginalIndex] = sourceOriginalEntry;
+    }
 
     return entry;
 }
@@ -4385,20 +4488,116 @@ export function createWorldInfoEntry(_name, data) {
 
     const newEntry = { uid: newUid, ...structuredClone(newWorldInfoEntryTemplate) };
     data.entries[newUid] = newEntry;
+    appendWIOriginalDataEntry(data, newEntry);
 
     return newEntry;
 }
 
-async function _save(name, data) {
-    // Prevent double saving if both immediate and debounced save are called
-    cancelDebounce(saveWorldDebounced);
+function appendWIOriginalDataEntry(data, entry) {
+    if (!data.originalData || !Array.isArray(data.originalData.entries)) {
+        return;
+    }
 
-    await fetch('/api/worldinfo/edit', {
-        method: 'POST',
-        headers: getRequestHeaders(),
-        body: JSON.stringify({ name: name, data: data }),
+    data.originalDataUidMap ??= {};
+    data.originalDataUidMap[entry.uid] = data.originalData.entries.length;
+    data.originalData.entries.push({
+        id: entry.uid,
+        keys: structuredClone(entry.key ?? []),
+        secondary_keys: structuredClone(entry.keysecondary ?? []),
+        comment: entry.comment ?? '',
+        content: entry.content ?? '',
+        constant: entry.constant ?? false,
+        selective: entry.selective ?? false,
+        insertion_order: entry.order ?? 100,
+        enabled: !entry.disable,
+        position: entry.position === world_info_position.before ? 'before_char' : 'after_char',
+        use_regex: false,
+        extensions: {
+            ...entry.extensions,
+            position: entry.position,
+            probability: entry.probability ?? 100,
+            useProbability: entry.useProbability ?? true,
+        },
     });
-    await eventSource.emit(event_types.WORLDINFO_UPDATED, name, data);
+}
+
+async function _save(name, data) {
+    const previousSave = worldInfoSaveQueues.get(name) ?? Promise.resolve();
+    const save = previousSave.catch(() => undefined).then(async () => {
+        const response = await fetch('/api/worldinfo/edit', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ name: name, data: data }),
+        });
+        if (!response.ok) {
+            throw new Error(`World Info save failed with status ${response.status}`);
+        }
+        await eventSource.emit(event_types.WORLDINFO_UPDATED, name, data);
+    });
+    worldInfoSaveQueues.set(name, save);
+    try {
+        await save;
+    } finally {
+        if (worldInfoSaveQueues.get(name) === save) {
+            worldInfoSaveQueues.delete(name);
+        }
+    }
+}
+
+function cancelPendingWorldInfoSave(name) {
+    const pendingSave = pendingWorldInfoSaves.get(name);
+    if (pendingSave !== undefined) {
+        clearTimeout(pendingSave.timer);
+        pendingWorldInfoSaves.delete(name);
+    }
+    return pendingSave?.data;
+}
+
+async function settleWorldInfoSave(name) {
+    while (true) {
+        const pendingData = cancelPendingWorldInfoSave(name);
+        if (pendingData) {
+            await _save(name, pendingData);
+        }
+        const pendingSave = worldInfoSaveQueues.get(name);
+        if (!pendingSave) {
+            return;
+        }
+        await pendingSave;
+    }
+}
+
+function blockWorldInfoSaves(name) {
+    if (worldInfoSaveBlocks.has(name)) {
+        throw new Error(`World Info operation already in progress for ${name}`);
+    }
+    let releaseBlock = () => {};
+    const block = new Promise(resolve => {
+        releaseBlock = resolve;
+    });
+    worldInfoSaveBlocks.set(name, block);
+    return (targetName) => {
+        if (worldInfoSaveBlocks.get(name) === block) {
+            worldInfoSaveBlocks.delete(name);
+        }
+        releaseBlock(targetName);
+    };
+}
+
+async function getCanonicalWorldInfoName(name) {
+    const sanitizedName = await getSanitizedFilename(name);
+    const encoder = new TextEncoder();
+    let result = '';
+    let bytes = 0;
+    for (const character of sanitizedName) {
+        const characterBytes = encoder.encode(character).length;
+        if (bytes + characterBytes > MAX_WORLD_INFO_NAME_BYTES) {
+            break;
+        }
+        result += character;
+        bytes += characterBytes;
+    }
+    return result;
 }
 
 
@@ -4420,45 +4619,107 @@ export async function saveWorldInfo(name, data, immediately = false) {
         return;
     }
 
+    const saveBlock = worldInfoSaveBlocks.get(name);
+    if (saveBlock) {
+        const targetName = await saveBlock;
+        if (!targetName) {
+            return;
+        }
+        name = targetName;
+    }
+
     // Update cache immediately, so any future call can pull from this
     worldInfoCache.set(name, data);
 
     if (immediately) {
+        cancelPendingWorldInfoSave(name);
         return await _save(name, data);
     }
 
-    saveWorldDebounced(name, data);
+    cancelPendingWorldInfoSave(name);
+    const timer = setTimeout(() => {
+        pendingWorldInfoSaves.delete(name);
+        _save(name, data).catch(error => {
+            console.error(`Failed to save World Info ${name}:`, error);
+            toastr.error(String(error), t`World Info Save Failed`);
+        });
+    }, debounce_timeout.relaxed);
+    pendingWorldInfoSaves.set(name, { timer, data });
+}
+
+async function replaceWorldInfoData(name, data) {
+    const releaseSaveBlock = blockWorldInfoSaves(name);
+    let saveTarget = name;
+    try {
+        await settleWorldInfoSave(name);
+        await _save(name, data);
+        saveTarget = null;
+        worldInfoCache.set(name, data);
+    } finally {
+        releaseSaveBlock(saveTarget);
+    }
 }
 
 async function renameWorldInfo(name, data) {
     const oldName = name;
-    const newName = await Popup.show.input('Rename World Info', 'Enter a new name:', oldName);
+    const requestedName = await Popup.show.input('Rename World Info', 'Enter a new name:', oldName);
 
-    if (oldName === newName || !newName) {
+    if (oldName === requestedName || !requestedName) {
         console.debug('World info rename cancelled');
         return;
     }
-    if (equalsIgnoreCaseAndAccents(oldName, newName)) {
+    const newName = await getCanonicalWorldInfoName(requestedName);
+    const oldCanonicalName = await getCanonicalWorldInfoName(oldName);
+    if (!newName) {
+        return;
+    }
+    if (oldCanonicalName === newName || equalsIgnoreCaseAndAccents(oldName, newName)) {
         toastr.warning(t`Name not accepted, as it is the same as before (ignoring case and accents).`, t`Rename World Info`);
+        return;
+    }
+    if (world_names.some(worldName => equalsIgnoreCaseAndAccents(worldName, newName))) {
+        toastr.warning(t`Name not accepted, as a World Info with that name already exists.`, t`Rename World Info`);
         return;
     }
 
     const entryPreviouslySelected = selected_world_info.findIndex((e) => e === oldName);
+    const releaseSaveBlock = blockWorldInfoSaves(oldName);
+    let saveTarget = oldName;
+    try {
+        await settleWorldInfoSave(oldName);
+        const response = await fetch('/api/worldinfo/rename', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ oldName, newName, data }),
+        });
+        if (!response.ok) {
+            toastr.error(t`World Info could not be renamed.`, t`Rename World Info`);
+            return;
+        }
+        saveTarget = newName;
 
-    await saveWorldInfo(newName, data, true);
-    await deleteWorldInfo(oldName);
+        worldInfoCache.delete(oldName);
+        worldInfoCache.set(newName, data);
+        if (entryPreviouslySelected !== -1) {
+            selected_world_info[entryPreviouslySelected] = newName;
+            saveSettingsDebounced();
+        }
 
-    await updateWorldInfoLinks(oldName, newName);
+        await updateWorldInfoLinks(oldName, newName);
+        await updateWorldInfoList();
 
-    if (entryPreviouslySelected !== -1) {
-        const wiElement = getWIElement(newName);
-        wiElement.prop('selected', true);
-        $('#world_info').trigger('change');
-    }
+        if (entryPreviouslySelected !== -1) {
+            const wiElement = getWIElement(newName);
+            wiElement.prop('selected', true);
+            $('#world_info').trigger('change');
+        }
 
-    const selectedIndex = world_names.indexOf(newName);
-    if (selectedIndex !== -1) {
-        $('#world_editor_select').val(selectedIndex).trigger('change');
+        const selectedIndex = world_names.indexOf(newName);
+        if (selectedIndex !== -1) {
+            $('#world_editor_select').val(selectedIndex).trigger('change');
+        }
+    } finally {
+        releaseSaveBlock(saveTarget);
     }
 }
 
@@ -4469,7 +4730,7 @@ async function renameWorldInfo(name, data) {
  * @returns {Promise<void>}
  */
 async function updateWorldInfoLinks(oldName, newName) {
-    const existingCharLores = world_info.charLore?.filter((e) => e.extraBooks.includes(oldName));
+    const existingCharLores = world_info.charLore?.filter((e) => e.extraBooks?.includes(oldName));
     if (existingCharLores && existingCharLores.length > 0) {
         existingCharLores.forEach((charLore) => {
             const tempCharLore = charLore.extraBooks.filter((e) => e !== oldName);
@@ -4477,6 +4738,26 @@ async function updateWorldInfoLinks(oldName, newName) {
             charLore.extraBooks = tempCharLore;
         });
         saveSettingsDebounced();
+    }
+
+    if (power_user.persona_description_lorebook === oldName) {
+        power_user.persona_description_lorebook = newName;
+        const descriptor = getOrCreatePersonaDescriptor();
+        descriptor.lorebook = newName;
+        setPersonaDescription();
+        saveSettingsDebounced();
+    }
+
+    for (const descriptor of Object.values(power_user.persona_descriptions ?? {})) {
+        if (descriptor?.lorebook === oldName) {
+            descriptor.lorebook = newName;
+            saveSettingsDebounced();
+        }
+    }
+
+    if (chat_metadata[METADATA_KEY] === oldName) {
+        chat_metadata[METADATA_KEY] = newName;
+        await saveMetadata();
     }
 
     // find all characters using the old lorebook name as their primary world
@@ -4557,48 +4838,56 @@ export async function deleteWorldInfo(worldInfoName) {
         return false;
     }
 
-    const response = await fetch('/api/worldinfo/delete', {
-        method: 'POST',
-        headers: getRequestHeaders(),
-        body: JSON.stringify({ name: worldInfoName }),
-    });
+    const releaseSaveBlock = blockWorldInfoSaves(worldInfoName);
+    let saveTarget = worldInfoName;
+    try {
+        await settleWorldInfoSave(worldInfoName);
+        const response = await fetch('/api/worldinfo/delete', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ name: worldInfoName }),
+        });
 
-    if (!response.ok) {
-        return false;
-    }
-
-    if (worldInfoCache.has(worldInfoName)) {
-        worldInfoCache.delete(worldInfoName);
-    }
-
-    const existingWorldIndex = selected_world_info.findIndex((e) => e === worldInfoName);
-    if (existingWorldIndex !== -1) {
-        selected_world_info.splice(existingWorldIndex, 1);
-        saveSettingsDebounced();
-    }
-
-    await updateWorldInfoList();
-    $('#world_editor_select').trigger('change');
-
-    if ($('#character_world').val() === worldInfoName) {
-        $('#character_world').val('').trigger('change');
-        setWorldInfoButtonClass(undefined, false);
-        if (menu_type != 'create') {
-            saveCharacterDebounced();
+        if (!response.ok) {
+            return false;
         }
-    }
+        saveTarget = null;
 
-    if (power_user.persona_description_lorebook === worldInfoName) {
-        power_user.persona_description_lorebook = '';
-        if (power_user.personas[user_avatar]) {
-            const object = getOrCreatePersonaDescriptor();
-            object.lorebook = '';
+        if (worldInfoCache.has(worldInfoName)) {
+            worldInfoCache.delete(worldInfoName);
         }
-        $('#persona_lore_button').toggleClass('world_set', false);
-        saveSettingsDebounced();
-    }
 
-    return true;
+        const existingWorldIndex = selected_world_info.findIndex((e) => e === worldInfoName);
+        if (existingWorldIndex !== -1) {
+            selected_world_info.splice(existingWorldIndex, 1);
+            saveSettingsDebounced();
+        }
+
+        await updateWorldInfoList();
+        $('#world_editor_select').trigger('change');
+
+        if ($('#character_world').val() === worldInfoName) {
+            $('#character_world').val('').trigger('change');
+            setWorldInfoButtonClass(undefined, false);
+            if (menu_type != 'create') {
+                saveCharacterDebounced();
+            }
+        }
+
+        if (power_user.persona_description_lorebook === worldInfoName) {
+            power_user.persona_description_lorebook = '';
+            if (power_user.personas[user_avatar]) {
+                const object = getOrCreatePersonaDescriptor();
+                object.lorebook = '';
+            }
+            $('#persona_lore_button').toggleClass('world_set', false);
+            saveSettingsDebounced();
+        }
+
+        return true;
+    } finally {
+        releaseSaveBlock(saveTarget);
+    }
 }
 
 export function getFreeWorldEntryUid(data) {
@@ -4661,17 +4950,25 @@ export async function createNewWorldInfo(worldName, { interactive = false } = {}
         return false;
     }
 
-    const sanitizedWorldName = await getSanitizedFilename(worldName);
+    const sanitizedWorldName = await getCanonicalWorldInfoName(worldName);
+    if (!sanitizedWorldName) {
+        return false;
+    }
 
-    const allowed = await checkOverwriteExistingData('World Info', world_names, sanitizedWorldName, { interactive: interactive, actionName: 'Create', deleteAction: (existingName) => deleteWorldInfo(existingName) });
+    const existingWorldName = findMatchingLorebookName(world_names, sanitizedWorldName);
+    const persistedWorldName = existingWorldName ?? sanitizedWorldName;
+    const allowed = await checkOverwriteExistingData('World Info', world_names, sanitizedWorldName, {
+        interactive: interactive,
+        actionName: 'Create',
+    });
     if (!allowed) {
         return false;
     }
 
-    await saveWorldInfo(worldName, worldInfoTemplate, true);
+    await replaceWorldInfoData(persistedWorldName, worldInfoTemplate);
     await updateWorldInfoList();
 
-    const selectedIndex = world_names.indexOf(worldName);
+    const selectedIndex = world_names.indexOf(persistedWorldName);
     if (selectedIndex !== -1) {
         $('#world_editor_select').val(selectedIndex).trigger('change');
     } else {
@@ -4721,7 +5018,7 @@ async function getCharacterLore() {
         }
 
         const data = await loadWorldInfo(worldName);
-        const newEntries = data ? Object.keys(data.entries).map((x) => data.entries[x]).map(({ uid, ...rest }) => ({ uid, world: worldName, ...rest })) : [];
+        const newEntries = getWorldEntries(data, worldName);
         entries = entries.concat(newEntries);
 
         if (!newEntries.length) {
@@ -4733,6 +5030,22 @@ async function getCharacterLore() {
     return entries;
 }
 
+function getWorldEntries(data, worldName) {
+    if (!data?.entries || typeof data.entries !== 'object' || Array.isArray(data.entries)) {
+        if (data) {
+            console.warn(`[WI] Skipping malformed World Info '${worldName}'`);
+        }
+        return [];
+    }
+
+    return Object.entries(data.entries)
+        .filter(([, entry]) => entry && typeof entry === 'object' && !Array.isArray(entry))
+        .map(([key, entry]) => {
+            const { uid = Number.isNaN(Number(key)) ? key : Number(key), ...rest } = entry;
+            return { uid, world: worldName, ...rest };
+        });
+}
+
 async function getGlobalLore() {
     if (!selected_world_info?.length) {
         return [];
@@ -4741,7 +5054,7 @@ async function getGlobalLore() {
     let entries = [];
     for (const worldName of selected_world_info) {
         const data = await loadWorldInfo(worldName);
-        const newEntries = data ? Object.keys(data.entries).map((x) => data.entries[x]).map(({ uid, ...rest }) => ({ uid, world: worldName, ...rest })) : [];
+        const newEntries = getWorldEntries(data, worldName);
         entries = entries.concat(newEntries);
     }
 
@@ -4763,7 +5076,7 @@ async function getChatLore() {
     }
 
     const data = await loadWorldInfo(chatWorld);
-    const entries = data ? Object.keys(data.entries).map((x) => data.entries[x]).map(({ uid, ...rest }) => ({ uid, world: chatWorld, ...rest })) : [];
+    const entries = getWorldEntries(data, chatWorld);
 
     console.debug(`[WI] Chat lore has ${entries.length} entries`, [chatWorld]);
 
@@ -4789,7 +5102,7 @@ async function getPersonaLore() {
     }
 
     const data = await loadWorldInfo(personaWorld);
-    const entries = data ? Object.keys(data.entries).map((x) => data.entries[x]).map(({ uid, ...rest }) => ({ uid, world: personaWorld, ...rest })) : [];
+    const entries = getWorldEntries(data, personaWorld);
 
     console.debug(`[WI] Persona lore has ${entries.length} entries`, [personaWorld]);
 
@@ -4846,7 +5159,7 @@ export async function getSortedEntries() {
             // positions strictly and silently drops anything else, so normalize at scan time.
             // Runs after hashing to keep existing timed-effect entry hashes stable.
             const position = normalizeWorldInfoPosition(entry.position, world_info_position) ?? world_info_position.before;
-            return { ...entry, position };
+            return normalizeWorldInfoProbability({ ...entry, position });
         });
 
         console.debug(`[WI] Found ${entries.length} world lore entries. Sorted by strategy`, Object.entries(world_info_insertion_strategy).find((x) => x[1] === world_info_character_strategy));
@@ -4885,9 +5198,9 @@ function parseDecorators(content) {
     };
 
     if (content.startsWith('@@')) {
-        let newContent = content;
-        const splited = content.split('\n');
-        let decorators = [];
+        let newContent = '';
+        const splited = content.split(/\r?\n/);
+        const decorators = [];
         let fallbacked = false;
 
         for (let i = 0; i < splited.length; i++) {
@@ -4967,10 +5280,10 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
     }
 
     /** @type {number[]} Represents the delay levels for entries that are delayed until recursion */
-    const availableRecursionDelayLevels = [...new Set(sortedEntries
+    const availableRecursionDelayLevels = world_info_recursive ? [...new Set(sortedEntries
         .filter(entry => entry.delayUntilRecursion)
         .map(entry => entry.delayUntilRecursion === true ? 1 : entry.delayUntilRecursion),
-    )].sort((a, b) => a - b);
+    )].sort((a, b) => a - b) : [];
     // Already preset with the first level
     let currentRecursionDelayLevel = availableRecursionDelayLevels.shift() ?? 0;
     if (currentRecursionDelayLevel > 0 && availableRecursionDelayLevels.length) {
@@ -5010,7 +5323,8 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             };
 
             // Already processed, considered and then skipped entries should still be skipped
-            if (failedProbabilityChecks.has(entry) || allActivatedEntries.has(`${entry.world}.${entry.uid}`)) {
+            const entryKey = getWorldInfoEntryKey(entry);
+            if (failedProbabilityChecks.has(entryKey) || allActivatedEntries.has(entryKey)) {
                 continue;
             }
 
@@ -5128,8 +5442,8 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
             // PRIMARY KEYWORDS
             let primaryKeyMatch = entry.key.find(key => {
-                const substituted = substituteParams(key);
-                return substituted && buffer.matchKeys(textToScan, substituted.trim(), entry);
+                const normalizedKey = normalizeWorldInfoKey(key, substituteParams);
+                return normalizedKey && buffer.matchKeys(textToScan, normalizedKey, entry);
             });
 
             if (!primaryKeyMatch) {
@@ -5137,11 +5451,10 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                 continue;
             }
 
-            const hasSecondaryKeywords = (
-                entry.selective && //all entries are selective now
-                Array.isArray(entry.keysecondary) && //always true
-                entry.keysecondary.length //ignore empties
-            );
+            const normalizedSecondaryKeys = Array.isArray(entry.keysecondary)
+                ? entry.keysecondary.map(key => normalizeWorldInfoKey(key, substituteParams)).filter(Boolean)
+                : [];
+            const hasSecondaryKeywords = entry.selective && normalizedSecondaryKeys.length;
 
             if (!hasSecondaryKeywords) {
                 // Handle cases where secondary is empty
@@ -5159,9 +5472,8 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             const matchSecondaryKeys = () => {
                 let hasAnyMatch = false;
                 let hasAllMatch = true;
-                for (let keysecondary of entry.keysecondary) {
-                    const secondarySubstituted = substituteParams(keysecondary);
-                    const hasSecondaryMatch = secondarySubstituted && buffer.matchKeys(textToScan, secondarySubstituted.trim(), entry);
+                for (const secondarySubstituted of normalizedSecondaryKeys) {
+                    const hasSecondaryMatch = buffer.matchKeys(textToScan, secondarySubstituted, entry);
 
                     if (hasSecondaryMatch) hasAnyMatch = true;
                     if (!hasSecondaryMatch) hasAllMatch = false;
@@ -5207,15 +5519,21 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         console.debug(`[WI] Search done. Found ${activatedNow.size} possible entries.`);
 
         // Sort the entries for the probability and the budget limit checks
+        const entryOrder = new Map(sortedEntries.map((entry, index) => [getWorldInfoEntryKey(entry), index]));
         const newEntries = [...activatedNow]
             .sort((a, b) => {
                 const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
                 const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
-                return isBSticky - isASticky || sortedEntries.indexOf(a) - sortedEntries.indexOf(b);
+                const isAConstant = a.constant ? 1 : 0;
+                const isBConstant = b.constant ? 1 : 0;
+                return isBSticky - isASticky
+                    || isBConstant - isAConstant
+                    || (entryOrder.get(getWorldInfoEntryKey(a)) ?? Number.MAX_SAFE_INTEGER) - (entryOrder.get(getWorldInfoEntryKey(b)) ?? Number.MAX_SAFE_INTEGER);
             });
 
 
-        let newContent = '';
+        let acceptedContent = '';
+        const successfulNewEntries = [];
         const textToScanTokens = await getTokenCountAsync(allActivatedText);
 
         filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanState, timedEffects);
@@ -5235,25 +5553,13 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             }
 
             const verifyProbability = () => {
-                // If we don't need to roll, it's always true
-                if (!entry.useProbability || entry.probability === 100) {
-                    console.debug(`WI entry ${entry.uid} does not use probability`);
-                    return true;
-                }
-
                 const isSticky = timedEffects.isEffectActive('sticky', entry);
-                if (isSticky) {
-                    console.debug(`WI entry ${entry.uid} is sticky, does not need to re-roll probability`);
-                    return true;
-                }
-
-                const rollValue = Math.random() * 100;
-                if (rollValue <= entry.probability) {
+                if (passesWorldInfoProbability(entry, Math.random, isSticky)) {
                     console.debug(`WI entry ${entry.uid} passed probability check of ${entry.probability}%`);
                     return true;
                 }
 
-                failedProbabilityChecks.add(entry);
+                failedProbabilityChecks.add(getWorldInfoEntryKey(entry));
                 return false;
             };
 
@@ -5265,9 +5571,9 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
             // Substitute macros inline, for both this checking and also future processing
             entry.content = substituteParams(entry.content);
-            newContent += `${entry.content}\n`;
+            const nextContent = `${acceptedContent}${entry.content}\n`;
 
-            if (!entry.ignoreBudget && (textToScanTokens + (await getTokenCountAsync(newContent))) >= budget) {
+            if (!entry.ignoreBudget && (textToScanTokens + (await getTokenCountAsync(nextContent))) >= budget) {
                 if (!token_budget_overflowed) {
                     console.debug('[WI] --- BUDGET OVERFLOW CHECK ---');
                     if (world_info_overflow_alert) {
@@ -5281,12 +5587,16 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                 continue;
             }
 
-            allActivatedEntries.set(`${entry.world}.${entry.uid}`, entry);
+            acceptedContent = nextContent;
+            successfulNewEntries.push(entry);
+            allActivatedEntries.set(getWorldInfoEntryKey(entry), entry);
             console.debug(`[WI] Entry ${entry.uid} activation successful, adding to prompt`, entry);
         }
 
-        const successfulNewEntries = newEntries.filter(x => !failedProbabilityChecks.has(x));
         const successfulNewEntriesForRecursion = successfulNewEntries.filter(x => !x.preventRecursion);
+        if (acceptedContent) {
+            allActivatedText = acceptedContent + allActivatedText;
+        }
 
         console.debug(`[WI] --- LOOP #${count} RESULT ---`);
         if (!newEntries.length) {
@@ -5322,8 +5632,8 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
             let over_max = (
                 world_info_min_activations_depth_max > 0 &&
-                buffer.getDepth() > world_info_min_activations_depth_max
-            ) || (buffer.getDepth() > chat.length);
+                buffer.getDepth() >= world_info_min_activations_depth_max
+            ) || (buffer.getDepth() >= chat.length);
 
             if (!over_max) {
                 nextScanState = scan_state.MIN_ACTIVATIONS; // loop
@@ -5335,7 +5645,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         }
 
         // If the scan is done, but we still have open "delay until recursion" levels, we should continue with the next one
-        if (nextScanState === scan_state.NONE && availableRecursionDelayLevels.length) {
+        if (world_info_recursive && scanState === scan_state.RECURSION && nextScanState === scan_state.NONE && availableRecursionDelayLevels.length) {
             nextScanState = scan_state.RECURSION;
             currentRecursionDelayLevel = availableRecursionDelayLevels.shift();
             logNextState('[WI] Open delayed recursion levels left. Preparing next delayed recursion level', currentRecursionDelayLevel, '. Still delayed:', availableRecursionDelayLevels);
@@ -5349,7 +5659,6 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                 .map(x => x.content).join('\n');
             if (text) {
                 buffer.addRecurse(text);
-                allActivatedText = (text + '\n' + allActivatedText);
             }
         } else {
             logNextState('[WI] Scan done. No new entries to prompt. Stopping.');
@@ -5442,12 +5751,13 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                 ANBottomEntries.unshift(content);
                 break;
             case world_info_position.atDepth: {
-                const existingDepthIndex = WIDepthEntries.findIndex((e) => e.depth === (entry.depth ?? DEFAULT_DEPTH) && e.role === (entry.role ?? extension_prompt_roles.SYSTEM));
+                const depth = entry.depth ?? DEFAULT_DEPTH;
+                const existingDepthIndex = WIDepthEntries.findIndex((e) => e.depth === depth && e.role === (entry.role ?? extension_prompt_roles.SYSTEM));
                 if (existingDepthIndex !== -1) {
                     WIDepthEntries[existingDepthIndex].entries.unshift(content);
                 } else {
                     WIDepthEntries.push({
-                        depth: entry.depth,
+                        depth,
                         entries: [content],
                         role: entry.role ?? extension_prompt_roles.SYSTEM,
                     });
@@ -5460,7 +5770,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                     break;
                 }
                 if (Array.isArray(WIOutletEntries[entry.outletName])) {
-                    WIOutletEntries[entry.outletName].push(content);
+                    WIOutletEntries[entry.outletName].unshift(content);
                 } else {
                     WIOutletEntries[entry.outletName] = [content];
                 }
@@ -5513,24 +5823,23 @@ function filterGroupsByScoring(groups, buffer, removeEntry, scanState, hasSticky
             continue;
         }
 
-        const scores = group.map(entry => buffer.getScore(entry, scanState));
+        const scoringEntries = [...group];
+        const scores = scoringEntries.map(entry => buffer.getScore(entry, scanState));
         const maxScore = Math.max(...scores);
         console.debug(`[WI] Group '${key}' max score:`, maxScore);
         //console.table(group.map((entry, i) => ({ uid: entry.uid, key: JSON.stringify(entry.key), score: scores[i] })));
 
-        for (let i = 0; i < group.length; i++) {
-            const isScored = group[i].useGroupScoring ?? world_info_use_group_scoring;
+        for (let i = 0; i < scoringEntries.length; i++) {
+            const entry = scoringEntries[i];
+            const isScored = entry.useGroupScoring ?? world_info_use_group_scoring;
 
             if (!isScored) {
                 continue;
             }
 
             if (scores[i] < maxScore) {
-                console.debug(`[WI] Entry ${group[i].uid}`, `removed as score loser from inclusion group '${key}'`, group[i]);
-                removeEntry(group[i]);
-                group.splice(i, 1);
-                scores.splice(i, 1);
-                i--;
+                console.debug(`[WI] Entry ${entry.uid}`, `removed as score loser from inclusion group '${key}'`, entry);
+                removeEntry(entry);
             }
         }
     }
@@ -5553,7 +5862,7 @@ function filterGroupsByTimedEffects(groups, timedEffects, removeEntry) {
         // If the group has any sticky entries, leave only the sticky entries
         const stickyEntries = group.filter(x => timedEffects.isEffectActive('sticky', x));
         if (stickyEntries.length) {
-            for (const entry of group) {
+            for (const entry of [...group]) {
                 if (stickyEntries.includes(entry)) {
                     continue;
                 }
@@ -5598,7 +5907,7 @@ function filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanSt
     console.debug('[WI] --- INCLUSION GROUP CHECKS ---');
 
     const grouped = newEntries.filter(x => x.group).reduce((acc, item) => {
-        item.group.split(/,\s*/).filter(x => x).forEach(group => {
+        getWorldInfoGroupNames(item.group).forEach(group => {
             if (!acc[group]) {
                 acc[group] = [];
             }
@@ -5612,9 +5921,20 @@ function filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanSt
         return;
     }
 
-    const removeEntry = (entry) => newEntries.splice(newEntries.indexOf(entry), 1);
+    const removeEntry = (entry) => {
+        const entryIndex = newEntries.indexOf(entry);
+        if (entryIndex !== -1) {
+            newEntries.splice(entryIndex, 1);
+        }
+        for (const group of Object.values(grouped)) {
+            const groupIndex = group.indexOf(entry);
+            if (groupIndex !== -1) {
+                group.splice(groupIndex, 1);
+            }
+        }
+    };
     function removeAllBut(group, chosen, logging = true) {
-        for (const entry of group) {
+        for (const entry of [...group]) {
             if (entry === chosen) {
                 continue;
             }
@@ -5637,7 +5957,7 @@ function filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanSt
             continue;
         }
 
-        if (Array.from(allActivatedEntries.values()).some(x => x.group === key)) {
+        if (Array.from(allActivatedEntries.values()).some(x => getWorldInfoGroupNames(x.group).includes(key))) {
             console.debug(`[WI] Skipping inclusion group check, group '${key}' was already activated`);
             // We need to forcefully deactivate all other entries in the group
             removeAllBut(group, null, false);
@@ -5751,7 +6071,7 @@ function convertRisuLorebook(inputObj) {
             delayUntilRecursion: false,
             displayIndex: index,
             probability: entry.activationPercent ?? 100,
-            useProbability: entry.activationPercent ?? true,
+            useProbability: true,
             outletName: '',
             group: '',
             groupOverride: false,
@@ -5824,19 +6144,19 @@ function convertNovelLorebook(inputObj) {
 }
 
 export function convertCharacterBook(characterBook) {
-    const result = { entries: {}, originalData: characterBook };
+    const originalData = structuredClone(characterBook);
+    const result = { entries: {}, originalData, originalDataUidMap: {} };
 
     characterBook.entries.forEach((entry, index) => {
-        // Not in the spec, but this is needed to find the entry in the original data
-        if (entry.id === undefined) {
-            entry.id = index;
-        }
-
-        result.entries[entry.id] = {
+        const uid = getFreeWorldEntryUid(result);
+        const toRegex = key => entry.use_regex && !parseRegexFromString(key)
+            ? `/${escapeCharacterBookRegex(key)}/`
+            : key;
+        result.entries[uid] = {
             ...newWorldInfoEntryTemplate,
-            uid: entry.id,
-            key: entry.keys,
-            keysecondary: entry.secondary_keys || [],
+            uid,
+            key: Array.isArray(entry.keys) ? entry.keys.map(toRegex) : [],
+            keysecondary: Array.isArray(entry.secondary_keys) ? entry.secondary_keys.map(toRegex) : [],
             comment: entry.comment || '',
             content: entry.content,
             constant: entry.constant || false,
@@ -5846,7 +6166,7 @@ export function convertCharacterBook(characterBook) {
             excludeRecursion: entry.extensions?.exclude_recursion ?? false,
             preventRecursion: entry.extensions?.prevent_recursion ?? false,
             delayUntilRecursion: entry.extensions?.delay_until_recursion ?? false,
-            disable: !entry.enabled,
+            disable: entry.enabled === false,
             addMemo: !!entry.comment,
             displayIndex: entry.extensions?.display_index ?? index,
             probability: entry.extensions?.probability ?? 100,
@@ -5858,7 +6178,7 @@ export function convertCharacterBook(characterBook) {
             groupOverride: entry.extensions?.group_override ?? false,
             groupWeight: entry.extensions?.group_weight ?? DEFAULT_WEIGHT,
             scanDepth: entry.extensions?.scan_depth ?? null,
-            caseSensitive: entry.extensions?.case_sensitive ?? null,
+            caseSensitive: entry.case_sensitive ?? entry.extensions?.case_sensitive ?? null,
             matchWholeWords: entry.extensions?.match_whole_words ?? null,
             useGroupScoring: entry.extensions?.use_group_scoring ?? null,
             automationId: entry.extensions?.automation_id ?? '',
@@ -5878,6 +6198,7 @@ export function convertCharacterBook(characterBook) {
             ignoreBudget: entry.extensions?.ignore_budget ?? false,
             agentBlacklisted: entry.extensions?.agent_blacklisted ?? entry.agentBlacklisted ?? false,
         };
+        result.originalDataUidMap[uid] = index;
     });
 
     return result;
@@ -5921,9 +6242,10 @@ export function checkEmbeddedWorld(chid) {
                 const html = `<h3>This character has an embedded World/Lorebook.</h3>
                 <h3>Would you like to import it now?</h3>
                 <div class="m-b-1">If you want to import it later, select "Import Card Lore" in the "More..." dropdown menu on the character panel.</div>`;
-                const checkResult = (result) => {
+                const checkResult = async (result) => {
                     if (result) {
-                        importEmbeddedWorldInfo(true);
+                        await importEmbeddedWorldInfo(true);
+                        saveCharacterDebounced();
                     }
                 };
                 callGenericPopup(html, POPUP_TYPE.CONFIRM, '', { okButton: 'Yes' }).then(checkResult);
@@ -5954,22 +6276,31 @@ export async function importEmbeddedWorldInfo(skipPopup = false) {
         return;
     }
 
-    const bookName = characters[chid]?.data?.character_book?.name || `${characters[chid]?.name}'s Lorebook`;
+    const rawBookName = characters[chid]?.data?.character_book?.name || `${characters[chid]?.name}'s Lorebook`;
+    const bookName = await getCanonicalWorldInfoName(rawBookName);
+    if (!bookName) {
+        return;
+    }
+    const existingBookName = findMatchingLorebookName(world_names, bookName);
+    const persistedBookName = existingBookName ?? bookName;
 
     if (!skipPopup) {
-        const confirmation = await Popup.show.confirm(t`Are you sure you want to import '${bookName}'?`, world_names.includes(bookName) ? t`It will overwrite the World/Lorebook with the same name.` : '');
+        const confirmation = await Popup.show.confirm(t`Are you sure you want to import '${persistedBookName}'?`, world_names.includes(persistedBookName) ? t`It will overwrite the World/Lorebook with the same name.` : '');
         if (!confirmation) {
             return;
         }
     }
 
-    await importEmbeddedWorldInfoForCharacter(chid);
+    const result = await importEmbeddedWorldInfoForCharacter(chid, { targetName: persistedBookName, collision: Boolean(existingBookName) });
+    if (result.status !== 'imported') {
+        return;
+    }
     await updateWorldInfoList();
-    $('#character_world').val(bookName).trigger('change');
+    $('#character_world').val(result.bookName).trigger('change');
 
-    toastr.success(t`The world '${bookName}' has been imported and linked to the character successfully.`, t`World/Lorebook imported`);
+    toastr.success(t`The world '${result.bookName}' has been imported and linked to the character successfully.`, t`World/Lorebook imported`);
 
-    const newIndex = world_names.indexOf(bookName);
+    const newIndex = world_names.indexOf(result.bookName);
     if (newIndex >= 0) {
         //show&draw the WI panel before..
         openWorldInfoCharacterPanelTab();
@@ -5984,22 +6315,31 @@ export async function importEmbeddedWorldInfo(skipPopup = false) {
  * Imports the embedded lorebook for a single character by chid.
  * Pure helper — saves the world info but does not touch the active-character UI.
  * @param {number} chid - Character hash id
+ * @param {object} [options={}] Optional import settings
+ * @param {string} [options.targetName] Existing persisted name to overwrite
+ * @param {boolean} [options.collision] Whether the target replaces an existing book
  * @returns {Promise<{chid: number, characterName: string, bookName: string, status: 'imported'|'skipped', collision: boolean}>}
  */
-export async function importEmbeddedWorldInfoForCharacter(chid) {
+export async function importEmbeddedWorldInfoForCharacter(chid, { targetName, collision } = {}) {
     const character = characters[chid];
 
     if (!character?.data?.character_book) {
         return { chid, characterName: character?.name ?? 'Unknown', bookName: '', status: 'skipped', collision: false };
     }
 
-    const bookName = character.data.character_book.name || `${character.name}'s Lorebook`;
-    const collision = world_names.includes(bookName);
+    const rawBookName = character.data.character_book.name || `${character.name}'s Lorebook`;
+    const bookName = await getCanonicalWorldInfoName(rawBookName);
+    if (!bookName) {
+        return { chid, characterName: character.name, bookName: '', status: 'skipped', collision: false };
+    }
+    const existingName = findMatchingLorebookName(world_names, bookName);
+    const persistedBookName = targetName ?? existingName ?? bookName;
+    const didCollide = collision ?? Boolean(existingName);
     const convertedBook = convertCharacterBook(character.data.character_book);
 
-    await saveWorldInfo(bookName, convertedBook, true);
+    await replaceWorldInfoData(persistedBookName, convertedBook);
 
-    return { chid, characterName: character.name, bookName, status: 'imported', collision };
+    return { chid, characterName: character.name, bookName: persistedBookName, status: 'imported', collision: didCollide };
 }
 
 /**
@@ -6014,7 +6354,11 @@ export async function importEmbeddedWorldInfoBatch() {
         .filter(e => e.type === 'character' && e.id !== undefined && e.id !== -1)
         .map(e => ({ chid: e.id, character: e.item }));
 
-    const candidates = detectEmbeddedLorebookCandidates(visibleCharList, world_names);
+    const canonicalNames = new Map(await Promise.all(visibleCharList.map(async ({ chid, character }) => {
+        const bookName = character.data.character_book?.name || `${character.name}'s Lorebook`;
+        return [chid, await getCanonicalWorldInfoName(bookName)];
+    })));
+    const candidates = detectEmbeddedLorebookCandidates(visibleCharList, world_names, canonicalNames);
 
     if (candidates.length === 0) {
         toastr.info(t`No visible character cards have embedded lorebooks.`, t`Batch Import`);
@@ -6107,11 +6451,15 @@ export async function importEmbeddedWorldInfoBatch() {
     }
 
     const results = [];
+    const importedNames = [...world_names];
     for (const candidate of selected) {
         try {
-            const result = await importEmbeddedWorldInfoForCharacter(candidate.chid);
+            const existingName = findMatchingLorebookName(importedNames, candidate.bookName);
+            const targetName = existingName ?? candidate.bookName;
+            const result = await importEmbeddedWorldInfoForCharacter(candidate.chid, { targetName, collision: Boolean(existingName) });
 
             if (result.status === 'imported') {
+                importedNames.push(result.bookName);
                 const characterKey = characters[candidate.chid]?.avatar;
                 if (characterKey) {
                     const fileName = getCharaFilename(null, { manualAvatarKey: characterKey });
@@ -6272,22 +6620,25 @@ export async function importWorldInfo(file) {
             return;
         }
 
-        // Convert Novel Lorebook
-        if (jsonData.lorebookVersion !== undefined) {
+        const isNativeWorldInfo = jsonData.entries && typeof jsonData.entries === 'object' && !Array.isArray(jsonData.entries);
+        const characterBook = jsonData.spec === 'lorebook_v3' ? jsonData.data : jsonData;
+
+        if (isNativeWorldInfo) {
+            console.log('Importing native World Info');
+        } else if (jsonData.lorebookVersion !== undefined) {
             console.log('Converting Novel Lorebook');
-            formData.append('convertedData', JSON.stringify(convertNovelLorebook(jsonData)));
-        }
-
-        // Convert Agnai Memory Book
-        if (jsonData.kind === 'memory') {
+            formData.set('convertedData', JSON.stringify(convertNovelLorebook(jsonData)));
+        } else if (jsonData.kind === 'memory' && Array.isArray(jsonData.entries)) {
             console.log('Converting Agnai Memory Book');
-            formData.append('convertedData', JSON.stringify(convertAgnaiMemoryBook(jsonData)));
-        }
-
-        // Convert Risu Lorebook
-        if (jsonData.type === 'risu') {
+            formData.set('convertedData', JSON.stringify(convertAgnaiMemoryBook(jsonData)));
+        } else if (jsonData.type === 'risu' && Array.isArray(jsonData.data)) {
             console.log('Converting Risu Lorebook');
-            formData.append('convertedData', JSON.stringify(convertRisuLorebook(jsonData)));
+            formData.set('convertedData', JSON.stringify(convertRisuLorebook(jsonData)));
+        } else if (Array.isArray(characterBook?.entries)) {
+            console.log('Converting CharacterBook');
+            formData.set('convertedData', JSON.stringify(convertCharacterBook(characterBook)));
+        } else {
+            throw new Error('Unsupported World Info format');
         }
     } catch (error) {
         toastr.error(`Error parsing file: ${error}`);
@@ -6295,13 +6646,25 @@ export async function importWorldInfo(file) {
     }
 
     const worldName = file.name.substr(0, file.name.lastIndexOf('.'));
-    const sanitizedWorldName = await getSanitizedFilename(worldName);
-    const allowed = await checkOverwriteExistingData('World Info', world_names, sanitizedWorldName, { interactive: true, actionName: 'Import', deleteAction: (existingName) => deleteWorldInfo(existingName) });
+    const sanitizedWorldName = await getCanonicalWorldInfoName(worldName);
+    if (!sanitizedWorldName) {
+        return false;
+    }
+    const existingWorldName = findMatchingLorebookName(world_names, sanitizedWorldName);
+    const persistedWorldName = existingWorldName ?? sanitizedWorldName;
+    const allowed = await checkOverwriteExistingData('World Info', world_names, sanitizedWorldName, {
+        interactive: true,
+        actionName: 'Import',
+    });
     if (!allowed) {
         return false;
     }
+    formData.set('name', persistedWorldName);
+    const releaseSaveBlock = blockWorldInfoSaves(persistedWorldName);
+    let saveTarget = persistedWorldName;
 
     try {
+        await settleWorldInfoSave(persistedWorldName);
         const result = await fetch('/api/worldinfo/import', {
             method: 'POST',
             headers: getRequestHeaders({ omitContentType: true }),
@@ -6312,10 +6675,12 @@ export async function importWorldInfo(file) {
         if (!result.ok) {
             throw new Error(`Failed to import world info: ${result.statusText}`);
         }
+        saveTarget = null;
 
         const data = await result.json();
 
         if (data.name) {
+            worldInfoCache.delete(data.name);
             await updateWorldInfoList();
 
             const newIndex = world_names.indexOf(data.name);
@@ -6328,6 +6693,8 @@ export async function importWorldInfo(file) {
     } catch (error) {
         console.error('Error importing world info:', error);
         toastr.error(t`Failed to import World Info`);
+    } finally {
+        releaseSaveBlock(saveTarget);
     }
 }
 
@@ -6437,6 +6804,10 @@ export async function moveWorldInfoEntry(sourceName, targetName, uid, { deleteOr
         }
 
         const entryToMove = structuredClone(sourceData.entries[entryUidString]);
+        const sourceOriginalIndex = getWIOriginalDataIndex(sourceData, entryUidString);
+        const sourceOriginalEntry = sourceOriginalIndex >= 0
+            ? structuredClone(sourceData.originalData.entries[sourceOriginalIndex])
+            : null;
 
         const newUid = getFreeWorldEntryUid(targetData);
         if (newUid === null) {
@@ -6450,12 +6821,17 @@ export async function moveWorldInfoEntry(sourceName, targetName, uid, { deleteOr
         entryToMove.displayIndex = maxDisplayIndex + 1;
 
         targetData.entries[newUid] = entryToMove;
+        appendWIOriginalDataEntry(targetData, entryToMove);
+        const targetOriginalIndex = targetData.originalDataUidMap?.[newUid];
+        if (sourceOriginalEntry && Number.isInteger(targetOriginalIndex)) {
+            sourceOriginalEntry.id = newUid;
+            targetData.originalData.entries[targetOriginalIndex] = sourceOriginalEntry;
+        }
 
         if (deleteOriginal) {
             delete sourceData.entries[entryUidString];
             // Remove from originalData if it exists
             deleteWIOriginalDataValue(sourceData, entryUidString);
-            // TODO: setWIOriginalDataValue
             console.debug(`[WI Move] Removed entry UID ${entryUidString} from source '${sourceName}'.`);
         }
 
@@ -6645,6 +7021,7 @@ export function initWorldInfo() {
     });
 
     $('#world_editor_select').on('change', async () => {
+        cancelDebounce(debouncedWorldInfoSearch);
         $('#world_info_search').val('');
         worldInfoFilter.setFilterData(FILTER_TYPES.WORLD_INFO_SEARCH, '', true);
         const selectedIndex = String($('#world_editor_select').find(':selected').val());
@@ -6720,12 +7097,12 @@ export function initWorldInfo() {
 
     $('#world_info_overflow_alert').on('change', function () {
         world_info_overflow_alert = !!$(this).prop('checked');
-        saveSettingsDebounced();
+        saveSettings();
     });
 
     $('#world_info_use_group_scoring').on('change', function () {
         world_info_use_group_scoring = !!$(this).prop('checked');
-        saveSettingsDebounced();
+        saveSettings();
     });
 
     $('#world_info_budget_cap').on('input', function () {
@@ -6796,8 +7173,9 @@ export function initWorldInfo() {
 
     $('#world_info_sort_order').on('change', function () {
         const value = String($(this).find(':selected').val());
+        const rule = String($(this).find(':selected').data('rule'));
         // Save sort order, but do not save search sorting, as this is a temporary sorting option
-        if (value !== 'search') accountStorage.setItem(SORT_ORDER_KEY, value);
+        if (rule !== 'search') accountStorage.setItem(SORT_ORDER_KEY, value);
         updateEditor(navigation_option.none);
     });
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -6165,6 +6165,7 @@ export function convertCharacterBook(characterBook) {
             caseSensitive: entry.case_sensitive ?? entry.extensions?.case_sensitive ?? null,
             matchWholeWords: entry.extensions?.match_whole_words ?? null,
             useGroupScoring: entry.extensions?.use_group_scoring ?? null,
+            characterFilter: entry.character_filter,
             automationId: entry.extensions?.automation_id ?? '',
             role: entry.extensions?.role ?? extension_prompt_roles.SYSTEM,
             vectorized: entry.extensions?.vectorized ?? false,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -25,7 +25,7 @@ import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
 import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from './world-info-character-book.js';
 import { detectEmbeddedLorebookCandidates, findMatchingLorebookName, getLinkedAuxBooks, isEmbeddedBookLinked } from './world-info-batch-helpers.js';
-import { getTimedEffectWindow, getWorldInfoEntryKey, getWorldInfoGroupNames, normalizeWorldInfoKey, normalizeWorldInfoProbability, passesWorldInfoProbability } from './world-info-scan-core.js';
+import { getTimedEffectWindow, getWorldInfoGroupNames, normalizeWorldInfoKey, normalizeWorldInfoProbability, passesWorldInfoProbability } from './world-info-scan-core.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -625,7 +625,7 @@ class WorldInfoTimedEffects {
      * @returns {WITimedEffect} Timed effect for the entry
      */
     #getEntryTimedEffect(type, entry, isProtected) {
-        const { start, end } = getTimedEffectWindow(this.#chat.length, Number(entry[type]), isProtected);
+        const { start, end } = getTimedEffectWindow(this.#chat.length, Number(entry[type]));
         return {
             hash: this.#getEntryHash(entry),
             start,
@@ -4369,14 +4369,7 @@ export function duplicateWorldInfoEntry(data, uid) {
     Object.assign(entry, originalData);
     const targetOriginalIndex = data.originalDataUidMap?.[entry.uid];
     if (Number.isInteger(targetOriginalIndex)) {
-        if (sourceOriginalEntry) {
-            sourceOriginalEntry.id = entry.uid;
-            data.originalData.entries[targetOriginalIndex] = sourceOriginalEntry;
-        } else {
-            // No source record to carry over: replace the blank-template record
-            // appended by createWorldInfoEntry with the fully copied entry.
-            data.originalData.entries[targetOriginalIndex] = structuredClone(serializeWorldInfoEntry(entry, world_info_position));
-        }
+        data.originalData.entries[targetOriginalIndex] = structuredClone(serializeWorldInfoEntry(entry, world_info_position, sourceOriginalEntry ?? undefined));
     }
 
     return entry;
@@ -4500,7 +4493,7 @@ export function createWorldInfoEntry(_name, data) {
     return newEntry;
 }
 
-function appendWIOriginalDataEntry(data, entry) {
+function appendWIOriginalDataEntry(data, entry, originalEntry = undefined) {
     if (!data.originalData || !Array.isArray(data.originalData.entries)) {
         return;
     }
@@ -4509,7 +4502,7 @@ function appendWIOriginalDataEntry(data, entry) {
     data.originalDataUidMap[entry.uid] = data.originalData.entries.length;
     // Clone: the serialized record aliases live entry objects (extensions, triggers)
     // and must not track later editor mutations.
-    data.originalData.entries.push(structuredClone(serializeWorldInfoEntry(entry, world_info_position)));
+    data.originalData.entries.push(structuredClone(serializeWorldInfoEntry(entry, world_info_position, originalEntry)));
 }
 
 async function _save(name, data) {
@@ -5249,7 +5242,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
     let scanState = scan_state.INITIAL;
     let token_budget_overflowed = false;
     let count = 0;
-    let allActivatedEntries = new Map();
+    let allActivatedEntries = new Set();
     let failedProbabilityChecks = new Set();
     let allActivatedText = '';
 
@@ -5314,7 +5307,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             };
 
             // Already processed, considered and then skipped entries should still be skipped
-            if (failedProbabilityChecks.has(entry) || allActivatedEntries.has(getWorldInfoEntryKey(entry))) {
+            if (failedProbabilityChecks.has(entry) || allActivatedEntries.has(entry)) {
                 continue;
             }
 
@@ -5580,7 +5573,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
             acceptedContent = nextContent;
             successfulNewEntries.push(entry);
-            allActivatedEntries.set(getWorldInfoEntryKey(entry), entry);
+            allActivatedEntries.add(entry);
             console.debug(`[WI] Entry ${entry.uid} activation successful, adding to prompt`, entry);
         }
 
@@ -5889,7 +5882,7 @@ function filterGroupsByTimedEffects(groups, timedEffects, removeEntry) {
 /**
  * Filters entries by inclusion groups.
  * @param {object[]} newEntries Entries activated on current recursion level
- * @param {Map<string, object>} allActivatedEntries Map of all activated entries
+ * @param {Set<object>} allActivatedEntries Set of all activated entries
  * @param {WorldInfoBuffer} buffer The buffer to use for scanning
  * @param {number} scanState The current scan state
  * @param {WorldInfoTimedEffects} timedEffects The timed effects currently active
@@ -6812,12 +6805,7 @@ export async function moveWorldInfoEntry(sourceName, targetName, uid, { deleteOr
         entryToMove.displayIndex = maxDisplayIndex + 1;
 
         targetData.entries[newUid] = entryToMove;
-        appendWIOriginalDataEntry(targetData, entryToMove);
-        const targetOriginalIndex = targetData.originalDataUidMap?.[newUid];
-        if (sourceOriginalEntry && Number.isInteger(targetOriginalIndex)) {
-            sourceOriginalEntry.id = newUid;
-            targetData.originalData.entries[targetOriginalIndex] = sourceOriginalEntry;
-        }
+        appendWIOriginalDataEntry(targetData, entryToMove, sourceOriginalEntry ?? undefined);
 
         if (deleteOriginal) {
             delete sourceData.entries[entryUidString];

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -818,7 +818,7 @@ function convertWorldInfoToCharacterBook(name, entries) {
             selective: entry.selective,
             insertion_order: entry.order,
             enabled: !entry.disable,
-            position: entry.position === 1 ? 'after_char' : 'before_char',
+            position: entry.position == 0 ? 'before_char' : 'after_char',
             use_regex: useRegex,
             case_sensitive: entry.caseSensitive ?? null,
             extensions: {

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -587,6 +587,7 @@ function convertToV2(char, directories) {
         depth_prompt_prompt: char.depth_prompt_prompt,
         depth_prompt_depth: char.depth_prompt_depth,
         depth_prompt_role: char.depth_prompt_role,
+        world: char.world ?? char.data?.extensions?.world,
     }, directories);
 
     result.chat = char.chat ?? `${char.name} - ${humanizedDateTime()}`;
@@ -733,12 +734,12 @@ function charaFormatData(data, directories) {
             const file = readWorldInfoFile(directories, data.world, false);
 
             // File was imported - save it to the character book
-            if (file && file.originalData) {
-                _.set(char, 'data.character_book', file.originalData);
-            }
-
-            // File was not imported - convert the world info to the character book
-            if (file && file.entries) {
+            if (file?.originalData && Array.isArray(file.originalData.entries)) {
+                const originalData = structuredClone(file.originalData);
+                originalData.extensions ??= {};
+                _.set(char, 'data.character_book', originalData);
+            } else if (file && file.entries) {
+                // File was not imported - convert the world info to the character book
                 _.set(char, 'data.character_book', convertWorldInfoToCharacterBook(data.world, file.entries));
             }
         } catch {
@@ -764,24 +765,62 @@ function charaFormatData(data, directories) {
  * @param {object} entries Entries object
  */
 function convertWorldInfoToCharacterBook(name, entries) {
-    /** @type {{ entries: object[]; name: string }} */
-    const result = { entries: [], name };
+    /** @type {{ entries: object[]; name: string; extensions: object }} */
+    const result = { entries: [], name, extensions: {} };
+    const sortedEntries = Object.values(entries).sort((a, b) => (a.displayIndex ?? a.uid ?? 0) - (b.displayIndex ?? b.uid ?? 0));
 
-    for (const index in entries) {
-        const entry = entries[index];
+    for (const entry of sortedEntries) {
+        const allKeys = [...(entry.key ?? []), ...(entry.keysecondary ?? [])];
+        const parseRegexKey = key => {
+            const match = String(key).match(/^\/([\s\S]+)\/([gimsuy]*)$/);
+            if (!match) {
+                return null;
+            }
+            for (let index = 0; index < match[1].length; index++) {
+                if (match[1][index] !== '/') {
+                    continue;
+                }
+                let backslashes = 0;
+                for (let cursor = index - 1; cursor >= 0 && match[1][cursor] === '\\'; cursor--) {
+                    backslashes++;
+                }
+                if (backslashes % 2 === 0) {
+                    return null;
+                }
+            }
+            try {
+                RegExp(match[1], match[2]);
+                return match;
+            } catch {
+                return null;
+            }
+        };
+        const parsedKeys = allKeys.map(parseRegexKey);
+        const useRegex = allKeys.length > 0 && parsedKeys.every(Boolean);
+        const serializeKey = key => {
+            if (!useRegex) {
+                return key;
+            }
+            const match = parseRegexKey(key);
+            if (match?.[2]) {
+                return key;
+            }
+            return match?.[1]?.replace(/(\\*)\//g, (_slash, backslashes) => `${backslashes.slice(0, -1)}/`) ?? key;
+        };
 
         const originalEntry = {
             id: entry.uid,
-            keys: entry.key,
-            secondary_keys: entry.keysecondary,
+            keys: (entry.key ?? []).map(serializeKey),
+            secondary_keys: (entry.keysecondary ?? []).map(serializeKey),
             comment: entry.comment,
             content: entry.content,
             constant: entry.constant,
             selective: entry.selective,
             insertion_order: entry.order,
             enabled: !entry.disable,
-            position: entry.position == 0 ? 'before_char' : 'after_char',
-            use_regex: true, // ST keys are always regex
+            position: entry.position === 1 ? 'after_char' : 'before_char',
+            use_regex: useRegex,
+            case_sensitive: entry.caseSensitive ?? null,
             extensions: {
                 ...entry.extensions,
                 position: entry.position,

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -854,6 +854,7 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 match_creator_notes: entry.matchCreatorNotes ?? false,
                 triggers: entry.triggers ?? [],
                 ignore_budget: entry.ignoreBudget ?? false,
+                agent_blacklisted: entry.agentBlacklisted ?? false,
             },
         };
 

--- a/src/endpoints/worldinfo.js
+++ b/src/endpoints/worldinfo.js
@@ -6,6 +6,119 @@ import sanitize from 'sanitize-filename';
 import _ from 'lodash';
 import { tryParse, tryWriteFileSync } from '../util.js';
 
+const WORLD_INFO_EXTENSION = '.json';
+const MAX_FILENAME_BYTES = 255;
+const ATOMIC_WRITE_SUFFIX_BYTES = 16;
+
+function truncateUtf8(value, maxBytes) {
+    let result = '';
+    let bytes = 0;
+    for (const character of value) {
+        const characterBytes = Buffer.byteLength(character);
+        if (bytes + characterBytes > maxBytes) {
+            break;
+        }
+        result += character;
+        bytes += characterBytes;
+    }
+    return result;
+}
+
+/**
+ * Gets the canonical filename for a World Info name.
+ * @param {string} name World Info name
+ * @returns {string} Canonical JSON filename
+ */
+export function getWorldInfoFilename(name) {
+    const worldName = getWorldInfoName(name);
+    return worldName ? `${worldName}${WORLD_INFO_EXTENSION}` : '';
+}
+
+/**
+ * Gets the canonical persisted name for a World Info name.
+ * @param {string} name World Info name
+ * @returns {string} Canonical World Info name
+ */
+export function getWorldInfoName(name) {
+    const sanitizedName = sanitize(String(name ?? ''));
+    return truncateUtf8(sanitizedName, MAX_FILENAME_BYTES - Buffer.byteLength(WORLD_INFO_EXTENSION) - ATOMIC_WRITE_SUFFIX_BYTES);
+}
+
+function getLegacyWorldInfoFilename(name) {
+    return sanitize(`${String(name ?? '')}${WORLD_INFO_EXTENSION}`);
+}
+
+function getExistingWorldInfoFilename(directories, name) {
+    const legacyFilename = getLegacyWorldInfoFilename(name);
+    if (legacyFilename && fs.existsSync(path.join(directories.worlds, legacyFilename))) {
+        return legacyFilename;
+    }
+
+    const canonicalFilename = getWorldInfoFilename(name);
+    if (canonicalFilename && fs.existsSync(path.join(directories.worlds, canonicalFilename))) {
+        return canonicalFilename;
+    }
+
+    return null;
+}
+
+function writeWorldInfoFile(filePath, data) {
+    const canUseAtomicSuffix = Buffer.byteLength(path.basename(filePath)) + ATOMIC_WRITE_SUFFIX_BYTES <= MAX_FILENAME_BYTES;
+    if (canUseAtomicSuffix) {
+        tryWriteFileSync(filePath, data);
+        return;
+    }
+
+    const tempDirectory = fs.mkdtempSync(path.join(path.dirname(filePath), '.wi-write-'));
+    const tempPath = path.join(tempDirectory, 'new');
+    const backupPath = path.join(tempDirectory, 'old');
+    let preserveTempDirectory = false;
+    try {
+        fs.writeFileSync(tempPath, data, 'utf8');
+        try {
+            fs.renameSync(tempPath, filePath);
+        } catch (error) {
+            if (!fs.existsSync(filePath)) {
+                throw error;
+            }
+            fs.renameSync(filePath, backupPath);
+            try {
+                fs.renameSync(tempPath, filePath);
+            } catch (replacementError) {
+                try {
+                    fs.renameSync(backupPath, filePath);
+                } catch (rollbackError) {
+                    preserveTempDirectory = true;
+                    throw new AggregateError([replacementError, rollbackError], `Failed to replace or restore ${filePath}`);
+                }
+                throw replacementError;
+            }
+        }
+    } finally {
+        if (!preserveTempDirectory) {
+            fs.rmSync(tempDirectory, { recursive: true, force: true });
+        }
+    }
+}
+
+/**
+ * Validates the minimum native World Info shape required by the editor and scanner.
+ * @param {unknown} data World Info data
+ * @returns {boolean} Whether the data has a usable entries object
+ */
+export function isValidWorldInfoData(data) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return false;
+    }
+
+    const entries = data.entries;
+    if (!entries || typeof entries !== 'object' || Array.isArray(entries)) {
+        return false;
+    }
+
+    return Object.values(entries).every(entry => entry && typeof entry === 'object' && !Array.isArray(entry));
+}
+
 /**
  * Reads a World Info file and returns its contents
  * @param {import('../users.js').UserDirectoryList} directories User directories
@@ -20,13 +133,12 @@ export function readWorldInfoFile(directories, worldInfoName, allowDummy) {
         return dummyObject;
     }
 
-    const filename = sanitize(`${worldInfoName}.json`);
-    const pathToWorldInfo = path.join(directories.worlds, filename);
-
-    if (!fs.existsSync(pathToWorldInfo)) {
-        console.error(`World info file ${filename} doesn't exist.`);
+    const filename = getExistingWorldInfoFilename(directories, worldInfoName);
+    if (!filename) {
+        console.error(`World info file ${getWorldInfoFilename(worldInfoName)} doesn't exist.`);
         return dummyObject;
     }
+    const pathToWorldInfo = path.join(directories.worlds, filename);
 
     const worldInfoText = fs.readFileSync(pathToWorldInfo, 'utf8');
     const worldInfo = JSON.parse(worldInfoText);
@@ -72,7 +184,11 @@ router.post('/get', (request, response) => {
         return response.sendStatus(400);
     }
 
-    const file = readWorldInfoFile(request.user.directories, request.body.name, true);
+    const file = readWorldInfoFile(request.user.directories, request.body.name, false);
+
+    if (!file) {
+        return response.sendStatus(404);
+    }
 
     return response.send(file);
 });
@@ -83,12 +199,11 @@ router.post('/delete', (request, response) => {
     }
 
     const worldInfoName = request.body.name;
-    const filename = sanitize(`${worldInfoName}.json`);
-    const pathToWorldInfo = path.join(request.user.directories.worlds, filename);
-
-    if (!fs.existsSync(pathToWorldInfo)) {
-        throw new Error(`World info file ${filename} doesn't exist.`);
+    const filename = getExistingWorldInfoFilename(request.user.directories, worldInfoName);
+    if (!filename) {
+        return response.sendStatus(404);
     }
+    const pathToWorldInfo = path.join(request.user.directories.worlds, filename);
 
     fs.unlinkSync(pathToWorldInfo);
 
@@ -98,36 +213,36 @@ router.post('/delete', (request, response) => {
 router.post('/import', (request, response) => {
     if (!request.file) return response.sendStatus(400);
 
-    const filename = `${path.parse(sanitize(request.file.originalname)).name}.json`;
-
-    let fileContents = null;
-
-    if (request.body.convertedData) {
-        fileContents = request.body.convertedData;
-    } else {
-        const pathToUpload = path.join(request.file.destination, request.file.filename);
-        fileContents = fs.readFileSync(pathToUpload, 'utf8');
-        fs.unlinkSync(pathToUpload);
-    }
+    const pathToUpload = path.join(request.file.destination, request.file.filename);
 
     try {
+        const requestedName = request.body.name ?? path.parse(request.file.originalname).name;
+        const filename = getExistingWorldInfoFilename(request.user.directories, requestedName)
+            ?? getWorldInfoFilename(requestedName);
+        if (!filename) {
+            throw new Error('World file must have a name');
+        }
+        const fileContents = request.body.convertedData ?? fs.readFileSync(pathToUpload, 'utf8');
         const worldContent = JSON.parse(fileContents);
-        if (!('entries' in worldContent)) {
+        if (!isValidWorldInfoData(worldContent)) {
             throw new Error('File must contain a world info entries list');
         }
+
+        const pathToNewFile = path.join(request.user.directories.worlds, filename);
+        const worldName = path.parse(pathToNewFile).name;
+
+        if (!worldName) {
+            return response.status(400).send('World file must have a name');
+        }
+
+        writeWorldInfoFile(pathToNewFile, fileContents);
+        return response.send({ name: worldName });
     } catch (err) {
+        console.warn('World Info import failed:', err);
         return response.status(400).send('Is not a valid world info file');
+    } finally {
+        fs.rmSync(pathToUpload, { force: true });
     }
-
-    const pathToNewFile = path.join(request.user.directories.worlds, filename);
-    const worldName = path.parse(pathToNewFile).name;
-
-    if (!worldName) {
-        return response.status(400).send('World file must have a name');
-    }
-
-    tryWriteFileSync(pathToNewFile, fileContents);
-    return response.send({ name: worldName });
 });
 
 router.post('/edit', (request, response) => {
@@ -140,17 +255,53 @@ router.post('/edit', (request, response) => {
     }
 
     try {
-        if (!('entries' in request.body.data)) {
+        if (!isValidWorldInfoData(request.body.data)) {
             throw new Error('World info must contain an entries list');
         }
     } catch (err) {
         return response.status(400).send('Is not a valid world info file');
     }
 
-    const filename = sanitize(`${request.body.name}.json`);
+    const filename = getExistingWorldInfoFilename(request.user.directories, request.body.name)
+        ?? getWorldInfoFilename(request.body.name);
     const pathToFile = path.join(request.user.directories.worlds, filename);
+    const worldName = path.parse(filename).name;
 
-    tryWriteFileSync(pathToFile, JSON.stringify(request.body.data, null, 4));
+    if (!worldName) {
+        return response.status(400).send('World file must have a name');
+    }
 
-    return response.send({ ok: true });
+    writeWorldInfoFile(pathToFile, JSON.stringify(request.body.data, null, 4));
+
+    return response.send({ ok: true, name: worldName });
+});
+
+router.post('/rename', (request, response) => {
+    const { oldName, newName, data } = request.body ?? {};
+    if (!oldName || !newName || !isValidWorldInfoData(data)) {
+        return response.sendStatus(400);
+    }
+
+    const oldFilename = getExistingWorldInfoFilename(request.user.directories, oldName);
+    const newFilename = getWorldInfoFilename(newName);
+    const canonicalName = getWorldInfoName(newName);
+    if (!oldFilename || !newFilename || getWorldInfoName(oldName) === canonicalName) {
+        return response.status(400).send('World file must have a different name');
+    }
+
+    const oldPath = path.join(request.user.directories.worlds, oldFilename);
+    const newPath = path.join(request.user.directories.worlds, newFilename);
+    const existingTargetFilename = getExistingWorldInfoFilename(request.user.directories, newName);
+    if (existingTargetFilename || fs.existsSync(newPath)) {
+        return response.sendStatus(409);
+    }
+
+    try {
+        writeWorldInfoFile(oldPath, JSON.stringify(data, null, 4));
+        fs.renameSync(oldPath, newPath);
+        return response.send({ ok: true, name: canonicalName });
+    } catch (err) {
+        console.error('World Info rename failed:', err);
+        return response.sendStatus(500);
+    }
 });

--- a/src/endpoints/worldinfo.js
+++ b/src/endpoints/worldinfo.js
@@ -220,26 +220,22 @@ router.post('/import', (request, response) => {
         const filename = getExistingWorldInfoFilename(request.user.directories, requestedName)
             ?? getWorldInfoFilename(requestedName);
         if (!filename) {
-            throw new Error('World file must have a name');
-        }
-        const fileContents = request.body.convertedData ?? fs.readFileSync(pathToUpload, 'utf8');
-        const worldContent = JSON.parse(fileContents);
-        if (!isValidWorldInfoData(worldContent)) {
-            throw new Error('File must contain a world info entries list');
-        }
-
-        const pathToNewFile = path.join(request.user.directories.worlds, filename);
-        const worldName = path.parse(pathToNewFile).name;
-
-        if (!worldName) {
             return response.status(400).send('World file must have a name');
         }
 
+        const fileContents = request.body.convertedData ?? fs.readFileSync(pathToUpload, 'utf8');
+        const worldContent = tryParse(fileContents);
+        if (!isValidWorldInfoData(worldContent)) {
+            console.warn(`World Info import rejected: '${requestedName}' is not a valid world info file`);
+            return response.status(400).send('Is not a valid world info file');
+        }
+
+        const pathToNewFile = path.join(request.user.directories.worlds, filename);
         writeWorldInfoFile(pathToNewFile, fileContents);
-        return response.send({ name: worldName });
+        return response.send({ name: path.parse(pathToNewFile).name });
     } catch (err) {
-        console.warn('World Info import failed:', err);
-        return response.status(400).send('Is not a valid world info file');
+        console.error('World Info import failed:', err);
+        return response.sendStatus(500);
     } finally {
         fs.rmSync(pathToUpload, { force: true });
     }

--- a/tests/world-info-batch-helpers.test.js
+++ b/tests/world-info-batch-helpers.test.js
@@ -1,6 +1,16 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { detectEmbeddedLorebookCandidates, getLinkedAuxBooks, isEmbeddedBookLinked } from '../public/scripts/world-info-batch-helpers.js';
+import { detectEmbeddedLorebookCandidates, findMatchingLorebookName, getLinkedAuxBooks, isEmbeddedBookLinked } from '../public/scripts/world-info-batch-helpers.js';
+
+describe('findMatchingLorebookName', () => {
+    test('prefers an exact name over an earlier equivalent spelling', () => {
+        expect(findMatchingLorebookName(['Lore', 'Lóre'], 'Lóre')).toBe('Lóre');
+    });
+
+    test('falls back to case-insensitive and accent-insensitive matching', () => {
+        expect(findMatchingLorebookName(['Lóre'], 'LORE')).toBe('Lóre');
+    });
+});
 
 describe('detectEmbeddedLorebookCandidates', () => {
     test('returns empty array when no characters have embedded lorebooks', () => {
@@ -43,6 +53,29 @@ describe('detectEmbeddedLorebookCandidates', () => {
         expect(result[1].collision).toBe(false);
     });
 
+    test('detects canonical and intra-batch collisions', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: { character_book: { name: 'A/B', entries: [] } } } },
+            { chid: 1, character: { name: 'Bob', data: { character_book: { name: 'AB', entries: [] } } } },
+        ];
+        const canonicalNames = new Map([[0, 'AB'], [1, 'AB']]);
+        const result = detectEmbeddedLorebookCandidates(charList, [], canonicalNames);
+
+        expect(result[0]).toMatchObject({ bookName: 'AB', collision: false });
+        expect(result[1]).toMatchObject({ bookName: 'AB', collision: true });
+    });
+
+    test('detects case-insensitive and accent-insensitive collisions', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: { character_book: { name: 'Lóre', entries: [] } } } },
+            { chid: 1, character: { name: 'Bob', data: { character_book: { name: 'LORE', entries: [] } } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, ['lore']);
+
+        expect(result[0].collision).toBe(true);
+        expect(result[1].collision).toBe(true);
+    });
+
     test('skips characters with undefined character_book', () => {
         const charList = [
             { chid: 0, character: { name: 'Alice', data: {} } },
@@ -56,6 +89,14 @@ describe('detectEmbeddedLorebookCandidates', () => {
 
     test('handles empty charList', () => {
         const result = detectEmbeddedLorebookCandidates([], ['Existing']);
+        expect(result).toEqual([]);
+    });
+
+    test('skips candidates with empty canonical names', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: { character_book: { name: '/', entries: [] } } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, [], new Map([[0, '']]));
         expect(result).toEqual([]);
     });
 });

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -100,12 +100,12 @@ describe('normalizeCharacterBookPosition', () => {
         expect(normalizeCharacterBookPosition('0', 'after_char', positions)).toBe(positions.before);
     });
 
-    test('falls back to before when no known position exists', () => {
-        expect(normalizeCharacterBookPosition('unknown', undefined, positions)).toBe(positions.before);
+    test('falls back to after when no known position exists', () => {
+        expect(normalizeCharacterBookPosition('unknown', undefined, positions)).toBe(positions.after);
     });
 
-    test('falls back to before for out-of-enum integer positions', () => {
-        expect(normalizeCharacterBookPosition(99, 12, positions)).toBe(positions.before);
+    test('falls back to after for out-of-enum integer positions', () => {
+        expect(normalizeCharacterBookPosition(99, 12, positions)).toBe(positions.after);
     });
 });
 

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { normalizeCharacterBookPosition, normalizeWorldInfoPosition } from '../public/scripts/world-info-character-book.js';
+import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys } from '../public/scripts/world-info-character-book.js';
 
 const positions = {
     before: 0,
@@ -100,11 +100,61 @@ describe('normalizeCharacterBookPosition', () => {
         expect(normalizeCharacterBookPosition('0', 'after_char', positions)).toBe(positions.before);
     });
 
-    test('falls back to after when no known position exists', () => {
-        expect(normalizeCharacterBookPosition('unknown', undefined, positions)).toBe(positions.after);
+    test('falls back to before when no known position exists', () => {
+        expect(normalizeCharacterBookPosition('unknown', undefined, positions)).toBe(positions.before);
     });
 
-    test('falls back to after for out-of-enum integer positions', () => {
-        expect(normalizeCharacterBookPosition(99, 12, positions)).toBe(positions.after);
+    test('falls back to before for out-of-enum integer positions', () => {
+        expect(normalizeCharacterBookPosition(99, 12, positions)).toBe(positions.before);
+    });
+});
+
+describe('serializeCharacterBookKeys', () => {
+    test('serializes unflagged regexes without delimiters', () => {
+        expect(serializeCharacterBookKeys(['/foo/'], ['/bar/'])).toEqual({
+            keys: ['foo'],
+            secondaryKeys: ['bar'],
+            useRegex: true,
+        });
+    });
+
+    test('preserves delimiters when they carry regex flags', () => {
+        expect(serializeCharacterBookKeys(['/foo/i'], [])).toEqual({
+            keys: ['/foo/i'],
+            secondaryKeys: [],
+            useRegex: true,
+        });
+    });
+
+    test('keeps internal keys unchanged when regex and plaintext keys are mixed', () => {
+        expect(serializeCharacterBookKeys(['/foo/i'], ['bar'])).toEqual({
+            keys: ['/foo/i'],
+            secondaryKeys: ['bar'],
+            useRegex: false,
+        });
+    });
+
+    test('does not classify plaintext with unescaped slashes as regex', () => {
+        expect(serializeCharacterBookKeys(['/foo/bar/'], [])).toEqual({
+            keys: ['/foo/bar/'],
+            secondaryKeys: [],
+            useRegex: false,
+        });
+    });
+
+    test('round-trips delimiter slashes without accumulating backslashes', () => {
+        const rawKey = 'foo/bar';
+        const internalKey = `/${escapeCharacterBookRegex(rawKey)}/`;
+        const serialized = serializeCharacterBookKeys([internalKey], []);
+
+        expect(internalKey).toBe('/foo\\/bar/');
+        expect(serialized.keys).toEqual([rawKey]);
+        expect(`/${escapeCharacterBookRegex(serialized.keys[0])}/`).toBe(internalKey);
+    });
+
+    test('preserves literal backslashes before delimiter slashes', () => {
+        const rawKey = String.raw`foo\\/bar`;
+        const internalKey = `/${escapeCharacterBookRegex(rawKey)}/`;
+        expect(serializeCharacterBookKeys([internalKey], []).keys).toEqual([rawKey]);
     });
 });

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
 
 import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
 
@@ -348,5 +349,12 @@ describe('serializeWorldInfoEntry', () => {
             ignore_budget: false,
             agent_blacklisted: false,
         });
+    });
+});
+
+describe('convertCharacterBook', () => {
+    test('maps CharacterBook filters to native entries', () => {
+        const source = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+        expect(source).toMatch(/characterFilter:\s*entry\.character_filter,/);
     });
 });

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys } from '../public/scripts/world-info-character-book.js';
+import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
 
 const positions = {
     before: 0,
@@ -156,5 +156,150 @@ describe('serializeCharacterBookKeys', () => {
         const rawKey = String.raw`foo\\/bar`;
         const internalKey = `/${escapeCharacterBookRegex(rawKey)}/`;
         expect(serializeCharacterBookKeys([internalKey], []).keys).toEqual([rawKey]);
+    });
+});
+
+describe('serializeWorldInfoEntry', () => {
+    test('serializes a fully populated entry to the character book shape', () => {
+        const entry = {
+            uid: 3,
+            key: ['/foo/'],
+            keysecondary: ['/bar/'],
+            comment: 'A comment',
+            content: 'Some content',
+            constant: true,
+            selective: true,
+            order: 42,
+            disable: true,
+            position: positions.atDepth,
+            caseSensitive: true,
+            excludeRecursion: true,
+            preventRecursion: true,
+            delayUntilRecursion: 2,
+            displayIndex: 5,
+            probability: 50,
+            useProbability: true,
+            depth: 2,
+            selectiveLogic: 1,
+            outletName: 'outlet-a',
+            group: 'g1,g2',
+            groupOverride: true,
+            groupWeight: 150,
+            scanDepth: 7,
+            matchWholeWords: true,
+            useGroupScoring: true,
+            automationId: 'auto-1',
+            role: 2,
+            vectorized: true,
+            sticky: 3,
+            cooldown: 4,
+            delay: 5,
+            matchPersonaDescription: true,
+            matchCharacterDescription: true,
+            matchCharacterPersonality: true,
+            matchCharacterDepthPrompt: true,
+            matchScenario: true,
+            matchCreatorNotes: true,
+            triggers: ['normal'],
+            ignoreBudget: true,
+            agentBlacklisted: true,
+            extensions: { foreign_field: 'kept' },
+        };
+
+        expect(serializeWorldInfoEntry(entry, positions)).toEqual({
+            id: 3,
+            keys: ['foo'],
+            secondary_keys: ['bar'],
+            comment: 'A comment',
+            content: 'Some content',
+            constant: true,
+            selective: true,
+            insertion_order: 42,
+            enabled: false,
+            position: 'after_char',
+            use_regex: true,
+            case_sensitive: true,
+            extensions: {
+                foreign_field: 'kept',
+                position: positions.atDepth,
+                exclude_recursion: true,
+                display_index: 5,
+                probability: 50,
+                useProbability: true,
+                depth: 2,
+                selectiveLogic: 1,
+                outlet_name: 'outlet-a',
+                group: 'g1,g2',
+                group_override: true,
+                group_weight: 150,
+                prevent_recursion: true,
+                delay_until_recursion: 2,
+                scan_depth: 7,
+                match_whole_words: true,
+                use_group_scoring: true,
+                case_sensitive: true,
+                automation_id: 'auto-1',
+                role: 2,
+                vectorized: true,
+                sticky: 3,
+                cooldown: 4,
+                delay: 5,
+                match_persona_description: true,
+                match_character_description: true,
+                match_character_personality: true,
+                match_character_depth_prompt: true,
+                match_scenario: true,
+                match_creator_notes: true,
+                triggers: ['normal'],
+                ignore_budget: true,
+                agent_blacklisted: true,
+            },
+        });
+    });
+
+    test('normalizes a legacy string position to before_char with a numeric extension position', () => {
+        const record = serializeWorldInfoEntry({ uid: 0, position: '0' }, positions);
+        expect(record.position).toBe('before_char');
+        expect(record.extensions.position).toBe(0);
+    });
+
+    test('serializes plain keys without regex mode', () => {
+        const record = serializeWorldInfoEntry({ uid: 1, key: ['alpha'], keysecondary: ['beta'] }, positions);
+        expect(record.keys).toEqual(['alpha']);
+        expect(record.secondary_keys).toEqual(['beta']);
+        expect(record.use_regex).toBe(false);
+    });
+
+    test('applies server-parity defaults for absent fields', () => {
+        const record = serializeWorldInfoEntry({ uid: 7 }, positions);
+        expect(record).not.toHaveProperty('character_filter');
+        expect(record).toMatchObject({
+            id: 7,
+            keys: [],
+            secondary_keys: [],
+            comment: '',
+            content: '',
+            constant: false,
+            selective: false,
+            insertion_order: 100,
+            enabled: true,
+            position: 'after_char',
+            use_regex: false,
+            case_sensitive: null,
+        });
+        expect(record.extensions).toMatchObject({
+            probability: null,
+            useProbability: false,
+            depth: 4,
+            selectiveLogic: 0,
+            group_weight: null,
+            delay_until_recursion: false,
+            sticky: null,
+            cooldown: null,
+            delay: null,
+            triggers: [],
+            ignore_budget: false,
+            agent_blacklisted: false,
+        });
     });
 });

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -203,6 +203,11 @@ describe('serializeWorldInfoEntry', () => {
             triggers: ['normal'],
             ignoreBudget: true,
             agentBlacklisted: true,
+            characterFilter: {
+                isExclude: true,
+                names: ['alice.png'],
+                tags: ['tag-1'],
+            },
             extensions: { foreign_field: 'kept' },
         };
 
@@ -219,6 +224,11 @@ describe('serializeWorldInfoEntry', () => {
             position: 'after_char',
             use_regex: true,
             case_sensitive: true,
+            character_filter: {
+                isExclude: true,
+                names: ['alice.png'],
+                tags: ['tag-1'],
+            },
             extensions: {
                 foreign_field: 'kept',
                 position: positions.atDepth,
@@ -268,6 +278,43 @@ describe('serializeWorldInfoEntry', () => {
         expect(record.keys).toEqual(['alpha']);
         expect(record.secondary_keys).toEqual(['beta']);
         expect(record.use_regex).toBe(false);
+    });
+
+    test('preserves unknown source metadata while replacing stale native fields', () => {
+        const originalEntry = {
+            id: 2,
+            comment: 'Stale comment',
+            character_filter: { isExclude: true, names: ['stale.png'], tags: [] },
+            foreign_top_level: 'kept',
+            extensions: {
+                display_index: 1,
+                foreign_extension: 'kept',
+            },
+        };
+        const entry = {
+            uid: 9,
+            comment: 'Current comment',
+            displayIndex: 12,
+            characterFilter: { isExclude: false, names: ['current.png'], tags: ['tag-2'] },
+        };
+
+        expect(serializeWorldInfoEntry(entry, positions, originalEntry)).toMatchObject({
+            id: 9,
+            comment: 'Current comment',
+            character_filter: entry.characterFilter,
+            foreign_top_level: 'kept',
+            extensions: {
+                display_index: 12,
+                foreign_extension: 'kept',
+            },
+        });
+    });
+
+    test('does not restore a stale character filter when the native entry has none', () => {
+        const record = serializeWorldInfoEntry({ uid: 7 }, positions, {
+            character_filter: { isExclude: true, names: ['stale.png'], tags: [] },
+        });
+        expect(record).not.toHaveProperty('character_filter');
     });
 
     test('applies server-parity defaults for absent fields', () => {

--- a/tests/world-info-endpoint-utils.test.js
+++ b/tests/world-info-endpoint-utils.test.js
@@ -1,0 +1,132 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+const { getWorldInfoFilename, getWorldInfoName, isValidWorldInfoData, router } = await import('../src/endpoints/worldinfo.js');
+
+describe('World Info endpoint helpers', () => {
+    test('canonicalizes names the same way for reads and writes', () => {
+        expect(getWorldInfoFilename('A/B')).toBe('AB.json');
+        expect(getWorldInfoName('A/B')).toBe('AB');
+    });
+
+    test('rejects names that sanitize to an empty stem', () => {
+        expect(getWorldInfoFilename('/')).toBe('');
+        expect(getWorldInfoName('CON')).toBe('');
+    });
+
+    test('reserves filename bytes for the JSON extension', () => {
+        const filename = getWorldInfoFilename('a'.repeat(255));
+        expect(filename.endsWith('.json')).toBe(true);
+        expect(Buffer.byteLength(filename) + 16).toBeLessThanOrEqual(255);
+        expect(getWorldInfoName('a'.repeat(255))).toHaveLength(234);
+    });
+
+    test('accepts native entry objects', () => {
+        expect(isValidWorldInfoData({ entries: {} })).toBe(true);
+        expect(isValidWorldInfoData({ entries: { 0: { uid: 0, content: '' } } })).toBe(true);
+    });
+
+    test('rejects malformed entry containers and values', () => {
+        expect(isValidWorldInfoData({ entries: null })).toBe(false);
+        expect(isValidWorldInfoData({ entries: [] })).toBe(false);
+        expect(isValidWorldInfoData({ entries: { 0: null } })).toBe(false);
+        expect(isValidWorldInfoData({ entries: { 0: 'bad' } })).toBe(false);
+    });
+});
+
+describe('World Info endpoints', () => {
+    let baseUrl;
+    let directories;
+    let server;
+    let tempRoot;
+
+    beforeAll(async () => {
+        const app = express();
+        app.use(express.json());
+        app.use((request, _response, next) => {
+            request.user = { directories };
+            next();
+        });
+        app.use('/api/worldinfo', router);
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-world-info-endpoints-'));
+        directories = { worlds: path.join(tempRoot, 'worlds') };
+        fs.mkdirSync(directories.worlds, { recursive: true });
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    });
+
+    test('rejects empty canonical edit names without creating a file', async () => {
+        const response = await postJson('/api/worldinfo/edit', { name: '/', data: { entries: {} } });
+        expect(response.status).toBe(400);
+        expect(fs.readdirSync(directories.worlds)).toEqual([]);
+    });
+
+    test('keeps maximum-length edit names discoverable as JSON files', async () => {
+        const response = await postJson('/api/worldinfo/edit', { name: 'a'.repeat(255), data: { entries: {} } });
+        expect(response.status).toBe(200);
+        const [filename] = fs.readdirSync(directories.worlds);
+        expect(filename.endsWith('.json')).toBe(true);
+        expect(Buffer.byteLength(filename)).toBeLessThanOrEqual(255);
+    });
+
+    test('returns not found for missing worlds', async () => {
+        const response = await postJson('/api/worldinfo/get', { name: 'Missing' });
+        expect(response.status).toBe(404);
+    });
+
+    test('renames a world without leaving the source file behind', async () => {
+        await postJson('/api/worldinfo/edit', { name: 'Old', data: { entries: {} } });
+        const response = await postJson('/api/worldinfo/rename', { oldName: 'Old', newName: 'New', data: { entries: {} } });
+        expect(response.status).toBe(200);
+        expect(fs.existsSync(path.join(directories.worlds, 'Old.json'))).toBe(false);
+        expect(fs.existsSync(path.join(directories.worlds, 'New.json'))).toBe(true);
+    });
+
+    test('reads, edits, and renames legacy long filenames without truncating the source', async () => {
+        const legacyName = 'l'.repeat(240);
+        const legacyFilename = `${legacyName}.json`;
+        const legacyPath = path.join(directories.worlds, legacyFilename);
+        fs.writeFileSync(legacyPath, JSON.stringify({ entries: {}, marker: 'old' }));
+
+        const getResponse = await postJson('/api/worldinfo/get', { name: legacyName });
+        expect(getResponse.status).toBe(200);
+        expect((await getResponse.json()).marker).toBe('old');
+
+        const editResponse = await postJson('/api/worldinfo/edit', { name: legacyName, data: { entries: {}, marker: 'edited' } });
+        expect(editResponse.status).toBe(200);
+        expect(JSON.parse(fs.readFileSync(legacyPath, 'utf8')).marker).toBe('edited');
+
+        const renameResponse = await postJson('/api/worldinfo/rename', { oldName: legacyName, newName: 'Renamed Legacy', data: { entries: {}, marker: 'renamed' } });
+        expect(renameResponse.status).toBe(200);
+        expect(fs.existsSync(legacyPath)).toBe(false);
+        expect(JSON.parse(fs.readFileSync(path.join(directories.worlds, 'Renamed Legacy.json'), 'utf8')).marker).toBe('renamed');
+    });
+
+    function postJson(route, body) {
+        return fetch(`${baseUrl}${route}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+    }
+});

--- a/tests/world-info-endpoint-utils.test.js
+++ b/tests/world-info-endpoint-utils.test.js
@@ -1,10 +1,12 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import express from 'express';
+import multer from 'multer';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { createUploadStorage } from '../src/middleware/uploadStorage.js';
 import { setConfigFilePath } from '../src/util.js';
 
 setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
@@ -46,10 +48,13 @@ describe('World Info endpoints', () => {
     let directories;
     let server;
     let tempRoot;
+    let uploadsPath;
 
     beforeAll(async () => {
+        uploadsPath = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-world-info-uploads-'));
         const app = express();
         app.use(express.json());
+        app.use(multer({ storage: createUploadStorage(uploadsPath) }).single('avatar'));
         app.use((request, _response, next) => {
             request.user = { directories };
             next();
@@ -68,11 +73,13 @@ describe('World Info endpoints', () => {
     });
 
     afterEach(() => {
+        jest.restoreAllMocks();
         fs.rmSync(tempRoot, { recursive: true, force: true });
     });
 
     afterAll(async () => {
         await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        fs.rmSync(uploadsPath, { recursive: true, force: true });
     });
 
     test('rejects empty canonical edit names without creating a file', async () => {
@@ -121,6 +128,82 @@ describe('World Info endpoints', () => {
         expect(fs.existsSync(legacyPath)).toBe(false);
         expect(JSON.parse(fs.readFileSync(path.join(directories.worlds, 'Renamed Legacy.json'), 'utf8')).marker).toBe('renamed');
     });
+
+    test('imports a native world info JSON file', async () => {
+        const contents = JSON.stringify({ entries: { 0: { uid: 0, content: 'hello' } } });
+        const response = await postImport({ filename: 'My World.json', contents });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ name: 'My World' });
+        expect(fs.readFileSync(path.join(directories.worlds, 'My World.json'), 'utf8')).toBe(contents);
+        expect(fs.readdirSync(uploadsPath)).toEqual([]);
+    });
+
+    test('prefers the requested name from the form body over the filename', async () => {
+        const contents = JSON.stringify({ entries: {} });
+        const response = await postImport({ filename: 'Ignored.json', contents, name: 'Renamed' });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ name: 'Renamed' });
+        expect(fs.existsSync(path.join(directories.worlds, 'Renamed.json'))).toBe(true);
+        expect(fs.existsSync(path.join(directories.worlds, 'Ignored.json'))).toBe(false);
+    });
+
+    test('uses convertedData over the uploaded file body', async () => {
+        const convertedData = JSON.stringify({ entries: {} });
+        const response = await postImport({ filename: 'Converted.json', contents: 'not json at all', convertedData });
+        expect(response.status).toBe(200);
+        expect(fs.readFileSync(path.join(directories.worlds, 'Converted.json'), 'utf8')).toBe(convertedData);
+    });
+
+    test('rejects invalid JSON uploads with a 400', async () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const response = await postImport({ filename: 'Broken.json', contents: '{ not json' });
+        expect(response.status).toBe(400);
+        expect(await response.text()).toBe('Is not a valid world info file');
+        expect(fs.readdirSync(directories.worlds)).toEqual([]);
+        expect(fs.readdirSync(uploadsPath)).toEqual([]);
+    });
+
+    test('rejects JSON without an entries object', async () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const noEntries = await postImport({ filename: 'NoEntries.json', contents: JSON.stringify({ name: 'x' }) });
+        expect(noEntries.status).toBe(400);
+        const arrayEntries = await postImport({ filename: 'ArrayEntries.json', contents: JSON.stringify({ entries: [] }) });
+        expect(arrayEntries.status).toBe(400);
+        expect(fs.readdirSync(directories.worlds)).toEqual([]);
+    });
+
+    test('rejects import names that sanitize to an empty stem', async () => {
+        const response = await postImport({ filename: 'Valid.json', contents: JSON.stringify({ entries: {} }), name: '/' });
+        expect(response.status).toBe(400);
+        expect(await response.text()).toBe('World file must have a name');
+        expect(fs.readdirSync(directories.worlds)).toEqual([]);
+    });
+
+    test('reports import storage failures as a 500 instead of an invalid file', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        fs.mkdirSync(path.join(directories.worlds, 'Blocked.json'));
+        const response = await postImport({ filename: 'Blocked.json', contents: JSON.stringify({ entries: {} }) });
+        expect(response.status).toBe(500);
+        expect(fs.statSync(path.join(directories.worlds, 'Blocked.json')).isDirectory()).toBe(true);
+        expect(fs.readdirSync(uploadsPath)).toEqual([]);
+    });
+
+    test('rejects import requests without an uploaded file', async () => {
+        const response = await postJson('/api/worldinfo/import', {});
+        expect(response.status).toBe(400);
+    });
+
+    function postImport({ filename, contents, name, convertedData }) {
+        const formData = new FormData();
+        formData.append('avatar', new Blob([contents], { type: 'application/json' }), filename);
+        if (name !== undefined) {
+            formData.set('name', name);
+        }
+        if (convertedData !== undefined) {
+            formData.set('convertedData', convertedData);
+        }
+        return fetch(`${baseUrl}/api/worldinfo/import`, { method: 'POST', body: formData });
+    }
 
     function postJson(route, body) {
         return fetch(`${baseUrl}${route}`, {

--- a/tests/world-info-scan-chat.test.js
+++ b/tests/world-info-scan-chat.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+
+import { buildWorldInfoScanChat, substituteWorldInfoGreeting } from '../public/scripts/world-info-scan-chat.js';
+
+describe('World Info scan chat', () => {
+    test('prompt assembly does not overwrite the stored greeting', () => {
+        const source = readFileSync(new URL('../public/script.js', import.meta.url), 'utf8');
+        expect(source).not.toMatch(/chat\[0\]\.mes\s*=/);
+    });
+
+    test('prefixes speaker names only when enabled', () => {
+        const chat = [{ name: 'Kaveh & Alhaitham', mes: 'Hello', index: 0 }];
+        expect(buildWorldInfoScanChat(chat, [], new Map(), true)).toEqual(['Kaveh & Alhaitham: Hello']);
+        expect(buildWorldInfoScanChat(chat, [], new Map(), false)).toEqual(['Hello']);
+    });
+
+    test('preserves automatic greeting names while expanding other macros', () => {
+        let substitutions = 0;
+        const substitute = value => value
+            .replace('{{season}}', () => {
+                substitutions++;
+                return 'summer';
+            });
+        const greeting = '{{char}} and <BOT> greet {{user}} and <USER> in {{season}}. Literal Kaveh stays.';
+
+        expect(substituteWorldInfoGreeting(greeting, substitute, { char: 'Kaveh & Alhaitham', user: 'Traveler' })).toEqual({
+            prompt: 'Kaveh & Alhaitham and Kaveh & Alhaitham greet Traveler and Traveler in summer. Literal Kaveh stays.',
+            worldInfo: '{{char}} and <BOT> greet {{user}} and <USER> in summer. Literal Kaveh stays.',
+        });
+        expect(substitutions).toBe(1);
+    });
+
+    test('uses a name-excluded greeting variant without removing literal authored names', () => {
+        const prompt = 'Kaveh & Alhaitham greets Traveler. Literal Kaveh stays.';
+        const worldInfo = '{{char}} greets {{user}}. Literal Kaveh stays.';
+        const chat = [{ name: 'Kaveh & Alhaitham', mes: prompt, index: 0 }];
+        const variants = new Map([[0, { prompt, worldInfo }]]);
+
+        expect(buildWorldInfoScanChat(chat, [], variants, false)).toEqual([worldInfo]);
+    });
+});

--- a/tests/world-info-scan-core.test.js
+++ b/tests/world-info-scan-core.test.js
@@ -2,7 +2,6 @@ import { describe, expect, jest, test } from '@jest/globals';
 
 import {
     getTimedEffectWindow,
-    getWorldInfoEntryKey,
     getWorldInfoGroupNames,
     normalizeWorldInfoKey,
     normalizeWorldInfoProbability,
@@ -57,34 +56,20 @@ describe('World Info scan normalization', () => {
         expect(getWorldInfoGroupNames(' alpha, beta, alpha, , gamma ')).toEqual(['alpha', 'beta', 'gamma']);
         expect(getWorldInfoGroupNames(null)).toEqual([]);
     });
-
-    test('uses the world and UID as stable entry identity', () => {
-        expect(getWorldInfoEntryKey({ world: 'Lore', uid: 7 })).toBe('Lore.7');
-    });
 });
 
 describe('World Info timed effect windows', () => {
-    // The scanner expires an effect once chat.length >= end and drops a
-    // non-protected effect when chat.length <= start (chat did not advance).
-    test('keeps a duration-1 effect active for exactly the next message', () => {
-        const { start, end } = getTimedEffectWindow(10, 1, false);
+    test('uses the upstream duration boundary', () => {
+        const { start, end } = getTimedEffectWindow(10, 1);
         expect(start).toBe(10);
-        // Survives the scan at chat length 11, expires at 12 — without the
-        // window extension a duration-1 sticky or cooldown would never apply.
-        expect(end).toBe(12);
+        expect(end).toBe(11);
     });
 
-    test('covers scans N+1 through N+d for a non-protected duration-d effect', () => {
-        expect(getTimedEffectWindow(10, 3, false)).toEqual({ start: 10, end: 14 });
-    });
-
-    test('does not extend protected windows that already cover the creating scan', () => {
-        // A cooldown born from an ended sticky is buffered for the creating
-        // scan itself, so its persisted window stays d-1 slots for d total.
-        expect(getTimedEffectWindow(10, 3, true)).toEqual({ start: 10, end: 13 });
+    test('does not extend the duration window', () => {
+        expect(getTimedEffectWindow(10, 3)).toEqual({ start: 10, end: 13 });
     });
 
     test('coerces string durations from legacy metadata', () => {
-        expect(getTimedEffectWindow(5, '2', false)).toEqual({ start: 5, end: 8 });
+        expect(getTimedEffectWindow(5, '2')).toEqual({ start: 5, end: 7 });
     });
 });

--- a/tests/world-info-scan-core.test.js
+++ b/tests/world-info-scan-core.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals';
 
 import {
+    getTimedEffectWindow,
     getWorldInfoEntryKey,
     getWorldInfoGroupNames,
     normalizeWorldInfoKey,
@@ -59,5 +60,31 @@ describe('World Info scan normalization', () => {
 
     test('uses the world and UID as stable entry identity', () => {
         expect(getWorldInfoEntryKey({ world: 'Lore', uid: 7 })).toBe('Lore.7');
+    });
+});
+
+describe('World Info timed effect windows', () => {
+    // The scanner expires an effect once chat.length >= end and drops a
+    // non-protected effect when chat.length <= start (chat did not advance).
+    test('keeps a duration-1 effect active for exactly the next message', () => {
+        const { start, end } = getTimedEffectWindow(10, 1, false);
+        expect(start).toBe(10);
+        // Survives the scan at chat length 11, expires at 12 — without the
+        // window extension a duration-1 sticky or cooldown would never apply.
+        expect(end).toBe(12);
+    });
+
+    test('covers scans N+1 through N+d for a non-protected duration-d effect', () => {
+        expect(getTimedEffectWindow(10, 3, false)).toEqual({ start: 10, end: 14 });
+    });
+
+    test('does not extend protected windows that already cover the creating scan', () => {
+        // A cooldown born from an ended sticky is buffered for the creating
+        // scan itself, so its persisted window stays d-1 slots for d total.
+        expect(getTimedEffectWindow(10, 3, true)).toEqual({ start: 10, end: 13 });
+    });
+
+    test('coerces string durations from legacy metadata', () => {
+        expect(getTimedEffectWindow(5, '2', false)).toEqual({ start: 5, end: 8 });
     });
 });

--- a/tests/world-info-scan-core.test.js
+++ b/tests/world-info-scan-core.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import {
+    getWorldInfoEntryKey,
+    getWorldInfoGroupNames,
+    normalizeWorldInfoKey,
+    normalizeWorldInfoProbability,
+    passesWorldInfoProbability,
+} from '../public/scripts/world-info-scan-core.js';
+
+describe('World Info scan probability', () => {
+    test('normalizes CharacterBook extension fields', () => {
+        expect(normalizeWorldInfoProbability({ extensions: { probability: 25, useProbability: false } })).toMatchObject({
+            probability: 25,
+            useProbability: false,
+        });
+    });
+
+    test('preserves explicit top-level zero and false values', () => {
+        expect(normalizeWorldInfoProbability({
+            probability: 0,
+            useProbability: false,
+            extensions: { probability: 75, useProbability: true },
+        })).toMatchObject({
+            probability: 0,
+            useProbability: false,
+        });
+    });
+
+    test('never activates zero percent, including a zero roll', () => {
+        expect(passesWorldInfoProbability({ probability: 0, useProbability: true }, () => 0)).toBe(false);
+    });
+
+    test('uses a strict percentage boundary', () => {
+        expect(passesWorldInfoProbability({ probability: 50, useProbability: true }, () => 0.499)).toBe(true);
+        expect(passesWorldInfoProbability({ probability: 50, useProbability: true }, () => 0.5)).toBe(false);
+    });
+
+    test('always activates disabled, sticky, and 100 percent checks without rolling', () => {
+        const random = jest.fn(() => 0.99);
+        expect(passesWorldInfoProbability({ probability: 1, useProbability: false }, random)).toBe(true);
+        expect(passesWorldInfoProbability({ probability: 1, useProbability: true }, random, true)).toBe(true);
+        expect(passesWorldInfoProbability({ probability: 100, useProbability: true }, random)).toBe(true);
+        expect(random).not.toHaveBeenCalled();
+    });
+});
+
+describe('World Info scan normalization', () => {
+    test('rejects keys that are empty after substitution and trimming', () => {
+        expect(normalizeWorldInfoKey('   ', value => value)).toBeNull();
+        expect(normalizeWorldInfoKey('{{empty}}', () => '')).toBeNull();
+        expect(normalizeWorldInfoKey('  {{user}}  ', () => ' Alice ')).toBe('Alice');
+    });
+
+    test('parses unique nonempty inclusion-group names', () => {
+        expect(getWorldInfoGroupNames(' alpha, beta, alpha, , gamma ')).toEqual(['alpha', 'beta', 'gamma']);
+        expect(getWorldInfoGroupNames(null)).toEqual([]);
+    });
+
+    test('uses the world and UID as stable entry identity', () => {
+        expect(getWorldInfoEntryKey({ world: 'Lore', uid: 7 })).toBe('Lore.7');
+    });
+});


### PR DESCRIPTION
This PR audits lorebooks for general bugs and fixes bugs that I've found, such as percentage chances not working, and excluding the name of the character doesn't include if the character card is a group card (e.g. my card Kaveh & Alhaitham constantly triggers the entries for Kaveh and Alhaitham and their relationships separately.)

## Summary
### Main Problems Fixed
- Percentage chances could be ignored, especially for imported lorebooks.
- A 0% entry could rarely activate.
- Character names from greetings could trigger lore when “Include Names” was disabled.
- Group-card names like “Kaveh & Alhaitham” could trigger separate entries unintentionally.
- Empty keywords could activate entries unexpectedly.
- Some entries rejected by the lorebook budget could still affect later scans.
- Grouped lore entries could remove the wrong entry.
- Recursion, cooldowns, sticky entries, ordering, and scan-depth settings had several edge-case errors.

### Data Safety
- Editing two lorebooks quickly could lose one book’s changes.
- Failed saves could be reported as successful.
- Renaming could overwrite or delete another lorebook.
- Imports, replacements, and deletions could race against unsaved edits.
- Chat, character, and persona lorebook links could break after renaming.
- Very long and unusual lorebook names are now handled safely.
- Invalid lorebook files can no longer disable every other active lorebook.

### Import And Character Cards
- Standard CharacterBook and Lorebook V3 files can now be imported properly.
- Imported metadata and unknown fields are preserved more reliably.
- Duplicate or unusual entry IDs no longer overwrite entries.
- Regex keywords, capitalization settings, probability settings, and ordering survive import/export more accurately.
- Embedded character-card lorebooks now save and link correctly.
- Batch imports detect duplicate or equivalent names before overwriting anything.

### Editor Fixes
- Merely opening an entry no longer silently changes its settings.
- New entries are saved immediately.
- Unknown character filters are preserved.
- Rapidly switching lorebooks no longer displays the wrong book.
- Search, sorting, group weights, and recursion-level controls behave more consistently.