### PR TITLE
chore: hardcoded values revised for z index in extension menu/options/popper modal

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1260,7 +1260,9 @@ body .panelControlBar {
 #extensionsMenu,
 .popup .popper-modal {
     display: flex;
-    z-index: 29999;
+    /* SillyBunny: fold the hardcoded 29999 into the --sb-z-* scale. Critical tier
+       keeps these menus above zoomed avatars/MovingUI panels (9999) like before. */
+    z-index: var(--sb-z-critical, 10000);
     background-color: var(--SmartThemeBlurTintColor);
     -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
     backdrop-filter: blur(var(--SmartThemeBlurStrength));


### PR DESCRIPTION
Technical details:

`style.css`

`#options`/`#extensionsMenu`/`.popper-modal` used a hardcoded `z-index: 29999` outside the `--sb-z-*` scale. Now `var(--sb-z-critical, 10000)` — verified nothing legitimate sits between 10000 and 29999, so stacking order is unchanged (zoomed avatars at 9999 stay beneath).
