### PR TITLE
fix: overlap between favorites bar and Roleplay/Conversation selector

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2079,6 +2079,9 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         min-width: 0;
         overflow: hidden;
         justify-content: flex-start;
+        /* The mode toggle (right: 56px) and close button float over this row;
+           reserve their footprint so the last favorites stay visible and tappable. */
+        margin-right: 136px;
     }
 
     /* Horizontal-rail treatment like .sb-character-create-bar: the strip must

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2154,6 +2154,17 @@ body.sb-shell-resizing * {
     display: none;
 }
 
+/* The mode toggle is absolutely positioned, so header text lays out underneath it.
+   The header is a start-aligned flex column, so cap the fit-content width instead
+   of using margin: reserve the toggle footprint (~215px + 66px right offset) so
+   long text ellipsizes instead of running under the pill. */
+@media screen and (min-width: 769px) {
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-title,
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-subtitle {
+        max-width: calc(100% - 276px);
+    }
+}
+
 .sb-character-shell-mode-toggle {
     position: absolute;
     top: 18px;


### PR DESCRIPTION
What it says on the tin.

The pill overlapped header subtitles on desktop and covered the avatar + their tap target on mobile. Fixed.
