### PR TITLE
fix(proxy): resolve the 'None' no-proxy error

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -9867,6 +9867,19 @@ function runProxyCallback(_, value) {
     }
 
     const proxyNames = proxies.map(preset => preset.name);
+
+    // SillyBunny: 'None' is the no-proxy sentinel connection profiles send when they
+    // have no proxy configured, but the None preset itself is deletable. Resolve the
+    // sentinel exactly — fuzzy search could land on a real proxy — and recreate it
+    // silently instead of warning about a preset the user never chose.
+    if (value.trim().toLowerCase() === 'none' && !proxyNames.some(name => name.toLowerCase() === 'none')) {
+        setProxyPreset('None', '', '', '');
+        updateProxyPresetOption(selected_proxy);
+        $('#openai_proxy_preset').val(selected_proxy.name);
+        saveSettingsDebounced();
+        return selected_proxy.name;
+    }
+
     const fuse = new Fuse(proxyNames);
     const result = fuse.search(value);
 


### PR DESCRIPTION
Switching to a connection profile that has no proxy configured raises a "Proxy preset 'None' not found" warning toast whenever the built-in None preset is missing from the saved proxy list (it is deletable, and the delete flow has no guard). 

This is fixed now.

<img width="355" height="85" alt="image" src="https://github.com/user-attachments/assets/b008a7ea-c8dd-4679-9277-8134fa09a074" />