### PR TITLE
feat(ui): add option called “Icons only top bar” to put every icon on the top bar

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -92,14 +92,14 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 ### `public/scripts/sillybunny-tabs.js` - shell chat controls
 | Field | Value |
 | --- | --- |
-| Area | Mobile shell, chat navigation, and preset/API sync. |
-| Divergence reason | SillyBunny shell owns top/bottom navigation, chat controls, drawers, mobile actions, search shortcut focus, viewport-reset dispatches, and mirrored connection-profile controls that interact with chat and API state. |
+| Area | Mobile shell, top-bar layout, chat navigation, and preset/API sync. |
+| Divergence reason | SillyBunny shell owns top/bottom navigation, chat controls, drawers, mobile actions, search shortcut focus, viewport-reset dispatches, and mirrored connection-profile controls that interact with chat and API state. Its per-device icons-only top bar adds canonical Workspace, Customize, and Characters page clusters, hides redundant shell anchors, deduplicates Quick Access targets, and keeps trailing controls fixed while the page rail pans. |
 | Target seam | `public/scripts/chat-render-lifecycle/` for chat scroll requests; `public/scripts/mobile-shell-lifecycle/` for drawer/nav/viewport behavior; `public/scripts/preset-api-sync-lifecycle/` for active API and connection-profile mirror decisions. |
-| Adapter shape | Shell code keeps DOM wiring and requests lifecycle decisions for drawer bounds, viewport sync order, drawer-bound scheduling, overlay exclusivity, rail quick-action normalization and visibility, inline drawer auto-close and persistence keys, nav drag, page scroll, overlay open/close, auto-close, modal inert policy, search shortcut pre-focus, viewport reset timing, active API connect-button lookup, connection-profile source binding, connection-profile source mutation rebind decisions, connection-profile mirror state, connection-profile mirror updates, connection-profile status text, and connection-strip open state. |
-| Protecting tests | `tests/mobile-shell-lifecycle.test.js`, `tests/mobile-shell-lifecycle-drawer-bounds.test.js`, `tests/mobile-shell-lifecycle-viewport-sync.test.js`, `tests/mobile-shell-lifecycle-overlay-exclusion.test.js`, `tests/mobile-shell-lifecycle-rail-model.test.js`, `tests/mobile-shell-lifecycle-inline-drawers.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, `tests/mobile-shell-smoke.e2e.js`, `tests/preset-api-sync-lifecycle.test.js`, `tests/preset-api-sync-lifecycle-wiring.test.js`, future shell smoke checks for drawer/tab/preset/chat-scroll behavior. |
-| Validation | `node --check public/scripts/sillybunny-tabs.js`, `npm run lint`, `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-shell-lifecycle-drawer-bounds.test.js mobile-shell-lifecycle-viewport-sync.test.js mobile-shell-lifecycle-overlay-exclusion.test.js mobile-shell-lifecycle-rail-model.test.js mobile-shell-lifecycle-inline-drawers.test.js mobile-shell-lifecycle-wiring.test.js mobile-shell-lifecycle.test.js` from `tests/`, full `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json` from `tests/`, `npm run check:frontend-budgets`, `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npm run test:e2e -- mobile-shell-smoke.e2e.js` from `tests/`. |
+| Adapter shape | Shell code keeps DOM wiring and requests lifecycle decisions for drawer bounds, viewport sync order, drawer-bound scheduling, overlay exclusivity, rail quick-action normalization and visibility, inline drawer auto-close and persistence keys, nav drag, page scroll, overlay open/close, auto-close, modal inert policy, search shortcut pre-focus, viewport reset timing, active API connect-button lookup, connection-profile source binding, connection-profile source mutation rebind decisions, connection-profile mirror state, connection-profile mirror updates, connection-profile status text, and connection-strip open state. Keep icons-only behavior in the new top-bar helpers and the narrow integration points in `buildTopBar()`, `getShellProxyButton()`, `stopProxyPointerPropagation()`, `forceDrawerState()`, `syncCharacterShellTabs()`, `syncCharacterDrawerStateFromDom()`, `setActiveTab()`, `updateTopBarBrand()`, `updateShortcutButton()`, and `initAll()`. |
+| Protecting tests | `tests/mobile-shell-lifecycle.test.js`, `tests/mobile-shell-lifecycle-drawer-bounds.test.js`, `tests/mobile-shell-lifecycle-viewport-sync.test.js`, `tests/mobile-shell-lifecycle-overlay-exclusion.test.js`, `tests/mobile-shell-lifecycle-rail-model.test.js`, `tests/mobile-shell-lifecycle-inline-drawers.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, `tests/mobile-shell-smoke.e2e.js`, `tests/topbar-label-tap-cycle.test.js`, `tests/preset-api-sync-lifecycle.test.js`, `tests/preset-api-sync-lifecycle-wiring.test.js`, future shell smoke checks for drawer/tab/preset/chat-scroll behavior. |
+| Validation | `node --check public/scripts/sillybunny-tabs.js`, `npm run lint`, `npm run test:unit --prefix tests -- topbar-label-tap-cycle.test.js mobile-shell-lifecycle-wiring.test.js`, `npm run check:frontend-budgets`, desktop/mobile icons-only browser smoke, plus the existing shell lifecycle unit and e2e packs. |
 | Rollback path | Keep shell calls narrow so a bad adapter route can be reverted without removing shell UI. |
-| Last reviewed | 2026-06-13 connection-profile source mutation seam. |
+| Last reviewed | 2026-07-25 PR #685 icons-only top bar. |
 | Owner | Refactor integrator and mobile shell owner. |
 
 ### `public/scripts/browser-fixes.js` - mobile viewport reset guard
@@ -236,13 +236,13 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Mobile shell and character menu. |
-| Divergence reason | SillyBunny keeps horizontal labeled menu rails as the default, supports vertical rail mode without mixing Workspace and Customize shortcuts, and routes Character Menu controls through the canonical drawer when duplicate runtime nodes exist. |
+| Divergence reason | SillyBunny keeps horizontal labeled menu rails as the default, supports vertical rail mode without mixing Workspace and Customize shortcuts, and routes Character Menu controls through the canonical drawer when duplicate runtime nodes exist. In icons-only mode, complete character page controls replace the generic drawer-only interaction, and the Characters anchor explicitly opens and highlights only the base Characters page. |
 | Target seam | `public/scripts/mobile-shell-lifecycle/` for drawer/nav state; no separate seam yet for Character Menu tab copy and canonical DOM targeting. |
-| Adapter shape | Keep shell state updates and DOM routing in `sillybunny-tabs.js`; delegate only viewport/nav open-state decisions to lifecycle helpers where they already exist. |
-| Protecting tests | `tests/mobile-shell-lifecycle.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, focused browser smoke for horizontal labels, vertical rail separation, and Character Menu drawer tabs. |
-| Validation | `node --check public/scripts/sillybunny-tabs.js`, `git diff --check`, mobile/desktop browser smoke on Character Menu horizontal labels, vertical rail behavior, and canonical drawer targeting. |
+| Adapter shape | Keep shell state updates and DOM routing in `sillybunny-tabs.js`; delegate only viewport/nav open-state decisions to lifecycle helpers where they already exist. Keep the icons-only character state isolated through the top-bar page helpers and the narrow hooks in `buildTopBar()`, `getShellProxyButton()`, `forceDrawerState()`, `syncCharacterShellTabs()`, `syncCharacterDrawerStateFromDom()`, and `setActiveTab()` so the labeled layout retains its existing drawer toggle behavior. |
+| Protecting tests | `tests/mobile-shell-lifecycle.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, `tests/topbar-label-tap-cycle.test.js`, focused browser smoke for horizontal labels, vertical rail separation, icons-only character pages, and Character Menu drawer tabs. |
+| Validation | `node --check public/scripts/sillybunny-tabs.js`, `git diff --check`, `npm run test:unit --prefix tests -- topbar-label-tap-cycle.test.js mobile-shell-lifecycle-wiring.test.js`, and mobile/desktop browser smoke on both icons-only and labeled Character Menu behavior. |
 | Rollback path | Revert the nav default/rail action filtering and Character panel helper calls independently from the shell lifecycle helpers. |
-| Last reviewed | 2026-06-02 PR #315 menu layout polish. |
+| Last reviewed | 2026-07-25 PR #685 icons-only top bar. |
 | Owner | Refactor integrator and mobile shell owner. |
 
 ### `public/scripts/openai.js` and `public/scripts/textgen-models.js` - mobile OpenRouter selects
@@ -275,13 +275,13 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Mobile shell, settings, cache, and frontend boot. |
-| Divergence reason | SillyBunny UI polish needs responsive Character Menu rail sizing, mobile inline picker styling, Select2 z-layer fixes, welcome card text wrapping, and cache-busted asset references for the updated shell files. |
+| Divergence reason | SillyBunny UI polish needs responsive Character Menu rail sizing, mobile inline picker styling, Select2 z-layer fixes, welcome card text wrapping, and cache-busted asset references for the updated shell files. The icons-only top bar adds grouped page rails, mode-scoped shell-anchor hiding, mobile horizontal overflow handling, and guards that prevent mobile rules from restoring hidden Workspace controls. |
 | Target seam | CSS remains declarative; frontend asset/cache references stay in the existing boot files. |
-| Adapter shape | Keep CSS changes scoped to SillyBunny shell/select/menu classes and update only the affected boot/cache version strings. |
-| Protecting tests | `tests/frontend-assets.test.js`, frontend asset budget check, focused browser smoke for mobile/desktop menu layout and dropdown layering. |
-| Validation | `git diff --check`, frontend asset check in CI, browser smoke for mobile Character Menu, desktop Character Menu, and OpenRouter dropdown layering. |
+| Adapter shape | Keep CSS changes scoped to SillyBunny shell/select/menu classes and mode attributes; update only the affected stylesheet cache version strings in `public/index.html`. |
+| Protecting tests | `tests/frontend-assets.test.js`, `tests/topbar-label-tap-cycle.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, frontend asset budget check, focused browser smoke for mobile/desktop menu layout and dropdown layering. |
+| Validation | `git diff --check`, `npm run test:unit --prefix tests -- topbar-label-tap-cycle.test.js mobile-shell-lifecycle-wiring.test.js`, `npm run check:frontend-budgets`, frontend asset check in CI, and browser smoke for wide, cramped, and mobile icons-only layouts. |
 | Rollback path | Revert the cache-bust strings and scoped CSS blocks together if stale assets, menu layout, or dropdown layering regress. |
-| Last reviewed | 2026-06-02 PR #315 menu/layout polish. |
+| Last reviewed | 2026-07-25 PR #685 icons-only top bar. |
 | Owner | Refactor integrator and mobile shell owner. |
 
 ### `public/scripts/PromptManager.js` - prompt manager lifecycle

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/platinum/SillyBunny/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/platinum/SillyBunny/node_modules

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1324,6 +1324,18 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         min-height: var(--sb-mobile-toggle-size);
     }
 
+    /* Phones never show the brand label, and the characters pages ride the strip without their
+       anchor, so both cluster boundaries carry the divider rule here. The rule takes over the
+       seam, so the lead's extra margin steps aside to keep it centred. */
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider {
+        display: inline-block;
+        height: calc(var(--sb-mobile-toggle-size) * 0.5);
+    }
+
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider + .sb-topbar-cluster-lead {
+        margin-inline-start: 0;
+    }
+
     .sb-universal-search {
         width: 100%;
     }

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1294,16 +1294,12 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         display: none;
     }
 
-    /* One spacing rhythm for the whole bar: the rail inherits its own 8px token while the
-       groups sit at the 3-4px group gap, and the grid seam adds a third width. Identical
-       square buttons a few px apart at three different distances is what reads as awkward,
-       so everything keys off the group gap here. */
+    /* One spacing rhythm for the whole bar: the clusters and the groups both sit at the 3-4px
+       group gap, and the grid seam would otherwise add a third width. Identical square buttons a
+       few px apart at three different distances is what reads as awkward, so the seam keys off
+       the group gap too. */
     :root[data-sb-topbar-icons-only='true'] #sb-topbar-inner {
         grid-template-columns: minmax(0, 1fr) minmax(0, auto);
-        gap: var(--sb-topbar-group-gap);
-    }
-
-    :root[data-sb-topbar-icons-only='true'] .sb-topbar-pages {
         gap: var(--sb-topbar-group-gap);
     }
 
@@ -1314,6 +1310,18 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-left {
         justify-self: stretch;
         min-width: 0;
+    }
+
+    /* One target size for the whole bar. The page icons and Quick Access slots used to sit at the
+       26px chatbar size next to 40px anchors, which made them noticeably harder to hit
+       (Geechan review, #685). Home needs naming explicitly: its id-level min-width in
+       sillybunny-tabs.css outranks a class selector. */
+    :root[data-sb-topbar-icons-only='true'] .sb-proxy-button-icon-only,
+    :root[data-sb-topbar-icons-only='true'] #sb-home-toggle {
+        min-width: var(--sb-mobile-toggle-size);
+        width: var(--sb-mobile-toggle-size);
+        height: var(--sb-mobile-toggle-size);
+        min-height: var(--sb-mobile-toggle-size);
     }
 
     .sb-universal-search {
@@ -1340,6 +1348,7 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     #sb-left-shell-toggle,
     #sb-right-shell-toggle,
     #sb-character-toggle,
+    .sb-topbar-page-button,
     #sb-chatbar-visibility-toggle {
         min-width: var(--sb-mobile-toggle-size);
         width: var(--sb-mobile-toggle-size);
@@ -1355,6 +1364,7 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     #sb-left-shell-toggle span,
     #sb-right-shell-toggle span,
     #sb-character-toggle span,
+    .sb-topbar-page-button span,
     #sb-chatbar-visibility-toggle span {
         display: none;
     }
@@ -1365,6 +1375,7 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     #sb-left-shell-toggle::after,
     #sb-right-shell-toggle::after,
     #sb-character-toggle::after,
+    .sb-topbar-page-button::after,
     #sb-chatbar-visibility-toggle::after {
         left: var(--sb-proxy-underline-inset);
         right: var(--sb-proxy-underline-inset);
@@ -1377,6 +1388,7 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     #sb-left-shell-toggle i,
     #sb-right-shell-toggle i,
     #sb-character-toggle i,
+    .sb-topbar-page-button i,
     #sb-chatbar-visibility-toggle i {
         font-size: var(--sb-topbar-compact-icon-size);
     }

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1256,8 +1256,8 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         display: none;
     }
 
-    :root[data-sb-mobile-nav-layout='horizontal'][data-sb-mobile-nav-customize='shown'] #sb-left-shell-toggle,
-    :root[data-sb-mobile-nav-replacement='shown'] #sb-left-shell-toggle {
+    :root:not([data-sb-topbar-icons-only='true'])[data-sb-mobile-nav-layout='horizontal'][data-sb-mobile-nav-customize='shown'] #sb-left-shell-toggle,
+    :root:not([data-sb-topbar-icons-only='true'])[data-sb-mobile-nav-replacement='shown'] #sb-left-shell-toggle {
         display: inline-flex;
     }
 

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1324,16 +1324,10 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         min-height: var(--sb-mobile-toggle-size);
     }
 
-    /* Phones never show the brand label, and the characters pages ride the strip without their
-       anchor, so both cluster boundaries carry the divider rule here. The rule takes over the
-       seam, so the lead's extra margin steps aside to keep it centred. */
+    /* Visibility and seam handling live in sillybunny-tabs.css; the phone strip only shortens
+       the rule to match its smaller squares. */
     :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider {
-        display: inline-block;
         height: calc(var(--sb-mobile-toggle-size) * 0.5);
-    }
-
-    :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider + .sb-topbar-cluster-lead {
-        margin-inline-start: 0;
     }
 
     .sb-universal-search {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1294,8 +1294,17 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         display: none;
     }
 
+    /* One spacing rhythm for the whole bar: the rail inherits its own 8px token while the
+       groups sit at the 3-4px group gap, and the grid seam adds a third width. Identical
+       square buttons a few px apart at three different distances is what reads as awkward,
+       so everything keys off the group gap here. */
     :root[data-sb-topbar-icons-only='true'] #sb-topbar-inner {
         grid-template-columns: minmax(0, 1fr) minmax(0, auto);
+        gap: var(--sb-topbar-group-gap);
+    }
+
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-pages {
+        gap: var(--sb-topbar-group-gap);
     }
 
     :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-right {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1288,10 +1288,18 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         padding: 0 2px;
     }
 
-    /* Icons only top bar: hand the flexible column to the page rail so it scrolls in place
-       instead of pushing the title and the right-hand anchors off screen. */
+    /* Icons only top bar: phones have no room for both the rail and the centre brand, so drop
+       the label here and hand its column to the rail. Desktop keeps the label. */
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-brand {
+        display: none;
+    }
+
     :root[data-sb-topbar-icons-only='true'] #sb-topbar-inner {
-        grid-template-columns: minmax(0, 1fr) minmax(0, auto) auto;
+        grid-template-columns: minmax(0, 1fr) minmax(0, auto);
+    }
+
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-right {
+        min-width: 0;
     }
 
     :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-left {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1324,10 +1324,22 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         min-height: var(--sb-mobile-toggle-size);
     }
 
-    /* Visibility and seam handling live in sillybunny-tabs.css; the phone strip only shortens
+    /* Visibility and seam handling live in sillybunny-tabs.css; the phone bar only shortens
        the rule to match its smaller squares. */
-    :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider {
+    .sb-topbar-cluster-divider {
         height: calc(var(--sb-mobile-toggle-size) * 0.5);
+    }
+
+    /* The Home|Characters boundary keeps its rule on phones in every mode, so the bar reads the
+       same whether or not the icons-only option is on. */
+    #sb-topbar-divider-home {
+        display: inline-block;
+    }
+
+    /* The strip's characters-pages boundary; equal specificity to the desktop hide in
+       sillybunny-tabs.css, so this sheet's later load order re-enables it on phones. */
+    :root[data-sb-topbar-icons-only='true'] #sb-topbar-divider-characters {
+        display: inline-block;
     }
 
     .sb-universal-search {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1288,6 +1288,17 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         padding: 0 2px;
     }
 
+    /* Icons only top bar: hand the flexible column to the page rail so it scrolls in place
+       instead of pushing the title and the right-hand anchors off screen. */
+    :root[data-sb-topbar-icons-only='true'] #sb-topbar-inner {
+        grid-template-columns: minmax(0, 1fr) minmax(0, auto) auto;
+    }
+
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-left {
+        justify-self: stretch;
+        min-width: 0;
+    }
+
     .sb-universal-search {
         width: 100%;
     }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1343,6 +1343,31 @@ body:not(.movingUI) .drawer-content.maximized {
     margin-inline-start: calc(var(--sb-topbar-cluster-gap) - var(--sb-topbar-group-gap));
 }
 
+/* Boundary rule between clusters. While the brand label is visible it breaks the bar in half and
+   the seams carry the rest; once it is hidden the seams alone are a few px of gap between
+   identical squares, so a 1px theme-derived rule marks where one cluster ends. The symmetric
+   margins reproduce the cluster seam around the rule. */
+.sb-topbar-cluster-divider {
+    display: none;
+    flex: 0 0 auto;
+    width: 1px;
+    height: calc(var(--sb-proxy-button-height) * 0.55);
+    border-radius: 999px;
+    margin-inline: calc((var(--sb-topbar-cluster-gap) - var(--sb-topbar-group-gap)) / 2);
+    background: var(--sb-shell-border);
+}
+
+/* Cramped desktop keeps the label off; only the Workspace|Customize boundary needs the rule,
+   because the characters rail still sits beside its own anchor there. The divider carries the
+   seam, so the lead's extra margin steps aside to keep the rule centred. */
+:root[data-sb-topbar-brand-cramped='true'] #sb-topbar-divider-customize {
+    display: inline-block;
+}
+
+:root[data-sb-topbar-brand-cramped='true'] #sb-topbar-divider-customize + .sb-topbar-cluster-lead {
+    margin-inline-start: 0;
+}
+
 /* Overflow state: the leading group scrolls and the trailing controls sit beside it, so Quick
    Actions, Home and Characters stay reachable however far the icons are scrolled.
    The icons deliberately scroll beside the trailing group rather than under it. Scrolling them

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1341,6 +1341,10 @@ body:not(.movingUI) .drawer-content.maximized {
     display: flex;
 }
 
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-pages-empty {
+    display: none;
+}
+
 
 /* #sb-home-toggle's id-level min-width outranks .sb-proxy-button-icon-only, so without this
    the home button keeps a label-width box with no label in it. */

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1317,32 +1317,64 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
+/* The rails do not scroll on their own. A nested scroll region ended mid-button and left an
+   unreadable sliver of an icon at its boundary; the whole bar scrolls as one axis instead. */
 .sb-topbar-pages {
     display: none;
     align-items: center;
     flex-wrap: nowrap;
     gap: var(--sb-proxy-button-gap);
+}
+
+
+/* Overflow state: one scroll axis across the bar, with the trailing controls pinned so Quick
+   Actions, Search, Home and Characters stay reachable however far the icons are scrolled. */
+:root[data-sb-topbar-scroll='true'] #sb-topbar-inner {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    /* Without this the nowrap content sets a min-content floor and the bar grows past the
+       viewport instead of scrolling inside it. */
     min-width: 0;
+    max-width: 100%;
     overflow-x: auto;
     overflow-y: hidden;
     overscroll-behavior-x: contain;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
-    /* No edge-fade mask here: it dimmed whichever icon sat on the rail boundary even when
-       nothing was scrolled out of view, which reads as a disabled button rather than as a
-       scroll hint. Clipping at the container edge is the honest affordance. */
-    scroll-padding-inline: var(--sb-topbar-group-gap);
-    scroll-snap-type: x proximity;
+    /* No scroll snapping: the first snap point is the leading page icon, so the browser pulled
+       the bar past the hamburger on load and hid it. */
+    scroll-padding-inline-end: var(--sb-topbar-group-gap);
 }
 
-/* Resting mid-icon makes the clipped remainder read as a random wider gap, so snap the rail
-   to whole icons whenever a swipe ends near one. */
-.sb-topbar-page-button {
-    scroll-snap-align: start;
-}
-
-.sb-topbar-pages::-webkit-scrollbar {
+:root[data-sb-topbar-scroll='true'] #sb-topbar-inner::-webkit-scrollbar {
     display: none;
+}
+
+/* The min-content floor propagates up through every flex/grid ancestor, so each one has to be
+   told it may shrink or the whole bar widens past the viewport instead of scrolling. */
+:root[data-sb-topbar-scroll='true'] #sb-topbar-stack,
+:root[data-sb-topbar-scroll='true'] #sb-topbar-primary {
+    min-width: 0;
+}
+
+:root[data-sb-topbar-scroll='true'] #sb-topbar-inner > .sb-topbar-group {
+    flex: 0 0 auto;
+    min-width: auto;
+}
+
+:root[data-sb-topbar-scroll='true'] .sb-topbar-group-right {
+    position: sticky;
+    right: 0;
+    z-index: 1;
+    padding-left: var(--sb-topbar-group-gap);
+    /* Reuses the bar's own glass language rather than repainting its themeable, translucent
+       background, which would double-darken and show as a seam. */
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    -webkit-mask-image: linear-gradient(to right, transparent 0, #000 var(--sb-topbar-group-gap));
+    mask-image: linear-gradient(to right, transparent 0, #000 var(--sb-topbar-group-gap));
 }
 
 :root[data-sb-topbar-icons-only='true'] .sb-topbar-pages {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1328,9 +1328,10 @@ body:not(.movingUI) .drawer-content.maximized {
     overscroll-behavior-x: contain;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
+    /* No edge-fade mask here: it dimmed whichever icon sat on the rail boundary even when
+       nothing was scrolled out of view, which reads as a disabled button rather than as a
+       scroll hint. Clipping at the container edge is the honest affordance. */
     scroll-padding-inline: var(--sb-topbar-group-gap);
-    -webkit-mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
-    mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
 }
 
 .sb-topbar-pages::-webkit-scrollbar {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1345,6 +1345,20 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
+/* Search only exists as a top bar button in icons-only mode; elsewhere it is reachable through
+   a Quick Access slot as before. */
+#sb-topbar-search-toggle {
+    display: none;
+}
+
+:root[data-sb-topbar-icons-only='true'] #sb-topbar-search-toggle {
+    display: inline-flex;
+}
+
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-page-duplicate {
+    display: none;
+}
+
 /* Once the label is squeezed out there is nothing left to centre on, so it yields its width to
    the rails; the two clusters then meet in the middle on their own. */
 :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-brand {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1314,8 +1314,8 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
-/* Icons only top bar: each Layer 2 anchor grows a cluster of its own page icons beside it, and the
-   anchors stay put with their labels suppressed.
+/* Icons only top bar: each section grows a cluster of its own page icons. Workspace and Customize
+   yield to their complete clusters while Home and Characters stay put with labels suppressed.
 
    Square hit boxes at the labelled buttons' own height. The icons used to be 30px wide inside a
    36px-tall bar, which read as a smaller, harder-to-hit control than the anchors beside them
@@ -1336,10 +1336,19 @@ body:not(.movingUI) .drawer-content.maximized {
     gap: var(--sb-topbar-group-gap);
 }
 
+:root[data-sb-topbar-icons-only='true'] #sb-left-shell-toggle,
+:root[data-sb-topbar-icons-only='true'] #sb-right-shell-toggle {
+    display: none;
+}
+
 /* A cluster's anchor sits tight against its own page icons; each new anchor opens the wider seam
    that separates the clusters, so Workspace, Customize and Characters read as three zones rather
    than one strip. Derived from the group gap so it follows the user's top bar scale. */
 :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-lead:not(:first-child) {
+    margin-inline-start: calc(var(--sb-topbar-cluster-gap) - var(--sb-topbar-group-gap));
+}
+
+:root[data-sb-topbar-icons-only='true'] #sb-topbar-cluster-workspace {
     margin-inline-start: calc(var(--sb-topbar-cluster-gap) - var(--sb-topbar-group-gap));
 }
 
@@ -1431,7 +1440,7 @@ body:not(.movingUI) .drawer-content.maximized {
     display: flex;
 }
 
-:root[data-sb-topbar-icons-only='true'] .sb-topbar-page-duplicate {
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-shortcut-duplicate {
     display: none;
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1343,10 +1343,9 @@ body:not(.movingUI) .drawer-content.maximized {
     margin-inline-start: calc(var(--sb-topbar-cluster-gap) - var(--sb-topbar-group-gap));
 }
 
-/* Boundary rule between clusters. While the brand label is visible it breaks the bar in half and
-   the seams carry the rest; once it is hidden the seams alone are a few px of gap between
-   identical squares, so a 1px theme-derived rule marks where one cluster ends. The symmetric
-   margins reproduce the cluster seam around the rule. */
+/* Boundary rule between clusters: a 1px theme-derived rule marks where one cluster ends and the
+   next begins -- Workspace|Customize on the left half, Home|Characters on the right -- at every
+   size while the mode is on. The symmetric margins reproduce the cluster seam around the rule. */
 .sb-topbar-cluster-divider {
     display: none;
     flex: 0 0 auto;
@@ -1357,15 +1356,13 @@ body:not(.movingUI) .drawer-content.maximized {
     background: var(--sb-shell-border);
 }
 
-/* Cramped desktop keeps the label off, so both boundaries carry the rule: Workspace|Customize on
-   the left half and Home|Characters on the right. The divider carries the seam, so the lead's
-   extra margin steps aside to keep the rule centred (this must follow the seam-margin rule above
-   to win on source order). */
-:root[data-sb-topbar-brand-cramped='true'] .sb-topbar-cluster-divider {
+/* The divider carries the seam, so the lead's extra margin steps aside to keep the rule centred
+   (this must follow the seam-margin rule above to win on source order). */
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider {
     display: inline-block;
 }
 
-:root[data-sb-topbar-brand-cramped='true'] .sb-topbar-cluster-divider + .sb-topbar-cluster-lead {
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider + .sb-topbar-cluster-lead {
     margin-inline-start: 0;
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1327,8 +1327,13 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 
-/* Overflow state: one scroll axis across the bar, with the trailing controls pinned so Quick
-   Actions, Search, Home and Characters stay reachable however far the icons are scrolled. */
+/* Overflow state: the leading group scrolls and the trailing controls sit beside it, so Quick
+   Actions, Search, Home and Characters stay reachable however far the icons are scrolled.
+   The icons deliberately scroll beside the trailing group rather than under it. Scrolling them
+   under would need the pinned group to paint over them, and its only theme-correct backing is
+   the bar's own translucent background: repainting that double-darkens, and backdrop-filter
+   silently no-ops in WebKit when nested inside another backdrop-filtered element (#top-bar),
+   leaving the group transparent with the icons showing straight through it on iOS. */
 :root[data-sb-topbar-scroll='true'] #sb-topbar-inner {
     display: flex;
     align-items: center;
@@ -1338,17 +1343,24 @@ body:not(.movingUI) .drawer-content.maximized {
        viewport instead of scrolling inside it. */
     min-width: 0;
     max-width: 100%;
+}
+
+:root[data-sb-topbar-scroll='true'] .sb-topbar-group-left {
+    flex: 1 1 auto;
+    min-width: 0;
     overflow-x: auto;
     overflow-y: hidden;
     overscroll-behavior-x: contain;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
+    /* Tell WebKit this axis is a pan target; without it the buttons swallow the gesture. */
+    touch-action: pan-x;
     /* No scroll snapping: the first snap point is the leading page icon, so the browser pulled
        the bar past the hamburger on load and hid it. */
     scroll-padding-inline-end: var(--sb-topbar-group-gap);
 }
 
-:root[data-sb-topbar-scroll='true'] #sb-topbar-inner::-webkit-scrollbar {
+:root[data-sb-topbar-scroll='true'] .sb-topbar-group-left::-webkit-scrollbar {
     display: none;
 }
 
@@ -1363,22 +1375,10 @@ body:not(.movingUI) .drawer-content.maximized {
     min-width: 0;
 }
 
-:root[data-sb-topbar-scroll='true'] #sb-topbar-inner > .sb-topbar-group {
+:root[data-sb-topbar-scroll='true'] .sb-topbar-group-right {
     flex: 0 0 auto;
     min-width: auto;
-}
-
-:root[data-sb-topbar-scroll='true'] .sb-topbar-group-right {
-    position: sticky;
-    right: 0;
-    z-index: 1;
     padding-left: var(--sb-topbar-group-gap);
-    /* Reuses the bar's own glass language rather than repainting its themeable, translucent
-       background, which would double-darken and show as a seam. */
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    -webkit-mask-image: linear-gradient(to right, transparent 0, #000 var(--sb-topbar-group-gap));
-    mask-image: linear-gradient(to right, transparent 0, #000 var(--sb-topbar-group-gap));
 }
 
 :root[data-sb-topbar-icons-only='true'] .sb-topbar-pages {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1345,18 +1345,48 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
+/* Once the label is squeezed out there is nothing left to centre on, so it yields its width to
+   the rails; the two clusters then meet in the middle on their own. */
+:root[data-sb-topbar-brand-cramped='true'] .sb-topbar-brand {
+    display: none;
+}
+
 /* The side tracks are equal, so the brand label already sits on the true centre. Both groups
    fill from the outer edge inward though, which leaves unequal slack next to the label and
-   reads as off-centre. Pushing each rail toward the label evens that slack out while the
-   anchors and home/characters stay pinned to the bar edges. Phones merge the rails and hide
-   the label, so this is desktop only. */
+   reads as off-centre. Clustering each group's icons against the label evens that slack out,
+   while home/characters stay pinned to the bar edge. Phones merge the rails and hide the
+   label, so this is desktop only. */
 @media screen and (min-width: 769px) {
-    :root[data-sb-topbar-icons-only='true'] #sb-topbar-pages {
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-left {
+        justify-content: flex-end;
+    }
+
+    :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-right {
+        justify-content: flex-start;
+    }
+
+    :root[data-sb-topbar-icons-only='true'] #sb-home-toggle {
         margin-left: auto;
     }
 
-    :root[data-sb-topbar-icons-only='true'] #sb-topbar-pages-right {
-        margin-right: auto;
+    /* With the label gone there is no centre column to balance against, so the equal side tracks
+       just strand the icons left of centre. Collapse the grid and centre the whole row as one
+       cluster instead. Must follow the rule above to win on source order. */
+    :root[data-sb-topbar-brand-cramped='true'] #sb-topbar-inner {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-group-left,
+    :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-group-right {
+        justify-content: center;
+        flex: 0 1 auto;
+        min-width: 0;
+    }
+
+    :root[data-sb-topbar-brand-cramped='true'] #sb-home-toggle {
+        margin-left: 0;
     }
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1353,9 +1353,13 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 /* The min-content floor propagates up through every flex/grid ancestor, so each one has to be
-   told it may shrink or the whole bar widens past the viewport instead of scrolling. */
-:root[data-sb-topbar-scroll='true'] #sb-topbar-stack,
-:root[data-sb-topbar-scroll='true'] #sb-topbar-primary {
+   told it may shrink or the whole bar widens past the viewport instead of scrolling.
+   Gated on icons-only rather than on the scroll state itself: the overflow verdict is measured
+   from #sb-topbar-inner's client width, and leaving these unset lets the bar inflate to fit its
+   own content, so a small overflow would never be detected and could never be scrolled. */
+:root[data-sb-topbar-icons-only='true'] #sb-topbar-stack,
+:root[data-sb-topbar-icons-only='true'] #sb-topbar-primary,
+:root[data-sb-topbar-icons-only='true'] #sb-topbar-inner {
     min-width: 0;
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1311,6 +1311,48 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
+/* Icons only top bar: a scrollable page rail takes the Quick Access position, and the
+   layer 2 anchors stay put with their labels suppressed. */
+#sb-topbar-parked {
+    display: none;
+}
+
+.sb-topbar-pages {
+    display: none;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: var(--sb-proxy-button-gap);
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    scroll-padding-inline: var(--sb-topbar-group-gap);
+    -webkit-mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+    mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+}
+
+.sb-topbar-pages::-webkit-scrollbar {
+    display: none;
+}
+
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-pages {
+    display: flex;
+}
+
+
+/* #sb-home-toggle's id-level min-width outranks .sb-proxy-button-icon-only, so without this
+   the home button keeps a label-width box with no label in it. */
+:root[data-sb-topbar-icons-only='true'] #sb-home-toggle {
+    min-width: var(--sb-chatbar-button-size);
+}
+
+.sb-shortcut-rows.is-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 #top-settings-holder > .sb-drawer-host:not(.sb-embedded-drawer) {
     width: 0;
     min-width: 0;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1357,14 +1357,15 @@ body:not(.movingUI) .drawer-content.maximized {
     background: var(--sb-shell-border);
 }
 
-/* Cramped desktop keeps the label off; only the Workspace|Customize boundary needs the rule,
-   because the characters rail still sits beside its own anchor there. The divider carries the
-   seam, so the lead's extra margin steps aside to keep the rule centred. */
-:root[data-sb-topbar-brand-cramped='true'] #sb-topbar-divider-customize {
+/* Cramped desktop keeps the label off, so both boundaries carry the rule: Workspace|Customize on
+   the left half and Home|Characters on the right. The divider carries the seam, so the lead's
+   extra margin steps aside to keep the rule centred (this must follow the seam-margin rule above
+   to win on source order). */
+:root[data-sb-topbar-brand-cramped='true'] .sb-topbar-cluster-divider {
     display: inline-block;
 }
 
-:root[data-sb-topbar-brand-cramped='true'] #sb-topbar-divider-customize + .sb-topbar-cluster-lead {
+:root[data-sb-topbar-brand-cramped='true'] .sb-topbar-cluster-divider + .sb-topbar-cluster-lead {
     margin-inline-start: 0;
 }
 
@@ -1436,6 +1437,13 @@ body:not(.movingUI) .drawer-content.maximized {
    width, so neither group is ever pulled toward the centre. */
 :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-brand {
     display: none;
+}
+
+/* display:none takes the label out of the grid entirely, and with only two items left the right
+   group would auto-place into the centre `auto` column and drift toward the middle, under the
+   left group's overflow. Collapse to two columns so each group keeps its own edge. */
+:root[data-sb-topbar-brand-cramped='true'] #sb-topbar-inner {
+    grid-template-columns: minmax(0, 1fr) minmax(0, auto);
 }
 
 /* #sb-home-toggle's id-level min-width outranks .sb-proxy-button-icon-only, so without this

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -76,6 +76,9 @@
     --sb-topbar-search-row-height: calc(var(--sb-topbar-search-row-height-base) * var(--sb-topbar-scale-active));
     --sb-topbar-search-panel-gap: calc(var(--sb-topbar-search-panel-gap-base) * var(--sb-topbar-scale-active));
     --sb-topbar-group-gap: calc(var(--sb-topbar-group-gap-base) * var(--sb-topbar-scale-active));
+    /* Seam between icons-only clusters. A multiple of the group gap rather than a fixed value, so
+       it tracks the user's top bar scale and compact mode instead of fighting them. */
+    --sb-topbar-cluster-gap: calc(var(--sb-topbar-group-gap) * 2.5);
     --sb-chatbar-height: calc(var(--sb-chatbar-height-base) * var(--sb-chatbar-scale-active));
     --sb-chatbar-gap: calc(var(--sb-chatbar-gap-base) * var(--sb-chatbar-scale-active));
     --sb-chatbar-cluster-gap: calc(var(--sb-chatbar-cluster-gap-base) * var(--sb-chatbar-scale-active));
@@ -1311,10 +1314,17 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
-/* Icons only top bar: a scrollable page rail takes the Quick Access position, and the
-   layer 2 anchors stay put with their labels suppressed. */
-#sb-topbar-parked {
-    display: none;
+/* Icons only top bar: each Layer 2 anchor grows a cluster of its own page icons beside it, and the
+   anchors stay put with their labels suppressed.
+
+   Square hit boxes at the labelled buttons' own height. The icons used to be 30px wide inside a
+   36px-tall bar, which read as a smaller, harder-to-hit control than the anchors beside them
+   (Geechan review, #685). Placed after .sb-proxy-button-icon-only so equal specificity resolves
+   here by source order. */
+.sb-topbar-page-button,
+:root[data-sb-topbar-icons-only='true'] .sb-proxy-button-icon-only {
+    width: var(--sb-proxy-button-height);
+    min-width: var(--sb-proxy-button-height);
 }
 
 /* The rails do not scroll on their own. A nested scroll region ended mid-button and left an
@@ -1323,12 +1333,18 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
     align-items: center;
     flex-wrap: nowrap;
-    gap: var(--sb-proxy-button-gap);
+    gap: var(--sb-topbar-group-gap);
 }
 
+/* A cluster's anchor sits tight against its own page icons; each new anchor opens the wider seam
+   that separates the clusters, so Workspace, Customize and Characters read as three zones rather
+   than one strip. Derived from the group gap so it follows the user's top bar scale. */
+:root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-lead:not(:first-child) {
+    margin-inline-start: calc(var(--sb-topbar-cluster-gap) - var(--sb-topbar-group-gap));
+}
 
 /* Overflow state: the leading group scrolls and the trailing controls sit beside it, so Quick
-   Actions, Search, Home and Characters stay reachable however far the icons are scrolled.
+   Actions, Home and Characters stay reachable however far the icons are scrolled.
    The icons deliberately scroll beside the trailing group rather than under it. Scrolling them
    under would need the pinned group to paint over them, and its only theme-correct backing is
    the bar's own translucent background: repainting that double-darkens, and backdrop-filter
@@ -1385,79 +1401,22 @@ body:not(.movingUI) .drawer-content.maximized {
     display: flex;
 }
 
-:root[data-sb-topbar-icons-only='true'] .sb-topbar-pages-empty {
-    display: none;
-}
-
-/* Search only exists as a top bar button in icons-only mode; elsewhere it is reachable through
-   a Quick Access slot as before. */
-#sb-topbar-search-toggle {
-    display: none;
-}
-
-:root[data-sb-topbar-icons-only='true'] #sb-topbar-search-toggle {
-    display: inline-flex;
-}
-
 :root[data-sb-topbar-icons-only='true'] .sb-topbar-page-duplicate {
     display: none;
 }
 
 /* Once the label is squeezed out there is nothing left to centre on, so it yields its width to
-   the rails; the two clusters then meet in the middle on their own. */
+   the clusters, which keep hugging their own edge of the bar. The clusters are positioned by
+   meaning here, not by balance: Workspace stays hard left and Characters hard right at every
+   width, so neither group is ever pulled toward the centre. */
 :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-brand {
     display: none;
 }
 
-/* The side tracks are equal, so the brand label already sits on the true centre. Both groups
-   fill from the outer edge inward though, which leaves unequal slack next to the label and
-   reads as off-centre. Clustering each group's icons against the label evens that slack out,
-   while home/characters stay pinned to the bar edge. Phones merge the rails and hide the
-   label, so this is desktop only. */
-@media screen and (min-width: 769px) {
-    :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-left {
-        justify-content: flex-end;
-    }
-
-    :root[data-sb-topbar-icons-only='true'] .sb-topbar-group-right {
-        justify-content: flex-start;
-    }
-
-    :root[data-sb-topbar-icons-only='true'] #sb-home-toggle {
-        margin-left: auto;
-    }
-
-    /* With the label gone there is no centre column to balance against, so the equal side tracks
-       just strand the icons left of centre. Collapse the grid and centre the whole row as one
-       cluster instead. Must follow the rule above to win on source order. */
-    :root[data-sb-topbar-brand-cramped='true'] #sb-topbar-inner {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-
-    :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-group-left,
-    :root[data-sb-topbar-brand-cramped='true'] .sb-topbar-group-right {
-        justify-content: center;
-        flex: 0 1 auto;
-        min-width: 0;
-    }
-
-    :root[data-sb-topbar-brand-cramped='true'] #sb-home-toggle {
-        margin-left: 0;
-    }
-}
-
-
 /* #sb-home-toggle's id-level min-width outranks .sb-proxy-button-icon-only, so without this
    the home button keeps a label-width box with no label in it. */
 :root[data-sb-topbar-icons-only='true'] #sb-home-toggle {
-    min-width: var(--sb-chatbar-button-size);
-}
-
-.sb-shortcut-rows.is-disabled {
-    opacity: 0.5;
-    pointer-events: none;
+    min-width: var(--sb-proxy-button-height);
 }
 
 #top-settings-holder > .sb-drawer-host:not(.sb-embedded-drawer) {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1345,6 +1345,21 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none;
 }
 
+/* The side tracks are equal, so the brand label already sits on the true centre. Both groups
+   fill from the outer edge inward though, which leaves unequal slack next to the label and
+   reads as off-centre. Pushing each rail toward the label evens that slack out while the
+   anchors and home/characters stay pinned to the bar edges. Phones merge the rails and hide
+   the label, so this is desktop only. */
+@media screen and (min-width: 769px) {
+    :root[data-sb-topbar-icons-only='true'] #sb-topbar-pages {
+        margin-left: auto;
+    }
+
+    :root[data-sb-topbar-icons-only='true'] #sb-topbar-pages-right {
+        margin-right: auto;
+    }
+}
+
 
 /* #sb-home-toggle's id-level min-width outranks .sb-proxy-button-icon-only, so without this
    the home button keeps a label-width box with no label in it. */

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1362,6 +1362,13 @@ body:not(.movingUI) .drawer-content.maximized {
     display: inline-block;
 }
 
+/* The characters divider is the phone strip's boundary marker; on desktop the home divider
+   already carries Home|Characters, so showing both would double the rule. The phone sheet
+   re-enables it at equal specificity and wins on load order. */
+:root[data-sb-topbar-icons-only='true'] #sb-topbar-divider-characters {
+    display: none;
+}
+
 :root[data-sb-topbar-icons-only='true'] .sb-topbar-cluster-divider + .sb-topbar-cluster-lead {
     margin-inline-start: 0;
 }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1332,6 +1332,13 @@ body:not(.movingUI) .drawer-content.maximized {
        nothing was scrolled out of view, which reads as a disabled button rather than as a
        scroll hint. Clipping at the container edge is the honest affordance. */
     scroll-padding-inline: var(--sb-topbar-group-gap);
+    scroll-snap-type: x proximity;
+}
+
+/* Resting mid-icon makes the clipped remainder read as a random wider gap, so snap the rail
+   to whole icons whenever a swipe ends near one. */
+.sb-topbar-page-button {
+    scroll-snap-align: start;
 }
 
 .sb-topbar-pages::-webkit-scrollbar {

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725d">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725c" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725e">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725e" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725f">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725f" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725g">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725b">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725c">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725c" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260711e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260724a" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725e" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725f">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725f" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,8 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725a" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260712b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725c">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725c" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -793,6 +793,10 @@ const MOBILE_DOCUMENT_PAN_HORIZONTAL_SCROLL_SELECTOR = [
     '.ica--template-pill-row',
     '.sb-shell-nav',
     '.sb-settings-tabs-nav',
+    // The icons-only top bar is made entirely of buttons, so every swipe on it matches
+    // MOBILE_DOCUMENT_PAN_CONTROL_SELECTOR and the pan guard blocks it unless the rail is
+    // allowlisted here.
+    '.sb-topbar-group-left',
     '.sb-conversation-channel-tabs',
     '.sb-conversation-quick-actions',
     '.sb-character-create-bar',

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4989,7 +4989,8 @@ function getTopbarGroupOrder({ iconsOnly, mobile }) {
         right.push('sb-shortcut-slot6', 'sb-shortcut-slot5', 'sb-shortcut-right');
     }
 
-    right.push('sb-home-toggle');
+    // The home divider marks the Home|Characters boundary; phones keep it in every mode.
+    right.push('sb-home-toggle', 'sb-topbar-divider-home');
 
     if (iconsOnly && mobile) {
         // The characters pages ride the strip, so the divider marks where they start there;
@@ -4997,7 +4998,8 @@ function getTopbarGroupOrder({ iconsOnly, mobile }) {
         right.push(characters.leadId);
         left.push('sb-topbar-divider-characters', characters.railId);
     } else {
-        // On desktop the divider marks the Home|Characters boundary instead.
+        // The characters divider rides along hidden here; the home divider above carries the
+        // Home|Characters boundary on desktop.
         right.push('sb-topbar-divider-characters', characters.leadId, characters.railId);
     }
 
@@ -9500,10 +9502,11 @@ function buildTopBar() {
     const customizeRail = buildTopbarPageRail(customizeCluster.railId, customizeCluster.pages);
     const charactersRail = buildTopbarPageRail(charactersCluster.railId, charactersCluster.pages);
     const customizeDivider = createTopbarClusterDivider('sb-topbar-divider-customize');
+    const homeDivider = createTopbarClusterDivider('sb-topbar-divider-home');
     const charactersDivider = createTopbarClusterDivider('sb-topbar-divider-characters');
 
     leftGroup.append(mobileButton, leftButton, workspaceRail, customizeDivider, rightButton, customizeRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersDivider, charactersButton, charactersRail);
+    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, homeDivider, charactersDivider, charactersButton, charactersRail);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4990,12 +4990,16 @@ function getTopbarGroupOrder({ iconsOnly, mobile }) {
         right.push('sb-shortcut-slot6', 'sb-shortcut-slot5', 'sb-shortcut-right');
     }
 
-    right.push('sb-home-toggle', characters.leadId);
+    right.push('sb-home-toggle');
 
     if (iconsOnly && mobile) {
+        // The characters pages ride the strip, so the divider marks where they start there;
+        // the anchor stays pinned right beside Home.
+        right.push(characters.leadId);
         left.push('sb-topbar-divider-characters', characters.railId);
     } else {
-        right.push('sb-topbar-divider-characters', characters.railId);
+        // On desktop the divider marks the Home|Characters boundary instead.
+        right.push('sb-topbar-divider-characters', characters.leadId, characters.railId);
     }
 
     return { left, right };
@@ -5107,6 +5111,11 @@ function syncTopbarBrandFit() {
 
             // Rails are scroll containers, so their laid-out width understates what they hold.
             needed += child.classList.contains('sb-topbar-pages') ? child.scrollWidth : child.offsetWidth;
+            // The cluster seams and divider centring live in margins, which offsetWidth omits.
+            // Leaving them uncounted opens a dead band where the bar overflows its grid tracks
+            // -- the groups visibly overlap -- yet the scroll verdict never trips.
+            const childStyle = getComputedStyle(child);
+            needed += (Number.parseFloat(childStyle.marginInlineStart) || 0) + (Number.parseFloat(childStyle.marginInlineEnd) || 0);
             needed += gap;
         }
     }
@@ -9495,7 +9504,7 @@ function buildTopBar() {
     const charactersDivider = createTopbarClusterDivider('sb-topbar-divider-characters');
 
     leftGroup.append(mobileButton, leftButton, workspaceRail, customizeDivider, rightButton, customizeRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton, charactersDivider, charactersRail);
+    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersDivider, charactersButton, charactersRail);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -739,8 +739,10 @@ const SB_TOPBAR_PAGE_TARGETS = Object.freeze([
     { value: 'right:background', shellKey: 'right', tabId: 'background' },
     { value: 'right:server', shellKey: 'right', tabId: 'server' },
     { value: 'right:console-logs', shellKey: 'right', tabId: 'console-logs' },
-    { value: 'action:search', shellKey: '', tabId: '' },
 ]);
+
+// Search is not a page and never rides the rail: it has a fixed berth immediately left of Home.
+const SB_TOPBAR_SEARCH_TARGET = Object.freeze({ value: 'action:search', shellKey: '', tabId: '' });
 
 // SillyBunny: in icons-only mode the Workspace and Customize toggles are redundant, because every
 // page they lead to has its own icon on the rail, so they step aside. Home and Characters stay and
@@ -4941,11 +4943,87 @@ function syncTopbarIconsOnlyLayout() {
         document.getElementById(buttonId)?.classList.toggle('sb-proxy-button-icon-only', iconsOnly);
     }
 
+    if (iconsOnly) {
+        syncTopbarRightClusterOrder();
+    }
+
     syncTopbarRailSplit();
+    syncTopbarIconsOnlyDedupe();
     syncTopbarBrandFit();
 
     for (const railId of ['sb-topbar-pages', 'sb-topbar-pages-right']) {
         document.getElementById(railId)?.toggleAttribute('inert', !iconsOnly);
+    }
+}
+
+// SillyBunny: icons-only mode pins a fixed running order to the right end of the bar --
+// Quick Actions, then Search, then Home, then Characters -- so those controls never move around
+// as the rails change. Turning the mode off restores the recorded group order instead.
+function syncTopbarRightClusterOrder() {
+    const rightGroup = document.querySelector('#sb-topbar-inner > .sb-topbar-group-right');
+
+    if (!(rightGroup instanceof HTMLElement)) {
+        return;
+    }
+
+    const ordered = [
+        document.getElementById('sb-topbar-pages-right'),
+        ...SB_SHORTCUT_SLOTS.map(side => document.getElementById(getShortcutButtonId(side))),
+        document.getElementById('sb-topbar-search-toggle'),
+        document.getElementById('sb-home-toggle'),
+        document.getElementById('sb-character-toggle'),
+    ];
+
+    for (const element of ordered) {
+        if (element instanceof HTMLElement) {
+            rightGroup.appendChild(element);
+        }
+    }
+}
+
+// SillyBunny: a Quick Access slot pointed at a page that already has a rail icon renders the same
+// glyph twice. Keep the rightmost copy: the rail icon yields to the slot, and a slot pointed at
+// Search yields to the dedicated Search button, which sits further right still.
+function syncTopbarIconsOnlyDedupe() {
+    const railButtons = document.querySelectorAll('.sb-topbar-page-button[data-sb-topbar-page]');
+
+    if (!sbState.topbarIconsOnly) {
+        for (const button of railButtons) {
+            button.classList.remove('sb-topbar-page-duplicate');
+        }
+
+        for (const side of SB_SHORTCUT_SLOTS) {
+            const button = document.getElementById(getShortcutButtonId(side));
+
+            if (button instanceof HTMLElement && getShortcutTarget(side) !== 'none') {
+                button.style.removeProperty('display');
+            }
+        }
+
+        return;
+    }
+
+    const claimed = new Set();
+
+    for (const side of SB_SHORTCUT_SLOTS) {
+        const button = document.getElementById(getShortcutButtonId(side));
+        const target = getShortcutTarget(side);
+
+        if (!(button instanceof HTMLElement) || target === 'none') {
+            continue;
+        }
+
+        if (isSearchShortcutTarget(target)) {
+            button.style.setProperty('display', 'none', 'important');
+            continue;
+        }
+
+        button.style.removeProperty('display');
+        claimed.add(target);
+    }
+
+    for (const button of railButtons) {
+        button.classList.toggle('sb-topbar-page-duplicate', claimed.has(button.dataset.sbTopbarPage));
     }
 }
 
@@ -7674,7 +7752,7 @@ function isTopbarPageActive(page) {
 }
 
 function syncTopbarPageButtonStates() {
-    for (const page of SB_TOPBAR_PAGE_TARGETS) {
+    for (const page of [...SB_TOPBAR_PAGE_TARGETS, SB_TOPBAR_SEARCH_TARGET]) {
         const button = document.querySelector(`[data-sb-topbar-page="${CSS.escape(page.value)}"]`);
 
         if (!(button instanceof HTMLElement)) {
@@ -9390,8 +9468,11 @@ function buildTopBar() {
         attrs: { 'aria-hidden': 'true' },
     });
 
+    const searchButton = createTopbarPageButton(SB_TOPBAR_SEARCH_TARGET);
+    searchButton.id = 'sb-topbar-search-toggle';
+
     leftGroup.append(mobileButton, leftButton, rightButton, pageRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(customizeRail, desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton);
+    rightGroup.append(customizeRail, desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, searchButton, homeButton, charactersButton);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 
@@ -13138,7 +13219,9 @@ function updateShortcutButton(side) {
     button.title = `Quick access: ${config.label}`;
     button.setAttribute('aria-label', `Quick access: ${config.label}`);
     button.dataset.sbUniversalSearchTrigger = String(isSearchShortcutTarget(target));
+    syncTopbarIconsOnlyDedupe();
     syncShortcutButtonActiveStates();
+    queueTopbarBrandFit();
 }
 
 function syncShortcutButtonActiveStates() {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4873,14 +4873,14 @@ function createTopbarPageButton(page) {
     return button;
 }
 
-function buildTopbarPageRail() {
+function buildTopbarPageRail(railId, pages) {
     const rail = createElement('div', {
-        id: 'sb-topbar-pages',
+        id: railId,
         className: 'sb-topbar-pages',
         attrs: { role: 'group' },
     });
 
-    for (const page of SB_TOPBAR_PAGE_TARGETS) {
+    for (const page of pages) {
         rail.appendChild(createTopbarPageButton(page));
     }
 
@@ -4927,7 +4927,37 @@ function syncTopbarIconsOnlyLayout() {
         document.getElementById(buttonId)?.classList.toggle('sb-proxy-button-icon-only', iconsOnly);
     }
 
-    document.getElementById('sb-topbar-pages')?.toggleAttribute('inert', !iconsOnly);
+    syncTopbarRailSplit();
+
+    for (const railId of ['sb-topbar-pages', 'sb-topbar-pages-right']) {
+        document.getElementById(railId)?.toggleAttribute('inert', !iconsOnly);
+    }
+}
+
+// SillyBunny: the two-rail split exists to fill the gap either side of the brand label. Phones
+// hide that label and have no width to spare, so the Customize pages fold back into the single
+// left rail there — otherwise the right group's fixed buttons squeeze the left rail to nothing.
+function syncTopbarRailSplit() {
+    const leftRail = document.getElementById('sb-topbar-pages');
+    const rightRail = document.getElementById('sb-topbar-pages-right');
+
+    if (!(leftRail instanceof HTMLElement) || !(rightRail instanceof HTMLElement)) {
+        return;
+    }
+
+    const shouldMerge = isMobileViewport();
+    const customizeButtons = [...leftRail.children, ...rightRail.children]
+        .filter(button => button instanceof HTMLElement && button.dataset.sbTopbarPage?.startsWith('right:'));
+
+    for (const button of customizeButtons) {
+        if (shouldMerge) {
+            leftRail.appendChild(button);
+        } else {
+            rightRail.appendChild(button);
+        }
+    }
+
+    rightRail.classList.toggle('sb-topbar-pages-empty', shouldMerge);
 }
 
 function bindSearchShortcutPreFocus(button, targetGetter) {
@@ -8727,6 +8757,10 @@ function scheduleCharacterToggleGhostSync() {
     }
 }
 window.addEventListener('resize', syncCharacterToggleGhostRect, { passive: true });
+window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener('change', () => {
+    syncTopbarRailSplit();
+    queueTopbarPageStateSync();
+});
 
 document.addEventListener('click', (e) => {
     if (characterToggleDispatchGuard) return;
@@ -9269,16 +9303,20 @@ function buildTopBar() {
         <div id="sb-topbar-title" class="sb-brand-title" role="button" tabindex="0" aria-label="Tap to preview top bar label options">${SB_IDLE_BRAND_LABEL}</div>
     `;
 
-    // SillyBunny: the page rail takes the left Quick Access position when icons-only mode is on;
-    // the parked bay holds the Quick Access slots while it does.
-    const pageRail = buildTopbarPageRail();
+    // SillyBunny: the page rails take the Quick Access positions when icons-only mode is on, and
+    // the parked bay holds the Quick Access slots while they do. Customize pages ride the right
+    // rail so the space beside the brand label is used instead of scrolling one long strip.
+    const leftPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey !== 'right');
+    const rightPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey === 'right');
+    const pageRail = buildTopbarPageRail('sb-topbar-pages', leftPages);
+    const customizeRail = buildTopbarPageRail('sb-topbar-pages-right', rightPages);
     const parkedBay = createElement('div', {
         id: 'sb-topbar-parked',
         attrs: { 'aria-hidden': 'true' },
     });
 
     leftGroup.append(mobileButton, leftButton, rightButton, pageRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton);
+    rightGroup.append(customizeRail, desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -9252,6 +9252,9 @@ function observeProxyButton(buttonId, iconSelector) {
 
     const observer = new MutationObserver(() => {
         syncProxyButtonState(proxyButton, sourceIcon);
+        if (isTopbarIconsOnlyActive()) {
+            queueTopbarPageStateSync();
+        }
     });
 
     observer.observe(sourceIcon, { attributes: true, attributeFilter: ['class'] });

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -5003,6 +5003,12 @@ function syncTopbarIconsOnlyDedupe() {
         return;
     }
 
+    const railByTarget = new Map();
+
+    for (const button of railButtons) {
+        railByTarget.set(button.dataset.sbTopbarPage, button);
+    }
+
     const claimed = new Set();
 
     for (const side of SB_SHORTCUT_SLOTS) {
@@ -5014,6 +5020,13 @@ function syncTopbarIconsOnlyDedupe() {
         }
 
         if (isSearchShortcutTarget(target)) {
+            button.style.setProperty('display', 'none', 'important');
+            continue;
+        }
+
+        // Workspace pages keep their berth on the left, so the slot yields to the rail icon.
+        // Anything else -- Customize pages, character pages -- resolves to the right instead.
+        if (target.startsWith('left:') && railByTarget.has(target)) {
             button.style.setProperty('display', 'none', 'important');
             continue;
         }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4949,9 +4949,8 @@ function buildTopbarPageRail(railId, pages) {
     return rail;
 }
 
-// SillyBunny: a 1px rule between two clusters. While the brand label is visible it breaks the bar
-// in half and the seams carry the rest, so CSS keeps these hidden until the label is out of sight
-// (phones always; cramped desktop) and the seams alone would read as plain gaps.
+// SillyBunny: a 1px rule between two clusters, visible at every size while icons-only mode is on
+// so the boundaries read the same with or without the brand label between them.
 function createTopbarClusterDivider(id) {
     return createElement('span', {
         id,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -60,7 +60,11 @@ const SB_STORAGE_KEYS = Object.freeze({
     mobileQuickActionsLegacy: 'sb-mobile-quick-actions',
     settingsDrawerAutoClose: 'sb-settings-drawer-auto-close',
     compactMode: 'sb-compact-mode',
+    // Legacy single-key form of the per-device pair below; kept as a read-only seed so a bar
+    // configured before the split keeps its look on both devices.
     topbarIconsOnly: 'sb-topbar-icons-only',
+    desktopTopbarIconsOnly: 'sb-desktop-topbar-icons-only',
+    mobileTopbarIconsOnly: 'sb-mobile-topbar-icons-only',
     frontendIcon: 'sb-frontend-icon',
     characterEditorSubTab: 'sb-character-editor-sub-tab',
     bottomChatBarVisible: 'sb-bottom-chat-bar-visible',
@@ -775,6 +779,15 @@ const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
 ]);
 const SB_TOPBAR_BRAND_MIN_WIDTH = 60;
 
+// The per-device key wins; the legacy single key seeds both sides of the split so a bar
+// configured before it keeps its look everywhere until a device is set on its own.
+function readTopbarIconsOnlySetting(storageKey) {
+    return normalizeStoredBoolean(
+        safeGetItem(storageKey),
+        normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), false),
+    );
+}
+
 const sbState = {
     initialized: false,
     initRetryTimer: 0,
@@ -789,7 +802,10 @@ const sbState = {
     paperTextureEnabled: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.paperTextureEnabled), false),
     paperTextureOpacity: normalizePaperTextureOpacity(safeGetItem(SB_STORAGE_KEYS.paperTextureOpacity)),
     compactMode: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), false),
-    topbarIconsOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), false),
+    topbarIconsOnly: {
+        desktop: readTopbarIconsOnlySetting(SB_STORAGE_KEYS.desktopTopbarIconsOnly),
+        mobile: readTopbarIconsOnlySetting(SB_STORAGE_KEYS.mobileTopbarIconsOnly),
+    },
     topbarPages: {
         syncFrame: 0,
         fitFrame: 0,
@@ -1504,7 +1520,8 @@ function restorePersistedTopbarState() {
     sbState.chatbar.visible = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.chatbarVisible), sbState.chatbar.visible);
     sbState.chatbar.topbarOffset = normalizeTopbarOffset(safeGetItem(SB_STORAGE_KEYS.topbarOffset));
     sbState.compactMode = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), sbState.compactMode);
-    sbState.topbarIconsOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), sbState.topbarIconsOnly);
+    sbState.topbarIconsOnly.desktop = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopTopbarIconsOnly), sbState.topbarIconsOnly.desktop);
+    sbState.topbarIconsOnly.mobile = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileTopbarIconsOnly), sbState.topbarIconsOnly.mobile);
     sbState.bottomChatBar.visible = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.bottomChatBarVisible), sbState.bottomChatBar.visible);
     sbState.shellSizing.snapToChatWidth = normalizeStoredBoolean(
         safeGetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth),
@@ -1931,20 +1948,35 @@ function setCompactMode(enabled, { persist = true } = {}) {
     updateThemePickerUi();
 }
 
+// SillyBunny: the icons-only top bar is stored per device -- the Desktop Navigation copy governs
+// desktop viewports and the Mobile Navigation copy governs phones -- so turning the dense bar on
+// for a phone does not also restyle the desktop, and vice versa. Only the viewport's own setting
+// is ever in force.
+function isTopbarIconsOnlyActive() {
+    return isMobileViewport() ? sbState.topbarIconsOnly.mobile : sbState.topbarIconsOnly.desktop;
+}
+
 function applyTopbarIconsOnlyPreference() {
-    document.documentElement.dataset.sbTopbarIconsOnly = String(sbState.topbarIconsOnly);
+    document.documentElement.dataset.sbTopbarIconsOnly = String(isTopbarIconsOnlyActive());
     syncTopbarIconsOnlyLayout();
     queueTopbarPageStateSync();
     scheduleCharacterToggleGhostSync();
 }
 
-function setTopbarIconsOnly(enabled, { persist = true } = {}) {
+function setTopbarIconsOnly(mode, enabled, { persist = true } = {}) {
+    const isDesktop = mode === 'desktop';
     const nextEnabled = Boolean(enabled);
-    sbState.topbarIconsOnly = nextEnabled;
+
+    if (isDesktop) {
+        sbState.topbarIconsOnly.desktop = nextEnabled;
+    } else {
+        sbState.topbarIconsOnly.mobile = nextEnabled;
+    }
+
     applyTopbarIconsOnlyPreference();
 
     if (persist) {
-        safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly, String(nextEnabled));
+        safeSetItem(isDesktop ? SB_STORAGE_KEYS.desktopTopbarIconsOnly : SB_STORAGE_KEYS.mobileTopbarIconsOnly, String(nextEnabled));
     }
 
     updateThemePickerUi();
@@ -4917,6 +4949,17 @@ function buildTopbarPageRail(railId, pages) {
     return rail;
 }
 
+// SillyBunny: a 1px rule between two clusters. While the brand label is visible it breaks the bar
+// in half and the seams carry the rest, so CSS keeps these hidden until the label is out of sight
+// (phones always; cramped desktop) and the seams alone would read as plain gaps.
+function createTopbarClusterDivider(id) {
+    return createElement('span', {
+        id,
+        className: 'sb-topbar-cluster-divider',
+        attrs: { 'aria-hidden': 'true' },
+    });
+}
+
 // SillyBunny: the whole bar has one canonical child order per group per mode, and the layout is
 // applied by replaying that order rather than by moving individual buttons and remembering where
 // each came from. appendChild on a node the group already holds is a move, so replaying is
@@ -4929,10 +4972,12 @@ function buildTopbarPageRail(railId, pages) {
 function getTopbarGroupOrder({ iconsOnly, mobile }) {
     const [workspace, customize, characters] = SB_TOPBAR_CLUSTERS;
     const quickAccessIds = SB_SHORTCUT_SLOTS.map(side => getShortcutButtonId(side));
+    // The divider spans ride the order too; CSS decides when they are visible.
     const left = [
         'sb-hamburger',
         workspace.leadId,
         workspace.railId,
+        'sb-topbar-divider-customize',
         customize.leadId,
         customize.railId,
     ];
@@ -4948,9 +4993,9 @@ function getTopbarGroupOrder({ iconsOnly, mobile }) {
     right.push('sb-home-toggle', characters.leadId);
 
     if (iconsOnly && mobile) {
-        left.push(characters.railId);
+        left.push('sb-topbar-divider-characters', characters.railId);
     } else {
-        right.push(characters.railId);
+        right.push('sb-topbar-divider-characters', characters.railId);
     }
 
     return { left, right };
@@ -4965,7 +5010,7 @@ function syncTopbarGroupOrder() {
     }
 
     const order = getTopbarGroupOrder({
-        iconsOnly: sbState.topbarIconsOnly,
+        iconsOnly: isTopbarIconsOnlyActive(),
         mobile: isMobileViewport(),
     });
 
@@ -4981,7 +5026,7 @@ function syncTopbarGroupOrder() {
 }
 
 function syncTopbarIconsOnlyLayout() {
-    const iconsOnly = sbState.topbarIconsOnly;
+    const iconsOnly = isTopbarIconsOnlyActive();
 
     for (const buttonId of SB_TOPBAR_ANCHOR_IDS) {
         // Layer 2 anchors always stay on the bar; icons-only mode only drops their text labels.
@@ -5002,7 +5047,7 @@ function syncTopbarIconsOnlyLayout() {
 function syncTopbarIconsOnlyDedupe() {
     const clusterButtons = document.querySelectorAll('.sb-topbar-page-button[data-sb-topbar-page]');
 
-    if (!sbState.topbarIconsOnly) {
+    if (!isTopbarIconsOnlyActive()) {
         for (const button of clusterButtons) {
             button.classList.remove('sb-topbar-page-duplicate');
         }
@@ -5037,7 +5082,7 @@ function syncTopbarBrandFit() {
         return;
     }
 
-    if (!sbState.topbarIconsOnly) {
+    if (!isTopbarIconsOnlyActive()) {
         delete document.documentElement.dataset.sbTopbarBrandCramped;
         delete document.documentElement.dataset.sbTopbarScroll;
         return;
@@ -8891,9 +8936,10 @@ function scheduleCharacterToggleGhostSync() {
 window.addEventListener('resize', syncCharacterToggleGhostRect, { passive: true });
 window.addEventListener('resize', queueTopbarBrandFit, { passive: true });
 window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener('change', () => {
-    syncTopbarGroupOrder();
+    // Crossing the breakpoint can change which device's icons-only setting is in force, so the
+    // whole preference re-applies rather than just the group order.
+    applyTopbarIconsOnlyPreference();
     queueTopbarBrandFit();
-    queueTopbarPageStateSync();
 });
 
 document.addEventListener('click', (e) => {
@@ -9445,9 +9491,11 @@ function buildTopBar() {
     const workspaceRail = buildTopbarPageRail(workspaceCluster.railId, workspaceCluster.pages);
     const customizeRail = buildTopbarPageRail(customizeCluster.railId, customizeCluster.pages);
     const charactersRail = buildTopbarPageRail(charactersCluster.railId, charactersCluster.pages);
+    const customizeDivider = createTopbarClusterDivider('sb-topbar-divider-customize');
+    const charactersDivider = createTopbarClusterDivider('sb-topbar-divider-characters');
 
-    leftGroup.append(mobileButton, leftButton, workspaceRail, rightButton, customizeRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton, charactersRail);
+    leftGroup.append(mobileButton, leftButton, workspaceRail, customizeDivider, rightButton, customizeRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
+    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton, charactersDivider, charactersRail);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 
@@ -12947,17 +12995,17 @@ function createNavigationSettingsGroup(mode = 'mobile') {
         icon: 'fa-icons',
         onChange: input => isDesktop ? setDesktopNavIconOnly(input.checked) : setMobileNavIconOnly(input.checked),
     });
-    // SillyBunny: one global setting rendered in both the Desktop and Mobile Navigation groups,
-    // mirrored the way Compact Mode already is -- it belongs with navigation rather than nested
-    // inside the Quick Access Shortcuts drawer. Sitting next to the shell-tab toggle above also
-    // keeps the two similarly named options readable side by side.
+    // SillyBunny: stored per device -- this group's copy governs its own viewport only, exactly
+    // like the shell-tab toggle above it -- and it belongs with navigation rather than nested
+    // inside the Quick Access Shortcuts drawer. Sitting next to the shell-tab toggle also keeps
+    // the two similarly named options readable side by side.
     const topbarIconsOnlyChoice = createMobileNavChoice({
         id: `sb-${modePrefix}-topbar-icons-only-input`,
         type: 'checkbox',
         value: 'topbar-icons-only',
         label: 'Icons only top bar',
         icon: 'fa-grip',
-        onChange: input => setTopbarIconsOnly(input.checked),
+        onChange: input => setTopbarIconsOnly(modePrefix, input.checked),
     });
     topbarIconsOnlyChoice.querySelector('input')?.setAttribute('data-sb-topbar-icons-only-input', modePrefix);
     const showCustomizeChoice = createMobileNavChoice({
@@ -13614,16 +13662,19 @@ function updateThemePickerUi() {
         input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
     }
 
-    // One global setting with a checkbox in both the Desktop and Mobile Navigation groups, so
-    // flipping either one has to settle the other. Quick Access stays fully live in icons-only
-    // mode -- the slots are part of the right-hand cluster now, not superseded by it.
+    // Each Navigation group's checkbox reflects its own device's stored value, not the state in
+    // force on this viewport. Quick Access stays fully live in icons-only mode -- the slots are
+    // part of the right-hand cluster now, not superseded by it.
     for (const input of document.querySelectorAll('[data-sb-topbar-icons-only-input]')) {
         if (!(input instanceof HTMLInputElement)) {
             continue;
         }
 
-        input.checked = sbState.topbarIconsOnly;
-        input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', sbState.topbarIconsOnly);
+        const isChecked = input.getAttribute('data-sb-topbar-icons-only-input') === 'desktop'
+            ? sbState.topbarIconsOnly.desktop
+            : sbState.topbarIconsOnly.mobile;
+        input.checked = isChecked;
+        input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
     }
 
     if (desktopNavIconOnlyInput instanceof HTMLInputElement) {
@@ -17011,7 +17062,7 @@ function initAll() {
     syncDesktopShellSizing();
     buildTopBar();
     // Must follow buildTopBar(): it rearranges the buttons that call creates.
-    setTopbarIconsOnly(sbState.topbarIconsOnly, { persist: false });
+    applyTopbarIconsOnlyPreference();
     bindLandingPageObserver();
     buildBottomChatBar();
     // Refresh again after the current JS task — APP_READY may have already
@@ -17128,8 +17179,8 @@ function initAll() {
         setCompactMode(value) {
             setCompactMode(value);
         },
-        setTopbarIconsOnly(value) {
-            setTopbarIconsOnly(value);
+        setTopbarIconsOnly(mode, value) {
+            setTopbarIconsOnly(mode, value);
         },
         setDesktopShellSnapToChatWidth(value) {
             setDesktopShellSnapToChatWidth(value);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -60,6 +60,7 @@ const SB_STORAGE_KEYS = Object.freeze({
     mobileQuickActionsLegacy: 'sb-mobile-quick-actions',
     settingsDrawerAutoClose: 'sb-settings-drawer-auto-close',
     compactMode: 'sb-compact-mode',
+    topbarIconsOnly: 'sb-topbar-icons-only',
     frontendIcon: 'sb-frontend-icon',
     characterEditorSubTab: 'sb-character-editor-sub-tab',
     bottomChatBarVisible: 'sb-bottom-chat-bar-visible',
@@ -720,6 +721,45 @@ const SB_MOBILE_NAV_PAGE_TARGETS = Object.freeze([
     { value: 'right:console-logs', shellKey: 'right', tabId: 'console-logs', label: 'Console Logs', icon: 'fa-terminal' },
 ]);
 
+// SillyBunny: destinations rendered by the optional icons-only top bar rail. Labels and icons are
+// resolved from SB_SHELLS / SB_CHARACTER_PANEL_TABS at build time so the rail cannot drift when a
+// page is renamed. Kept separate from SB_SHORTCUT_TARGETS and SB_MOBILE_NAV_PAGE_TARGETS because
+// those two are persisted in user settings and carry pseudo-entries this list must not inherit.
+const SB_TOPBAR_PAGE_TARGETS = Object.freeze([
+    { value: 'left:presets', shellKey: 'left', tabId: 'presets' },
+    { value: 'left:api', shellKey: 'left', tabId: 'api' },
+    { value: 'left:sampling', shellKey: 'left', tabId: 'sampling' },
+    { value: 'left:advanced-formatting', shellKey: 'left', tabId: 'advanced-formatting' },
+    { value: 'left:agents', shellKey: 'left', tabId: 'agents' },
+    { value: 'characters:groups', shellKey: 'characters', tabId: 'groups' },
+    { value: 'characters:world-info', shellKey: 'characters', tabId: 'world-info' },
+    { value: 'characters:persona', shellKey: 'characters', tabId: 'persona' },
+    { value: 'right:settings', shellKey: 'right', tabId: 'settings' },
+    { value: 'right:extensions', shellKey: 'right', tabId: 'extensions' },
+    { value: 'right:background', shellKey: 'right', tabId: 'background' },
+    { value: 'right:server', shellKey: 'right', tabId: 'server' },
+    { value: 'right:console-logs', shellKey: 'right', tabId: 'console-logs' },
+    { value: 'action:search', shellKey: '', tabId: '' },
+]);
+
+// SillyBunny: only the configurable Quick Access slots step aside for the rail. The PRODUCT.md
+// layer 2 anchors (workspace, customize, title, home, characters) stay put and merely drop their
+// labels, so the icons-only mode remains an expansion of the quick-access region, not a rewrite.
+const SB_TOPBAR_PARKED_IDS = Object.freeze([
+    'sb-shortcut-left',
+    'sb-shortcut-right',
+    'sb-shortcut-slot3',
+    'sb-shortcut-slot4',
+    'sb-shortcut-slot5',
+    'sb-shortcut-slot6',
+]);
+const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
+    'sb-left-shell-toggle',
+    'sb-right-shell-toggle',
+    'sb-home-toggle',
+    'sb-character-toggle',
+]);
+
 const sbState = {
     initialized: false,
     initRetryTimer: 0,
@@ -734,6 +774,11 @@ const sbState = {
     paperTextureEnabled: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.paperTextureEnabled), false),
     paperTextureOpacity: normalizePaperTextureOpacity(safeGetItem(SB_STORAGE_KEYS.paperTextureOpacity)),
     compactMode: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), false),
+    topbarIconsOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), false),
+    topbarPages: {
+        syncFrame: 0,
+        groupOrder: new Map(),
+    },
     bottomBarScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.bottomBarScale)),
     desktopButtonScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.desktopButtonScale)),
     mobileButtonScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.mobileButtonScale)),
@@ -1443,6 +1488,7 @@ function restorePersistedTopbarState() {
     sbState.chatbar.visible = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.chatbarVisible), sbState.chatbar.visible);
     sbState.chatbar.topbarOffset = normalizeTopbarOffset(safeGetItem(SB_STORAGE_KEYS.topbarOffset));
     sbState.compactMode = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), sbState.compactMode);
+    sbState.topbarIconsOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), sbState.topbarIconsOnly);
     sbState.bottomChatBar.visible = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.bottomChatBarVisible), sbState.bottomChatBar.visible);
     sbState.shellSizing.snapToChatWidth = normalizeStoredBoolean(
         safeGetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth),
@@ -1866,6 +1912,25 @@ function setCompactMode(enabled, { persist = true } = {}) {
     }
 
     queueComposerControlPlacement();
+    updateThemePickerUi();
+}
+
+function applyTopbarIconsOnlyPreference() {
+    document.documentElement.dataset.sbTopbarIconsOnly = String(sbState.topbarIconsOnly);
+    syncTopbarIconsOnlyLayout();
+    queueTopbarPageStateSync();
+    scheduleCharacterToggleGhostSync();
+}
+
+function setTopbarIconsOnly(enabled, { persist = true } = {}) {
+    const nextEnabled = Boolean(enabled);
+    sbState.topbarIconsOnly = nextEnabled;
+    applyTopbarIconsOnlyPreference();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly, String(nextEnabled));
+    }
+
     updateThemePickerUi();
 }
 
@@ -4766,6 +4831,105 @@ function createProxyButton({ id, icon, label, title, className = '' }, onClick) 
     return button;
 }
 
+function getTopbarPageConfig(page) {
+    if (isSearchShortcutTarget(page.value)) {
+        return getShortcutConfig(page.value);
+    }
+
+    if (page.shellKey === 'characters') {
+        return getCharacterPanelTabConfig(page.tabId);
+    }
+
+    const shellConfig = getShellConfig(page.shellKey);
+
+    return [
+        shellConfig?.baseTab,
+        ...(shellConfig?.embeddedTabs ?? []),
+        ...(shellConfig?.customTabs ?? []),
+    ].find(tab => tab?.id === page.tabId) ?? null;
+}
+
+function createTopbarPageButton(page) {
+    const config = getTopbarPageConfig(page);
+    const label = config?.label ?? page.tabId;
+    const button = createProxyButton(
+        {
+            id: '',
+            icon: config?.icon ?? 'fa-circle-dot',
+            label,
+            title: label,
+            className: 'sb-proxy-button-icon-only sb-topbar-page-button',
+        },
+        () => activateShortcutTarget(page.value),
+    );
+
+    button.dataset.sbTopbarPage = page.value;
+
+    if (isSearchShortcutTarget(page.value)) {
+        button.dataset.sbUniversalSearchTrigger = 'true';
+        bindSearchShortcutPreFocus(button, () => page.value);
+    }
+
+    return button;
+}
+
+function buildTopbarPageRail() {
+    const rail = createElement('div', {
+        id: 'sb-topbar-pages',
+        className: 'sb-topbar-pages',
+        attrs: { role: 'group' },
+    });
+
+    for (const page of SB_TOPBAR_PAGE_TARGETS) {
+        rail.appendChild(createTopbarPageButton(page));
+    }
+
+    return rail;
+}
+
+// SillyBunny: remember each top bar group's full child order so parked Quick Access slots can be
+// restored by replaying that order. Restoring by remembered nextSibling is not safe here, because
+// neighbouring slots are parked too and moveElementBefore would insertBefore a detached reference.
+function rememberTopbarGroupOrder(...groups) {
+    sbState.topbarPages.groupOrder.clear();
+
+    for (const group of groups) {
+        if (group instanceof HTMLElement) {
+            sbState.topbarPages.groupOrder.set(group, [...group.children]);
+        }
+    }
+}
+
+function syncTopbarIconsOnlyLayout() {
+    const iconsOnly = sbState.topbarIconsOnly;
+    const parkedBay = document.getElementById('sb-topbar-parked');
+
+    if (parkedBay instanceof HTMLElement) {
+        if (iconsOnly) {
+            for (const buttonId of SB_TOPBAR_PARKED_IDS) {
+                const button = document.getElementById(buttonId);
+
+                if (button instanceof HTMLElement) {
+                    moveElementBefore(button, parkedBay, null);
+                }
+            }
+        } else {
+            for (const [group, children] of sbState.topbarPages.groupOrder) {
+                for (const child of children) {
+                    group.appendChild(child);
+                }
+            }
+        }
+    }
+
+    for (const buttonId of SB_TOPBAR_ANCHOR_IDS) {
+        // Layer 2 anchors are never parked; icons-only mode only drops their text labels.
+        document.getElementById(buttonId)?.classList.toggle('sb-proxy-button-icon-only', iconsOnly);
+    }
+
+    document.getElementById('sb-topbar-pages')?.toggleAttribute('inert', !iconsOnly);
+}
+
 function bindSearchShortcutPreFocus(button, targetGetter) {
     if (!(button instanceof HTMLElement) || typeof targetGetter !== 'function') {
         return;
@@ -7396,6 +7560,47 @@ function queueMobileModalStateSync() {
     });
 }
 
+function isTopbarPageActive(page) {
+    if (isSearchShortcutTarget(page.value)) {
+        return getUniversalSearchState().expanded;
+    }
+
+    return page.shellKey === 'characters'
+        ? isCharacterPanelTabOpen(page.tabId)
+        : isShellTabOpen(page.shellKey, page.tabId);
+}
+
+function syncTopbarPageButtonStates() {
+    for (const page of SB_TOPBAR_PAGE_TARGETS) {
+        const button = document.querySelector(`[data-sb-topbar-page="${CSS.escape(page.value)}"]`);
+
+        if (!(button instanceof HTMLElement)) {
+            continue;
+        }
+
+        const isActive = isTopbarPageActive(page);
+        button.classList.toggle('is-current', isActive);
+        button.setAttribute('aria-expanded', String(isActive));
+
+        if (isActive) {
+            button.setAttribute('aria-current', 'page');
+        } else {
+            button.removeAttribute('aria-current');
+        }
+    }
+}
+
+function queueTopbarPageStateSync() {
+    if (sbState.topbarPages.syncFrame) {
+        return;
+    }
+
+    sbState.topbarPages.syncFrame = window.requestAnimationFrame(() => {
+        sbState.topbarPages.syncFrame = 0;
+        syncTopbarPageButtonStates();
+    });
+}
+
 function forceDrawerState(drawerRootOrId, shouldOpen, drawerIconOrSelector = null) {
     const el = typeof drawerRootOrId === 'string'
         ? document.getElementById(drawerRootOrId)
@@ -7405,6 +7610,7 @@ function forceDrawerState(drawerRootOrId, shouldOpen, drawerIconOrSelector = nul
     el.classList.toggle('closedDrawer', !shouldOpen);
     syncDrawerIconState(drawerIconOrSelector, shouldOpen);
     queueMobileModalStateSync();
+    queueTopbarPageStateSync();
 }
 
 function isShellOpen(shellKey) {
@@ -8250,6 +8456,8 @@ function syncCharacterShellTabs(activeTab = null) {
         }
     });
 
+    queueTopbarPageStateSync();
+
     if (panel instanceof HTMLElement && panel.classList.contains('openDrawer')) {
         const tabConfig = getCharacterPanelTabConfig(normalizedTab);
         document.dispatchEvent(new CustomEvent('sb:shell-tab-activated', {
@@ -8405,6 +8613,7 @@ function syncCharacterDrawerStateFromDom({ force = false } = {}) {
 
     syncChatbarVisibilityState();
     queueMobileModalStateSync();
+    queueTopbarPageStateSync();
 }
 
 function bindCharacterDrawerStateObserver() {
@@ -9060,13 +9269,23 @@ function buildTopBar() {
         <div id="sb-topbar-title" class="sb-brand-title" role="button" tabindex="0" aria-label="Tap to preview top bar label options">${SB_IDLE_BRAND_LABEL}</div>
     `;
 
-    leftGroup.append(mobileButton, leftButton, rightButton, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
+    // SillyBunny: the page rail takes the left Quick Access position when icons-only mode is on;
+    // the parked bay holds the Quick Access slots while it does.
+    const pageRail = buildTopbarPageRail();
+    const parkedBay = createElement('div', {
+        id: 'sb-topbar-parked',
+        attrs: { 'aria-hidden': 'true' },
+    });
+
+    leftGroup.append(mobileButton, leftButton, rightButton, pageRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
     rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 
-    stack.append(primaryRow, searchRow);
+    stack.append(primaryRow, searchRow, parkedBay);
     topBar.append(stack, ...preservedExtensionChildren);
+
+    rememberTopbarGroupOrder(leftGroup, rightGroup);
 
     observeProxyButton('sb-left-shell-toggle', getShellConfig('left').hostIconSelector);
     observeProxyButton('sb-right-shell-toggle', getShellConfig('right').hostIconSelector);
@@ -9083,6 +9302,7 @@ function buildTopBar() {
     syncTopbarLayoutState();
     queueLandingPageStateSync();
     scheduleCharacterToggleGhostSync();
+    queueTopbarPageStateSync();
 }
 
 function hideHostToggles() {
@@ -12076,6 +12296,28 @@ function createTopbarLabelOption(mode, part) {
     return option;
 }
 
+function createTopbarIconsOnlySettingsGroup() {
+    const group = createElement('section', {
+        className: 'sb-theme-slider-group sb-topbar-icons-only-group',
+    });
+    const description = createElement('p', {
+        className: 'sb-theme-slider-caption',
+        text: 'Turn this toggle on to include every page icon on the top bar.',
+    });
+    const toggleChoice = createMobileNavChoice({
+        id: 'sb-topbar-icons-only-input',
+        type: 'checkbox',
+        value: 'topbar-icons-only',
+        label: 'Icons only top bar',
+        icon: 'fa-grip',
+        onChange: input => setTopbarIconsOnly(input.checked),
+    });
+
+    group.append(description, toggleChoice);
+
+    return group;
+}
+
 function createShortcutSettingsGroup() {
     const description = createElement('p', {
         className: 'sb-theme-slider-caption',
@@ -12127,7 +12369,7 @@ function createShortcutSettingsGroup() {
     return createThemeSettingsDrawer({
         id: 'sb-quick-access-shortcuts-drawer',
         title: 'Quick Access Shortcuts',
-        content: [description, rows],
+        content: [createTopbarIconsOnlySettingsGroup(), description, rows],
     });
 }
 
@@ -12800,6 +13042,8 @@ function syncShortcutButtonActiveStates() {
         const target = getShortcutTarget(side);
         setButtonPressed(button, isSearchShortcutTarget(target) && searchExpanded);
     }
+
+    queueTopbarPageStateSync();
 }
 
 function createTopbarLabelSettingsGroup() {
@@ -13066,6 +13310,7 @@ function updateThemePickerUi() {
     const mobileButtonScaleInput = document.getElementById('sb-mobile-button-scale-input');
     const mobileButtonScaleValue = document.getElementById('sb-mobile-button-scale-value');
     const customTextInput = document.getElementById('sb-topbar-custom-text-input');
+    const topbarIconsOnlyInput = document.getElementById('sb-topbar-icons-only-input');
     const desktopNavIconOnlyInput = document.getElementById('sb-desktop-nav-icon-only-input');
     const desktopNavShowCustomizeInput = document.getElementById('sb-desktop-nav-show-customize-input');
     const desktopNavShowQuickActionsInput = document.getElementById('sb-desktop-nav-show-quick-actions-input');
@@ -13202,6 +13447,13 @@ function updateThemePickerUi() {
         const isChecked = input.value === sbState.mobileNav.layout;
         input.checked = isChecked;
         input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
+    }
+
+    if (topbarIconsOnlyInput instanceof HTMLInputElement) {
+        topbarIconsOnlyInput.checked = sbState.topbarIconsOnly;
+        topbarIconsOnlyInput.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', sbState.topbarIconsOnly);
+        // The page rail supersedes the slots below, so surface them as inactive instead of live-but-ignored.
+        document.querySelector('.sb-shortcut-rows')?.classList.toggle('is-disabled', sbState.topbarIconsOnly);
     }
 
     if (desktopNavIconOnlyInput instanceof HTMLInputElement) {
@@ -13931,6 +14183,7 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
     }
 
     syncMobileShellRailActionState(shellKey, tabId);
+    queueTopbarPageStateSync();
 
     const activeTab = shellState.tabs.get(tabId);
     shellState.headerTitle.textContent = activeTab.label;
@@ -16587,6 +16840,8 @@ function initAll() {
     initChatAvatarVariables();
     syncDesktopShellSizing();
     buildTopBar();
+    // Must follow buildTopBar(): it rearranges the buttons that call creates.
+    setTopbarIconsOnly(sbState.topbarIconsOnly, { persist: false });
     bindLandingPageObserver();
     buildBottomChatBar();
     // Refresh again after the current JS task — APP_READY may have already
@@ -16702,6 +16957,9 @@ function initAll() {
         },
         setCompactMode(value) {
             setCompactMode(value);
+        },
+        setTopbarIconsOnly(value) {
+            setTopbarIconsOnly(value);
         },
         setDesktopShellSnapToChatWidth(value) {
             setDesktopShellSnapToChatWidth(value);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -7795,6 +7795,8 @@ function syncTopbarPageButtonStates() {
             button.removeAttribute('aria-current');
         }
     }
+
+    syncCharacterTopbarButtonState();
 }
 
 function queueTopbarPageStateSync() {
@@ -9205,10 +9207,37 @@ function syncProxyButtonState(proxyButton, sourceIcon) {
 
     const isOpen = sourceIcon.classList.contains('openIcon');
     const isPinned = sourceIcon.classList.contains('drawerPinnedOpen');
+    const isCharacterButton = proxyButton.id === 'sb-character-toggle';
+
+    if (isCharacterButton && isTopbarIconsOnlyActive()) {
+        const isCurrent = isCharacterPanelTabOpen(SB_CHARACTER_PANEL_DEFAULT_TAB);
+        proxyButton.classList.remove('is-open', 'is-pinned');
+        proxyButton.classList.toggle('is-current', isCurrent);
+        proxyButton.setAttribute('aria-expanded', String(isCurrent));
+
+        if (isCurrent) {
+            proxyButton.setAttribute('aria-current', 'page');
+        } else {
+            proxyButton.removeAttribute('aria-current');
+        }
+        return;
+    }
 
     proxyButton.classList.toggle('is-open', isOpen);
     proxyButton.classList.toggle('is-pinned', isPinned);
     proxyButton.setAttribute('aria-expanded', String(isOpen));
+
+    if (isCharacterButton) {
+        proxyButton.classList.remove('is-current');
+        proxyButton.removeAttribute('aria-current');
+    }
+}
+
+function syncCharacterTopbarButtonState() {
+    syncProxyButtonState(
+        document.getElementById('sb-character-toggle'),
+        document.querySelector('#rightNavDrawerIcon'),
+    );
 }
 
 function observeProxyButton(buttonId, iconSelector) {
@@ -9226,6 +9255,15 @@ function observeProxyButton(buttonId, iconSelector) {
     });
 
     observer.observe(sourceIcon, { attributes: true, attributeFilter: ['class'] });
+}
+
+function activateCharacterTopbarButton() {
+    if (isTopbarIconsOnlyActive()) {
+        openCharacterPanelTab(SB_CHARACTER_PANEL_DEFAULT_TAB);
+        return;
+    }
+
+    toggleCharacterPanel();
 }
 
 function wasShellJustOpened(shellKey) {
@@ -9433,7 +9471,7 @@ function buildTopBar() {
             label: 'Characters',
             title: 'Open character management',
         },
-        () => toggleCharacterPanel(),
+        activateCharacterTopbarButton,
     );
 
     const leftShortcutConfig = getShortcutConfig(getShortcutTarget('left'));

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4824,7 +4824,9 @@ function stopProxyPointerPropagation(element) {
 
     element.addEventListener('mousedown', stop);
     element.addEventListener('pointerdown', stop);
-    element.addEventListener('touchstart', stop);
+    // Passive: the handler never calls preventDefault, and a non-passive touchstart on every
+    // button pulls WebKit off its compositor scrolling path, which stalls the icons-only rail.
+    element.addEventListener('touchstart', stop, { passive: true });
 }
 
 function createProxyButton({ id, icon, label, title, className = '' }, onClick) {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -5039,10 +5039,14 @@ function syncTopbarBrandFit() {
         return;
     }
 
-    if (!sbState.topbarIconsOnly || isMobileViewport()) {
+    if (!sbState.topbarIconsOnly) {
         delete document.documentElement.dataset.sbTopbarBrandCramped;
+        delete document.documentElement.dataset.sbTopbarScroll;
         return;
     }
+
+    // Phones drop the label unconditionally, so only the overflow verdict matters there.
+    const labelCanFit = !isMobileViewport();
 
     if (isActuallyVisible(brand)) {
         sbState.topbarPages.brandWidth = Math.max(brand.scrollWidth, SB_TOPBAR_BRAND_MIN_WIDTH);
@@ -5065,12 +5069,21 @@ function syncTopbarBrandFit() {
     }
 
     const reservation = sbState.topbarPages.brandWidth || SB_TOPBAR_BRAND_MIN_WIDTH;
-    const cramped = needed + reservation + gap > inner.clientWidth;
+    const available = inner.clientWidth;
 
-    if (cramped) {
+    if (labelCanFit && needed + reservation + gap > available) {
         document.documentElement.dataset.sbTopbarBrandCramped = 'true';
     } else {
         delete document.documentElement.dataset.sbTopbarBrandCramped;
+    }
+
+    // Even with the label gone the icons can outrun the bar. Rather than let a rail clip a
+    // button to an unreadable sliver, hand the whole bar one scroll axis and pin the trailing
+    // controls so Quick Actions, Search, Home and Characters stay reachable at any width.
+    if (needed > available) {
+        document.documentElement.dataset.sbTopbarScroll = 'true';
+    } else {
+        delete document.documentElement.dataset.sbTopbarScroll;
     }
 }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -742,23 +742,18 @@ const SB_TOPBAR_PAGE_TARGETS = Object.freeze([
     { value: 'action:search', shellKey: '', tabId: '' },
 ]);
 
-// SillyBunny: only the configurable Quick Access slots step aside for the rail. The PRODUCT.md
-// layer 2 anchors (workspace, customize, title, home, characters) stay put and merely drop their
-// labels, so the icons-only mode remains an expansion of the quick-access region, not a rewrite.
+// SillyBunny: in icons-only mode the Workspace and Customize toggles are redundant, because every
+// page they lead to has its own icon on the rail, so they step aside. Home and Characters stay and
+// merely drop their labels. The Quick Access slots stay visible alongside the rails.
 const SB_TOPBAR_PARKED_IDS = Object.freeze([
-    'sb-shortcut-left',
-    'sb-shortcut-right',
-    'sb-shortcut-slot3',
-    'sb-shortcut-slot4',
-    'sb-shortcut-slot5',
-    'sb-shortcut-slot6',
-]);
-const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
     'sb-left-shell-toggle',
     'sb-right-shell-toggle',
+]);
+const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
     'sb-home-toggle',
     'sb-character-toggle',
 ]);
+const SB_TOPBAR_BRAND_MIN_WIDTH = 60;
 
 const sbState = {
     initialized: false,
@@ -777,6 +772,8 @@ const sbState = {
     topbarIconsOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), false),
     topbarPages: {
         syncFrame: 0,
+        fitFrame: 0,
+        brandWidth: 0,
         groupOrder: new Map(),
     },
     bottomBarScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.bottomBarScale)),
@@ -2306,6 +2303,22 @@ function prefersReducedMotion() {
 function getShellProxyButton(shellKey) {
     const shellConfig = getShellConfig(shellKey);
     const proxyButton = shellConfig?.proxyButtonId ? document.getElementById(shellConfig.proxyButtonId) : null;
+
+    if (proxyButton instanceof HTMLElement && isActuallyVisible(proxyButton)) {
+        return proxyButton;
+    }
+
+    // SillyBunny: icons-only mode parks the shell toggles, and focusing a display:none button
+    // silently drops focus to <body>. Fall back to the rail icon for the shell's active tab.
+    const activeTabId = getShellState(shellKey)?.activeTabId;
+    const pageButton = activeTabId
+        ? document.querySelector(`[data-sb-topbar-page="${CSS.escape(`${shellKey}:${activeTabId}`)}"]`)
+        : null;
+
+    if (pageButton instanceof HTMLElement && isActuallyVisible(pageButton)) {
+        return pageButton;
+    }
+
     return proxyButton instanceof HTMLElement ? proxyButton : null;
 }
 
@@ -4687,6 +4700,7 @@ function updateTopBarBrand() {
     title.classList.toggle('is-chat', isActiveChat);
     title.classList.toggle('is-previewing', Boolean(sbState.topbarLabel.cyclePart));
     brand.dataset.brandState = isActiveChat ? 'chat' : 'idle';
+    queueTopbarBrandFit();
 }
 
 function scheduleTopBarBrandBindingRetry(delay = 240) {
@@ -4928,10 +4942,69 @@ function syncTopbarIconsOnlyLayout() {
     }
 
     syncTopbarRailSplit();
+    syncTopbarBrandFit();
 
     for (const railId of ['sb-topbar-pages', 'sb-topbar-pages-right']) {
         document.getElementById(railId)?.toggleAttribute('inert', !iconsOnly);
     }
+}
+
+// SillyBunny: once the icon count outgrows the bar the brand label is the least useful thing on
+// it, so it yields its width to the rails. The decision is made from the rails' full content
+// width plus a fixed label reservation, never from the label's current state, so showing and
+// hiding it cannot feed back into itself and oscillate.
+function syncTopbarBrandFit() {
+    const inner = document.getElementById('sb-topbar-inner');
+    const brand = document.querySelector('.sb-topbar-brand');
+
+    if (!(inner instanceof HTMLElement) || !(brand instanceof HTMLElement)) {
+        return;
+    }
+
+    if (!sbState.topbarIconsOnly || isMobileViewport()) {
+        delete document.documentElement.dataset.sbTopbarBrandCramped;
+        return;
+    }
+
+    if (isActuallyVisible(brand)) {
+        sbState.topbarPages.brandWidth = Math.max(brand.scrollWidth, SB_TOPBAR_BRAND_MIN_WIDTH);
+    }
+
+    const groups = [...inner.querySelectorAll(':scope > .sb-topbar-group')];
+    const gap = Number.parseFloat(getComputedStyle(inner).columnGap) || 0;
+    let needed = 0;
+
+    for (const group of groups) {
+        for (const child of group.children) {
+            if (!(child instanceof HTMLElement) || !isActuallyVisible(child)) {
+                continue;
+            }
+
+            // Rails are scroll containers, so their laid-out width understates what they hold.
+            needed += child.classList.contains('sb-topbar-pages') ? child.scrollWidth : child.offsetWidth;
+            needed += gap;
+        }
+    }
+
+    const reservation = sbState.topbarPages.brandWidth || SB_TOPBAR_BRAND_MIN_WIDTH;
+    const cramped = needed + reservation + gap > inner.clientWidth;
+
+    if (cramped) {
+        document.documentElement.dataset.sbTopbarBrandCramped = 'true';
+    } else {
+        delete document.documentElement.dataset.sbTopbarBrandCramped;
+    }
+}
+
+function queueTopbarBrandFit() {
+    if (sbState.topbarPages.fitFrame) {
+        return;
+    }
+
+    sbState.topbarPages.fitFrame = window.requestAnimationFrame(() => {
+        sbState.topbarPages.fitFrame = 0;
+        syncTopbarBrandFit();
+    });
 }
 
 // SillyBunny: the two-rail split exists to fill the gap either side of the brand label. Phones
@@ -8757,8 +8830,10 @@ function scheduleCharacterToggleGhostSync() {
     }
 }
 window.addEventListener('resize', syncCharacterToggleGhostRect, { passive: true });
+window.addEventListener('resize', queueTopbarBrandFit, { passive: true });
 window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener('change', () => {
     syncTopbarRailSplit();
+    queueTopbarBrandFit();
     queueTopbarPageStateSync();
 });
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -726,14 +726,11 @@ const SB_MOBILE_NAV_PAGE_TARGETS = Object.freeze([
 ]);
 
 // SillyBunny: the optional icons-only top bar does not pool every page into one strip. It expands
-// each Layer 2 anchor in place into that anchor's own Layer 3 pages, so the bar keeps the skeleton
-// PRODUCT.md prescribes -- Workspace, Customize, title, quick access, Home, Characters -- and each
-// cluster stays readable as its own zone. Deliberately capped at three pages per cluster: the
-// anchor toggle still opens the full page list, so a page left off the bar is demoted a layer, not
-// removed. Labels and icons resolve from SB_SHELLS / SB_CHARACTER_PANEL_TABS at build time so a
-// cluster cannot drift when a page is renamed. Kept separate from SB_SHORTCUT_TARGETS and
-// SB_MOBILE_NAV_PAGE_TARGETS because those two are persisted in user settings and carry
-// pseudo-entries these lists must not inherit.
+// each section in place into that section's own pages, so the bar keeps the skeleton PRODUCT.md
+// prescribes and each cluster stays readable as its own zone. Labels and icons resolve from
+// SB_SHELLS / SB_CHARACTER_PANEL_TABS at build time so a cluster cannot drift when a page is
+// renamed. Kept separate from SB_SHORTCUT_TARGETS and SB_MOBILE_NAV_PAGE_TARGETS because those two
+// are persisted in user settings and carry pseudo-entries these lists must not inherit.
 const SB_TOPBAR_CLUSTERS = Object.freeze([
     {
         key: 'workspace',
@@ -743,6 +740,8 @@ const SB_TOPBAR_CLUSTERS = Object.freeze([
             { value: 'left:presets', shellKey: 'left', tabId: 'presets' },
             { value: 'left:api', shellKey: 'left', tabId: 'api' },
             { value: 'left:sampling', shellKey: 'left', tabId: 'sampling' },
+            { value: 'left:advanced-formatting', shellKey: 'left', tabId: 'advanced-formatting' },
+            { value: 'left:agents', shellKey: 'left', tabId: 'agents' },
         ]),
     },
     {
@@ -753,6 +752,8 @@ const SB_TOPBAR_CLUSTERS = Object.freeze([
             { value: 'right:settings', shellKey: 'right', tabId: 'settings' },
             { value: 'right:extensions', shellKey: 'right', tabId: 'extensions' },
             { value: 'right:background', shellKey: 'right', tabId: 'background' },
+            { value: 'right:server', shellKey: 'right', tabId: 'server' },
+            { value: 'right:console-logs', shellKey: 'right', tabId: 'console-logs' },
         ]),
     },
     {
@@ -761,19 +762,18 @@ const SB_TOPBAR_CLUSTERS = Object.freeze([
         railId: 'sb-topbar-cluster-characters',
         pages: Object.freeze([
             { value: 'characters:groups', shellKey: 'characters', tabId: 'groups' },
+            { value: 'characters:editor', shellKey: 'characters', tabId: 'editor' },
             { value: 'characters:world-info', shellKey: 'characters', tabId: 'world-info' },
             { value: 'characters:persona', shellKey: 'characters', tabId: 'persona' },
+            { value: 'characters:import', shellKey: 'characters', tabId: 'import' },
         ]),
     },
 ]);
 const SB_TOPBAR_PAGE_TARGETS = Object.freeze(SB_TOPBAR_CLUSTERS.flatMap(cluster => cluster.pages));
 
-// SillyBunny: every Layer 2 anchor stays on the bar in icons-only mode and only drops its text
-// label. Nothing is parked: the clusters are capped, so an anchor is the only way back to the pages
-// its cluster left off, and removing it would bury them.
+// SillyBunny: Home and Characters remain as Layer 2 anchors. Workspace and Customize are redundant
+// once all of their pages are shown, so CSS hides those two only while icons-only mode is active.
 const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
-    'sb-left-shell-toggle',
-    'sb-right-shell-toggle',
     'sb-home-toggle',
     'sb-character-toggle',
 ]);
@@ -2359,8 +2359,8 @@ function getShellProxyButton(shellKey) {
         return proxyButton;
     }
 
-    // SillyBunny: the Workspace toggle is display:none on phones, and focusing a display:none
-    // button silently drops focus to <body>. Fall back to the cluster icon for the active tab.
+    // SillyBunny: Workspace and Customize are hidden in icons-only mode, and Workspace is also
+    // hidden on phones. Fall back to the cluster icon so focus does not silently drop to <body>.
     const activeTabId = getShellState(shellKey)?.activeTabId;
     const pageButton = activeTabId
         ? document.querySelector(`[data-sb-topbar-page="${CSS.escape(`${shellKey}:${activeTabId}`)}"]`)
@@ -5034,7 +5034,6 @@ function syncTopbarIconsOnlyLayout() {
     const iconsOnly = isTopbarIconsOnlyActive();
 
     for (const buttonId of SB_TOPBAR_ANCHOR_IDS) {
-        // Layer 2 anchors always stay on the bar; icons-only mode only drops their text labels.
         document.getElementById(buttonId)?.classList.toggle('sb-proxy-button-icon-only', iconsOnly);
     }
 
@@ -5047,31 +5046,22 @@ function syncTopbarIconsOnlyLayout() {
     }
 }
 
-// SillyBunny: a Quick Access slot pointed at a page that also has a cluster icon renders the same
-// glyph twice. The slot wins, because the user picked it deliberately, and the cluster copy hides.
+// SillyBunny: the complete clusters keep their canonical positions. A Quick Access slot pointed at
+// one of those pages yields in icons-only mode; non-cluster actions such as Search remain visible.
 function syncTopbarIconsOnlyDedupe() {
     const clusterButtons = document.querySelectorAll('.sb-topbar-page-button[data-sb-topbar-page]');
-
-    if (!isTopbarIconsOnlyActive()) {
-        for (const button of clusterButtons) {
-            button.classList.remove('sb-topbar-page-duplicate');
-        }
-
-        return;
-    }
-
-    const claimed = new Set();
+    const claimedByClusters = new Set(Array.from(clusterButtons, button => button.dataset.sbTopbarPage));
+    const iconsOnly = isTopbarIconsOnlyActive();
 
     for (const side of SB_SHORTCUT_SLOTS) {
-        const target = getShortcutTarget(side);
+        const button = document.getElementById(getShortcutButtonId(side));
 
-        if (target !== 'none') {
-            claimed.add(target);
+        if (button instanceof HTMLElement) {
+            button.classList.toggle(
+                'sb-topbar-shortcut-duplicate',
+                iconsOnly && claimedByClusters.has(getShortcutTarget(side)),
+            );
         }
-    }
-
-    for (const button of clusterButtons) {
-        button.classList.toggle('sb-topbar-page-duplicate', claimed.has(button.dataset.sbTopbarPage));
     }
 }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -721,37 +721,55 @@ const SB_MOBILE_NAV_PAGE_TARGETS = Object.freeze([
     { value: 'right:console-logs', shellKey: 'right', tabId: 'console-logs', label: 'Console Logs', icon: 'fa-terminal' },
 ]);
 
-// SillyBunny: destinations rendered by the optional icons-only top bar rail. Labels and icons are
-// resolved from SB_SHELLS / SB_CHARACTER_PANEL_TABS at build time so the rail cannot drift when a
-// page is renamed. Kept separate from SB_SHORTCUT_TARGETS and SB_MOBILE_NAV_PAGE_TARGETS because
-// those two are persisted in user settings and carry pseudo-entries this list must not inherit.
-const SB_TOPBAR_PAGE_TARGETS = Object.freeze([
-    { value: 'left:presets', shellKey: 'left', tabId: 'presets' },
-    { value: 'left:api', shellKey: 'left', tabId: 'api' },
-    { value: 'left:sampling', shellKey: 'left', tabId: 'sampling' },
-    { value: 'left:advanced-formatting', shellKey: 'left', tabId: 'advanced-formatting' },
-    { value: 'left:agents', shellKey: 'left', tabId: 'agents' },
-    { value: 'characters:groups', shellKey: 'characters', tabId: 'groups' },
-    { value: 'characters:world-info', shellKey: 'characters', tabId: 'world-info' },
-    { value: 'characters:persona', shellKey: 'characters', tabId: 'persona' },
-    { value: 'right:settings', shellKey: 'right', tabId: 'settings' },
-    { value: 'right:extensions', shellKey: 'right', tabId: 'extensions' },
-    { value: 'right:background', shellKey: 'right', tabId: 'background' },
-    { value: 'right:server', shellKey: 'right', tabId: 'server' },
-    { value: 'right:console-logs', shellKey: 'right', tabId: 'console-logs' },
+// SillyBunny: the optional icons-only top bar does not pool every page into one strip. It expands
+// each Layer 2 anchor in place into that anchor's own Layer 3 pages, so the bar keeps the skeleton
+// PRODUCT.md prescribes -- Workspace, Customize, title, quick access, Home, Characters -- and each
+// cluster stays readable as its own zone. Deliberately capped at three pages per cluster: the
+// anchor toggle still opens the full page list, so a page left off the bar is demoted a layer, not
+// removed. Labels and icons resolve from SB_SHELLS / SB_CHARACTER_PANEL_TABS at build time so a
+// cluster cannot drift when a page is renamed. Kept separate from SB_SHORTCUT_TARGETS and
+// SB_MOBILE_NAV_PAGE_TARGETS because those two are persisted in user settings and carry
+// pseudo-entries these lists must not inherit.
+const SB_TOPBAR_CLUSTERS = Object.freeze([
+    {
+        key: 'workspace',
+        leadId: 'sb-left-shell-toggle',
+        railId: 'sb-topbar-cluster-workspace',
+        pages: Object.freeze([
+            { value: 'left:presets', shellKey: 'left', tabId: 'presets' },
+            { value: 'left:api', shellKey: 'left', tabId: 'api' },
+            { value: 'left:sampling', shellKey: 'left', tabId: 'sampling' },
+        ]),
+    },
+    {
+        key: 'customize',
+        leadId: 'sb-right-shell-toggle',
+        railId: 'sb-topbar-cluster-customize',
+        pages: Object.freeze([
+            { value: 'right:settings', shellKey: 'right', tabId: 'settings' },
+            { value: 'right:extensions', shellKey: 'right', tabId: 'extensions' },
+            { value: 'right:background', shellKey: 'right', tabId: 'background' },
+        ]),
+    },
+    {
+        key: 'characters',
+        leadId: 'sb-character-toggle',
+        railId: 'sb-topbar-cluster-characters',
+        pages: Object.freeze([
+            { value: 'characters:groups', shellKey: 'characters', tabId: 'groups' },
+            { value: 'characters:world-info', shellKey: 'characters', tabId: 'world-info' },
+            { value: 'characters:persona', shellKey: 'characters', tabId: 'persona' },
+        ]),
+    },
 ]);
+const SB_TOPBAR_PAGE_TARGETS = Object.freeze(SB_TOPBAR_CLUSTERS.flatMap(cluster => cluster.pages));
 
-// Search is not a page and never rides the rail: it has a fixed berth immediately left of Home.
-const SB_TOPBAR_SEARCH_TARGET = Object.freeze({ value: 'action:search', shellKey: '', tabId: '' });
-
-// SillyBunny: in icons-only mode the Workspace and Customize toggles are redundant, because every
-// page they lead to has its own icon on the rail, so they step aside. Home and Characters stay and
-// merely drop their labels. The Quick Access slots stay visible alongside the rails.
-const SB_TOPBAR_PARKED_IDS = Object.freeze([
+// SillyBunny: every Layer 2 anchor stays on the bar in icons-only mode and only drops its text
+// label. Nothing is parked: the clusters are capped, so an anchor is the only way back to the pages
+// its cluster left off, and removing it would bury them.
+const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
     'sb-left-shell-toggle',
     'sb-right-shell-toggle',
-]);
-const SB_TOPBAR_ANCHOR_IDS = Object.freeze([
     'sb-home-toggle',
     'sb-character-toggle',
 ]);
@@ -776,7 +794,6 @@ const sbState = {
         syncFrame: 0,
         fitFrame: 0,
         brandWidth: 0,
-        groupOrder: new Map(),
     },
     bottomBarScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.bottomBarScale)),
     desktopButtonScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.desktopButtonScale)),
@@ -2310,8 +2327,8 @@ function getShellProxyButton(shellKey) {
         return proxyButton;
     }
 
-    // SillyBunny: icons-only mode parks the shell toggles, and focusing a display:none button
-    // silently drops focus to <body>. Fall back to the rail icon for the shell's active tab.
+    // SillyBunny: the Workspace toggle is display:none on phones, and focusing a display:none
+    // button silently drops focus to <body>. Fall back to the cluster icon for the active tab.
     const activeTabId = getShellState(shellKey)?.activeTabId;
     const pageButton = activeTabId
         ? document.querySelector(`[data-sb-topbar-page="${CSS.escape(`${shellKey}:${activeTabId}`)}"]`)
@@ -4883,11 +4900,6 @@ function createTopbarPageButton(page) {
 
     button.dataset.sbTopbarPage = page.value;
 
-    if (isSearchShortcutTarget(page.value)) {
-        button.dataset.sbUniversalSearchTrigger = 'true';
-        bindSearchShortcutPreFocus(button, () => page.value);
-    }
-
     return button;
 }
 
@@ -4905,139 +4917,110 @@ function buildTopbarPageRail(railId, pages) {
     return rail;
 }
 
-// SillyBunny: remember each top bar group's full child order so parked Quick Access slots can be
-// restored by replaying that order. Restoring by remembered nextSibling is not safe here, because
-// neighbouring slots are parked too and moveElementBefore would insertBefore a detached reference.
-function rememberTopbarGroupOrder(...groups) {
-    sbState.topbarPages.groupOrder.clear();
+// SillyBunny: the whole bar has one canonical child order per group per mode, and the layout is
+// applied by replaying that order rather than by moving individual buttons and remembering where
+// each came from. appendChild on a node the group already holds is a move, so replaying is
+// idempotent and no remembered reference node can go stale.
+//
+// The cluster rails are display:none while the mode is off, so the "off" order renders exactly as
+// the bar always has: the button sequence never changes between modes, only labels and the added
+// clusters do. Phones fold the Characters pages into the single scrolling left strip, because the
+// right group is pinned at its natural width there and would otherwise starve the strip.
+function getTopbarGroupOrder({ iconsOnly, mobile }) {
+    const [workspace, customize, characters] = SB_TOPBAR_CLUSTERS;
+    const quickAccessIds = SB_SHORTCUT_SLOTS.map(side => getShortcutButtonId(side));
+    const left = [
+        'sb-hamburger',
+        workspace.leadId,
+        workspace.railId,
+        customize.leadId,
+        customize.railId,
+    ];
+    const right = [];
 
-    for (const group of groups) {
-        if (group instanceof HTMLElement) {
-            sbState.topbarPages.groupOrder.set(group, [...group.children]);
+    if (iconsOnly) {
+        right.push(...quickAccessIds);
+    } else {
+        left.push('sb-shortcut-left', 'sb-shortcut-slot3', 'sb-shortcut-slot4');
+        right.push('sb-shortcut-slot6', 'sb-shortcut-slot5', 'sb-shortcut-right');
+    }
+
+    right.push('sb-home-toggle', characters.leadId);
+
+    if (iconsOnly && mobile) {
+        left.push(characters.railId);
+    } else {
+        right.push(characters.railId);
+    }
+
+    return { left, right };
+}
+
+function syncTopbarGroupOrder() {
+    const leftGroup = document.querySelector('#sb-topbar-inner > .sb-topbar-group-left');
+    const rightGroup = document.querySelector('#sb-topbar-inner > .sb-topbar-group-right');
+
+    if (!(leftGroup instanceof HTMLElement) || !(rightGroup instanceof HTMLElement)) {
+        return;
+    }
+
+    const order = getTopbarGroupOrder({
+        iconsOnly: sbState.topbarIconsOnly,
+        mobile: isMobileViewport(),
+    });
+
+    for (const [group, ids] of [[leftGroup, order.left], [rightGroup, order.right]]) {
+        for (const id of ids) {
+            const element = document.getElementById(id);
+
+            if (element instanceof HTMLElement) {
+                group.appendChild(element);
+            }
         }
     }
 }
 
 function syncTopbarIconsOnlyLayout() {
     const iconsOnly = sbState.topbarIconsOnly;
-    const parkedBay = document.getElementById('sb-topbar-parked');
-
-    if (parkedBay instanceof HTMLElement) {
-        if (iconsOnly) {
-            for (const buttonId of SB_TOPBAR_PARKED_IDS) {
-                const button = document.getElementById(buttonId);
-
-                if (button instanceof HTMLElement) {
-                    moveElementBefore(button, parkedBay, null);
-                }
-            }
-        } else {
-            for (const [group, children] of sbState.topbarPages.groupOrder) {
-                for (const child of children) {
-                    group.appendChild(child);
-                }
-            }
-        }
-    }
 
     for (const buttonId of SB_TOPBAR_ANCHOR_IDS) {
-        // Layer 2 anchors are never parked; icons-only mode only drops their text labels.
+        // Layer 2 anchors always stay on the bar; icons-only mode only drops their text labels.
         document.getElementById(buttonId)?.classList.toggle('sb-proxy-button-icon-only', iconsOnly);
     }
 
-    if (iconsOnly) {
-        syncTopbarRightClusterOrder();
-    }
-
-    syncTopbarRailSplit();
+    syncTopbarGroupOrder();
     syncTopbarIconsOnlyDedupe();
     syncTopbarBrandFit();
 
-    for (const railId of ['sb-topbar-pages', 'sb-topbar-pages-right']) {
-        document.getElementById(railId)?.toggleAttribute('inert', !iconsOnly);
+    for (const cluster of SB_TOPBAR_CLUSTERS) {
+        document.getElementById(cluster.railId)?.toggleAttribute('inert', !iconsOnly);
     }
 }
 
-// SillyBunny: icons-only mode pins a fixed running order to the right end of the bar --
-// Quick Actions, then Search, then Home, then Characters -- so those controls never move around
-// as the rails change. Turning the mode off restores the recorded group order instead.
-function syncTopbarRightClusterOrder() {
-    const rightGroup = document.querySelector('#sb-topbar-inner > .sb-topbar-group-right');
-
-    if (!(rightGroup instanceof HTMLElement)) {
-        return;
-    }
-
-    const ordered = [
-        document.getElementById('sb-topbar-pages-right'),
-        ...SB_SHORTCUT_SLOTS.map(side => document.getElementById(getShortcutButtonId(side))),
-        document.getElementById('sb-topbar-search-toggle'),
-        document.getElementById('sb-home-toggle'),
-        document.getElementById('sb-character-toggle'),
-    ];
-
-    for (const element of ordered) {
-        if (element instanceof HTMLElement) {
-            rightGroup.appendChild(element);
-        }
-    }
-}
-
-// SillyBunny: a Quick Access slot pointed at a page that already has a rail icon renders the same
-// glyph twice. Keep the rightmost copy: the rail icon yields to the slot, and a slot pointed at
-// Search yields to the dedicated Search button, which sits further right still.
+// SillyBunny: a Quick Access slot pointed at a page that also has a cluster icon renders the same
+// glyph twice. The slot wins, because the user picked it deliberately, and the cluster copy hides.
 function syncTopbarIconsOnlyDedupe() {
-    const railButtons = document.querySelectorAll('.sb-topbar-page-button[data-sb-topbar-page]');
+    const clusterButtons = document.querySelectorAll('.sb-topbar-page-button[data-sb-topbar-page]');
 
     if (!sbState.topbarIconsOnly) {
-        for (const button of railButtons) {
+        for (const button of clusterButtons) {
             button.classList.remove('sb-topbar-page-duplicate');
         }
 
-        for (const side of SB_SHORTCUT_SLOTS) {
-            const button = document.getElementById(getShortcutButtonId(side));
-
-            if (button instanceof HTMLElement && getShortcutTarget(side) !== 'none') {
-                button.style.removeProperty('display');
-            }
-        }
-
         return;
-    }
-
-    const railByTarget = new Map();
-
-    for (const button of railButtons) {
-        railByTarget.set(button.dataset.sbTopbarPage, button);
     }
 
     const claimed = new Set();
 
     for (const side of SB_SHORTCUT_SLOTS) {
-        const button = document.getElementById(getShortcutButtonId(side));
         const target = getShortcutTarget(side);
 
-        if (!(button instanceof HTMLElement) || target === 'none') {
-            continue;
+        if (target !== 'none') {
+            claimed.add(target);
         }
-
-        if (isSearchShortcutTarget(target)) {
-            button.style.setProperty('display', 'none', 'important');
-            continue;
-        }
-
-        // Workspace pages keep their berth on the left, so the slot yields to the rail icon.
-        // Anything else -- Customize pages, character pages -- resolves to the right instead.
-        if (target.startsWith('left:') && railByTarget.has(target)) {
-            button.style.setProperty('display', 'none', 'important');
-            continue;
-        }
-
-        button.style.removeProperty('display');
-        claimed.add(target);
     }
 
-    for (const button of railButtons) {
+    for (const button of clusterButtons) {
         button.classList.toggle('sb-topbar-page-duplicate', claimed.has(button.dataset.sbTopbarPage));
     }
 }
@@ -5111,32 +5094,6 @@ function queueTopbarBrandFit() {
         sbState.topbarPages.fitFrame = 0;
         syncTopbarBrandFit();
     });
-}
-
-// SillyBunny: the two-rail split exists to fill the gap either side of the brand label. Phones
-// hide that label and have no width to spare, so the Customize pages fold back into the single
-// left rail there — otherwise the right group's fixed buttons squeeze the left rail to nothing.
-function syncTopbarRailSplit() {
-    const leftRail = document.getElementById('sb-topbar-pages');
-    const rightRail = document.getElementById('sb-topbar-pages-right');
-
-    if (!(leftRail instanceof HTMLElement) || !(rightRail instanceof HTMLElement)) {
-        return;
-    }
-
-    const shouldMerge = isMobileViewport();
-    const customizeButtons = [...leftRail.children, ...rightRail.children]
-        .filter(button => button instanceof HTMLElement && button.dataset.sbTopbarPage?.startsWith('right:'));
-
-    for (const button of customizeButtons) {
-        if (shouldMerge) {
-            leftRail.appendChild(button);
-        } else {
-            rightRail.appendChild(button);
-        }
-    }
-
-    rightRail.classList.toggle('sb-topbar-pages-empty', shouldMerge);
 }
 
 function bindSearchShortcutPreFocus(button, targetGetter) {
@@ -7770,17 +7727,13 @@ function queueMobileModalStateSync() {
 }
 
 function isTopbarPageActive(page) {
-    if (isSearchShortcutTarget(page.value)) {
-        return getUniversalSearchState().expanded;
-    }
-
     return page.shellKey === 'characters'
         ? isCharacterPanelTabOpen(page.tabId)
         : isShellTabOpen(page.shellKey, page.tabId);
 }
 
 function syncTopbarPageButtonStates() {
-    for (const page of [...SB_TOPBAR_PAGE_TARGETS, SB_TOPBAR_SEARCH_TARGET]) {
+    for (const page of SB_TOPBAR_PAGE_TARGETS) {
         const button = document.querySelector(`[data-sb-topbar-page="${CSS.escape(page.value)}"]`);
 
         if (!(button instanceof HTMLElement)) {
@@ -8938,7 +8891,7 @@ function scheduleCharacterToggleGhostSync() {
 window.addEventListener('resize', syncCharacterToggleGhostRect, { passive: true });
 window.addEventListener('resize', queueTopbarBrandFit, { passive: true });
 window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener('change', () => {
-    syncTopbarRailSplit();
+    syncTopbarGroupOrder();
     queueTopbarBrandFit();
     queueTopbarPageStateSync();
 });
@@ -9484,30 +9437,27 @@ function buildTopBar() {
         <div id="sb-topbar-title" class="sb-brand-title" role="button" tabindex="0" aria-label="Tap to preview top bar label options">${SB_IDLE_BRAND_LABEL}</div>
     `;
 
-    // SillyBunny: the page rails take the Quick Access positions when icons-only mode is on, and
-    // the parked bay holds the Quick Access slots while they do. Customize pages ride the right
-    // rail so the space beside the brand label is used instead of scrolling one long strip.
-    const leftPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey !== 'right');
-    const rightPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey === 'right');
-    const pageRail = buildTopbarPageRail('sb-topbar-pages', leftPages);
-    const customizeRail = buildTopbarPageRail('sb-topbar-pages-right', rightPages);
-    const parkedBay = createElement('div', {
-        id: 'sb-topbar-parked',
-        attrs: { 'aria-hidden': 'true' },
-    });
+    // SillyBunny: each cluster rail is built beside the Layer 2 anchor it belongs to and stays
+    // display:none until icons-only mode is on, so one static child order serves both modes and the
+    // button sequence never shifts when the option is toggled. Search gets no dedicated button: it
+    // rides a Quick Access slot here exactly as it does with the option off.
+    const [workspaceCluster, customizeCluster, charactersCluster] = SB_TOPBAR_CLUSTERS;
+    const workspaceRail = buildTopbarPageRail(workspaceCluster.railId, workspaceCluster.pages);
+    const customizeRail = buildTopbarPageRail(customizeCluster.railId, customizeCluster.pages);
+    const charactersRail = buildTopbarPageRail(charactersCluster.railId, charactersCluster.pages);
 
-    const searchButton = createTopbarPageButton(SB_TOPBAR_SEARCH_TARGET);
-    searchButton.id = 'sb-topbar-search-toggle';
-
-    leftGroup.append(mobileButton, leftButton, rightButton, pageRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(customizeRail, desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, searchButton, homeButton, charactersButton);
+    leftGroup.append(mobileButton, leftButton, workspaceRail, rightButton, customizeRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
+    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, charactersButton, charactersRail);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 
-    stack.append(primaryRow, searchRow, parkedBay);
+    stack.append(primaryRow, searchRow);
     topBar.append(stack, ...preservedExtensionChildren);
 
-    rememberTopbarGroupOrder(leftGroup, rightGroup);
+    // The anchor that leads a cluster carries the wider seam that separates the clusters.
+    for (const cluster of SB_TOPBAR_CLUSTERS) {
+        document.getElementById(cluster.leadId)?.classList.add('sb-topbar-cluster-lead');
+    }
 
     observeProxyButton('sb-left-shell-toggle', getShellConfig('left').hostIconSelector);
     observeProxyButton('sb-right-shell-toggle', getShellConfig('right').hostIconSelector);
@@ -12518,28 +12468,6 @@ function createTopbarLabelOption(mode, part) {
     return option;
 }
 
-function createTopbarIconsOnlySettingsGroup() {
-    const group = createElement('section', {
-        className: 'sb-theme-slider-group sb-topbar-icons-only-group',
-    });
-    const description = createElement('p', {
-        className: 'sb-theme-slider-caption',
-        text: 'Turn this toggle on to include every page icon on the top bar.',
-    });
-    const toggleChoice = createMobileNavChoice({
-        id: 'sb-topbar-icons-only-input',
-        type: 'checkbox',
-        value: 'topbar-icons-only',
-        label: 'Icons only top bar',
-        icon: 'fa-grip',
-        onChange: input => setTopbarIconsOnly(input.checked),
-    });
-
-    group.append(description, toggleChoice);
-
-    return group;
-}
-
 function createShortcutSettingsGroup() {
     const description = createElement('p', {
         className: 'sb-theme-slider-caption',
@@ -12591,7 +12519,7 @@ function createShortcutSettingsGroup() {
     return createThemeSettingsDrawer({
         id: 'sb-quick-access-shortcuts-drawer',
         title: 'Quick Access Shortcuts',
-        content: [createTopbarIconsOnlySettingsGroup(), description, rows],
+        content: [description, rows],
     });
 }
 
@@ -13019,6 +12947,19 @@ function createNavigationSettingsGroup(mode = 'mobile') {
         icon: 'fa-icons',
         onChange: input => isDesktop ? setDesktopNavIconOnly(input.checked) : setMobileNavIconOnly(input.checked),
     });
+    // SillyBunny: one global setting rendered in both the Desktop and Mobile Navigation groups,
+    // mirrored the way Compact Mode already is -- it belongs with navigation rather than nested
+    // inside the Quick Access Shortcuts drawer. Sitting next to the shell-tab toggle above also
+    // keeps the two similarly named options readable side by side.
+    const topbarIconsOnlyChoice = createMobileNavChoice({
+        id: `sb-${modePrefix}-topbar-icons-only-input`,
+        type: 'checkbox',
+        value: 'topbar-icons-only',
+        label: 'Icons only top bar',
+        icon: 'fa-grip',
+        onChange: input => setTopbarIconsOnly(input.checked),
+    });
+    topbarIconsOnlyChoice.querySelector('input')?.setAttribute('data-sb-topbar-icons-only-input', modePrefix);
     const showCustomizeChoice = createMobileNavChoice({
         id: `sb-${modePrefix}-nav-show-customize-input`,
         type: 'checkbox',
@@ -13100,6 +13041,7 @@ function createNavigationSettingsGroup(mode = 'mobile') {
         header,
         layoutGrid,
         iconOnlyChoice,
+        topbarIconsOnlyChoice,
         createMobileNavDivider(),
         showCustomizeChoice,
         showQuickActionsChoice,
@@ -13534,7 +13476,6 @@ function updateThemePickerUi() {
     const mobileButtonScaleInput = document.getElementById('sb-mobile-button-scale-input');
     const mobileButtonScaleValue = document.getElementById('sb-mobile-button-scale-value');
     const customTextInput = document.getElementById('sb-topbar-custom-text-input');
-    const topbarIconsOnlyInput = document.getElementById('sb-topbar-icons-only-input');
     const desktopNavIconOnlyInput = document.getElementById('sb-desktop-nav-icon-only-input');
     const desktopNavShowCustomizeInput = document.getElementById('sb-desktop-nav-show-customize-input');
     const desktopNavShowQuickActionsInput = document.getElementById('sb-desktop-nav-show-quick-actions-input');
@@ -13673,11 +13614,16 @@ function updateThemePickerUi() {
         input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
     }
 
-    if (topbarIconsOnlyInput instanceof HTMLInputElement) {
-        topbarIconsOnlyInput.checked = sbState.topbarIconsOnly;
-        topbarIconsOnlyInput.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', sbState.topbarIconsOnly);
-        // The page rail supersedes the slots below, so surface them as inactive instead of live-but-ignored.
-        document.querySelector('.sb-shortcut-rows')?.classList.toggle('is-disabled', sbState.topbarIconsOnly);
+    // One global setting with a checkbox in both the Desktop and Mobile Navigation groups, so
+    // flipping either one has to settle the other. Quick Access stays fully live in icons-only
+    // mode -- the slots are part of the right-hand cluster now, not superseded by it.
+    for (const input of document.querySelectorAll('[data-sb-topbar-icons-only-input]')) {
+        if (!(input instanceof HTMLInputElement)) {
+            continue;
+        }
+
+        input.checked = sbState.topbarIconsOnly;
+        input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', sbState.topbarIconsOnly);
     }
 
     if (desktopNavIconOnlyInput instanceof HTMLInputElement) {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -408,6 +408,7 @@ describe('mobile shell lifecycle wiring', () => {
             ['#left-nav-panel', '.ica--agent-tabs'],
             ['.popup', '.ica--template-pill-row'],
             ['#user-settings-block', '.sb-settings-tabs-nav'],
+            ['#top-bar', '.sb-topbar-group-left'],
             ['#sheld', '.sb-conversation-channel-tabs'],
             ['#sheld', '.sb-conversation-quick-actions'],
             ['#right-nav-panel', '.sb-character-create-bar'],

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -227,7 +227,7 @@ describe('icons only top bar', () => {
         const orderSource = getFunctionSource('getTopbarGroupOrder');
         expect(orderSource).toContain('if (iconsOnly && mobile) {');
         expect(orderSource).toContain('left.push(\'sb-topbar-divider-characters\', characters.railId);');
-        expect(orderSource).toContain('right.push(\'sb-topbar-divider-characters\', characters.railId);');
+        expect(orderSource).toContain('right.push(\'sb-topbar-divider-characters\', characters.leadId, characters.railId);');
         expect(getFunctionSource('syncTopbarGroupOrder')).toContain('mobile: isMobileViewport(),');
         expect(normalizedTabsSource).toContain('window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener(\'change\'');
     });
@@ -245,14 +245,14 @@ describe('icons only top bar', () => {
         expect(baseRule[0]).toContain('width: 1px;');
         expect(baseRule[0]).toContain('background: var(--sb-shell-border);');
 
-        // Desktop shows the Workspace|Customize rule only while the label is squeezed out; the
-        // characters divider stays desktop-hidden because that rail sits beside its own anchor.
-        expect(cssSource).toContain(':root[data-sb-topbar-brand-cramped=\'true\'] #sb-topbar-divider-customize {');
-        expect(cssSource).not.toMatch(/data-sb-topbar-brand-cramped='true'\] #sb-topbar-divider-characters/);
+        // While the label is squeezed out, cramped desktop shows both rules: Workspace|Customize
+        // on the left half and Home|Characters on the right, where the divider sits between Home
+        // and the characters anchor rather than between the anchor and its own rail.
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] \.sb-topbar-cluster-divider \{/);
 
-        // Phones show both; the divider takes over the seam so it sits centred in it.
+        // Phones show both too; the divider takes over the seam so it sits centred in it.
         expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{/);
-        expect(cssSource).toContain('#sb-topbar-divider-customize + .sb-topbar-cluster-lead');
+        expect(cssSource).toContain('.sb-topbar-cluster-divider + .sb-topbar-cluster-lead');
         expect(mobileCss).toContain('.sb-topbar-cluster-divider + .sb-topbar-cluster-lead');
     });
 
@@ -272,7 +272,12 @@ describe('icons only top bar', () => {
         // both groups toward the brand label, which is the opposite of the requested layout.
         expect(cssSource).not.toContain('.sb-topbar-group-left {\n        justify-content: flex-end;');
         expect(cssSource).not.toContain('#sb-home-toggle {\n        margin-left: auto;');
-        expect(cssSource).not.toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] #sb-topbar-inner/);
+
+        // display:none takes the hidden label out of the grid, and with only two items left the
+        // right group would auto-place into the centre `auto` column and drift toward the middle,
+        // under the left group's overflow. Cramped mode collapses the grid to two columns.
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] #sb-topbar-inner \{\n\s*grid-template-columns: minmax\(0, 1fr\) minmax\(0, auto\);\n\}/);
+        expect(cssSource).not.toMatch(/data-sb-topbar-brand-cramped='true'\][^{]*\{\n[^}]*justify-content: center/);
     });
 
     test('sizes the icons to match the labelled buttons beside them', () => {
@@ -407,6 +412,10 @@ describe('icons only top bar', () => {
         // overflow, which would hide it again, which would make it fit -- an oscillation.
         expect(fitSource).toContain('const reservation = sbState.topbarPages.brandWidth || SB_TOPBAR_BRAND_MIN_WIDTH;');
         expect(fitSource).toContain('child.classList.contains(\'sb-topbar-pages\') ? child.scrollWidth : child.offsetWidth');
+        // Cluster seams and divider centring live in margins, which offsetWidth omits; leaving
+        // them uncounted opens a dead band where the bar overflows but scroll never trips.
+        expect(fitSource).toContain('childStyle.marginInlineStart');
+        expect(fitSource).toContain('childStyle.marginInlineEnd');
         expect(fitSource).toContain('dataset.sbTopbarBrandCramped');
         expect(cssSource).toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] \.sb-topbar-brand \{\n\s*display: none;\n\}/);
     });

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -219,6 +219,18 @@ describe('icons only top bar', () => {
         expect(pageStateSource).toContain('syncCharacterTopbarButtonState();');
     });
 
+    test('clears shell page highlights after native drawer dismissal only in icons-only mode', () => {
+        const activeStateSource = getFunctionSource('isTopbarPageActive');
+        expect(activeStateSource).toContain('isShellTabOpen(page.shellKey, page.tabId)');
+
+        const shellTabSource = getFunctionSource('isShellTabOpen');
+        expect(shellTabSource).toContain('isShellOpen(shellKey) && shellState.activeTabId === tabId');
+
+        const observerSource = getFunctionSource('observeProxyButton');
+        expect(observerSource).toContain('syncProxyButtonState(proxyButton, sourceIcon);');
+        expect(observerSource).toContain('if (isTopbarIconsOnlyActive()) {\n            queueTopbarPageStateSync();\n        }');
+    });
+
     test('keeps one canonical button order per mode instead of moving buttons around', () => {
         // appendChild on a node the group already holds is a move, so replaying a whole order is
         // idempotent -- unlike remembering a nextSibling that a neighbouring move can detach.

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -221,6 +221,17 @@ describe('icons only top bar', () => {
         expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-pages-empty');
     });
 
+    test('evens out the whitespace either side of the brand label', () => {
+        // Equal side tracks already put the label on the true centre, but both groups fill from
+        // the outer edge inward, so the leftover slack lands next to the label unequally and
+        // reads as off-centre. Auto margins pull each rail up against the label instead.
+        expect(cssSource).toMatch(/#sb-topbar-pages \{\n\s*margin-left: auto;\n\s*\}/);
+        expect(cssSource).toMatch(/#sb-topbar-pages-right \{\n\s*margin-right: auto;\n\s*\}/);
+        // Desktop only: phones merge the rails and hide the label entirely.
+        const desktopBlocks = cssSource.match(/@media screen and \(min-width: 769px\) \{[\s\S]*?\n\}/g) ?? [];
+        expect(desktopBlocks.some(block => block.includes('margin-left: auto'))).toBe(true);
+    });
+
     test('scrolls the rail rather than wrapping it', () => {
         const railRuleMatch = cssSource.match(/\.sb-topbar-pages\s*\{[^}]*\}/);
         expect(railRuleMatch).not.toBeNull();

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -307,9 +307,10 @@ describe('icons only top bar', () => {
         expect(railRuleMatch[0]).not.toContain('overflow-x: auto;');
         expect(railRuleMatch[0]).toContain('flex-wrap: nowrap;');
 
-        const innerRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-inner \{[^}]*\}/);
-        expect(innerRule).not.toBeNull();
-        expect(innerRule[0]).toContain('overflow-x: auto;');
+        // The leading group is the scroll region; the inner row itself only lays it out.
+        const scrollerRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] \.sb-topbar-group-left \{[^}]*\}/);
+        expect(scrollerRule).not.toBeNull();
+        expect(scrollerRule[0]).toContain('overflow-x: auto;');
         // The min-content floor propagates through every flex/grid ancestor, and the shrink
         // permission must be gated on icons-only rather than on the scroll state: the overflow
         // verdict is read from the inner's client width, so gating it on the verdict lets the
@@ -318,25 +319,40 @@ describe('icons only top bar', () => {
         expect(cssSource).not.toMatch(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-stack/);
         // Snapping pulled the bar past the hamburger on load, because the first snap point is
         // the leading page icon rather than the start of the bar.
-        expect(innerRule[0]).not.toContain('scroll-snap-type');
+        expect(scrollerRule[0]).not.toContain('scroll-snap-type');
         expect(cssSource).not.toContain('scroll-snap-align: start;');
     });
 
-    test('pins the trailing controls while the icons scroll under them', () => {
-        const stickyRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] \.sb-topbar-group-right \{[^}]*\}/);
-        expect(stickyRule).not.toBeNull();
-        expect(stickyRule[0]).toContain('position: sticky;');
-        expect(stickyRule[0]).toContain('right: 0;');
-        // Repainting the bar's themeable translucent background would double-darken and seam,
-        // so the pinned cluster reuses the bar's own glass treatment instead.
-        expect(stickyRule[0]).toContain('backdrop-filter: blur(12px);');
-        expect(stickyRule[0]).toContain('-webkit-backdrop-filter: blur(12px);');
-        expect(stickyRule[0]).toContain('-webkit-mask-image:');
+    test('keeps the trailing controls beside the scrolling icons, never under them', () => {
+        // Scrolling icons *under* the trailing group needs that group to paint over them, and
+        // its only theme-correct backing is the bar's own translucent background: repainting
+        // double-darkens, and backdrop-filter silently no-ops in WebKit when nested inside
+        // another backdrop-filtered element, leaving icons showing through it on iOS.
+        const rightRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] \.sb-topbar-group-right \{[^}]*\}/);
+        expect(rightRule).not.toBeNull();
+        expect(rightRule[0]).toContain('flex: 0 0 auto;');
+        expect(rightRule[0]).not.toContain('position: sticky;');
+        expect(rightRule[0]).not.toContain('backdrop-filter');
+
+        const leftRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] \.sb-topbar-group-left \{[^}]*\}/);
+        expect(leftRule).not.toBeNull();
+        expect(leftRule[0]).toContain('overflow-x: auto;');
+        // WebKit needs the pan axis declared or the buttons swallow the gesture.
+        expect(leftRule[0]).toContain('touch-action: pan-x;');
+        expect(leftRule[0]).toContain('-webkit-overflow-scrolling: touch;');
 
         // Only engages when the icons actually outrun the bar.
         const fitSource = getFunctionSource('syncTopbarBrandFit');
         expect(fitSource).toContain('if (needed > available) {');
         expect(fitSource).toContain('dataset.sbTopbarScroll');
+    });
+
+    test('keeps button touch handlers off WebKit slow path', () => {
+        // A non-passive touchstart on every button pulls WebKit off compositor scrolling, which
+        // stalls the rail on iOS. The handler only stops propagation, so passive is correct.
+        const propagationSource = getFunctionSource('stopProxyPointerPropagation');
+        expect(propagationSource).toContain('element.addEventListener(\'touchstart\', stop, { passive: true });');
+        expect(propagationSource).toContain('stopPropagation');
     });
 
     test('keeps one spacing rhythm across the mobile bar', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -140,31 +140,15 @@ describe('icons only top bar', () => {
             .toEqual(['workspace', 'customize', 'characters']);
     });
 
-    test('caps every cluster at three pages', () => {
-        // Clutter reduction is the point: an anchor still opens the full page list, so a page left
-        // off the bar is demoted a layer rather than removed.
-        const clusterBlocks = getClustersSource().split('pages: Object.freeze([').slice(1);
+    test('keeps every requested page in its canonical cluster order', () => {
+        const pageLists = [...getClustersSource().matchAll(/pages: Object\.freeze\(\[([\s\S]*?)\]\),/g)]
+            .map(match => [...match[1].matchAll(/value: '([^']+)'/g)].map(pageMatch => pageMatch[1]));
 
-        expect(clusterBlocks).toHaveLength(3);
-
-        for (const block of clusterBlocks) {
-            const pages = [...block.matchAll(/value: '([^']+)'/g)].map(match => match[1]);
-            expect(pages.length).toBeGreaterThan(0);
-            expect(pages.length).toBeLessThanOrEqual(3);
-        }
-    });
-
-    test('leaves the maintenance and duplicate pages off the bar', () => {
-        const clustersSource = getClustersSource();
-
-        // Server and Console Logs are troubleshooting surfaces, Formatting is rarely touched
-        // mid-write, and Agents is the documented default for the left Quick Access slot.
-        for (const target of ['right:server', 'right:console-logs', 'left:advanced-formatting', 'left:agents']) {
-            expect(clustersSource).not.toContain(`'${target}'`);
-        }
-
-        // Still selectable as a Quick Access target, so nothing became unreachable.
-        expect(normalizedTabsSource).toContain('{ value: \'left:agents\', label: \'Agents\', icon: \'fa-robot\' }');
+        expect(pageLists).toEqual([
+            ['left:presets', 'left:api', 'left:sampling', 'left:advanced-formatting', 'left:agents'],
+            ['right:settings', 'right:extensions', 'right:background', 'right:server', 'right:console-logs'],
+            ['characters:groups', 'characters:editor', 'characters:world-info', 'characters:persona', 'characters:import'],
+        ]);
     });
 
     test('derives page labels and icons from the shell registries', () => {
@@ -176,17 +160,35 @@ describe('icons only top bar', () => {
         const configSource = getFunctionSource('getTopbarPageConfig');
         expect(configSource).toContain('getCharacterPanelTabConfig(page.tabId)');
         expect(configSource).toContain('getShellConfig(page.shellKey)');
+
+        const buttonSource = getFunctionSource('createTopbarPageButton');
+        expect(buttonSource).toContain('icon: config?.icon ?? \'fa-circle-dot\'');
+        for (const entry of [
+            "id: 'advanced-formatting',",
+            "id: 'agents',",
+            "id: 'server',",
+            "id: 'console-logs',",
+            "{ id: 'editor', label: 'Editor', icon: 'fa-pen-to-square' }",
+            "{ id: 'import', label: 'Import', icon: 'fa-file-import' }",
+        ]) {
+            expect(normalizedTabsSource).toContain(entry);
+        }
     });
 
-    test('keeps every layer 2 anchor on the bar and parks nothing', () => {
-        // Trimming the clusters makes the section toggles the only way back to the pages they left
-        // off, so removing them would bury those pages rather than hide them.
+    test('hides only redundant section anchors in icons-only mode and parks nothing', () => {
         const anchorMatch = normalizedTabsSource.match(/const SB_TOPBAR_ANCHOR_IDS = Object\.freeze\(\[[\s\S]*?\]\);/);
         expect(anchorMatch).not.toBeNull();
 
-        for (const anchorId of ['sb-left-shell-toggle', 'sb-right-shell-toggle', 'sb-home-toggle', 'sb-character-toggle']) {
+        for (const anchorId of ['sb-home-toggle', 'sb-character-toggle']) {
             expect(anchorMatch[0]).toContain(`'${anchorId}'`);
         }
+        for (const anchorId of ['sb-left-shell-toggle', 'sb-right-shell-toggle']) {
+            expect(anchorMatch[0]).not.toContain(`'${anchorId}'`);
+        }
+
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] #sb-left-shell-toggle,\n:root\[data-sb-topbar-icons-only='true'\] #sb-right-shell-toggle \{\n\s*display: none;\n\}/);
+        expect(mobileCss).toContain(":root:not([data-sb-topbar-icons-only='true'])[data-sb-mobile-nav-layout='horizontal'][data-sb-mobile-nav-customize='shown'] #sb-left-shell-toggle");
+        expect(mobileCss).toContain(":root:not([data-sb-topbar-icons-only='true'])[data-sb-mobile-nav-replacement='shown'] #sb-left-shell-toggle");
 
         // The parking machinery and its bay are gone entirely.
         expect(normalizedTabsSource).not.toContain('SB_TOPBAR_PARKED_IDS');
@@ -267,7 +269,7 @@ describe('icons only top bar', () => {
         // "The different buttons should be placed in more appropriate locations, with some
         // appropriate gaps." Derived from the group gap so it tracks the user's top bar scale.
         expect(cssSource).toContain('--sb-topbar-cluster-gap: calc(var(--sb-topbar-group-gap) * 2.5);');
-        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-lead:not\(:first-child\) \{\n\s*margin-inline-start: calc\(var\(--sb-topbar-cluster-gap\) - var\(--sb-topbar-group-gap\)\);\n\}/);
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-cluster-workspace \{\n\s*margin-inline-start: calc\(var\(--sb-topbar-cluster-gap\) - var\(--sb-topbar-group-gap\)\);\n\}/);
 
         const railRule = cssSource.match(/\.sb-topbar-pages \{[^}]*\}/);
         expect(railRule[0]).toContain('gap: var(--sb-topbar-group-gap);');
@@ -312,18 +314,17 @@ describe('icons only top bar', () => {
         expect(getFunctionSource('syncTopbarPageButtonStates')).toContain('for (const page of SB_TOPBAR_PAGE_TARGETS) {');
     });
 
-    test('keeps quick access fully live rather than superseded', () => {
-        // The slots are part of the right-hand cluster now, so greying the settings rows out would
-        // be wrong -- and no slot is hidden to make room for a cluster icon.
+    test('keeps canonical cluster icons and yields duplicate quick access slots', () => {
         expect(normalizedTabsSource).not.toContain('.sb-shortcut-rows\')?.classList.toggle(\'is-disabled\'');
         expect(cssSource).not.toContain('.sb-shortcut-rows.is-disabled');
 
         const dedupeSource = getFunctionSource('syncTopbarIconsOnlyDedupe');
         expect(dedupeSource).not.toContain('style.setProperty(\'display\'');
-        // A slot pointed at a page that also has a cluster icon wins; the cluster copy hides.
-        expect(dedupeSource).toContain('claimed.add(target);');
-        expect(dedupeSource).toContain('button.classList.toggle(\'sb-topbar-page-duplicate\', claimed.has(button.dataset.sbTopbarPage));');
-        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-page-duplicate');
+        expect(dedupeSource).toContain('const claimedByClusters = new Set(Array.from(clusterButtons, button => button.dataset.sbTopbarPage));');
+        expect(dedupeSource).toContain("'sb-topbar-shortcut-duplicate'");
+        expect(dedupeSource).toContain('iconsOnly && claimedByClusters.has(getShortcutTarget(side))');
+        expect(normalizedTabsSource).not.toContain('sb-topbar-page-duplicate');
+        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-shortcut-duplicate');
     });
 
     test('re-runs dedupe and refit when a quick action is reassigned', () => {
@@ -397,8 +398,8 @@ describe('icons only top bar', () => {
     });
 
     test('keeps shell focus on a visible control', () => {
-        // The Workspace toggle is display:none on phones, and focusing a display:none button
-        // silently drops focus to <body> when a shell closes.
+        // Workspace and Customize are hidden in icons-only mode, so shell-close focus falls back
+        // to the active page icon instead of silently dropping to <body>.
         const proxySource = getFunctionSource('getShellProxyButton');
         expect(proxySource).toContain('isActuallyVisible(proxyButton)');
         expect(proxySource).toContain('data-sb-topbar-page');

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -226,10 +226,34 @@ describe('icons only top bar', () => {
         // four-icon right cluster would starve the scrolling left strip.
         const orderSource = getFunctionSource('getTopbarGroupOrder');
         expect(orderSource).toContain('if (iconsOnly && mobile) {');
-        expect(orderSource).toContain('left.push(characters.railId);');
-        expect(orderSource).toContain('right.push(characters.railId);');
+        expect(orderSource).toContain('left.push(\'sb-topbar-divider-characters\', characters.railId);');
+        expect(orderSource).toContain('right.push(\'sb-topbar-divider-characters\', characters.railId);');
         expect(getFunctionSource('syncTopbarGroupOrder')).toContain('mobile: isMobileViewport(),');
         expect(normalizedTabsSource).toContain('window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener(\'change\'');
+    });
+
+    test('marks the cluster boundaries once the brand label is out of sight', () => {
+        // With the centre label hidden the seams alone are a few px of gap between identical
+        // squares, so a 1px theme-derived rule marks where one cluster ends and the next begins.
+        expect(normalizedTabsSource).toContain('function createTopbarClusterDivider(');
+        const orderSource = getFunctionSource('getTopbarGroupOrder');
+        expect(orderSource).toContain('\'sb-topbar-divider-customize\',');
+
+        const baseRule = cssSource.match(/\.sb-topbar-cluster-divider \{[^}]*\}/);
+        expect(baseRule).not.toBeNull();
+        expect(baseRule[0]).toContain('display: none;');
+        expect(baseRule[0]).toContain('width: 1px;');
+        expect(baseRule[0]).toContain('background: var(--sb-shell-border);');
+
+        // Desktop shows the Workspace|Customize rule only while the label is squeezed out; the
+        // characters divider stays desktop-hidden because that rail sits beside its own anchor.
+        expect(cssSource).toContain(':root[data-sb-topbar-brand-cramped=\'true\'] #sb-topbar-divider-customize {');
+        expect(cssSource).not.toMatch(/data-sb-topbar-brand-cramped='true'\] #sb-topbar-divider-characters/);
+
+        // Phones show both; the divider takes over the seam so it sits centred in it.
+        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{/);
+        expect(cssSource).toContain('#sb-topbar-divider-customize + .sb-topbar-cluster-lead');
+        expect(mobileCss).toContain('.sb-topbar-cluster-divider + .sb-topbar-cluster-lead');
     });
 
     test('separates the clusters with a wider seam than the icons inside one', () => {
@@ -304,7 +328,7 @@ describe('icons only top bar', () => {
         const navSource = getFunctionSource('createNavigationSettingsGroup');
         expect(navSource).toContain('id: `sb-${modePrefix}-topbar-icons-only-input`');
         expect(navSource).toContain('label: \'Icons only top bar\',');
-        expect(navSource).toContain('onChange: input => setTopbarIconsOnly(input.checked),');
+        expect(navSource).toContain('onChange: input => setTopbarIconsOnly(modePrefix, input.checked),');
         expect(navSource).toContain('topbarIconsOnlyChoice,');
 
         expect(normalizedTabsSource).not.toContain('createTopbarIconsOnlySettingsGroup');
@@ -313,12 +337,35 @@ describe('icons only top bar', () => {
         expect(normalizedTabsSource.match(/'Icons only top bar'/g)).toHaveLength(1);
     });
 
-    test('mirrors the one global setting across both navigation groups', () => {
-        // Same shape as Compact Mode: one storage key, two checkboxes, one sync loop.
+    test('stores the toggle per device and applies only the active viewport\'s setting', () => {
+        // The Desktop Navigation copy governs desktop viewports and the Mobile Navigation copy
+        // governs phones, so turning the dense bar on for a phone does not restyle the desktop.
+        expect(normalizedTabsSource).toContain('desktopTopbarIconsOnly: \'sb-desktop-topbar-icons-only\',');
+        expect(normalizedTabsSource).toContain('mobileTopbarIconsOnly: \'sb-mobile-topbar-icons-only\',');
+        expect(normalizedTabsSource).toContain('function setTopbarIconsOnly(mode, enabled');
+
+        const activeSource = getFunctionSource('isTopbarIconsOnlyActive');
+        expect(activeSource).toContain('isMobileViewport() ? sbState.topbarIconsOnly.mobile : sbState.topbarIconsOnly.desktop');
+
+        // Crossing the breakpoint can change which device's setting is in force.
+        const listenerMatch = normalizedTabsSource.match(/window\.matchMedia\(SB_MOBILE_MEDIA_QUERY\)\.addEventListener\('change', \(\) => \{[\s\S]*?\}\);/);
+        expect(listenerMatch).not.toBeNull();
+        expect(listenerMatch[0]).toContain('applyTopbarIconsOnlyPreference();');
+
+        // Each checkbox reflects its own device's stored value, not the viewport-active state.
         expect(normalizedTabsSource).toContain('topbarIconsOnlyChoice.querySelector(\'input\')?.setAttribute(\'data-sb-topbar-icons-only-input\', modePrefix);');
-        expect(normalizedTabsSource).toContain('for (const input of document.querySelectorAll(\'[data-sb-topbar-icons-only-input]\')) {');
-        expect(normalizedTabsSource).toContain('input.checked = sbState.topbarIconsOnly;');
+        expect(normalizedTabsSource).toContain('input.getAttribute(\'data-sb-topbar-icons-only-input\') === \'desktop\'');
         expect(normalizedTabsSource).not.toContain('getElementById(\'sb-topbar-icons-only-input\')');
+    });
+
+    test('seeds both devices from the legacy single toggle key', () => {
+        // The pre-split key stays as a read-only fallback so an existing choice carries over.
+        const readSource = getFunctionSource('readTopbarIconsOnlySetting');
+        expect(readSource).toContain('safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly)');
+        expect(normalizedTabsSource).toContain('desktop: readTopbarIconsOnlySetting(SB_STORAGE_KEYS.desktopTopbarIconsOnly),');
+        expect(normalizedTabsSource).toContain('mobile: readTopbarIconsOnlySetting(SB_STORAGE_KEYS.mobileTopbarIconsOnly),');
+        // But nothing writes it back; the per-device keys are the live state.
+        expect(normalizedTabsSource).not.toContain('safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly,');
     });
 
     test('stays distinct from the shell tab icon-only setting', () => {
@@ -331,9 +378,10 @@ describe('icons only top bar', () => {
     test('toggles state without rebuilding the top bar', () => {
         const setterSource = getFunctionSource('setTopbarIconsOnly');
         expect(setterSource).not.toContain('buildTopBar(');
-        expect(setterSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly, String(nextEnabled));');
+        expect(setterSource).toContain('isDesktop ? SB_STORAGE_KEYS.desktopTopbarIconsOnly : SB_STORAGE_KEYS.mobileTopbarIconsOnly');
         expect(setterSource).toContain('updateThemePickerUi();');
-        expect(normalizedTabsSource).toContain('sbState.topbarIconsOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), sbState.topbarIconsOnly);');
+        expect(normalizedTabsSource).toContain('sbState.topbarIconsOnly.desktop = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopTopbarIconsOnly), sbState.topbarIconsOnly.desktop);');
+        expect(normalizedTabsSource).toContain('sbState.topbarIconsOnly.mobile = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileTopbarIconsOnly), sbState.topbarIconsOnly.mobile);');
     });
 
     test('keeps shell focus on a visible control', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -304,8 +304,9 @@ describe('icons only top bar', () => {
         const railRule = railRuleMatch[0];
         expect(railRule).toContain('overflow-x: auto;');
         expect(railRule).toContain('flex-wrap: nowrap;');
-        expect(railRule).toContain('mask-image:');
-        expect(railRule).toContain('-webkit-mask-image:');
+        // An edge-fade mask dimmed the boundary icon even with nothing scrolled out of view,
+        // making a live button look disabled. Clipping at the container edge instead.
+        expect(railRule).not.toContain('mask-image:');
         expect(cssSource).toContain('#sb-topbar-parked {\n    display: none;\n}');
         expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] #sb-home-toggle');
     });

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -307,6 +307,19 @@ describe('icons only top bar', () => {
         // An edge-fade mask dimmed the boundary icon even with nothing scrolled out of view,
         // making a live button look disabled. Clipping at the container edge instead.
         expect(railRule).not.toContain('mask-image:');
+        // Resting mid-icon reads as a random wider gap, so swipes settle on whole icons.
+        expect(railRule).toContain('scroll-snap-type: x proximity;');
+        expect(cssSource).toMatch(/\.sb-topbar-page-button \{\n\s*scroll-snap-align: start;\n\}/);
+    });
+
+    test('keeps one spacing rhythm across the mobile bar', () => {
+        // Rail gap, group gap and the grid seam were three different widths between identical
+        // square buttons, which is what read as awkward spacing. All key off the group gap.
+        const mobileCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-pages \{\n\s*gap: var\(--sb-topbar-group-gap\);\n\s*\}/);
+        const innerRule = mobileCss.match(/:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-inner \{[^}]*\}/);
+        expect(innerRule).not.toBeNull();
+        expect(innerRule[0]).toContain('gap: var(--sb-topbar-group-gap);');
         expect(cssSource).toContain('#sb-topbar-parked {\n    display: none;\n}');
         expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] #sb-home-toggle');
     });

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -297,19 +297,41 @@ describe('icons only top bar', () => {
         expect(getFunctionSource('syncTopbarPageButtonStates')).toContain('[...SB_TOPBAR_PAGE_TARGETS, SB_TOPBAR_SEARCH_TARGET]');
     });
 
-    test('scrolls the rail rather than wrapping it', () => {
+    test('scrolls the whole bar rather than each rail', () => {
+        // A nested scroll region ended mid-button and left an unreadable sliver of an icon at
+        // its boundary, so the rails no longer scroll on their own.
         const railRuleMatch = cssSource.match(/\.sb-topbar-pages\s*\{[^}]*\}/);
         expect(railRuleMatch).not.toBeNull();
+        expect(railRuleMatch[0]).not.toContain('overflow-x: auto;');
+        expect(railRuleMatch[0]).toContain('flex-wrap: nowrap;');
 
-        const railRule = railRuleMatch[0];
-        expect(railRule).toContain('overflow-x: auto;');
-        expect(railRule).toContain('flex-wrap: nowrap;');
-        // An edge-fade mask dimmed the boundary icon even with nothing scrolled out of view,
-        // making a live button look disabled. Clipping at the container edge instead.
-        expect(railRule).not.toContain('mask-image:');
-        // Resting mid-icon reads as a random wider gap, so swipes settle on whole icons.
-        expect(railRule).toContain('scroll-snap-type: x proximity;');
-        expect(cssSource).toMatch(/\.sb-topbar-page-button \{\n\s*scroll-snap-align: start;\n\}/);
+        const innerRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-inner \{[^}]*\}/);
+        expect(innerRule).not.toBeNull();
+        expect(innerRule[0]).toContain('overflow-x: auto;');
+        // The min-content floor propagates through every flex/grid ancestor.
+        expect(innerRule[0]).toContain('min-width: 0;');
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-stack,\n:root\[data-sb-topbar-scroll='true'\] #sb-topbar-primary \{\n\s*min-width: 0;\n\}/);
+        // Snapping pulled the bar past the hamburger on load, because the first snap point is
+        // the leading page icon rather than the start of the bar.
+        expect(innerRule[0]).not.toContain('scroll-snap-type');
+        expect(cssSource).not.toContain('scroll-snap-align: start;');
+    });
+
+    test('pins the trailing controls while the icons scroll under them', () => {
+        const stickyRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] \.sb-topbar-group-right \{[^}]*\}/);
+        expect(stickyRule).not.toBeNull();
+        expect(stickyRule[0]).toContain('position: sticky;');
+        expect(stickyRule[0]).toContain('right: 0;');
+        // Repainting the bar's themeable translucent background would double-darken and seam,
+        // so the pinned cluster reuses the bar's own glass treatment instead.
+        expect(stickyRule[0]).toContain('backdrop-filter: blur(12px);');
+        expect(stickyRule[0]).toContain('-webkit-backdrop-filter: blur(12px);');
+        expect(stickyRule[0]).toContain('-webkit-mask-image:');
+
+        // Only engages when the icons actually outrun the bar.
+        const fitSource = getFunctionSource('syncTopbarBrandFit');
+        expect(fitSource).toContain('if (needed > available) {');
+        expect(fitSource).toContain('dataset.sbTopbarScroll');
     });
 
     test('keeps one spacing rhythm across the mobile bar', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -197,6 +197,28 @@ describe('icons only top bar', () => {
         expect(cssSource).not.toContain('#sb-topbar-parked');
     });
 
+    test('uses the Characters anchor as a page only in icons-only mode', () => {
+        const activationSource = getFunctionSource('activateCharacterTopbarButton');
+        expect(activationSource).toContain('if (isTopbarIconsOnlyActive())');
+        expect(activationSource).toContain('openCharacterPanelTab(SB_CHARACTER_PANEL_DEFAULT_TAB);');
+        expect(activationSource).toContain('toggleCharacterPanel();');
+
+        const buildSource = getFunctionSource('buildTopBar');
+        expect(buildSource).toContain('activateCharacterTopbarButton,');
+
+        const proxyStateSource = getFunctionSource('syncProxyButtonState');
+        expect(proxyStateSource).toContain("const isCharacterButton = proxyButton.id === 'sb-character-toggle';");
+        expect(proxyStateSource).toContain('if (isCharacterButton && isTopbarIconsOnlyActive())');
+        expect(proxyStateSource).toContain('isCharacterPanelTabOpen(SB_CHARACTER_PANEL_DEFAULT_TAB)');
+        expect(proxyStateSource).toContain("proxyButton.classList.remove('is-open', 'is-pinned');");
+        expect(proxyStateSource).toContain("proxyButton.classList.toggle('is-current', isCurrent);");
+        expect(proxyStateSource).toContain("proxyButton.classList.toggle('is-open', isOpen);");
+        expect(proxyStateSource).toContain("proxyButton.classList.toggle('is-pinned', isPinned);");
+
+        const pageStateSource = getFunctionSource('syncTopbarPageButtonStates');
+        expect(pageStateSource).toContain('syncCharacterTopbarButtonState();');
+    });
+
     test('keeps one canonical button order per mode instead of moving buttons around', () => {
         // appendChild on a node the group already holds is a move, so replaying a whole order is
         // idempotent -- unlike remembering a nextSibling that a neighbouring move can detach.

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -119,3 +119,97 @@ describe('topbar label tap cycle', () => {
         expect(titleRule).not.toContain('margin: -2px -6px;');
     });
 });
+
+describe('icons only top bar', () => {
+    test('parks only the configurable quick access slots', () => {
+        // PRODUCT.md layer 2 prescribes the top bar anchors; icons-only mode may drop their
+        // labels but must never remove them from the bar.
+        const parkedMatch = normalizedTabsSource.match(/const SB_TOPBAR_PARKED_IDS = Object\.freeze\(\[[\s\S]*?\]\);/);
+        expect(parkedMatch).not.toBeNull();
+
+        const parkedSource = parkedMatch[0];
+        for (const slotId of ['sb-shortcut-left', 'sb-shortcut-right', 'sb-shortcut-slot3', 'sb-shortcut-slot4', 'sb-shortcut-slot5', 'sb-shortcut-slot6']) {
+            expect(parkedSource).toContain(`'${slotId}'`);
+        }
+
+        for (const anchorId of ['sb-hamburger', 'sb-left-shell-toggle', 'sb-right-shell-toggle', 'sb-home-toggle', 'sb-character-toggle']) {
+            expect(parkedSource).not.toContain(`'${anchorId}'`);
+        }
+    });
+
+    test('keeps the centre brand label on every viewport', () => {
+        const mobileCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+        expect(cssSource).not.toMatch(/data-sb-topbar-icons-only='true'\]\s+\.sb-topbar-brand/);
+        expect(mobileCss).not.toMatch(/data-sb-topbar-icons-only='true'\]\s+\.sb-topbar-brand/);
+    });
+
+    test('keeps the character toggle measurable for anchored extension dropdowns', () => {
+        const layoutSource = getFunctionSource('syncTopbarIconsOnlyLayout');
+        expect(layoutSource).toContain('classList.toggle(\'sb-proxy-button-icon-only\', iconsOnly)');
+        expect(layoutSource).not.toContain('style.display');
+
+        const applySource = getFunctionSource('applyTopbarIconsOnlyPreference');
+        expect(applySource).toContain('scheduleCharacterToggleGhostSync();');
+    });
+
+    test('restores parked slots by replaying recorded group order', () => {
+        // Restoring via a remembered nextSibling is unsafe: neighbouring slots are parked too,
+        // so moveElementBefore would insertBefore a reference node that left the parent.
+        const layoutSource = getFunctionSource('syncTopbarIconsOnlyLayout');
+        expect(layoutSource).toContain('for (const [group, children] of sbState.topbarPages.groupOrder)');
+        expect(layoutSource).toContain('group.appendChild(child);');
+        expect(normalizedTabsSource).toContain('function rememberTopbarGroupOrder(');
+        expect(normalizedTabsSource).toContain('rememberTopbarGroupOrder(leftGroup, rightGroup);');
+    });
+
+    test('derives page labels and icons from the shell registries', () => {
+        const targetsMatch = normalizedTabsSource.match(/const SB_TOPBAR_PAGE_TARGETS = Object\.freeze\(\[[\s\S]*?\]\);/);
+        expect(targetsMatch).not.toBeNull();
+
+        const targetsSource = targetsMatch[0];
+        expect(targetsSource).toContain('\'action:search\'');
+        expect(targetsSource).not.toContain('\'none\'');
+        expect(targetsSource).not.toContain('label:');
+        expect(targetsSource).not.toContain('icon:');
+
+        const configSource = getFunctionSource('getTopbarPageConfig');
+        expect(configSource).toContain('getCharacterPanelTabConfig(page.tabId)');
+        expect(configSource).toContain('getShellConfig(page.shellKey)');
+    });
+
+    test('toggles state without rebuilding the top bar', () => {
+        const setterSource = getFunctionSource('setTopbarIconsOnly');
+        expect(setterSource).not.toContain('buildTopBar(');
+        expect(setterSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly, String(nextEnabled));');
+        expect(setterSource).toContain('updateThemePickerUi();');
+        expect(normalizedTabsSource).toContain('sbState.topbarIconsOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), sbState.topbarIconsOnly);');
+    });
+
+    test('stays distinct from the shell tab icon-only setting', () => {
+        expect(normalizedTabsSource).toContain('topbarIconsOnly: \'sb-topbar-icons-only\',');
+        expect(normalizedTabsSource).toContain('desktopNavIconOnly: \'sb-desktop-nav-icon-only\',');
+        expect(normalizedTabsSource).toContain('mobileNavIconOnly: \'sb-mobile-nav-icon-only\',');
+        expect(normalizedTabsSource).toContain('\'sb-topbar-icons-only-input\'');
+        expect(normalizedTabsSource).toContain('\'sb-desktop-nav-icon-only-input\'');
+    });
+
+    test('mounts the toggle in the quick access shortcuts drawer', () => {
+        const groupSource = getFunctionSource('createShortcutSettingsGroup');
+        expect(groupSource).toContain('createTopbarIconsOnlySettingsGroup()');
+        expect(normalizedTabsSource.match(/'Icons only top bar'/g)).toHaveLength(1);
+        expect(normalizedTabsSource).not.toContain('lorum ipsum');
+    });
+
+    test('scrolls the rail rather than wrapping it', () => {
+        const railRuleMatch = cssSource.match(/\.sb-topbar-pages\s*\{[^}]*\}/);
+        expect(railRuleMatch).not.toBeNull();
+
+        const railRule = railRuleMatch[0];
+        expect(railRule).toContain('overflow-x: auto;');
+        expect(railRule).toContain('flex-wrap: nowrap;');
+        expect(railRule).toContain('mask-image:');
+        expect(railRule).toContain('-webkit-mask-image:');
+        expect(cssSource).toContain('#sb-topbar-parked {\n    display: none;\n}');
+        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] #sb-home-toggle');
+    });
+});

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -121,26 +121,236 @@ describe('topbar label tap cycle', () => {
 });
 
 describe('icons only top bar', () => {
-    test('parks only the redundant shell toggles', () => {
-        // Every page the Workspace and Customize toggles lead to has its own rail icon, so they
-        // step aside. Home, Characters, the hamburger and the Quick Access slots all stay.
-        const parkedMatch = normalizedTabsSource.match(/const SB_TOPBAR_PARKED_IDS = Object\.freeze\(\[[\s\S]*?\]\);/);
-        expect(parkedMatch).not.toBeNull();
+    const mobileCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
 
-        const parkedSource = parkedMatch[0];
-        expect(parkedSource).toContain('\'sb-left-shell-toggle\'');
-        expect(parkedSource).toContain('\'sb-right-shell-toggle\'');
+    function getClustersSource() {
+        const match = normalizedTabsSource.match(/const SB_TOPBAR_CLUSTERS = Object\.freeze\(\[[\s\S]*?\n\]\);/);
+        expect(match).not.toBeNull();
+        return match[0];
+    }
 
-        for (const keptId of ['sb-hamburger', 'sb-home-toggle', 'sb-character-toggle', 'sb-shortcut-left', 'sb-shortcut-right', 'sb-shortcut-slot3']) {
-            expect(parkedSource).not.toContain(`'${keptId}'`);
+    test('expands each layer 2 anchor into its own cluster', () => {
+        // The bar is not a flat strip: every anchor keeps its prescribed slot and grows a cluster
+        // of that section's own pages beside it, in the PRODUCT.md left-to-right order.
+        const clustersSource = getClustersSource();
+        const leadIds = [...clustersSource.matchAll(/leadId: '([^']+)'/g)].map(match => match[1]);
+
+        expect(leadIds).toEqual(['sb-left-shell-toggle', 'sb-right-shell-toggle', 'sb-character-toggle']);
+        expect([...clustersSource.matchAll(/key: '([^']+)'/g)].map(match => match[1]))
+            .toEqual(['workspace', 'customize', 'characters']);
+    });
+
+    test('caps every cluster at three pages', () => {
+        // Clutter reduction is the point: an anchor still opens the full page list, so a page left
+        // off the bar is demoted a layer rather than removed.
+        const clusterBlocks = getClustersSource().split('pages: Object.freeze([').slice(1);
+
+        expect(clusterBlocks).toHaveLength(3);
+
+        for (const block of clusterBlocks) {
+            const pages = [...block.matchAll(/value: '([^']+)'/g)].map(match => match[1]);
+            expect(pages.length).toBeGreaterThan(0);
+            expect(pages.length).toBeLessThanOrEqual(3);
         }
     });
 
-    test('keeps shell focus on a visible control once the toggles are parked', () => {
-        // Focusing a display:none button silently drops focus to <body> when a shell closes.
+    test('leaves the maintenance and duplicate pages off the bar', () => {
+        const clustersSource = getClustersSource();
+
+        // Server and Console Logs are troubleshooting surfaces, Formatting is rarely touched
+        // mid-write, and Agents is the documented default for the left Quick Access slot.
+        for (const target of ['right:server', 'right:console-logs', 'left:advanced-formatting', 'left:agents']) {
+            expect(clustersSource).not.toContain(`'${target}'`);
+        }
+
+        // Still selectable as a Quick Access target, so nothing became unreachable.
+        expect(normalizedTabsSource).toContain('{ value: \'left:agents\', label: \'Agents\', icon: \'fa-robot\' }');
+    });
+
+    test('derives page labels and icons from the shell registries', () => {
+        const clustersSource = getClustersSource();
+        expect(clustersSource).not.toContain('label:');
+        expect(clustersSource).not.toContain('icon:');
+        expect(normalizedTabsSource).toContain('const SB_TOPBAR_PAGE_TARGETS = Object.freeze(SB_TOPBAR_CLUSTERS.flatMap(cluster => cluster.pages));');
+
+        const configSource = getFunctionSource('getTopbarPageConfig');
+        expect(configSource).toContain('getCharacterPanelTabConfig(page.tabId)');
+        expect(configSource).toContain('getShellConfig(page.shellKey)');
+    });
+
+    test('keeps every layer 2 anchor on the bar and parks nothing', () => {
+        // Trimming the clusters makes the section toggles the only way back to the pages they left
+        // off, so removing them would bury those pages rather than hide them.
+        const anchorMatch = normalizedTabsSource.match(/const SB_TOPBAR_ANCHOR_IDS = Object\.freeze\(\[[\s\S]*?\]\);/);
+        expect(anchorMatch).not.toBeNull();
+
+        for (const anchorId of ['sb-left-shell-toggle', 'sb-right-shell-toggle', 'sb-home-toggle', 'sb-character-toggle']) {
+            expect(anchorMatch[0]).toContain(`'${anchorId}'`);
+        }
+
+        // The parking machinery and its bay are gone entirely.
+        expect(normalizedTabsSource).not.toContain('SB_TOPBAR_PARKED_IDS');
+        expect(normalizedTabsSource).not.toContain('rememberTopbarGroupOrder');
+        expect(normalizedTabsSource).not.toContain('sb-topbar-parked');
+        expect(cssSource).not.toContain('#sb-topbar-parked');
+    });
+
+    test('keeps one canonical button order per mode instead of moving buttons around', () => {
+        // appendChild on a node the group already holds is a move, so replaying a whole order is
+        // idempotent -- unlike remembering a nextSibling that a neighbouring move can detach.
+        const orderSource = getFunctionSource('getTopbarGroupOrder');
+        const replaySource = getFunctionSource('syncTopbarGroupOrder');
+
+        expect(orderSource).toContain('const [workspace, customize, characters] = SB_TOPBAR_CLUSTERS;');
+        expect(replaySource).toContain('group.appendChild(element);');
+        expect(normalizedTabsSource).not.toContain('syncTopbarRightClusterOrder');
+        expect(normalizedTabsSource).not.toContain('syncTopbarRailSplit');
+
+        // Right half follows PRODUCT.md Layer 2: quick access, then Home, then Characters.
+        const homeIndex = orderSource.indexOf('\'sb-home-toggle\'');
+        expect(orderSource.indexOf('quickAccessIds')).toBeLessThan(homeIndex);
+        expect(homeIndex).toBeLessThan(orderSource.indexOf('characters.leadId'));
+    });
+
+    test('leaves the button sequence unchanged when the option is off', () => {
+        // The clusters are display:none while the mode is off, so the "off" order has to reproduce
+        // the bar exactly as it has always been -- toggling must not reshuffle anything else.
+        const orderSource = getFunctionSource('getTopbarGroupOrder');
+        expect(orderSource).toContain('left.push(\'sb-shortcut-left\', \'sb-shortcut-slot3\', \'sb-shortcut-slot4\');');
+        expect(orderSource).toContain('right.push(\'sb-shortcut-slot6\', \'sb-shortcut-slot5\', \'sb-shortcut-right\');');
+        expect(cssSource).toMatch(/\.sb-topbar-pages \{\n(?:[^}]*\n)?\s*display: none;/);
+    });
+
+    test('folds the characters cluster left on phones only', () => {
+        // The right group is pinned at its natural width in the overflow state, so on a phone a
+        // four-icon right cluster would starve the scrolling left strip.
+        const orderSource = getFunctionSource('getTopbarGroupOrder');
+        expect(orderSource).toContain('if (iconsOnly && mobile) {');
+        expect(orderSource).toContain('left.push(characters.railId);');
+        expect(orderSource).toContain('right.push(characters.railId);');
+        expect(getFunctionSource('syncTopbarGroupOrder')).toContain('mobile: isMobileViewport(),');
+        expect(normalizedTabsSource).toContain('window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener(\'change\'');
+    });
+
+    test('separates the clusters with a wider seam than the icons inside one', () => {
+        // "The different buttons should be placed in more appropriate locations, with some
+        // appropriate gaps." Derived from the group gap so it tracks the user's top bar scale.
+        expect(cssSource).toContain('--sb-topbar-cluster-gap: calc(var(--sb-topbar-group-gap) * 2.5);');
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-lead:not\(:first-child\) \{\n\s*margin-inline-start: calc\(var\(--sb-topbar-cluster-gap\) - var\(--sb-topbar-group-gap\)\);\n\}/);
+
+        const railRule = cssSource.match(/\.sb-topbar-pages \{[^}]*\}/);
+        expect(railRule[0]).toContain('gap: var(--sb-topbar-group-gap);');
+        expect(normalizedTabsSource).toContain('document.getElementById(cluster.leadId)?.classList.add(\'sb-topbar-cluster-lead\');');
+    });
+
+    test('keeps the clusters pinned to their own edge of the bar', () => {
+        // Workspace stays hard left and Characters hard right at every width. The old rules pulled
+        // both groups toward the brand label, which is the opposite of the requested layout.
+        expect(cssSource).not.toContain('.sb-topbar-group-left {\n        justify-content: flex-end;');
+        expect(cssSource).not.toContain('#sb-home-toggle {\n        margin-left: auto;');
+        expect(cssSource).not.toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] #sb-topbar-inner/);
+    });
+
+    test('sizes the icons to match the labelled buttons beside them', () => {
+        // They were 30px wide in a 36px-tall bar on desktop, and 26px next to 40px anchors on
+        // phones, which is what made them small targets.
+        expect(cssSource).toMatch(/\.sb-topbar-page-button,\n:root\[data-sb-topbar-icons-only='true'\] \.sb-proxy-button-icon-only \{\n\s*width: var\(--sb-proxy-button-height\);\n\s*min-width: var\(--sb-proxy-button-height\);\n\}/);
+        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] #sb-home-toggle {\n    min-width: var(--sb-proxy-button-height);\n}');
+
+        // Phones key off the hamburger/Home/Characters size instead.
+        const mobileRule = mobileCss.match(/:root\[data-sb-topbar-icons-only='true'\] \.sb-proxy-button-icon-only,\n\s*:root\[data-sb-topbar-icons-only='true'\] #sb-home-toggle \{[^}]*\}/);
+        expect(mobileRule).not.toBeNull();
+        expect(mobileRule[0]).toContain('min-width: var(--sb-mobile-toggle-size);');
+        expect(mobileRule[0]).toContain('height: var(--sb-mobile-toggle-size);');
+        expect(mobileCss).toContain('.sb-topbar-page-button i,');
+    });
+
+    test('reaches search through a quick access slot, exactly as with the option off', () => {
+        // A dedicated Search button silently suppressed the user's own slot, which is the
+        // inconsistent-patterns-across-contexts anti-pattern.
+        expect(normalizedTabsSource).not.toContain('SB_TOPBAR_SEARCH_TARGET');
+        expect(normalizedTabsSource).not.toContain('sb-topbar-search-toggle');
+        expect(cssSource).not.toContain('#sb-topbar-search-toggle');
+        expect(getClustersSource()).not.toContain('action:search');
+        expect(normalizedTabsSource).toContain('right: \'action:search\',');
+        expect(getFunctionSource('syncTopbarPageButtonStates')).toContain('for (const page of SB_TOPBAR_PAGE_TARGETS) {');
+    });
+
+    test('keeps quick access fully live rather than superseded', () => {
+        // The slots are part of the right-hand cluster now, so greying the settings rows out would
+        // be wrong -- and no slot is hidden to make room for a cluster icon.
+        expect(normalizedTabsSource).not.toContain('.sb-shortcut-rows\')?.classList.toggle(\'is-disabled\'');
+        expect(cssSource).not.toContain('.sb-shortcut-rows.is-disabled');
+
+        const dedupeSource = getFunctionSource('syncTopbarIconsOnlyDedupe');
+        expect(dedupeSource).not.toContain('style.setProperty(\'display\'');
+        // A slot pointed at a page that also has a cluster icon wins; the cluster copy hides.
+        expect(dedupeSource).toContain('claimed.add(target);');
+        expect(dedupeSource).toContain('button.classList.toggle(\'sb-topbar-page-duplicate\', claimed.has(button.dataset.sbTopbarPage));');
+        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-page-duplicate');
+    });
+
+    test('re-runs dedupe and refit when a quick action is reassigned', () => {
+        // The slot dropdown calls updateShortcutButton, so the top bar must settle from there
+        // rather than waiting for the next toggle or resize.
+        const updateSource = getFunctionSource('updateShortcutButton');
+        expect(updateSource).toContain('syncTopbarIconsOnlyDedupe();');
+        expect(updateSource).toContain('queueTopbarBrandFit();');
+    });
+
+    test('mounts the toggle in the desktop and mobile navigation groups', () => {
+        // Geechan review: nesting it inside the Quick Access Shortcuts drawer is a nested menu,
+        // and Navigation is where a top bar layout option is intuitively expected.
+        const navSource = getFunctionSource('createNavigationSettingsGroup');
+        expect(navSource).toContain('id: `sb-${modePrefix}-topbar-icons-only-input`');
+        expect(navSource).toContain('label: \'Icons only top bar\',');
+        expect(navSource).toContain('onChange: input => setTopbarIconsOnly(input.checked),');
+        expect(navSource).toContain('topbarIconsOnlyChoice,');
+
+        expect(normalizedTabsSource).not.toContain('createTopbarIconsOnlySettingsGroup');
+        expect(getFunctionSource('createShortcutSettingsGroup')).toContain('content: [description, rows],');
+        // One shared factory builds both groups, so the label exists once in source.
+        expect(normalizedTabsSource.match(/'Icons only top bar'/g)).toHaveLength(1);
+    });
+
+    test('mirrors the one global setting across both navigation groups', () => {
+        // Same shape as Compact Mode: one storage key, two checkboxes, one sync loop.
+        expect(normalizedTabsSource).toContain('topbarIconsOnlyChoice.querySelector(\'input\')?.setAttribute(\'data-sb-topbar-icons-only-input\', modePrefix);');
+        expect(normalizedTabsSource).toContain('for (const input of document.querySelectorAll(\'[data-sb-topbar-icons-only-input]\')) {');
+        expect(normalizedTabsSource).toContain('input.checked = sbState.topbarIconsOnly;');
+        expect(normalizedTabsSource).not.toContain('getElementById(\'sb-topbar-icons-only-input\')');
+    });
+
+    test('stays distinct from the shell tab icon-only setting', () => {
+        expect(normalizedTabsSource).toContain('topbarIconsOnly: \'sb-topbar-icons-only\',');
+        expect(normalizedTabsSource).toContain('desktopNavIconOnly: \'sb-desktop-nav-icon-only\',');
+        expect(normalizedTabsSource).toContain('mobileNavIconOnly: \'sb-mobile-nav-icon-only\',');
+        expect(normalizedTabsSource).toContain('label: \'Icons only in shell tabs\',');
+    });
+
+    test('toggles state without rebuilding the top bar', () => {
+        const setterSource = getFunctionSource('setTopbarIconsOnly');
+        expect(setterSource).not.toContain('buildTopBar(');
+        expect(setterSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly, String(nextEnabled));');
+        expect(setterSource).toContain('updateThemePickerUi();');
+        expect(normalizedTabsSource).toContain('sbState.topbarIconsOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), sbState.topbarIconsOnly);');
+    });
+
+    test('keeps shell focus on a visible control', () => {
+        // The Workspace toggle is display:none on phones, and focusing a display:none button
+        // silently drops focus to <body> when a shell closes.
         const proxySource = getFunctionSource('getShellProxyButton');
         expect(proxySource).toContain('isActuallyVisible(proxyButton)');
         expect(proxySource).toContain('data-sb-topbar-page');
+    });
+
+    test('keeps the character toggle measurable for anchored extension dropdowns', () => {
+        const layoutSource = getFunctionSource('syncTopbarIconsOnlyLayout');
+        expect(layoutSource).toContain('classList.toggle(\'sb-proxy-button-icon-only\', iconsOnly)');
+        expect(layoutSource).not.toContain('style.display');
+
+        const applySource = getFunctionSource('applyTopbarIconsOnlyPreference');
+        expect(applySource).toContain('scheduleCharacterToggleGhostSync();');
     });
 
     test('hides the brand label once the icons outgrow the bar', () => {
@@ -156,152 +366,13 @@ describe('icons only top bar', () => {
     test('drops the centre brand label on phones only', () => {
         // Desktop has room for the label, so the hide lives in the phone-gated sheet alone.
         // (0,3,0) outranks the plain .sb-topbar-brand rules in both fork sheets, no !important.
-        const mobileCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
         expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-brand \{\n\s*display: none;\n\s*\}/);
         expect(cssSource).not.toMatch(/data-sb-topbar-icons-only='true'\]\s+\.sb-topbar-brand/);
     });
 
-    test('keeps the character toggle measurable for anchored extension dropdowns', () => {
-        const layoutSource = getFunctionSource('syncTopbarIconsOnlyLayout');
-        expect(layoutSource).toContain('classList.toggle(\'sb-proxy-button-icon-only\', iconsOnly)');
-        expect(layoutSource).not.toContain('style.display');
-
-        const applySource = getFunctionSource('applyTopbarIconsOnlyPreference');
-        expect(applySource).toContain('scheduleCharacterToggleGhostSync();');
-    });
-
-    test('restores parked slots by replaying recorded group order', () => {
-        // Restoring via a remembered nextSibling is unsafe: neighbouring slots are parked too,
-        // so moveElementBefore would insertBefore a reference node that left the parent.
-        const layoutSource = getFunctionSource('syncTopbarIconsOnlyLayout');
-        expect(layoutSource).toContain('for (const [group, children] of sbState.topbarPages.groupOrder)');
-        expect(layoutSource).toContain('group.appendChild(child);');
-        expect(normalizedTabsSource).toContain('function rememberTopbarGroupOrder(');
-        expect(normalizedTabsSource).toContain('rememberTopbarGroupOrder(leftGroup, rightGroup);');
-    });
-
-    test('derives page labels and icons from the shell registries', () => {
-        const targetsMatch = normalizedTabsSource.match(/const SB_TOPBAR_PAGE_TARGETS = Object\.freeze\(\[[\s\S]*?\]\);/);
-        expect(targetsMatch).not.toBeNull();
-
-        const targetsSource = targetsMatch[0];
-        expect(targetsSource).not.toContain('\'none\'');
-        expect(targetsSource).not.toContain('label:');
-        expect(targetsSource).not.toContain('icon:');
-
-        const configSource = getFunctionSource('getTopbarPageConfig');
-        expect(configSource).toContain('getCharacterPanelTabConfig(page.tabId)');
-        expect(configSource).toContain('getShellConfig(page.shellKey)');
-    });
-
-    test('toggles state without rebuilding the top bar', () => {
-        const setterSource = getFunctionSource('setTopbarIconsOnly');
-        expect(setterSource).not.toContain('buildTopBar(');
-        expect(setterSource).toContain('safeSetItem(SB_STORAGE_KEYS.topbarIconsOnly, String(nextEnabled));');
-        expect(setterSource).toContain('updateThemePickerUi();');
-        expect(normalizedTabsSource).toContain('sbState.topbarIconsOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.topbarIconsOnly), sbState.topbarIconsOnly);');
-    });
-
-    test('stays distinct from the shell tab icon-only setting', () => {
-        expect(normalizedTabsSource).toContain('topbarIconsOnly: \'sb-topbar-icons-only\',');
-        expect(normalizedTabsSource).toContain('desktopNavIconOnly: \'sb-desktop-nav-icon-only\',');
-        expect(normalizedTabsSource).toContain('mobileNavIconOnly: \'sb-mobile-nav-icon-only\',');
-        expect(normalizedTabsSource).toContain('\'sb-topbar-icons-only-input\'');
-        expect(normalizedTabsSource).toContain('\'sb-desktop-nav-icon-only-input\'');
-    });
-
-    test('mounts the toggle in the quick access shortcuts drawer', () => {
-        const groupSource = getFunctionSource('createShortcutSettingsGroup');
-        expect(groupSource).toContain('createTopbarIconsOnlySettingsGroup()');
-        expect(normalizedTabsSource.match(/'Icons only top bar'/g)).toHaveLength(1);
-        expect(normalizedTabsSource).not.toContain('lorum ipsum');
-    });
-
-    test('splits customize pages onto a second rail beside the brand label', () => {
-        expect(normalizedTabsSource).toContain('const leftPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey !== \'right\');');
-        expect(normalizedTabsSource).toContain('const rightPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey === \'right\');');
-        expect(normalizedTabsSource).toContain('buildTopbarPageRail(\'sb-topbar-pages-right\', rightPages);');
-        expect(normalizedTabsSource).toContain('rightGroup.append(customizeRail,');
-    });
-
-    test('folds both rails back together on phones', () => {
-        // The split fills the gap either side of the brand label; phones hide that label and
-        // have no width to spare, so the right group's fixed buttons would starve the left rail.
-        const splitSource = getFunctionSource('syncTopbarRailSplit');
-        expect(splitSource).toContain('const shouldMerge = isMobileViewport();');
-        expect(splitSource).toContain('leftRail.appendChild(button);');
-        expect(splitSource).toContain('rightRail.appendChild(button);');
-        expect(splitSource).toContain('classList.toggle(\'sb-topbar-pages-empty\', shouldMerge);');
-        expect(normalizedTabsSource).toContain('window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener(\'change\'');
-        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-pages-empty');
-    });
-
-    test('evens out the whitespace either side of the brand label', () => {
-        // Equal side tracks already put the label on the true centre, but both groups fill from
-        // the outer edge inward, so the leftover slack lands next to the label unequally and
-        // reads as off-centre. Clustering each group against the label evens that out.
-        const desktopBlocks = cssSource.match(/@media screen and \(min-width: 769px\) \{[\s\S]*?\n\}/g) ?? [];
-        const clusterBlock = desktopBlocks.find(block => block.includes('data-sb-topbar-icons-only'));
-        expect(clusterBlock).toBeDefined();
-        expect(clusterBlock).toContain('.sb-topbar-group-left {\n        justify-content: flex-end;');
-        expect(clusterBlock).toContain('.sb-topbar-group-right {\n        justify-content: flex-start;');
-        expect(clusterBlock).toContain('#sb-home-toggle {\n        margin-left: auto;');
-    });
-
-    test('centres the whole row once the brand label is dropped', () => {
-        // Equal side tracks with no centre column strand the icons left of centre, so the grid
-        // collapses to a centred flex row. Must come after the margin-left: auto rule to win.
-        const desktopBlocks = cssSource.match(/@media screen and \(min-width: 769px\) \{[\s\S]*?\n\}/g) ?? [];
-        const clusterBlock = desktopBlocks.find(block => block.includes('data-sb-topbar-brand-cramped'));
-        expect(clusterBlock).toBeDefined();
-        expect(clusterBlock).toContain('#sb-topbar-inner {\n        display: flex;\n        justify-content: center;');
-        expect(clusterBlock).toContain('#sb-home-toggle {\n        margin-left: 0;');
-        expect(clusterBlock.indexOf('margin-left: auto')).toBeLessThan(clusterBlock.indexOf('margin-left: 0'));
-    });
-
-    test('pins quick actions, search, home and characters to the right in that order', () => {
-        const orderSource = getFunctionSource('syncTopbarRightClusterOrder');
-        const ids = ['sb-topbar-pages-right', 'sb-topbar-search-toggle', 'sb-home-toggle', 'sb-character-toggle'];
-        const positions = ids.map(id => orderSource.indexOf(id));
-        expect(positions.every(position => position >= 0)).toBe(true);
-        expect([...positions].sort((a, b) => a - b)).toEqual(positions);
-        // Quick Actions sit between the rail and Search.
-        expect(orderSource.indexOf('SB_SHORTCUT_SLOTS')).toBeGreaterThan(positions[0]);
-        expect(orderSource.indexOf('SB_SHORTCUT_SLOTS')).toBeLessThan(positions[1]);
-    });
-
-    test('keeps the rightmost copy when a quick action duplicates a rail icon', () => {
-        const dedupeSource = getFunctionSource('syncTopbarIconsOnlyDedupe');
-        // The rail icon yields to the slot, and a slot pointed at Search yields to the dedicated
-        // Search button, which sits further right still.
-        expect(dedupeSource).toContain('claimed.add(target);');
-        expect(dedupeSource).toContain('button.classList.toggle(\'sb-topbar-page-duplicate\', claimed.has(button.dataset.sbTopbarPage));');
-        expect(dedupeSource).toContain('if (isSearchShortcutTarget(target)) {');
-        // Workspace pages are the exception: they keep the left rail berth and the slot yields.
-        expect(dedupeSource).toContain('if (target.startsWith(\'left:\') && railByTarget.has(target)) {');
-        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-page-duplicate');
-    });
-
-    test('re-runs dedupe and refit when a quick action is reassigned', () => {
-        // The slot dropdown calls updateShortcutButton, so the top bar must settle from there
-        // rather than waiting for the next toggle or resize.
-        const updateSource = getFunctionSource('updateShortcutButton');
-        expect(updateSource).toContain('syncTopbarIconsOnlyDedupe();');
-        expect(updateSource).toContain('queueTopbarBrandFit();');
-    });
-
-    test('keeps search off the rail and gives it a fixed berth', () => {
-        const targetsMatch = normalizedTabsSource.match(/const SB_TOPBAR_PAGE_TARGETS = Object\.freeze\(\[[\s\S]*?\]\);/);
-        expect(targetsMatch[0]).not.toContain('action:search');
-        expect(normalizedTabsSource).toContain('const SB_TOPBAR_SEARCH_TARGET = Object.freeze({ value: \'action:search\'');
-        expect(normalizedTabsSource).toContain('searchButton.id = \'sb-topbar-search-toggle\';');
-        // Still reflects open/closed state alongside the page icons.
-        expect(getFunctionSource('syncTopbarPageButtonStates')).toContain('[...SB_TOPBAR_PAGE_TARGETS, SB_TOPBAR_SEARCH_TARGET]');
-    });
-
-    test('scrolls the whole bar rather than each rail', () => {
+    test('scrolls the whole bar rather than each cluster', () => {
         // A nested scroll region ended mid-button and left an unreadable sliver of an icon at
-        // its boundary, so the rails no longer scroll on their own.
+        // its boundary, so the clusters no longer scroll on their own.
         const railRuleMatch = cssSource.match(/\.sb-topbar-pages\s*\{[^}]*\}/);
         expect(railRuleMatch).not.toBeNull();
         expect(railRuleMatch[0]).not.toContain('overflow-x: auto;');
@@ -349,21 +420,18 @@ describe('icons only top bar', () => {
 
     test('keeps button touch handlers off WebKit slow path', () => {
         // A non-passive touchstart on every button pulls WebKit off compositor scrolling, which
-        // stalls the rail on iOS. The handler only stops propagation, so passive is correct.
+        // stalls the strip on iOS. The handler only stops propagation, so passive is correct.
         const propagationSource = getFunctionSource('stopProxyPointerPropagation');
         expect(propagationSource).toContain('element.addEventListener(\'touchstart\', stop, { passive: true });');
         expect(propagationSource).toContain('stopPropagation');
     });
 
     test('keeps one spacing rhythm across the mobile bar', () => {
-        // Rail gap, group gap and the grid seam were three different widths between identical
+        // Cluster gap, group gap and the grid seam were three different widths between identical
         // square buttons, which is what read as awkward spacing. All key off the group gap.
-        const mobileCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
-        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-pages \{\n\s*gap: var\(--sb-topbar-group-gap\);\n\s*\}/);
         const innerRule = mobileCss.match(/:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-inner \{[^}]*\}/);
         expect(innerRule).not.toBeNull();
         expect(innerRule[0]).toContain('gap: var(--sb-topbar-group-gap);');
-        expect(cssSource).toContain('#sb-topbar-parked {\n    display: none;\n}');
-        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] #sb-home-toggle');
+        expect(mobileCss).toContain('.sb-topbar-group-left');
     });
 });

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -277,6 +277,8 @@ describe('icons only top bar', () => {
         expect(dedupeSource).toContain('claimed.add(target);');
         expect(dedupeSource).toContain('button.classList.toggle(\'sb-topbar-page-duplicate\', claimed.has(button.dataset.sbTopbarPage));');
         expect(dedupeSource).toContain('if (isSearchShortcutTarget(target)) {');
+        // Workspace pages are the exception: they keep the left rail berth and the slot yields.
+        expect(dedupeSource).toContain('if (target.startsWith(\'left:\') && railByTarget.has(target)) {');
         expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-page-duplicate');
     });
 
@@ -308,9 +310,12 @@ describe('icons only top bar', () => {
         const innerRule = cssSource.match(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-inner \{[^}]*\}/);
         expect(innerRule).not.toBeNull();
         expect(innerRule[0]).toContain('overflow-x: auto;');
-        // The min-content floor propagates through every flex/grid ancestor.
-        expect(innerRule[0]).toContain('min-width: 0;');
-        expect(cssSource).toMatch(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-stack,\n:root\[data-sb-topbar-scroll='true'\] #sb-topbar-primary \{\n\s*min-width: 0;\n\}/);
+        // The min-content floor propagates through every flex/grid ancestor, and the shrink
+        // permission must be gated on icons-only rather than on the scroll state: the overflow
+        // verdict is read from the inner's client width, so gating it on the verdict lets the
+        // bar inflate to fit its own content and a small overflow is never detected.
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-stack,\n:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-primary,\n:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-inner \{\n\s*min-width: 0;\n\}/);
+        expect(cssSource).not.toMatch(/:root\[data-sb-topbar-scroll='true'\] #sb-topbar-stack/);
         // Snapping pulled the bar past the hamburger on load, because the first snap point is
         // the leading page icon rather than the start of the bar.
         expect(innerRule[0]).not.toContain('scroll-snap-type');

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -239,6 +239,7 @@ describe('icons only top bar', () => {
         expect(normalizedTabsSource).toContain('function createTopbarClusterDivider(');
         const orderSource = getFunctionSource('getTopbarGroupOrder');
         expect(orderSource).toContain('\'sb-topbar-divider-customize\',');
+        expect(orderSource).toContain('right.push(\'sb-home-toggle\', \'sb-topbar-divider-home\');');
 
         const baseRule = cssSource.match(/\.sb-topbar-cluster-divider \{[^}]*\}/);
         expect(baseRule).not.toBeNull();
@@ -250,9 +251,16 @@ describe('icons only top bar', () => {
         expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{\n\s*display: inline-block;\n\}/);
         expect(cssSource).not.toMatch(/data-sb-topbar-brand-cramped='true'\] [^{]*\.sb-topbar-cluster-divider/);
 
-        // The divider takes over the seam so it sits centred in it; phones only shorten the rule.
+        // The home divider owns Home|Characters everywhere; the characters divider is the phone
+        // strip's marker, so desktop hides it or the boundary would carry a double rule.
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-divider-characters \{\n\s*display: none;\n\}/);
+        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] #sb-topbar-divider-characters \{\n\s*display: inline-block;\n\s*\}/);
+
+        // The divider takes over the seam so it sits centred in it; phones shorten the rule to
+        // their smaller squares and keep the Home|Characters boundary marked in every mode.
         expect(cssSource).toContain('.sb-topbar-cluster-divider + .sb-topbar-cluster-lead');
-        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{\n\s*height: calc\(var\(--sb-mobile-toggle-size\) \* 0\.5\);\n\s*\}/);
+        expect(mobileCss).toMatch(/\.sb-topbar-cluster-divider \{\n\s*height: calc\(var\(--sb-mobile-toggle-size\) \* 0\.5\);\n\s*\}/);
+        expect(mobileCss).toMatch(/#sb-topbar-divider-home \{\n\s*display: inline-block;\n\s*\}/);
     });
 
     test('separates the clusters with a wider seam than the icons inside one', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -121,20 +121,36 @@ describe('topbar label tap cycle', () => {
 });
 
 describe('icons only top bar', () => {
-    test('parks only the configurable quick access slots', () => {
-        // PRODUCT.md layer 2 prescribes the top bar anchors; icons-only mode may drop their
-        // labels but must never remove them from the bar.
+    test('parks only the redundant shell toggles', () => {
+        // Every page the Workspace and Customize toggles lead to has its own rail icon, so they
+        // step aside. Home, Characters, the hamburger and the Quick Access slots all stay.
         const parkedMatch = normalizedTabsSource.match(/const SB_TOPBAR_PARKED_IDS = Object\.freeze\(\[[\s\S]*?\]\);/);
         expect(parkedMatch).not.toBeNull();
 
         const parkedSource = parkedMatch[0];
-        for (const slotId of ['sb-shortcut-left', 'sb-shortcut-right', 'sb-shortcut-slot3', 'sb-shortcut-slot4', 'sb-shortcut-slot5', 'sb-shortcut-slot6']) {
-            expect(parkedSource).toContain(`'${slotId}'`);
-        }
+        expect(parkedSource).toContain('\'sb-left-shell-toggle\'');
+        expect(parkedSource).toContain('\'sb-right-shell-toggle\'');
 
-        for (const anchorId of ['sb-hamburger', 'sb-left-shell-toggle', 'sb-right-shell-toggle', 'sb-home-toggle', 'sb-character-toggle']) {
-            expect(parkedSource).not.toContain(`'${anchorId}'`);
+        for (const keptId of ['sb-hamburger', 'sb-home-toggle', 'sb-character-toggle', 'sb-shortcut-left', 'sb-shortcut-right', 'sb-shortcut-slot3']) {
+            expect(parkedSource).not.toContain(`'${keptId}'`);
         }
+    });
+
+    test('keeps shell focus on a visible control once the toggles are parked', () => {
+        // Focusing a display:none button silently drops focus to <body> when a shell closes.
+        const proxySource = getFunctionSource('getShellProxyButton');
+        expect(proxySource).toContain('isActuallyVisible(proxyButton)');
+        expect(proxySource).toContain('data-sb-topbar-page');
+    });
+
+    test('hides the brand label once the icons outgrow the bar', () => {
+        const fitSource = getFunctionSource('syncTopbarBrandFit');
+        // The verdict must not depend on the label's current state, or showing it would make it
+        // overflow, which would hide it again, which would make it fit -- an oscillation.
+        expect(fitSource).toContain('const reservation = sbState.topbarPages.brandWidth || SB_TOPBAR_BRAND_MIN_WIDTH;');
+        expect(fitSource).toContain('child.classList.contains(\'sb-topbar-pages\') ? child.scrollWidth : child.offsetWidth');
+        expect(fitSource).toContain('dataset.sbTopbarBrandCramped');
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] \.sb-topbar-brand \{\n\s*display: none;\n\}/);
     });
 
     test('drops the centre brand label on phones only', () => {
@@ -224,12 +240,24 @@ describe('icons only top bar', () => {
     test('evens out the whitespace either side of the brand label', () => {
         // Equal side tracks already put the label on the true centre, but both groups fill from
         // the outer edge inward, so the leftover slack lands next to the label unequally and
-        // reads as off-centre. Auto margins pull each rail up against the label instead.
-        expect(cssSource).toMatch(/#sb-topbar-pages \{\n\s*margin-left: auto;\n\s*\}/);
-        expect(cssSource).toMatch(/#sb-topbar-pages-right \{\n\s*margin-right: auto;\n\s*\}/);
-        // Desktop only: phones merge the rails and hide the label entirely.
+        // reads as off-centre. Clustering each group against the label evens that out.
         const desktopBlocks = cssSource.match(/@media screen and \(min-width: 769px\) \{[\s\S]*?\n\}/g) ?? [];
-        expect(desktopBlocks.some(block => block.includes('margin-left: auto'))).toBe(true);
+        const clusterBlock = desktopBlocks.find(block => block.includes('data-sb-topbar-icons-only'));
+        expect(clusterBlock).toBeDefined();
+        expect(clusterBlock).toContain('.sb-topbar-group-left {\n        justify-content: flex-end;');
+        expect(clusterBlock).toContain('.sb-topbar-group-right {\n        justify-content: flex-start;');
+        expect(clusterBlock).toContain('#sb-home-toggle {\n        margin-left: auto;');
+    });
+
+    test('centres the whole row once the brand label is dropped', () => {
+        // Equal side tracks with no centre column strand the icons left of centre, so the grid
+        // collapses to a centred flex row. Must come after the margin-left: auto rule to win.
+        const desktopBlocks = cssSource.match(/@media screen and \(min-width: 769px\) \{[\s\S]*?\n\}/g) ?? [];
+        const clusterBlock = desktopBlocks.find(block => block.includes('data-sb-topbar-brand-cramped'));
+        expect(clusterBlock).toBeDefined();
+        expect(clusterBlock).toContain('#sb-topbar-inner {\n        display: flex;\n        justify-content: center;');
+        expect(clusterBlock).toContain('#sb-home-toggle {\n        margin-left: 0;');
+        expect(clusterBlock.indexOf('margin-left: auto')).toBeLessThan(clusterBlock.indexOf('margin-left: 0'));
     });
 
     test('scrolls the rail rather than wrapping it', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -185,7 +185,6 @@ describe('icons only top bar', () => {
         expect(targetsMatch).not.toBeNull();
 
         const targetsSource = targetsMatch[0];
-        expect(targetsSource).toContain('\'action:search\'');
         expect(targetsSource).not.toContain('\'none\'');
         expect(targetsSource).not.toContain('label:');
         expect(targetsSource).not.toContain('icon:');
@@ -258,6 +257,44 @@ describe('icons only top bar', () => {
         expect(clusterBlock).toContain('#sb-topbar-inner {\n        display: flex;\n        justify-content: center;');
         expect(clusterBlock).toContain('#sb-home-toggle {\n        margin-left: 0;');
         expect(clusterBlock.indexOf('margin-left: auto')).toBeLessThan(clusterBlock.indexOf('margin-left: 0'));
+    });
+
+    test('pins quick actions, search, home and characters to the right in that order', () => {
+        const orderSource = getFunctionSource('syncTopbarRightClusterOrder');
+        const ids = ['sb-topbar-pages-right', 'sb-topbar-search-toggle', 'sb-home-toggle', 'sb-character-toggle'];
+        const positions = ids.map(id => orderSource.indexOf(id));
+        expect(positions.every(position => position >= 0)).toBe(true);
+        expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+        // Quick Actions sit between the rail and Search.
+        expect(orderSource.indexOf('SB_SHORTCUT_SLOTS')).toBeGreaterThan(positions[0]);
+        expect(orderSource.indexOf('SB_SHORTCUT_SLOTS')).toBeLessThan(positions[1]);
+    });
+
+    test('keeps the rightmost copy when a quick action duplicates a rail icon', () => {
+        const dedupeSource = getFunctionSource('syncTopbarIconsOnlyDedupe');
+        // The rail icon yields to the slot, and a slot pointed at Search yields to the dedicated
+        // Search button, which sits further right still.
+        expect(dedupeSource).toContain('claimed.add(target);');
+        expect(dedupeSource).toContain('button.classList.toggle(\'sb-topbar-page-duplicate\', claimed.has(button.dataset.sbTopbarPage));');
+        expect(dedupeSource).toContain('if (isSearchShortcutTarget(target)) {');
+        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-page-duplicate');
+    });
+
+    test('re-runs dedupe and refit when a quick action is reassigned', () => {
+        // The slot dropdown calls updateShortcutButton, so the top bar must settle from there
+        // rather than waiting for the next toggle or resize.
+        const updateSource = getFunctionSource('updateShortcutButton');
+        expect(updateSource).toContain('syncTopbarIconsOnlyDedupe();');
+        expect(updateSource).toContain('queueTopbarBrandFit();');
+    });
+
+    test('keeps search off the rail and gives it a fixed berth', () => {
+        const targetsMatch = normalizedTabsSource.match(/const SB_TOPBAR_PAGE_TARGETS = Object\.freeze\(\[[\s\S]*?\]\);/);
+        expect(targetsMatch[0]).not.toContain('action:search');
+        expect(normalizedTabsSource).toContain('const SB_TOPBAR_SEARCH_TARGET = Object.freeze({ value: \'action:search\'');
+        expect(normalizedTabsSource).toContain('searchButton.id = \'sb-topbar-search-toggle\';');
+        // Still reflects open/closed state alongside the page icons.
+        expect(getFunctionSource('syncTopbarPageButtonStates')).toContain('[...SB_TOPBAR_PAGE_TARGETS, SB_TOPBAR_SEARCH_TARGET]');
     });
 
     test('scrolls the rail rather than wrapping it', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -232,9 +232,10 @@ describe('icons only top bar', () => {
         expect(normalizedTabsSource).toContain('window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener(\'change\'');
     });
 
-    test('marks the cluster boundaries once the brand label is out of sight', () => {
-        // With the centre label hidden the seams alone are a few px of gap between identical
-        // squares, so a 1px theme-derived rule marks where one cluster ends and the next begins.
+    test('marks the cluster boundaries at every size while the mode is on', () => {
+        // A 1px theme-derived rule marks where one cluster ends and the next begins --
+        // Workspace|Customize on the left half, Home|Characters on the right -- with or without
+        // the brand label between them.
         expect(normalizedTabsSource).toContain('function createTopbarClusterDivider(');
         const orderSource = getFunctionSource('getTopbarGroupOrder');
         expect(orderSource).toContain('\'sb-topbar-divider-customize\',');
@@ -245,15 +246,13 @@ describe('icons only top bar', () => {
         expect(baseRule[0]).toContain('width: 1px;');
         expect(baseRule[0]).toContain('background: var(--sb-shell-border);');
 
-        // While the label is squeezed out, cramped desktop shows both rules: Workspace|Customize
-        // on the left half and Home|Characters on the right, where the divider sits between Home
-        // and the characters anchor rather than between the anchor and its own rail.
-        expect(cssSource).toMatch(/:root\[data-sb-topbar-brand-cramped='true'\] \.sb-topbar-cluster-divider \{/);
+        // Gated on the mode itself, not on the label being squeezed out.
+        expect(cssSource).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{\n\s*display: inline-block;\n\}/);
+        expect(cssSource).not.toMatch(/data-sb-topbar-brand-cramped='true'\] [^{]*\.sb-topbar-cluster-divider/);
 
-        // Phones show both too; the divider takes over the seam so it sits centred in it.
-        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{/);
+        // The divider takes over the seam so it sits centred in it; phones only shorten the rule.
         expect(cssSource).toContain('.sb-topbar-cluster-divider + .sb-topbar-cluster-lead');
-        expect(mobileCss).toContain('.sb-topbar-cluster-divider + .sb-topbar-cluster-lead');
+        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-cluster-divider \{\n\s*height: calc\(var\(--sb-mobile-toggle-size\) \* 0\.5\);\n\s*\}/);
     });
 
     test('separates the clusters with a wider seam than the icons inside one', () => {

--- a/tests/topbar-label-tap-cycle.test.js
+++ b/tests/topbar-label-tap-cycle.test.js
@@ -137,10 +137,12 @@ describe('icons only top bar', () => {
         }
     });
 
-    test('keeps the centre brand label on every viewport', () => {
+    test('drops the centre brand label on phones only', () => {
+        // Desktop has room for the label, so the hide lives in the phone-gated sheet alone.
+        // (0,3,0) outranks the plain .sb-topbar-brand rules in both fork sheets, no !important.
         const mobileCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+        expect(mobileCss).toMatch(/:root\[data-sb-topbar-icons-only='true'\] \.sb-topbar-brand \{\n\s*display: none;\n\s*\}/);
         expect(cssSource).not.toMatch(/data-sb-topbar-icons-only='true'\]\s+\.sb-topbar-brand/);
-        expect(mobileCss).not.toMatch(/data-sb-topbar-icons-only='true'\]\s+\.sb-topbar-brand/);
     });
 
     test('keeps the character toggle measurable for anchored extension dropdowns', () => {
@@ -198,6 +200,25 @@ describe('icons only top bar', () => {
         expect(groupSource).toContain('createTopbarIconsOnlySettingsGroup()');
         expect(normalizedTabsSource.match(/'Icons only top bar'/g)).toHaveLength(1);
         expect(normalizedTabsSource).not.toContain('lorum ipsum');
+    });
+
+    test('splits customize pages onto a second rail beside the brand label', () => {
+        expect(normalizedTabsSource).toContain('const leftPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey !== \'right\');');
+        expect(normalizedTabsSource).toContain('const rightPages = SB_TOPBAR_PAGE_TARGETS.filter(page => page.shellKey === \'right\');');
+        expect(normalizedTabsSource).toContain('buildTopbarPageRail(\'sb-topbar-pages-right\', rightPages);');
+        expect(normalizedTabsSource).toContain('rightGroup.append(customizeRail,');
+    });
+
+    test('folds both rails back together on phones', () => {
+        // The split fills the gap either side of the brand label; phones hide that label and
+        // have no width to spare, so the right group's fixed buttons would starve the left rail.
+        const splitSource = getFunctionSource('syncTopbarRailSplit');
+        expect(splitSource).toContain('const shouldMerge = isMobileViewport();');
+        expect(splitSource).toContain('leftRail.appendChild(button);');
+        expect(splitSource).toContain('rightRail.appendChild(button);');
+        expect(splitSource).toContain('classList.toggle(\'sb-topbar-pages-empty\', shouldMerge);');
+        expect(normalizedTabsSource).toContain('window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener(\'change\'');
+        expect(cssSource).toContain(':root[data-sb-topbar-icons-only=\'true\'] .sb-topbar-pages-empty');
     });
 
     test('scrolls the rail rather than wrapping it', () => {


### PR DESCRIPTION
An option in the Settings page called "Icons only top bar" to remove the text and place every page icon on the top bar instead, similar to upstream SillyTavern.
Includes any user-toggled Quick Actions buttons.
Note: Workspace buttons always on the left regardless of custom Quick Actions
Reviewed against the new PRODUCT.md and DESIGN.md.

Looks like this:
1. Tablet size
<img width="807" height="58" alt="image" src="https://github.com/user-attachments/assets/552393a2-4bd5-48da-9be9-bdbf48ff01d8" />

2, Desktop size
<img width="1381" height="70" alt="image" src="https://github.com/user-attachments/assets/c56bdf58-a761-4a44-b147-298a910b590f" />

3. Mobile - Scrollable horizontally (Btw there is a divider, just not visible with my personal theme)
<img width="1179" height="180" alt="image" src="https://github.com/user-attachments/assets/e4d1a968-4f10-45ad-86cb-ed13bf47298e" />

Turn it on here
<img width="906" height="732" alt="image" src="https://github.com/user-attachments/assets/55d3901e-9ce6-4cf5-a287-b1719ec8ef80" />

**Note**: this technically goes against one of the philosophies in DESIGN.md: "Don't hide essential writing controls behind mystery meat navigation." The icons-only mode is, by definition, label-free. Each button has a title attribute and the cluster grouping provides spatial context, but on touch devices title is not surfaced at all. 

However, given this is opt-in and a deliberate design decision, it is safe to implement with that concession.