### PR TITLE
feat(launcher): gate bun --smol behind SILLYBUNNY_BUN_SMOL

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -110,13 +110,15 @@ bun run start:global   # SillyBunny-owned data paths
 bun run start:no-csrf  # disable CSRF (local dev)
 ```
 
-When you start through a launcher script through pm2, systemd or Docker, rather than `bun run`, set `SILLYBUNNY_BUN_SMOL=1` to get the same `bun run --smol` low-memory mode:
+If you launch through a script rather than `bun run` — pm2, systemd, Docker, or Termux — set `SILLYBUNNY_BUN_SMOL=1` to get the same low-memory mode as `start:mobile`:
 
 ```bash
 SILLYBUNNY_BUN_SMOL=1 ./start.sh
 ```
 
-This flag isn't supported in Node.js mode.
+`start.sh`, `Start.bat`, and the Docker entrypoint all honour it; for Docker, set it under `environment:` in `docker/docker-compose.yml`.
+
+`--smol` is a Bun flag, so it does nothing in Node.js mode — and Termux, macOS, and ARM hosts pick Node.js by default. Use `./start-bun.sh` (Termux: `bash start-termux-bun.sh`) to get Bun together with `--smol`. The launcher warns when the flag is set while Node.js is selected.
 
 ### macOS notes
 

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -110,6 +110,14 @@ bun run start:global   # SillyBunny-owned data paths
 bun run start:no-csrf  # disable CSRF (local dev)
 ```
 
+When you start through a launcher script through pm2, systemd or Docker, rather than `bun run`, set `SILLYBUNNY_BUN_SMOL=1` to get the same `bun run --smol` low-memory mode:
+
+```bash
+SILLYBUNNY_BUN_SMOL=1 ./start.sh
+```
+
+This flag isn't supported in Node.js mode.
+
 ### macOS notes
 
 - If the launcher window closes too fast, run `./Start.command` from Terminal to keep output visible

--- a/README.md
+++ b/README.md
@@ -108,15 +108,13 @@ bun run start:global   # SillyBunny-owned data paths
 bun run start:no-csrf  # disable CSRF (local dev)
 ```
 
-When you start through a launcher script rather than `bun run`, set `SILLYBUNNY_BUN_SMOL=1` to get the
-same `--smol` low-memory mode. This is the way to reach it from a process manager such as pm2, systemd
-or Docker, which invoke `start.sh` (or `Start.bat`) instead of the npm scripts:
+When you start through a launcher script through pm2, systemd or Docker, rather than `bun run`, set `SILLYBUNNY_BUN_SMOL=1` to get the same `bun run --smol` low-memory mode:
 
 ```bash
 SILLYBUNNY_BUN_SMOL=1 ./start.sh
 ```
 
-The flag is ignored when the Node runtime is selected, since it is a Bun option.
+This flag isn't supported in Node.js mode.
 
 ### macOS notes
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,15 @@ bun run start:global   # SillyBunny-owned data paths
 bun run start:no-csrf  # disable CSRF (local dev)
 ```
 
-When you start through a launcher script through pm2, systemd or Docker, rather than `bun run`, set `SILLYBUNNY_BUN_SMOL=1` to get the same `bun run --smol` low-memory mode:
+If you launch through a script rather than `bun run` — pm2, systemd, Docker, or Termux — set `SILLYBUNNY_BUN_SMOL=1` to get the same low-memory mode as `start:mobile`:
 
 ```bash
 SILLYBUNNY_BUN_SMOL=1 ./start.sh
 ```
 
-This flag isn't supported in Node.js mode.
+`start.sh`, `Start.bat`, and the Docker entrypoint all honour it; for Docker, set it under `environment:` in `docker/docker-compose.yml`.
+
+`--smol` is a Bun flag, so it does nothing in Node.js mode — and Termux, macOS, and ARM hosts pick Node.js by default. Use `./start-bun.sh` (Termux: `bash start-termux-bun.sh`) to get Bun together with `--smol`. The launcher warns when the flag is set while Node.js is selected.
 
 ### macOS notes
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ bun run start:global   # SillyBunny-owned data paths
 bun run start:no-csrf  # disable CSRF (local dev)
 ```
 
+When you start through a launcher script rather than `bun run`, set `SILLYBUNNY_BUN_SMOL=1` to get the
+same `--smol` low-memory mode. This is the way to reach it from a process manager such as pm2, systemd
+or Docker, which invoke `start.sh` (or `Start.bat`) instead of the npm scripts:
+
+```bash
+SILLYBUNNY_BUN_SMOL=1 ./start.sh
+```
+
+The flag is ignored when the Node runtime is selected, since it is a Bun option.
+
 ### macOS notes
 
 - If the launcher window closes too fast, run `./Start.command` from Terminal to keep output visible

--- a/Start.bat
+++ b/Start.bat
@@ -122,6 +122,10 @@ if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
 :server_loop
 if "!_server_runtime!"=="node" (
     node --no-warnings server.js %*
+) else if /I "!SILLYBUNNY_BUN_SMOL!"=="1" (
+    REM Bun grows the JSC heap freely while RAM looks plentiful; --smol trades
+    REM throughput for much more aggressive GC on memory-constrained hosts.
+    bun --smol server.js %*
 ) else (
     bun server.js %*
 )

--- a/Start.bat
+++ b/Start.bat
@@ -119,10 +119,23 @@ if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
     )
 )
 
+REM Normalise SILLYBUNNY_BUN_SMOL to a 0/1 flag so the accepted spellings match
+REM is_truthy in start.sh, rather than only the literal 1.
+set "_bun_smol=0"
+if /I "!SILLYBUNNY_BUN_SMOL!"=="1" set "_bun_smol=1"
+if /I "!SILLYBUNNY_BUN_SMOL!"=="true" set "_bun_smol=1"
+if /I "!SILLYBUNNY_BUN_SMOL!"=="yes" set "_bun_smol=1"
+if /I "!SILLYBUNNY_BUN_SMOL!"=="on" set "_bun_smol=1"
+
+if "!_bun_smol!"=="1" if "!_server_runtime!"=="node" (
+    echo [SillyBunny] SILLYBUNNY_BUN_SMOL is set, but Node.js was selected. --smol is a Bun flag and will be ignored.
+    echo [SillyBunny] For Bun with --smol, use Start-Bun.bat.
+)
+
 :server_loop
 if "!_server_runtime!"=="node" (
     node --no-warnings server.js %*
-) else if /I "!SILLYBUNNY_BUN_SMOL!"=="1" (
+) else if "!_bun_smol!"=="1" (
     REM Bun grows the JSC heap freely while RAM looks plentiful; --smol trades
     REM throughput for much more aggressive GC on memory-constrained hosts.
     bun --smol server.js %*

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       # Match container-created files to your host user and group by default.
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+      # Uncomment on memory-capped hosts to trade throughput for aggressive GC.
+      # - SILLYBUNNY_BUN_SMOL=1
     ports:
       - "4444:4444"
     volumes:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# Mirrors is_truthy in start.sh so SILLYBUNNY_* flags accept the same spellings
+# in containers as they do under the shell launchers.
+is_truthy() {
+    case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 # Function to handle startup logic (Config check + init + Start)
 start_sillybunny() {
     local PREFIX="$1"
@@ -15,6 +28,14 @@ start_sillybunny() {
     $PREFIX bun run init
 
     # Start the server
+    if is_truthy "${SILLYBUNNY_BUN_SMOL:-}"; then
+        # Bun grows the JSC heap freely while RAM looks plentiful, which reads as
+        # a leak under a container memory cap. --smol trades throughput for much
+        # more aggressive GC.
+        echo "[SillyBunny] SILLYBUNNY_BUN_SMOL set — starting Bun in low-memory mode (--smol)."
+        exec $PREFIX bun --smol server.js --listen "$@"
+    fi
+
     exec $PREFIX bun server.js --listen "$@"
 }
 

--- a/start.sh
+++ b/start.sh
@@ -325,6 +325,12 @@ server_restart_count=0
 run_server() {
     if [[ "$runtime_kind" == node ]]; then
         "$RUNTIME_CMD" --no-warnings server.js "$@"
+    elif is_truthy "${SILLYBUNNY_BUN_SMOL:-}"; then
+        # Bun grows the JSC heap freely while RAM looks plentiful, so on small
+        # hosts RSS sawtooths by more than a gigabyte between collections.
+        # --smol trades throughput for much more aggressive GC, matching the
+        # start:mobile script in package.json.
+        "$RUNTIME_CMD" --smol server.js "$@"
     else
         "$RUNTIME_CMD" server.js "$@"
     fi

--- a/start.sh
+++ b/start.sh
@@ -315,6 +315,11 @@ fi
 
 "$PACKAGE_MANAGER_CMD" run init
 
+if is_truthy "${SILLYBUNNY_BUN_SMOL:-}" && [[ "$runtime_kind" == node ]]; then
+    echo "[SillyBunny] SILLYBUNNY_BUN_SMOL is set, but this host resolved to Node.js — --smol is a Bun flag and will be ignored."
+    echo "[SillyBunny] For Bun with --smol, use ./start-bun.sh (Termux: bash start-termux-bun.sh)."
+fi
+
 echo "Entering SillyBunny..."
 export NODE_NO_WARNINGS=1
 export SILLYBUNNY_LAUNCHER=1

--- a/tests/sillybunny-launcher-smol.test.js
+++ b/tests/sillybunny-launcher-smol.test.js
@@ -1,0 +1,102 @@
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const startShSource = readFileSync(path.join(repoRoot, 'start.sh'), 'utf8');
+const startBatSource = readFileSync(path.join(repoRoot, 'Start.bat'), 'utf8');
+
+/**
+ * Lifts a top-level shell function out of start.sh so it can be exercised in
+ * isolation. Sourcing start.sh directly is not an option: it would run the
+ * dependency install and git auto-update on the way past.
+ */
+function extractShellFunction(source, name) {
+    const lines = source.split('\n');
+    const start = lines.findIndex(line => line.startsWith(`${name}() {`));
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = lines.findIndex((line, index) => index > start && line === '}');
+    expect(end).toBeGreaterThan(start);
+    return lines.slice(start, end + 1).join('\n');
+}
+
+let harnessDir;
+let harnessPath;
+
+beforeAll(() => {
+    harnessDir = mkdtempSync(path.join(tmpdir(), 'sb-launcher-smol-'));
+    harnessPath = path.join(harnessDir, 'harness.sh');
+    // Mirrors start.sh's own `set -euo pipefail` so that an unguarded empty
+    // array expansion would fail the test rather than pass silently.
+    writeFileSync(harnessPath, [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        extractShellFunction(startShSource, 'is_truthy'),
+        extractShellFunction(startShSource, 'run_server'),
+        'runtime_kind="$TEST_RUNTIME_KIND"',
+        'RUNTIME_CMD=echo',
+        'run_server "$@"',
+        '',
+    ].join('\n\n'));
+});
+
+afterAll(() => {
+    rmSync(harnessDir, { recursive: true, force: true });
+});
+
+/** Runs run_server with a stubbed runtime; returns the argv it would have used. */
+function runServer({ runtimeKind = 'bun', smol, args = [] } = {}) {
+    const env = { ...process.env, TEST_RUNTIME_KIND: runtimeKind };
+    if (smol === undefined) {
+        delete env.SILLYBUNNY_BUN_SMOL;
+    } else {
+        env.SILLYBUNNY_BUN_SMOL = smol;
+    }
+    return execFileSync('bash', [harnessPath, ...args], { env, encoding: 'utf8' }).trim();
+}
+
+describe('start.sh run_server --smol gating', () => {
+    test('omits --smol by default', () => {
+        expect(runServer()).toBe('server.js');
+    });
+
+    test('adds --smol when SILLYBUNNY_BUN_SMOL is truthy', () => {
+        for (const value of ['1', 'true', 'yes', 'on', 'TRUE', 'On']) {
+            expect(runServer({ smol: value })).toBe('--smol server.js');
+        }
+    });
+
+    test('omits --smol for falsy and unrecognised values', () => {
+        for (const value of ['', '0', 'false', 'no', 'off', 'maybe']) {
+            expect(runServer({ smol: value })).toBe('server.js');
+        }
+    });
+
+    test('ignores the flag on the Node runtime, where --smol does not exist', () => {
+        expect(runServer({ runtimeKind: 'node', smol: '1' })).toBe('--no-warnings server.js');
+    });
+
+    test('keeps forwarding caller arguments after the flag', () => {
+        expect(runServer({ smol: '1', args: ['--port', '8000'] }))
+            .toBe('--smol server.js --port 8000');
+        expect(runServer({ args: ['--port', '8000'] }))
+            .toBe('server.js --port 8000');
+    });
+});
+
+describe('Start.bat parity', () => {
+    // Start.bat cannot be executed on the CI runners, so assert the branch is
+    // wired. Without this, the Windows launcher silently loses the flag.
+    test('gates a --smol branch behind SILLYBUNNY_BUN_SMOL', () => {
+        expect(startBatSource).toMatch(/if\s+\/I\s+"!SILLYBUNNY_BUN_SMOL!"=="1"/);
+        expect(startBatSource).toMatch(/bun --smol server\.js %\*/);
+    });
+
+    test('still has the plain bun and node launch branches', () => {
+        expect(startBatSource).toMatch(/bun server\.js %\*/);
+        expect(startBatSource).toMatch(/node --no-warnings server\.js %\*/);
+    });
+});

--- a/tests/sillybunny-launcher-smol.test.js
+++ b/tests/sillybunny-launcher-smol.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { describe, test, expect, afterAll } from '@jest/globals';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -8,11 +8,16 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const startShSource = readFileSync(path.join(repoRoot, 'start.sh'), 'utf8');
 const startBatSource = readFileSync(path.join(repoRoot, 'Start.bat'), 'utf8');
+const dockerEntrypointSource = readFileSync(path.join(repoRoot, 'docker', 'docker-entrypoint.sh'), 'utf8');
 
 /**
  * Lifts a top-level shell function out of start.sh so it can be exercised in
  * isolation. Sourcing start.sh directly is not an option: it would run the
  * dependency install and git auto-update on the way past.
+ *
+ * Terminates on the first closing brace at column 0, which matches how every
+ * function in start.sh is written. A mis-extraction fails the behavioural
+ * assertions below rather than passing quietly.
  */
 function extractShellFunction(source, name) {
     const lines = source.split('\n');
@@ -23,29 +28,52 @@ function extractShellFunction(source, name) {
     return lines.slice(start, end + 1).join('\n');
 }
 
-let harnessDir;
-let harnessPath;
+const harnessDir = mkdtempSync(path.join(tmpdir(), 'sb-launcher-smol-'));
+const harnessPath = path.join(harnessDir, 'harness.sh');
 
-beforeAll(() => {
-    harnessDir = mkdtempSync(path.join(tmpdir(), 'sb-launcher-smol-'));
-    harnessPath = path.join(harnessDir, 'harness.sh');
-    // Mirrors start.sh's own `set -euo pipefail` so that an unguarded empty
-    // array expansion would fail the test rather than pass silently.
-    writeFileSync(harnessPath, [
-        '#!/usr/bin/env bash',
-        'set -euo pipefail',
-        extractShellFunction(startShSource, 'is_truthy'),
-        extractShellFunction(startShSource, 'run_server'),
-        'runtime_kind="$TEST_RUNTIME_KIND"',
-        'RUNTIME_CMD=echo',
-        'run_server "$@"',
-        '',
-    ].join('\n\n'));
-});
+// The harness mirrors start.sh's own `set -euo pipefail` so run_server is
+// exercised under the same strictness it runs under in production.
+writeFileSync(harnessPath, [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    extractShellFunction(startShSource, 'is_truthy'),
+    extractShellFunction(startShSource, 'run_server'),
+    'runtime_kind="$TEST_RUNTIME_KIND"',
+    'RUNTIME_CMD=echo',
+    'run_server "$@"',
+    '',
+].join('\n\n'));
 
 afterAll(() => {
     rmSync(harnessDir, { recursive: true, force: true });
 });
+
+/**
+ * Whether `bash` on PATH can actually run a script living in the temp dir. On
+ * Windows `bash` resolves to the WSL app-execution alias ahead of Git Bash, and
+ * that alias either has no distribution installed or cannot see the Windows temp
+ * path — so probe the exact mechanism these tests use rather than inferring
+ * capability from process.platform.
+ */
+function hasUsableBash() {
+    const probePath = path.join(harnessDir, 'probe.sh');
+    writeFileSync(probePath, '#!/usr/bin/env bash\nset -euo pipefail\necho ok\n');
+
+    try {
+        const stdout = execFileSync('bash', [probePath], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        return stdout.trim() === 'ok';
+    } catch {
+        return false;
+    }
+}
+
+// CI runs unit tests on ubuntu-latest, so this only spares Windows contributors
+// a wall of failures that say nothing about start.sh. The source-level parity
+// checks below still run everywhere.
+const describeShell = hasUsableBash() ? describe : describe.skip;
 
 /** Runs run_server with a stubbed runtime; returns the argv it would have used. */
 function runServer({ runtimeKind = 'bun', smol, args = [] } = {}) {
@@ -58,7 +86,7 @@ function runServer({ runtimeKind = 'bun', smol, args = [] } = {}) {
     return execFileSync('bash', [harnessPath, ...args], { env, encoding: 'utf8' }).trim();
 }
 
-describe('start.sh run_server --smol gating', () => {
+describeShell('start.sh run_server --smol gating', () => {
     test('omits --smol by default', () => {
         expect(runServer()).toBe('server.js');
     });
@@ -87,16 +115,45 @@ describe('start.sh run_server --smol gating', () => {
     });
 });
 
-describe('Start.bat parity', () => {
-    // Start.bat cannot be executed on the CI runners, so assert the branch is
-    // wired. Without this, the Windows launcher silently loses the flag.
-    test('gates a --smol branch behind SILLYBUNNY_BUN_SMOL', () => {
-        expect(startBatSource).toMatch(/if\s+\/I\s+"!SILLYBUNNY_BUN_SMOL!"=="1"/);
+// Neither Start.bat nor the Docker entrypoint can be executed on the CI runners,
+// and start.sh's Node-mode warning lives in top-level code the harness cannot
+// reach. Assert those branches are wired instead: without this, a launcher
+// silently drops the flag.
+describe('launcher parity', () => {
+    test('start.sh warns when the flag is set but Node.js was selected', () => {
+        expect(startShSource).toMatch(/is_truthy "\$\{SILLYBUNNY_BUN_SMOL:-\}" && \[\[ "\$runtime_kind" == node \]\]/);
+    });
+
+    test('Start.bat accepts the same spellings as is_truthy', () => {
+        for (const value of ['1', 'true', 'yes', 'on']) {
+            expect(startBatSource).toMatch(
+                new RegExp(`if\\s+/I\\s+"!SILLYBUNNY_BUN_SMOL!"=="${value}"\\s+set "_bun_smol=1"`),
+            );
+        }
+    });
+
+    test('Start.bat gates a --smol branch on the normalised flag', () => {
+        expect(startBatSource).toMatch(/else if "!_bun_smol!"=="1"/);
         expect(startBatSource).toMatch(/bun --smol server\.js %\*/);
     });
 
-    test('still has the plain bun and node launch branches', () => {
+    test('Start.bat still has the plain bun and node launch branches', () => {
         expect(startBatSource).toMatch(/bun server\.js %\*/);
         expect(startBatSource).toMatch(/node --no-warnings server\.js %\*/);
+    });
+
+    test('Start.bat warns when the flag is set but Node.js was selected', () => {
+        expect(startBatSource).toMatch(/if "!_bun_smol!"=="1" if "!_server_runtime!"=="node"/);
+    });
+
+    test('the Docker entrypoint gates --smol on the same accepted values', () => {
+        expect(dockerEntrypointSource).toMatch(/^\s*1\|true\|yes\|on\)/m);
+        expect(startShSource).toMatch(/^\s*1\|true\|yes\|on\)/m);
+        expect(dockerEntrypointSource).toMatch(/is_truthy "\$\{SILLYBUNNY_BUN_SMOL:-\}"/);
+        expect(dockerEntrypointSource).toMatch(/exec \$PREFIX bun --smol server\.js --listen "\$@"/);
+    });
+
+    test('the Docker entrypoint keeps its plain launch path', () => {
+        expect(dockerEntrypointSource).toMatch(/exec \$PREFIX bun server\.js --listen "\$@"/);
     });
 });


### PR DESCRIPTION
Adds bun --smol as an argument for start.sh.

```SILLYBUNNY_BUN_SMOL=1 ./start.sh```

Used to start for low-memory devices or devices prone to memory leaks that use pm2, docker or Termux (which use start.sh rather than bun run, which can do bun run --smol, but not pm2 or docker).

Added to the readme.md about it myself for clarification