### PR TITLE
fix: issue of being unable to import or rename any preset to any user-deleted bundled default presets

### DIFF
--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -863,7 +863,7 @@ class PresetManager {
      * @param {object} [options] Options for saving the preset
      * @param {boolean} [options.skipUpdate=false] If true, skips updating the preset list after saving.
      */
-    async savePreset(name, settings, { skipUpdate = false, restoreDefault = false } = {}) {
+    async savePreset(name, settings, { skipUpdate = false } = {}) {
         if (this.apiId === 'instruct' && settings) {
             await checkForSystemPromptInInstructTemplate(name, settings);
         }
@@ -877,15 +877,11 @@ class PresetManager {
         const response = await fetch('/api/presets/save', {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({ preset, name, apiId: this.apiId, restoreDefault }),
+            body: JSON.stringify({ preset, name, apiId: this.apiId }),
         });
 
         if (!response.ok) {
-            const responseData = await response.json().catch(() => ({}));
-            const errorMessage = responseData?.isDeletedDefault
-                ? t`This bundled default was deleted. Use Restore default presets to bring it back.`
-                : t`Check the server connection and reload the page to prevent data loss.`;
-            toastr.error(errorMessage, t`Preset could not be saved`);
+            toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Preset could not be saved`);
             console.error('Preset could not be saved', response);
             throw new Error('Preset could not be saved');
         }
@@ -1762,7 +1758,7 @@ export async function initPresetManager() {
             }
 
             await presetManager.deletePreset();
-            await presetManager.savePreset(name, data.preset, { restoreDefault: true });
+            await presetManager.savePreset(name, data.preset);
             const option = presetManager.findPreset(name);
             await presetManager.selectPreset(option);
             const successToast = !presetManager.isAdvancedFormatting() ? t`Default preset restored` : t`Default template restored`;

--- a/src/endpoints/presets.js
+++ b/src/endpoints/presets.js
@@ -10,7 +10,6 @@ import {
     findDefaultPreset,
     getDefaultPresetFile,
     getDefaultPresets,
-    isDefaultPresetDeleted,
     recordDefaultPresetDeletion,
     restoreDefaultPresetFiles,
 } from './content-manager.js';
@@ -83,21 +82,16 @@ router.post('/save', function (request, response) {
 
     const fullpath = path.join(settings.folder, filename);
     const defaultPreset = findDefaultPreset(request.user.directories, { folder: settings.folder, name });
-    const explicitDefaultRestore = Boolean(request.body.restoreDefault);
 
-    if (defaultPreset && isDefaultPresetDeleted(request.user.directories, defaultPreset) && !explicitDefaultRestore) {
-        return response.status(409).send({
-            error: 'This bundled default preset was deleted by the user and will not be recreated unless defaults are explicitly restored.',
-            isDeletedDefault: true,
-            name,
-        });
-    }
+    tryWriteFileSync(fullpath, JSON.stringify(request.body.preset, null, 4));
 
-    if (defaultPreset && explicitDefaultRestore) {
+    // A save request is always user-initiated (save, save as, rename, import, or restore), so it may
+    // claim a deleted bundled default's name. The tombstone only exists to stop the content seeder
+    // from recreating the file, and a file now exists at that path, so it is retired here.
+    if (defaultPreset) {
         clearDefaultPresetDeletion(request.user.directories, defaultPreset);
     }
 
-    tryWriteFileSync(fullpath, JSON.stringify(request.body.preset, null, 4));
     return response.send({ name });
 });
 

--- a/tests/preset-save-deleted-default.test.js
+++ b/tests/preset-save-deleted-default.test.js
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+import express from 'express';
+
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+const contentManager = await import('../src/endpoints/content-manager.js');
+const { router: presetsRouter } = await import('../src/endpoints/presets.js');
+
+const PRESET_NAME = 'Default';
+
+describe('saving over a deleted bundled default preset', () => {
+    let baseUrl;
+    let directories;
+    let server;
+    let tempRoot;
+
+    beforeAll(async () => {
+        const app = express();
+        app.use(express.json());
+        app.use((request, _response, next) => {
+            request.user = {
+                profile: { handle: 'preset-save-test-user' },
+                directories,
+            };
+            next();
+        });
+        app.use('/api/presets', presetsRouter);
+
+        await new Promise((resolve) => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-preset-save-'));
+        directories = {
+            root: tempRoot,
+            openAI_Settings: path.join(tempRoot, 'presets', 'openai'),
+        };
+        fs.mkdirSync(directories.openAI_Settings, { recursive: true });
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+        await new Promise((resolve) => server.close(resolve));
+    });
+
+    function savePreset(preset) {
+        return fetch(`${baseUrl}/api/presets/save`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: PRESET_NAME, apiId: 'openai', preset }),
+        });
+    }
+
+    function getDefaultPreset() {
+        return contentManager.findDefaultPreset(directories, {
+            folder: directories.openAI_Settings,
+            name: PRESET_NAME,
+        });
+    }
+
+    test('writes the preset and clears the tombstone', async () => {
+        const defaultPreset = getDefaultPreset();
+        expect(defaultPreset).toBeTruthy();
+        contentManager.recordDefaultPresetDeletion(directories, defaultPreset);
+
+        const response = await savePreset({ imported: true });
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ name: PRESET_NAME });
+
+        const targetPath = path.join(directories.openAI_Settings, `${PRESET_NAME}.json`);
+        expect(JSON.parse(fs.readFileSync(targetPath, 'utf8'))).toEqual({ imported: true });
+        expect(contentManager.isDefaultPresetDeleted(directories, defaultPreset)).toBe(false);
+    });
+
+    test('allows a rename onto a deleted default name without a restore flag', async () => {
+        const defaultPreset = getDefaultPreset();
+        contentManager.recordDefaultPresetDeletion(directories, defaultPreset);
+
+        const first = await savePreset({ renamed: 1 });
+        const second = await savePreset({ renamed: 2 });
+
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+
+        const targetPath = path.join(directories.openAI_Settings, `${PRESET_NAME}.json`);
+        expect(JSON.parse(fs.readFileSync(targetPath, 'utf8'))).toEqual({ renamed: 2 });
+    });
+
+    test('deleting the preset again records the tombstone', async () => {
+        const defaultPreset = getDefaultPreset();
+        await savePreset({ imported: true });
+
+        const response = await fetch(`${baseUrl}/api/presets/delete`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: PRESET_NAME, apiId: 'openai' }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(contentManager.isDefaultPresetDeleted(directories, defaultPreset)).toBe(true);
+        expect(fs.existsSync(path.join(directories.openAI_Settings, `${PRESET_NAME}.json`))).toBe(false);
+    });
+});


### PR DESCRIPTION
## Issue
Initially, my issue was when trying to import `TLD Card Conversion Preset (Standalone).json`, or renaming a preset to that, it throws this error in the console:

```
Preset could not be saved 
Response { type: "basic", url: "https://<redacted>/api/presets/save", redirected: false, status: 409, ok: false, statusText: "", headers: Headers(20), body: ReadableStream, bodyUsed: true }
​
body: ReadableStream { locked: true }
​
bodyUsed: true
​
headers: Headers(20) { "alt-svc" → 'h3=":443"; ma=2592000', "content-length" → "203", "content-type" → "application/json; charset=utf-8", … }
​
ok: false
​
redirected: false
​
status: 409
​
statusText: ""
​
type: "basic"
​
url: "https://<redacted>/api/presets/save"
​
<prototype>: ResponsePrototype { clone: clone(), arrayBuffer: arrayBuffer(), blob: blob(), … }
preset-manager.js:889:21

```

It only imports if I add anything else to the json name (such as 1).

## Fix
The program itself kept refusing to re-import any of the default bundled presets so long as I delete them. If the user intentionally deletes them, now they can be re-imported again.

## Testing
Tested and works.