### PR TITLE
fix: QR Stale Bar Fix

### DIFF
--- a/public/scripts/extensions/quick-reply/src/ui/ButtonUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ButtonUi.js
@@ -104,6 +104,9 @@ export class ButtonUi {
 
     renderBar() {
         if (!this.dom) {
+            // SillyBunny: integrations (guided-generations, mobile shell) may move the bar
+            // to other hosts; drop any stale instance so the id stays unique when re-rendering.
+            document.querySelectorAll('#qr--bar').forEach((el) => el.remove());
             let buttonHolder;
             const root = document.createElement('div'); {
                 this.dom = root;

--- a/tests/quick-reply-button-ui.test.js
+++ b/tests/quick-reply-button-ui.test.js
@@ -151,6 +151,11 @@ class FakeDocument {
         }
         return this.body.querySelector(selector);
     }
+
+    querySelectorAll(selector) {
+        const matches = this.body.matches(selector) ? [this.body] : [];
+        return matches.concat(this.body.querySelectorAll(selector));
+    }
 }
 
 let ButtonUi;
@@ -257,6 +262,24 @@ describe('Quick Reply button bar', () => {
         expect(qrBars).toHaveLength(1);
         expect(sendForm.children).toEqual([fileForm, qrBars[0], nonQrFormItems]);
         expect(qrBars[0].querySelector('.qr--button').textContent).toBe('HELP');
+    });
+
+    test('renderBar removes a stale bar left behind by an integration host', () => {
+        const { sendForm } = appendComposer();
+        const staleHost = document.createElement('div');
+        staleHost.id = 'gg-qr-container';
+        const staleBar = document.createElement('div');
+        staleBar.id = 'qr--bar';
+        staleHost.appendChild(staleBar);
+        document.body.append(staleHost);
+
+        const buttons = new ButtonUi(createSettings());
+        buttons.show();
+
+        const qrBars = document.body.querySelectorAll('#qr--bar');
+        expect(qrBars).toHaveLength(1);
+        expect(qrBars[0].parentElement).toBe(sendForm);
+        expect(staleHost.children).toEqual([]);
     });
 
     test('refresh renders updated visible quick replies from the active set', () => {


### PR DESCRIPTION
This one is pretty straightforward. There was a chance for an orphan QR Integrated bar. This makes that impossible. Technical details below:

`ButtonUi.js` + regression test

The live runtime had two `#qr--bar` nodes in the Guided Generations container — integrations move the bar between hosts, and a QR re-render could orphan the old node. `renderBar()` now removes any existing bar before creating the authoritative one. New Jest test covers the stale-bar-in-foreign-host case; suite 1971/1971.
