### PR TITLE
chore: Clean up dead references

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8621,7 +8621,7 @@
                 <div id="chara_cfg_container" style="display: none;">
                     <hr class="sysHR">
                     <div class="inline-drawer">
-                        <div id="charaANBlockToggle" class="inline-drawer-toggle inline-drawer-header">
+                        <div id="charaCfgBlockToggle" class="inline-drawer-toggle inline-drawer-header">
                             <b data-i18n="Character CFG">Character CFG</b>
                             <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
                         </div>
@@ -8656,7 +8656,7 @@
                 <div id="global_cfg_container">
                     <hr class="sysHR">
                     <div class="inline-drawer">
-                        <div id="defaultANBlockToggle" class="inline-drawer-toggle inline-drawer-header">
+                        <div id="globalCfgBlockToggle" class="inline-drawer-toggle inline-drawer-header">
                             <b data-i18n="Global CFG">Global CFG</b>
                             <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
                         </div>
@@ -8691,7 +8691,7 @@
                 <div id="cfg_prompt_combine_container">
                     <hr class="sysHR">
                     <div class="inline-drawer">
-                        <div id="defaultANBlockToggle" class="inline-drawer-toggle inline-drawer-header">
+                        <div id="cfgPromptCombineBlockToggle" class="inline-drawer-toggle inline-drawer-header">
                             <b data-i18n="CFG Prompt Cascading">CFG Prompt Cascading</b>
                             <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
                         </div>
@@ -8831,10 +8831,6 @@
     <!-- popups live outside sheld to avoid blur conflicts -->
     <div id="options" class="font-family-reset" style="display: none;">
         <div class="options-content">
-            <a id="option_close_chat" class="displayNone">
-                <i class="fa-lg fa-solid fa-times"></i>
-                <span data-i18n="Close chat">Close chat</span>
-            </a>
             <a id="option_settings" class="displayNone">
                 <i class="fa-lg fa-solid fa-cog"></i>
                 <span data-i18n="Toggle Panels">Toggle Panels</span>


### PR DESCRIPTION
Some technical dead ends cleaned up. Technical details below, but it's pretty straightforward.

`index.html`

Removes the dead hidden `option_close_chat` duplicate (jQuery/`getElementById` resolved to the hidden one) and renames the CFG panel's copy-pasted drawer ids (`charaANBlockToggle`/`defaultANBlockToggle` ×3) to `charaCfgBlockToggle`/`globalCfgBlockToggle`/`cfgPromptCombineBlockToggle`. Zero JS/CSS references existed to any of them.
