### PR TITLE
fix: characters with spaces show proper thumbnails

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10526,7 +10526,9 @@ function getFullAvatarUrl(type, file, t = false) {
  * @param {string} rawSrc Avatar image source.
  * @returns {{ type: 'avatar' | 'persona' | null, file: string, original: string } | null}
  */
-function parseAvatarSource(rawSrc) {
+// SillyBunny: exported so sillybunny-tabs.js reuses this parser instead of keeping a divergent copy
+// that skipped the pathname decode and re-encoded file names into "%2520".
+export function parseAvatarSource(rawSrc) {
     if (!rawSrc) {
         return null;
     }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -9,7 +9,7 @@ import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { hasServerReturnedAfterRestart } from './server-restart-monitor.js';
 import { conversationState } from './sillybunny-conversation/state.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
-import { flushCharacterSaveDebounced, getOneCharacter, refreshCsrfToken, saveSettingsDebounced } from '../script.js';
+import { flushCharacterSaveDebounced, getOneCharacter, getThumbnailUrl, parseAvatarSource, refreshCsrfToken, saveSettingsDebounced } from '../script.js';
 
 const sbMobileShellLifecycle = createMobileShellLifecycle();
 const sbPresetApiSyncLifecycle = createPresetApiSyncLifecycle();
@@ -3708,47 +3708,6 @@ function stripAvatarOrigin(url) {
         : normalizedUrl;
 }
 
-function safeDecodeUriComponent(value) {
-    try {
-        return decodeURIComponent(value);
-    } catch {
-        return value;
-    }
-}
-
-function parseChatAvatarSource(rawSrc) {
-    const normalizedSrc = stripAvatarOrigin(rawSrc);
-    if (!normalizedSrc) {
-        return null;
-    }
-
-    const trimmedSrc = normalizedSrc.startsWith('/') ? normalizedSrc.slice(1) : normalizedSrc;
-
-    try {
-        const parsedUrl = new URL(normalizedSrc, window.location.origin);
-        if (parsedUrl.pathname.endsWith('thumbnail')) {
-            const type = parsedUrl.searchParams.get('type');
-            const file = parsedUrl.searchParams.get('file');
-
-            if (type && file) {
-                return { type, file: safeDecodeUriComponent(file) };
-            }
-        }
-    } catch {
-        // Fall back to direct path inspection below.
-    }
-
-    if (trimmedSrc.startsWith('characters/')) {
-        return { type: 'avatar', file: trimmedSrc.replace(/^characters\//, '') };
-    }
-
-    if (trimmedSrc.startsWith('User Avatars/')) {
-        return { type: 'persona', file: trimmedSrc.replace(/^User Avatars\//, '') };
-    }
-
-    return { type: null, file: normalizedSrc };
-}
-
 function isAbsoluteAvatarUrl(path) {
     return /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(String(path ?? ''));
 }
@@ -3763,24 +3722,20 @@ function ensureAvatarPath(path) {
 }
 
 function getChatAvatarSources(rawSrc) {
-    const avatarInfo = parseChatAvatarSource(rawSrc);
+    // Reuses script.js's parser so the thumbnail URL is built from a file name decoded exactly once.
+    const avatarInfo = parseAvatarSource(stripAvatarOrigin(rawSrc));
     if (!avatarInfo) {
         return { thumb: '', original: '' };
     }
 
-    const { type, file } = avatarInfo;
+    const { type, file, original } = avatarInfo;
     const thumb = type === 'avatar' || type === 'persona'
-        ? `/thumbnail?type=${type}&file=${encodeURIComponent(file)}`
+        ? getThumbnailUrl(type, file)
         : ensureAvatarPath(file);
-    const original = type === 'avatar'
-        ? ensureAvatarPath(`characters/${file}`)
-        : type === 'persona'
-            ? ensureAvatarPath(`User Avatars/${file}`)
-            : ensureAvatarPath(file);
 
     return {
         thumb: stripAvatarOrigin(thumb),
-        original: stripAvatarOrigin(original),
+        original: stripAvatarOrigin(ensureAvatarPath(original)),
     };
 }
 

--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -83,6 +83,42 @@ function getOriginalFolder(directories, type) {
 }
 
 /**
+ * Resolves a requested file name to the name that actually exists in the original images folder.
+ * @param {import('../users.js').UserDirectoryList} directories User directories
+ * @param {ThumbnailType} type Thumbnail type
+ * @param {string} file Requested file name
+ * @returns {string} File name to use for thumbnail lookups
+ */
+// SillyBunny: diverges from upstream. Clients can send a `file` that was percent-encoded twice
+// ("Mara%2520Rodriguez.png"); Express decodes it once, leaving a literal "%20" that never matches
+// the file on disk. The name as sent always wins, so real '%' characters keep working.
+function resolveOriginalFileName(directories, type, file) {
+    if (!file.includes('%')) {
+        return file;
+    }
+
+    const originalFolder = getOriginalFolder(directories, type);
+    if (originalFolder === undefined || fs.existsSync(path.join(originalFolder, file))) {
+        return file;
+    }
+
+    let decodedFile;
+    try {
+        decodedFile = decodeURIComponent(file);
+    } catch {
+        // A '%' that is not a valid escape sequence is a legal file name character.
+        return file;
+    }
+
+    // Re-run the sanitizer so a decoded name can never escape the folder.
+    if (!decodedFile || decodedFile === file || decodedFile !== sanitize(decodedFile)) {
+        return file;
+    }
+
+    return fs.existsSync(path.join(originalFolder, decodedFile)) ? decodedFile : file;
+}
+
+/**
  * Removes the generated thumbnail from the disk.
  * @param {import('../users.js').UserDirectoryList} directories User directories
  * @param {ThumbnailType} type Type of the thumbnail
@@ -127,6 +163,8 @@ export async function generateThumbnail(directories, type, file, forceGenerate =
     const thumbnailFolder = getThumbnailFolder(directories, type);
     const originalFolder = getOriginalFolder(directories, type);
     if (thumbnailFolder === undefined || originalFolder === undefined) throw new Error('Invalid thumbnail type');
+    // SillyBunny: tolerate a double percent-encoded name (see resolveOriginalFileName).
+    file = resolveOriginalFileName(directories, type, file);
     const pathToCachedFile = path.join(thumbnailFolder, file);
 
     try {
@@ -272,8 +310,11 @@ publicRouter.get('/', async function (request, response) {
             return response.sendStatus(400);
         }
 
-        const file = sanitize(rawFile);
-        if (file !== rawFile) return response.sendStatus(403);
+        const sanitizedFile = sanitize(rawFile);
+        if (sanitizedFile !== rawFile) return response.sendStatus(403);
+
+        // SillyBunny: tolerate a double percent-encoded `file` param (see resolveOriginalFileName).
+        const file = resolveOriginalFileName(request.user.directories, type, sanitizedFile);
 
         const serveOriginal = () => {
             const folder = getOriginalFolder(request.user.directories, type);

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -161,6 +161,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "novelai_settings",
   "online_status",
   "openCharacterChat",
+  "parseAvatarSource",
   "parseMesExamples",
   "pingServer",
   "printCharacters",

--- a/tests/chat-avatar-thumbnail-urls.test.js
+++ b/tests/chat-avatar-thumbnail-urls.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const publicRoot = path.join(repoRoot, 'public');
+const scriptSource = fs.readFileSync(path.join(publicRoot, 'script.js'), 'utf8');
+const tabsSource = fs.readFileSync(path.join(publicRoot, 'scripts', 'sillybunny-tabs.js'), 'utf8');
+
+const IGNORED_DIRECTORIES = new Set(['lib', 'third-party', 'node_modules']);
+
+function listPublicScripts(directory = publicRoot, found = []) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+            if (!IGNORED_DIRECTORIES.has(entry.name)) {
+                listPublicScripts(path.join(directory, entry.name), found);
+            }
+            continue;
+        }
+        if (entry.name.endsWith('.js') && !entry.name.endsWith('.min.js')) {
+            found.push(path.join(directory, entry.name));
+        }
+    }
+
+    return found;
+}
+
+function getFunctionSource(source, name) {
+    const match = source.match(new RegExp(`function ${name}\\([\\s\\S]*?\\n\\}`));
+    expect(match).not.toBeNull();
+    return match[0];
+}
+
+/**
+ * Rebuilds the avatar URL pipeline that updateChatAvatarVariables runs in the browser, using the
+ * shipped function bodies. Neither module can be imported under Jest, so the sources are evaluated
+ * with the handful of globals they close over.
+ * @returns {{ getThumbnailUrl: Function, parseAvatarSource: Function, getChatAvatarSources: Function }}
+ */
+function loadAvatarPipeline() {
+    const body = [
+        getFunctionSource(scriptSource, 'getThumbnailUrl'),
+        getFunctionSource(scriptSource, 'getFullAvatarUrl'),
+        getFunctionSource(scriptSource, 'parseAvatarSource'),
+        getFunctionSource(tabsSource, 'stripAvatarOrigin'),
+        getFunctionSource(tabsSource, 'isAbsoluteAvatarUrl'),
+        getFunctionSource(tabsSource, 'ensureAvatarPath'),
+        getFunctionSource(tabsSource, 'getChatAvatarSources'),
+        'return { getThumbnailUrl, parseAvatarSource, getChatAvatarSources };',
+    ].join('\n\n');
+
+    const factory = new Function('window', 'isDataURL', 'default_avatar', body);
+
+    return factory(
+        { location: { origin: 'http://localhost:8000' } },
+        value => String(value).startsWith('data:'),
+        '/img/ai4.png',
+    );
+}
+
+describe('chat avatar thumbnail urls', () => {
+    test('only script.js builds thumbnail endpoint urls', () => {
+        const builders = listPublicScripts()
+            .filter(file => fs.readFileSync(file, 'utf8').includes('/thumbnail?type='))
+            .map(file => path.relative(repoRoot, file));
+
+        expect(builders).toEqual([path.join('public', 'script.js')]);
+    });
+
+    test('sillybunny-tabs.js reuses the shared parser instead of a local copy', () => {
+        expect(tabsSource).toContain('parseAvatarSource,');
+        expect(tabsSource).toContain('getThumbnailUrl,');
+        expect(tabsSource).toMatch(/import \{[^}]*parseAvatarSource[^}]*\} from '\.\.\/script\.js';/);
+        expect(tabsSource).not.toContain('function parseChatAvatarSource');
+        expect(tabsSource).not.toContain('function safeDecodeUriComponent');
+    });
+
+    test('script.js decodes the pathname before stripping the avatar folder prefix', () => {
+        expect(scriptSource).toContain('export function parseAvatarSource');
+        expect(getFunctionSource(scriptSource, 'parseAvatarSource'))
+            .toContain('const pathName = decodeURIComponent(parsed.pathname);');
+    });
+
+    test('decodes a spaced character path exactly once', () => {
+        const { parseAvatarSource } = loadAvatarPipeline();
+
+        expect(parseAvatarSource('/characters/Mara%20Rodriguez.png')).toEqual({
+            type: 'avatar',
+            file: 'Mara Rodriguez.png',
+            original: '/characters/Mara%20Rodriguez.png',
+        });
+    });
+
+    test('builds a single-encoded thumbnail url for a spaced character avatar', () => {
+        const { getChatAvatarSources } = loadAvatarPipeline();
+
+        const { thumb } = getChatAvatarSources('/characters/Mara%20Rodriguez.png');
+
+        expect(thumb).toBe('/thumbnail?type=avatar&file=Mara%20Rodriguez.png');
+        expect(thumb).not.toContain('%2520');
+    });
+
+    test('recognises a spaced persona path as a persona avatar', () => {
+        const { getChatAvatarSources, parseAvatarSource } = loadAvatarPipeline();
+
+        expect(parseAvatarSource('/User%20Avatars/Me%20Myself.png').type).toBe('persona');
+        expect(getChatAvatarSources('/User%20Avatars/Me%20Myself.png').thumb)
+            .toBe('/thumbnail?type=persona&file=Me%20Myself.png');
+    });
+
+    test('is idempotent when a thumbnail url is fed back through the pipeline', () => {
+        const { getChatAvatarSources } = loadAvatarPipeline();
+
+        const first = getChatAvatarSources('/characters/Mara%20Rodriguez.png').thumb;
+        const second = getChatAvatarSources(first).thumb;
+
+        expect(second).toBe(first);
+    });
+
+    test('decodes a thumbnail url file param exactly once', () => {
+        const { parseAvatarSource } = loadAvatarPipeline();
+
+        expect(parseAvatarSource('/thumbnail?type=avatar&file=100%2525.png').file).toBe('100%25.png');
+    });
+
+    test('leaves sources without a known avatar folder untouched', () => {
+        const { getChatAvatarSources } = loadAvatarPipeline();
+
+        expect(getChatAvatarSources('').thumb).toBe('');
+        expect(getChatAvatarSources('/img/ai4.png').thumb).toBe('/img/ai4.png');
+        expect(getChatAvatarSources('data:image/png;base64,AAAA').thumb).toBe('data:image/png;base64,AAAA');
+    });
+});

--- a/tests/thumbnails-endpoint.test.js
+++ b/tests/thumbnails-endpoint.test.js
@@ -1,0 +1,207 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const originalWorkingDirectory = process.cwd();
+process.chdir(repoRoot);
+setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
+
+const { generateThumbnail, publicRouter } = await import('../src/endpoints/thumbnails.js');
+
+// A real 8x8 PNG. The cached-thumbnail branch of generateThumbnail measures the file with
+// image-size, so those cases need parseable bytes rather than an arbitrary marker.
+const PNG_FIXTURE = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=', 'base64');
+const THUMBNAIL_MARKER = 'cached-thumbnail-bytes';
+const SECRET_MARKER = 'secret-outside-the-folder';
+
+describe('thumbnail file name resolution', () => {
+    let baseUrl;
+    let directories;
+    let server;
+    let tempRoot;
+
+    beforeAll(async () => {
+        const app = express();
+        app.use((request, _response, next) => {
+            request.user = {
+                profile: { handle: 'thumbnails-test-user' },
+                directories,
+            };
+            next();
+        });
+        app.use('/thumbnail', publicRouter);
+
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-thumbnails-'));
+        directories = {
+            root: tempRoot,
+            avatars: path.join(tempRoot, 'User Avatars'),
+            backgrounds: path.join(tempRoot, 'backgrounds'),
+            characters: path.join(tempRoot, 'characters'),
+            thumbnailsAvatar: path.join(tempRoot, 'thumbnails', 'avatar'),
+            thumbnailsBg: path.join(tempRoot, 'thumbnails', 'bg'),
+            thumbnailsPersona: path.join(tempRoot, 'thumbnails', 'persona'),
+        };
+        for (const directory of Object.values(directories)) {
+            fs.mkdirSync(directory, { recursive: true });
+        }
+        // Lives one level above the characters folder, so a successful traversal would expose it.
+        fs.writeFileSync(path.join(tempRoot, 'secret.png'), SECRET_MARKER);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+        if (server) {
+            await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        }
+        process.chdir(originalWorkingDirectory);
+    });
+
+    function writeCharacter(name) {
+        fs.writeFileSync(path.join(directories.characters, name), PNG_FIXTURE);
+    }
+
+    /**
+     * Writes a cached thumbnail whose timestamps are newer than the original, so the freshness
+     * check in generateThumbnail treats it as up to date instead of regenerating it.
+     * @param {string} name File name
+     * @param {Buffer|string} contents File contents
+     */
+    function writeCachedThumbnail(name, contents = THUMBNAIL_MARKER) {
+        const target = path.join(directories.thumbnailsAvatar, name);
+        fs.writeFileSync(target, contents);
+        const past = new Date(Date.now() - 60_000);
+        fs.utimesSync(path.join(directories.characters, name), past, past);
+    }
+
+    async function requestThumbnail(query) {
+        return await fetch(`${baseUrl}/thumbnail?${query}`);
+    }
+
+    test('serves the real thumbnail when the file name arrives percent-encoded twice', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        writeCharacter('Mara Rodriguez.png');
+        writeCachedThumbnail('Mara Rodriguez.png');
+
+        // Express decodes the query once, so the handler sees the literal "Mara%20Rodriguez.png".
+        const response = await requestThumbnail('type=avatar&file=Mara%2520Rodriguez.png');
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe(THUMBNAIL_MARKER);
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    test('still serves correctly encoded names containing a space', async () => {
+        writeCharacter('Mara Rodriguez.png');
+        writeCachedThumbnail('Mara Rodriguez.png');
+
+        const response = await requestThumbnail('type=avatar&file=Mara%20Rodriguez.png');
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe(THUMBNAIL_MARKER);
+    });
+
+    test('still serves plain names', async () => {
+        writeCharacter('Alice.png');
+        writeCachedThumbnail('Alice.png');
+
+        const response = await requestThumbnail('type=avatar&file=Alice.png');
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe(THUMBNAIL_MARKER);
+    });
+
+    test('rejects a traversal hidden behind double percent-encoding', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        // Express decodes these to "%2E%2E%2Fsecret.png" and "..%2Fsecret.png", which survive
+        // sanitize() untouched and therefore reach the decode fallback.
+        for (const query of ['type=avatar&file=%252E%252E%252Fsecret.png', 'type=avatar&file=..%252Fsecret.png', 'type=avatar&file=%2500.png']) {
+            const response = await requestThumbnail(query);
+            expect(response.status).toBe(404);
+            expect(await response.text()).not.toContain(SECRET_MARKER);
+        }
+    });
+
+    test('keeps rejecting a traversal that survives the query decode', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const response = await requestThumbnail('type=avatar&file=../secret.png');
+
+        expect(response.status).toBe(403);
+    });
+
+    test('does not fail when the name contains a malformed escape sequence', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const response = await requestThumbnail('type=avatar&file=missing%25.png');
+
+        expect(response.status).toBe(404);
+    });
+
+    test('serves a name whose literal percent sign is not an escape sequence', async () => {
+        writeCharacter('50% Off.png');
+        writeCachedThumbnail('50% Off.png');
+
+        const response = await requestThumbnail('type=avatar&file=50%25%20Off.png');
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe(THUMBNAIL_MARKER);
+    });
+
+    test('generateThumbnail resolves an over-encoded name to the file on disk', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        writeCharacter('Mara Rodriguez.png');
+        writeCachedThumbnail('Mara Rodriguez.png', PNG_FIXTURE);
+
+        const result = await generateThumbnail(directories, 'avatar', 'Mara%20Rodriguez.png');
+
+        expect(result.path).toBe(path.join(directories.thumbnailsAvatar, 'Mara Rodriguez.png'));
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    test('generateThumbnail prefers a literal percent name over its decoded form', async () => {
+        writeCharacter('100%25.png');
+        writeCharacter('100%.png');
+        writeCachedThumbnail('100%25.png', PNG_FIXTURE);
+        writeCachedThumbnail('100%.png', PNG_FIXTURE);
+
+        const result = await generateThumbnail(directories, 'avatar', '100%25.png');
+
+        expect(result.path).toBe(path.join(directories.thumbnailsAvatar, '100%25.png'));
+    });
+
+    test('generateThumbnail leaves a bare percent name untouched', async () => {
+        writeCharacter('50%.png');
+        writeCachedThumbnail('50%.png', PNG_FIXTURE);
+
+        const result = await generateThumbnail(directories, 'avatar', '50%.png');
+
+        expect(result.path).toBe(path.join(directories.thumbnailsAvatar, '50%.png'));
+    });
+
+    test('generateThumbnail refuses to resolve outside the originals folder', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const result = await generateThumbnail(directories, 'avatar', '%2E%2E%2Fsecret.png');
+
+        expect(result.path).toBeNull();
+        expect(fs.readdirSync(directories.thumbnailsAvatar)).toEqual([]);
+    });
+});


### PR DESCRIPTION
When a character card has spaces, it shows an error like this:
`STDERR [generateThumbnail] Cannot generate thumbnail, original file not found: data/default-user/characters/Mara%20Rodriguez.png`
However, the thumbnail truly does exist.

This PR resolves that.

## Fix
- Character name space became %2520 instead of %20.
- Deletes the broken duplicate and pointed to the copy that actually works.