### PR TITLE
fix: WI activation sliders width consistency

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -1345,6 +1345,9 @@ select.keyselect+span.select2-container .select2-selection--multiple {
 
     #WorldInfo.sb-shell-embedded-content #wiActivationSettings {
         flex-direction: column;
+        /* override the base align-items: start, which in column direction shrinks
+           #wiSliders/#wiCheckboxes to content width instead of filling the panel */
+        align-items: stretch;
     }
 
     #WorldInfo.sb-shell-embedded-content #wiSliders,


### PR DESCRIPTION
Fixes the activation sliders taking up 20% of the space but actually reserving the other 80% of it.
