### PR TITLE
fix: Chat saving issue resolution via hardening

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1810,7 +1810,8 @@ async function getExistingCharacterChats(characterId, fileName = '') {
     });
 
     if (!response.ok) {
-        return [];
+        // SillyBunny: an unreadable chat list must not look like a character with no chats.
+        throw new Error(`Could not list existing chats: ${response.statusText}`);
     }
 
     const data = await response.json();
@@ -3488,7 +3489,8 @@ export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfi
     const startIndex = [0, minId].includes(id) ? id : null;
     deleteItemizedPromptForMessage(id);
     updateViewMessageIds(startIndex);
-    saveChatDebounced();
+    // SillyBunny: this shrink is the user's own deletion, not an accidental overwrite.
+    saveChatDebounced({ allowShrink: true });
 
     if (this_edit_mes_id === id) {
         this_edit_mes_id = undefined;
@@ -10489,7 +10491,7 @@ export function saveChat(...saveChatArguments) {
     return saveTask;
 }
 
-async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, deferBackup = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
+async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, deferBackup = false, allowShrink = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
     if (wasGroupChat || (selected_group && !activeChatName)) {
         toastr.error(t`Operation was aborted to prevent data corruption.`, t`saveChat called for a group chat`);
         throw new Error('saveChat called for a group chat');
@@ -10550,6 +10552,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
                 avatar_url: resolvedAvatarUrl,
                 force: force,
                 deferBackup: Boolean(deferBackup),
+                allowShrink: Boolean(allowShrink),
             }),
         });
         const result = await fetch('/api/chats/save', saveChatRequest);
@@ -10564,6 +10567,16 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
         }
 
         const errorData = await result.json();
+
+        if (errorData?.error === 'destructive') {
+            console.error(`Chat save refused as destructive (${errorData?.reason}). The file on disk was left unchanged.`);
+            toastr.error(t`This save would have wiped messages, so the chat file was left unchanged. Reload the page to resync.`, t`Chat not saved`);
+            if (throwOnError) {
+                throw new Error('destructive');
+            }
+            return false;
+        }
+
         const isIntegrityError = errorData?.error === 'integrity' && !force;
         if (!isIntegrityError) {
             const errorMessage = typeof errorData?.error === 'string' ? errorData.error : result.statusText;
@@ -10586,7 +10599,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
             return false;
         }
 
-        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, activeChatName, characterName, avatarUrl, wasGroupChat });
+        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, allowShrink, activeChatName, characterName, avatarUrl, wasGroupChat });
     } catch (error) {
         console.error(error);
         toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Chat could not be saved`);
@@ -10943,7 +10956,10 @@ async function getChatResult({ emitCreated = false, switchMenu = true } = {}) {
             freshChat = true;
         }
         // Make sure the chat appears on the server
-        await saveChatConditional();
+        // SillyBunny: never persist a message-less chat over a file this load did not create.
+        if (emitCreated || freshChat) {
+            await saveChatConditional();
+        }
     }
     await loadItemizedPrompts(getCurrentChatId());
     await printMessages();
@@ -16807,7 +16823,8 @@ jQuery(async function () {
             chatElement.find(`.mes[mesid="${this_del_mes}"]`).remove();
             chat.length = this_del_mes;
             chat_metadata.tainted = true;
-            await saveChatConditional();
+            // SillyBunny: this shrink is the user's own deletion, not an accidental overwrite.
+            await saveChatConditional({ allowShrink: true });
             chatElement.scrollTop(chatElement[0].scrollHeight);
             await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
             chatElement.find('.mes').removeClass('last_mes');

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1123,13 +1123,14 @@ function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = f
             chatData: chatSnapshot,
             metadata: metadataSnapshot,
             deferBackup: Boolean(options.deferBackup),
+            allowShrink: Boolean(options.allowShrink),
         }));
 
     groupChatSaveQueue = saveTask.catch(() => {});
     return saveTask;
 }
 
-async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata, deferBackup = false }) {
+async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata, deferBackup = false, allowShrink = false }) {
     const group = groups.find(x => x.id == groupId);
     if (!group) {
         console.warn('Group not found', groupId);
@@ -1151,7 +1152,7 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
         character_name: 'unused',
     };
     const chatMessages = Array.isArray(chatData) ? chatData : cloneGroupChatSavePayload(chat);
-    const savePayload = JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup) });
+    const savePayload = JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup), allowShrink: Boolean(allowShrink) });
     const buildSaveGroupChatRequest = () => compressRequest({
         method: 'POST',
         headers: getRequestHeaders(),
@@ -1188,7 +1189,7 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
             return false;
         }
 
-        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup });
+        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup, allowShrink });
     }
 
     const responseData = await response.json().catch(() => ({}));

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -5129,7 +5129,8 @@ async function deleteMessagesByNameCallback(_, name) {
         }
     }
 
-    await saveChatConditional();
+    // SillyBunny: this shrink is the user's own deletion, not an accidental overwrite.
+    await saveChatConditional({ allowShrink: true });
     await reloadCurrentChat();
 
     toastr.info(t`Deleted ${messagesToDelete.length} messages from ${name}`);

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1786,8 +1786,9 @@ router.post('/chats', validateAvatarUrlMiddleware, async function (request, resp
 
         return response.send(validFiles);
     } catch (error) {
+        // SillyBunny: a listing failure must be distinguishable from a character that has no chats yet.
         console.error(error);
-        return response.send({ error: true });
+        return response.status(500).send({ error: true });
     }
 });
 

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -50,6 +50,29 @@ const CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX = 'chat_forced_overwrite_';
 const CHAT_PRE_WRITE_BACKUPS_PREFIX = 'chat_pre_write_';
 const PRE_WRITE_BACKUP_RING_SIZE = 3;
 
+/**
+ * Trims regular chat backups only. `CHAT_BACKUPS_PREFIX` is a prefix of the pre-write and
+ * forced-overwrite prefixes, so a plain prefix sweep would also rotate away those recovery layers.
+ * @param {string} directory The user's backup directory.
+ * @param {number} limit Maximum number of regular chat backups to keep.
+ */
+export function removeOldRegularChatBackups(directory, limit) {
+    const reservedPrefixes = [CHAT_PRE_WRITE_BACKUPS_PREFIX, CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX];
+    const files = fs.readdirSync(directory)
+        .filter(file => file.startsWith(CHAT_BACKUPS_PREFIX) && !reservedPrefixes.some(reserved => file.startsWith(reserved)))
+        .map(file => path.join(directory, file))
+        .sort((left, right) => fs.statSync(left).mtimeMs - fs.statSync(right).mtimeMs);
+
+    while (files.length > limit) {
+        const oldest = files.shift();
+        if (!oldest) {
+            break;
+        }
+
+        fs.unlinkSync(oldest);
+    }
+}
+
 function logBackupEvent(action, details = {}) {
     if (!isBackupLoggingEnabled) {
         return;
@@ -197,6 +220,10 @@ function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX, h
         if (isNaN(maxTotalChatBackups) || maxTotalChatBackups < 0) {
             return;
         }
+        if (backupPrefix === CHAT_BACKUPS_PREFIX) {
+            removeOldRegularChatBackups(directory, maxTotalChatBackups);
+            return;
+        }
         removeOldBackups(directory, backupPrefix, maxTotalChatBackups);
     } catch (err) {
         console.error(`Could not backup chat for ${name}`, err);
@@ -265,6 +292,26 @@ function isSuspiciousChatShrink(newData, existingSerializedChat) {
     }
 
     return Array.isArray(newData) && newData.length < existingLines * 0.5;
+}
+
+/**
+ * Classifies a save that would replace an existing chat with substantially less content.
+ * A chat payload carries one metadata header, so a length below two rows has no messages at all.
+ * @param {Array} newData Incoming chat array.
+ * @param {string} existingSerializedChat Current serialized chat on disk.
+ * @returns {''|'emptied'|'shrink'} Reason the save is destructive, or an empty string.
+ */
+function getDestructiveChatSaveReason(newData, existingSerializedChat) {
+    const existingLines = countSerializedChatLines(existingSerializedChat);
+    if (existingLines < 2 || !Array.isArray(newData)) {
+        return '';
+    }
+
+    if (newData.length < 2) {
+        return 'emptied';
+    }
+
+    return isSuspiciousChatShrink(newData, existingSerializedChat) ? 'shrink' : '';
 }
 
 /**
@@ -718,6 +765,18 @@ class InvalidChatDataError extends Error {
     }
 }
 
+// SillyBunny: a save that would destroy an existing chat is rejected unless the client forces it.
+class DestructiveChatSaveError extends Error {
+    constructor(reason, ...params) {
+        super(...params);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, DestructiveChatSaveError);
+        }
+        this.reason = reason;
+        this.date = new Date();
+    }
+}
+
 function isPlainObject(value) {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -781,8 +840,9 @@ function sendChatLoadResponse(response, target, { allowCreate = false } = {}) {
  * @param {object} [options] Additional save options.
  * @param {boolean} [options.deferBackup] Skip the regular chat backup for this save.
  * @param {object} [options.recoveryTarget] Exact chat recovery target.
+ * @param {boolean} [options.allowShrink] The client is deliberately removing messages, so allow a smaller chat.
  */
-export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory, { deferBackup = false, recoveryTarget = null } = {}) {
+export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory, { deferBackup = false, recoveryTarget = null, allowShrink = false } = {}) {
     if (!isValidChatSavePayload(chatData)) {
         throw new InvalidChatDataError('Invalid chat save payload. Expected a non-empty chat array with a metadata header.');
     }
@@ -813,11 +873,27 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
 
     if (fs.existsSync(filePath)) {
         const currentChatData = tryReadFileSync(filePath);
+
+        // SillyBunny: an existing chat that cannot be read can be neither checked nor backed up, so never overwrite it blind.
+        // An empty file reads back as '' rather than null, so this only catches a genuine read failure.
+        if (currentChatData === null && !skipIntegrityCheck && !allowShrink) {
+            throw new DestructiveChatSaveError('unreadable', `Refused a chat save for "${cardName}": the existing chat file could not be read, so it cannot be backed up before being replaced.`);
+        }
+
         if (currentChatData) {
+            const destructiveReason = getDestructiveChatSaveReason(savedChatData, currentChatData);
+            const existingLines = countSerializedChatLines(currentChatData);
+
+            // SillyBunny: reject before the pre-write ring runs, so a rejected save cannot evict the last good state.
+            // Deliberate message deletion sets allowShrink, which is not the same confirmation as an integrity overwrite.
+            if (destructiveReason && !skipIntegrityCheck && !allowShrink) {
+                throw new DestructiveChatSaveError(destructiveReason, `Refused a destructive chat save for "${cardName}" (${destructiveReason}): incoming payload has ${savedChatData.length} JSONL rows, existing file has ${existingLines} rows.`);
+            }
+
             backupChatPreWrite(backupDirectory, cardName, currentChatData, handle);
 
-            if (isSuspiciousChatShrink(savedChatData, currentChatData)) {
-                console.warn(`Suspicious chat shrink while saving "${cardName}": incoming payload has ${savedChatData.length} JSONL rows, existing file has ${countSerializedChatLines(currentChatData)} rows.`);
+            if (destructiveReason) {
+                console.warn(`Forced destructive chat save for "${cardName}" (${destructiveReason}): incoming payload has ${savedChatData.length} JSONL rows, existing file has ${existingLines} rows.`);
             }
 
             if (skipIntegrityCheck) {
@@ -828,6 +904,7 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
 
     if (isBackupEnabled && recoveryTarget) {
         // SillyBunny: exact snapshots are immediate and are not subject to history backup throttling.
+        // Destructive payloads are rejected above, so this cannot mirror a chat-destroying write.
         try {
             writeLatestChatSnapshot(recoveryTarget, jsonlData);
         } catch (error) {
@@ -860,6 +937,7 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
             const recoveryTarget = createChatRecoveryTarget(request, false, sanitizedChatFileName);
             const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, cardName, request.user.directories.backups, {
                 deferBackup: request.body.deferBackup === true,
+                allowShrink: request.body.allowShrink === true,
                 recoveryTarget,
             });
             return response.send({ ok: true, integrity: saveResult.integrity });
@@ -870,6 +948,10 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
         if (error instanceof IntegrityMismatchError) {
             console.error(error.message);
             return response.status(400).send({ error: 'integrity' });
+        }
+        if (error instanceof DestructiveChatSaveError) {
+            console.error(error.message);
+            return response.status(409).send({ error: 'destructive', reason: error.reason });
         }
         if (error instanceof InvalidChatDataError) {
             console.error(error.message);
@@ -1002,7 +1084,20 @@ router.post('/delete', validateAvatarUrlMiddleware, function (request, response)
         }
 
         //Return success if the file was deleted.
-        if (tryDeleteFile(chatFilePath)) {
+        let chatFileDeleted = false;
+        try {
+            chatFileDeleted = tryDeleteFile(chatFilePath);
+        } finally {
+            // SillyBunny: a chat that survived the delete must not keep a tombstone blocking its recovery.
+            if (isBackupEnabled && !chatFileDeleted) {
+                runChatRecoveryBestEffort(
+                    () => seedLatestChatSnapshot(recoveryTarget),
+                    'Failed to clear the chat recovery tombstone after a failed deletion.',
+                );
+            }
+        }
+
+        if (chatFileDeleted) {
             runChatRecoveryBestEffort(
                 () => clearChatRecoveryState(recoveryTarget),
                 'Failed to clear chat recovery state after deletion.',
@@ -1273,7 +1368,20 @@ router.post('/group/delete', (request, response) => {
         }
 
         //Return success if the file was deleted.
-        if (tryDeleteFile(chatFilePath)) {
+        let chatFileDeleted = false;
+        try {
+            chatFileDeleted = tryDeleteFile(chatFilePath);
+        } finally {
+            // SillyBunny: a chat that survived the delete must not keep a tombstone blocking its recovery.
+            if (isBackupEnabled && !chatFileDeleted) {
+                runChatRecoveryBestEffort(
+                    () => seedLatestChatSnapshot(recoveryTarget),
+                    'Failed to clear the chat recovery tombstone after a failed deletion.',
+                );
+            }
+        }
+
+        if (chatFileDeleted) {
             runChatRecoveryBestEffort(
                 () => clearChatRecoveryState(recoveryTarget),
                 'Failed to clear chat recovery state after deletion.',
@@ -1305,6 +1413,7 @@ router.post('/group/save', async function (request, response) {
             const recoveryTarget = createChatRecoveryTarget(request, true, chatFileName);
             const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, String(id), request.user.directories.backups, {
                 deferBackup: request.body.deferBackup === true,
+                allowShrink: request.body.allowShrink === true,
                 recoveryTarget,
             });
             return response.send({ ok: true, integrity: saveResult.integrity });
@@ -1315,6 +1424,10 @@ router.post('/group/save', async function (request, response) {
         if (error instanceof IntegrityMismatchError) {
             console.error(error.message);
             return response.status(400).send({ error: 'integrity' });
+        }
+        if (error instanceof DestructiveChatSaveError) {
+            console.error(error.message);
+            return response.status(409).send({ error: 'destructive', reason: error.reason });
         }
         if (error instanceof InvalidChatDataError) {
             console.error(error.message);

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -397,9 +397,36 @@ describe('chat integrity rotation', () => {
         expect(preWriteBackups).toHaveLength(3);
     });
 
-    test('warns on suspicious shrink but still preserves the existing chat', async () => {
+    test('rejects a suspicious shrink without overwriting the existing chat', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-shrink-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const originalChat = chatWithMessages('valid-integrity', ['one', 'two', 'three', 'four', 'five', 'six']);
+        const originalContent = originalChat.map(JSON.stringify).join('\n');
+        await fs.writeFile(chatFile, originalContent);
+
+        await expect(trySaveChat(
+            chatWithIntegrity('valid-integrity', 'short replacement'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        )).rejects.toMatchObject({ reason: 'shrink' });
+
+        await expect(fs.readFile(chatFile, 'utf8')).resolves.toBe(originalContent);
+
+        // A rejected save must not spend a slot in the pre-write ring that holds the last good state.
+        const backupFiles = await fs.readdir(backupDir);
+        expect(backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'))).toHaveLength(0);
+    });
+
+    test('still overwrites a shrunken chat when the client forces the save', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-shrink-forced-'));
         const chatFile = path.join(tempDir, 'chat.jsonl');
         const backupDir = path.join(tempDir, 'backups');
         await fs.mkdir(backupDir);
@@ -412,7 +439,7 @@ describe('chat integrity rotation', () => {
         await trySaveChat(
             chatWithIntegrity('valid-integrity', 'short replacement'),
             chatFile,
-            false,
+            true,
             'test-user',
             'Test Card',
             backupDir,
@@ -421,7 +448,7 @@ describe('chat integrity rotation', () => {
         const backupFiles = await fs.readdir(backupDir);
         const preWriteBackup = backupFiles.find(fileName => fileName.startsWith('chat_pre_write_test_card_'));
 
-        expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('Suspicious chat shrink'));
+        expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('Forced destructive chat save'));
         expect(preWriteBackup).toEqual(expect.any(String));
         await expect(fs.readFile(path.join(backupDir, preWriteBackup), 'utf8')).resolves.toBe(originalContent);
 
@@ -485,7 +512,7 @@ describe('chat integrity rotation', () => {
         expect(scriptSource).toContain('applyQueuedChatIntegrity(metadata, integrityKey, isActiveChatSave);');
         expect(scriptSource).toContain('rememberQueuedChatIntegrity(integrityKey, responseData?.integrity);');
         expect(scriptSource).toContain('deferBackup: Boolean(deferBackup)');
-        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, activeChatName, characterName, avatarUrl, wasGroupChat });');
+        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, allowShrink, activeChatName, characterName, avatarUrl, wasGroupChat });');
     });
 
     test('debounced chat saves abort after the active chat generation changes', async () => {
@@ -526,7 +553,7 @@ describe('chat integrity rotation', () => {
         expect(groupChatSource).toContain('applyQueuedGroupChatIntegrity(metadataForSave, chatId, isActiveGroupChatSave);');
         expect(groupChatSource).toContain('rememberQueuedGroupChatIntegrity(chatId, responseData?.integrity);');
         expect(groupChatSource).toContain('deferBackup: Boolean(options.deferBackup)');
-        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup });');
+        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup, allowShrink });');
         expect(groupChatSource).toContain('const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;');
         expect(groupChatSource).toContain('if (isActiveGroupChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });

--- a/tests/chat-save-destructive-write.test.js
+++ b/tests/chat-save-destructive-write.test.js
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+const { createCharacterChatTarget, getChatRecoveryPaths } = await import('../src/chat-recovery.js');
+const { removeOldRegularChatBackups, trySaveChat } = await import('../src/endpoints/chats.js');
+
+const OWNER = 'Test Character';
+const FILENAME = 'Test Character - chat.jsonl';
+const HANDLE = 'default-user';
+
+function header(extra = {}) {
+    return { chat_metadata: { ...extra }, user_name: 'unused', character_name: 'unused' };
+}
+
+function message(index) {
+    return { name: 'Test Character', is_user: index % 2 === 1, mes: `message ${index}`, extra: {} };
+}
+
+function populatedChat(messageCount) {
+    return [header(), ...Array.from({ length: messageCount }, (_, index) => message(index))];
+}
+
+function serialize(chatData) {
+    return chatData.map(row => JSON.stringify(row)).join('\n');
+}
+
+function countRows(serializedChat) {
+    return serializedChat.split('\n').filter(line => line.trim()).length;
+}
+
+describe('destructive chat save rejection', () => {
+    let root;
+    let chatsDirectory;
+    let backupDirectory;
+    let activeDirectory;
+    let activePath;
+    let recoveryTarget;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-chat-save-'));
+        chatsDirectory = path.join(root, 'chats');
+        backupDirectory = path.join(root, 'backups');
+        activeDirectory = path.join(chatsDirectory, OWNER);
+        fs.mkdirSync(activeDirectory, { recursive: true });
+        fs.mkdirSync(backupDirectory, { recursive: true });
+        activePath = path.join(activeDirectory, FILENAME);
+        recoveryTarget = createCharacterChatTarget({
+            chatsDirectory,
+            backupDirectory,
+            owner: OWNER,
+            filename: FILENAME,
+        });
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    const save = (chatData, { force = false, allowShrink = false } = {}) => trySaveChat(
+        chatData,
+        activePath,
+        force,
+        HANDLE,
+        OWNER,
+        backupDirectory,
+        { recoveryTarget, allowShrink },
+    );
+
+    test('refuses a message-less payload over a populated chat and leaves the file untouched', async () => {
+        const existing = serialize(populatedChat(8));
+        fs.writeFileSync(activePath, existing, 'utf8');
+
+        await expect(save([header()])).rejects.toMatchObject({ reason: 'emptied' });
+        expect(fs.readFileSync(activePath, 'utf8')).toBe(existing);
+    });
+
+    test('refuses a greeting-only payload over a populated chat', async () => {
+        const existing = serialize(populatedChat(8));
+        fs.writeFileSync(activePath, existing, 'utf8');
+
+        await expect(save([header(), message(0)])).rejects.toMatchObject({ reason: 'shrink' });
+        expect(countRows(fs.readFileSync(activePath, 'utf8'))).toBe(9);
+    });
+
+    test('allows a save that keeps most of the chat', async () => {
+        fs.writeFileSync(activePath, serialize(populatedChat(8)), 'utf8');
+
+        await expect(save(populatedChat(7))).resolves.toMatchObject({ integrity: expect.any(String) });
+        expect(countRows(fs.readFileSync(activePath, 'utf8'))).toBe(8);
+    });
+
+    test('allows a message-less save when the existing chat has no messages', async () => {
+        fs.writeFileSync(activePath, serialize([header()]), 'utf8');
+
+        await expect(save([header()])).resolves.toBeDefined();
+    });
+
+    test('allows a deliberate deletion that removes every message', async () => {
+        fs.writeFileSync(activePath, serialize(populatedChat(8)), 'utf8');
+
+        await expect(save([header()], { allowShrink: true })).resolves.toBeDefined();
+        expect(countRows(fs.readFileSync(activePath, 'utf8'))).toBe(1);
+    });
+
+    test('allows a deliberate deletion that removes most of the chat', async () => {
+        fs.writeFileSync(activePath, serialize(populatedChat(8)), 'utf8');
+
+        await expect(save(populatedChat(1), { allowShrink: true })).resolves.toBeDefined();
+        expect(countRows(fs.readFileSync(activePath, 'utf8'))).toBe(2);
+    });
+
+    test('refuses to overwrite an existing chat that cannot be read', async () => {
+        // A directory at the chat path exists but cannot be read, standing in for a locked or
+        // permission-denied file: the chat can be neither inspected nor backed up before the overwrite.
+        fs.mkdirSync(activePath);
+
+        await expect(save(populatedChat(9))).rejects.toMatchObject({ reason: 'unreadable' });
+        expect(fs.statSync(activePath).isDirectory()).toBe(true);
+    });
+
+    test('still allows a destructive save when the client forces it', async () => {
+        fs.writeFileSync(activePath, serialize(populatedChat(8)), 'utf8');
+
+        await expect(save([header()], { force: true })).resolves.toBeDefined();
+        expect(countRows(fs.readFileSync(activePath, 'utf8'))).toBe(1);
+    });
+
+    test('a refused save cannot mirror itself into the recovery snapshot', async () => {
+        const { latestPath } = getChatRecoveryPaths(recoveryTarget);
+        fs.writeFileSync(activePath, serialize(populatedChat(8)), 'utf8');
+
+        await save(populatedChat(9));
+        expect(countRows(fs.readFileSync(latestPath, 'utf8'))).toBe(10);
+
+        // The snapshot is only ever an exact mirror of a save that survived the destructive-write check.
+        await expect(save([header()])).rejects.toThrow();
+        expect(countRows(fs.readFileSync(latestPath, 'utf8'))).toBe(10);
+        expect(countRows(fs.readFileSync(activePath, 'utf8'))).toBe(10);
+    });
+
+    test('a refused save does not consume the pre-write backup ring', async () => {
+        fs.writeFileSync(activePath, serialize(populatedChat(8)), 'utf8');
+        const preWriteCount = () => fs.readdirSync(backupDirectory).filter(f => f.startsWith('chat_pre_write_')).length;
+
+        await save(populatedChat(9));
+        const afterGoodSave = preWriteCount();
+
+        await expect(save([header()])).rejects.toThrow();
+        expect(preWriteCount()).toBe(afterGoodSave);
+    });
+});
+
+describe('regular chat backup rotation', () => {
+    let backupDirectory;
+
+    beforeEach(() => {
+        backupDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-backup-rotation-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(backupDirectory, { recursive: true, force: true });
+    });
+
+    test('does not rotate away the pre-write and forced-overwrite recovery layers', () => {
+        const write = (name) => fs.writeFileSync(path.join(backupDirectory, name), 'x', 'utf8');
+        for (let index = 0; index < 6; index++) {
+            write(`chat_character_2026010${index}-000000.jsonl`);
+        }
+        write('chat_pre_write_character_20260101-000000_id.jsonl');
+        write('chat_forced_overwrite_character_20260101-000000.jsonl');
+
+        removeOldRegularChatBackups(backupDirectory, 2);
+
+        const remaining = fs.readdirSync(backupDirectory);
+        expect(remaining).toContain('chat_pre_write_character_20260101-000000_id.jsonl');
+        expect(remaining).toContain('chat_forced_overwrite_character_20260101-000000.jsonl');
+        expect(remaining.filter(f => f.startsWith('chat_character_'))).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
Ran a pass on chat saving structures this time around. Here's a list of what was fixed:

1- Root cause fix was a save payload on chat carries only one metadata header. If it has <2 rows, there's no messages.

The server accepted that as a valid save, and overwrote a **POPULATED CHAT** with it.

There's a shrink detector (hardeeharhar) that only caught the case and issued a warning. That's it. Since chat recovery happens based on the payload coming IN, the same request also destroyed the snapshot. So auto-restore did jack.

Now that's fixed. Take it away Claude:

**Server changes** (`src/endpoints/chats.js`, `src/endpoints/characters.js`):

1. Saves that would empty a chat (`emptied`), shrink it by more than half (`shrink`), or replace a file that exists but can't be read (`unreadable` — the Windows locked-file case, which previously skipped both the check and the pre-write backup and overwrote blind) are rejected with **HTTP 409** `{ error: 'destructive', reason }`, on both `/save` and `/group/save`.
2. The rejection happens **before** the pre-write backup runs, so a refused save can't flush the 3-deep ring holding the last good state. (Previously, the collapse fired several saves in seconds and rotated the good copy out of its own safety net.)
3. Two escape hatches, deliberately separate: `force` (existing, user-confirmed integrity overwrite) and a new `allowShrink` flag for deliberate message deletion — separate because reusing `force` would let a deletion skip the integrity check and clobber concurrent edits.
4. Backup rotation: `chat_` is a string prefix of `chat_pre_write_` and `chat_forced_overwrite_`, so the regular-backup sweep was rotating away those recovery layers too. Rotation now excludes the reserved prefixes.
5. Failed deletes: the delete tombstone is written before the unlink, and a locked file makes the unlink *throw*, leaving a tombstone that permanently blocks recovery of a chat that still exists. Both delete routes now clear it in a `try/finally`.
6. The chat-list endpoint returns 500 on internal failure instead of 200 `{ error: true }`, so a listing failure is distinguishable from "character has no chats". (The 200 signal for a genuinely missing chat directory is kept.)

Some other minor changes:

**Client changes** (`public/script.js`, `group-chats.js`, `slash-commands.js`):

7. Handles the 409: toast ("Chat not saved" / file unchanged, reload to resync), no retry loop, no OVERWRITE popup.
8. `allowShrink: true` threaded through the save pipeline and set at the three deliberate-deletion sites: bulk delete, single-message delete, `/delname`.
9. A failed chat listing now throws instead of returning `[]` — previously the client concluded "no chats", minted a fresh chat name, and *persisted* it, orphaning the real file.
10. After a load, a message-less chat is only saved to the server if this load actually created it — the client no longer papers over a damaged file with a fresh greeting.

Tests and stuff.

**Tests:** new `tests/chat-save-destructive-write.test.js` (11 tests covering rejection, both escape hatches, the unreadable case, snapshot/ring protection, rotation). `chat-integrity-rotation.test.js` updated — one test literally asserted the old warn-but-write behavior. Full suite: 208/208 suites, 1982 tests, lint clean. Branch is rebased onto current `staging` and pushed.
