### PR TITLE
fix(style): anchor bottom-positioned toasts to viewport on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -203,6 +203,13 @@ html {
     -webkit-transform: translateZ(0);
     -webkit-backface-visibility: hidden;
     -webkit-perspective: 1000;
+    /* SillyBunny: the translateZ flicker fix above makes <html> the containing
+       block for every position:fixed descendant. On mobile, body is itself
+       position:fixed (mobile-styles.css) and out of flow, collapsing <html> to
+       a 0px-tall box — bottom-anchored fixed elements (toast-bottom-* toast
+       containers) then resolve above the viewport and are never visible. Give
+       the box an explicit viewport height so fixed positioning anchors to it. */
+    height: 100dvh;
     /* SillyBunny: `clip` (unlike `hidden`) blocks programmatic viewport
        scrolling too, so scrollIntoView on search results can't shift the
        fixed-layout app and strand a black bar at the bottom. */


### PR DESCRIPTION
Basically the toasts didn't show on mobile.

Technically speaking (AI):

Toasts using a `toast-bottom-*` position never appear — the container renders entirely above the viewport.

Root Cause:

- `html { -webkit-transform: translateZ(0) }` (the Chrome flicker fix in style.css) makes `<html>` the containing block for every `position: fixed` descendant — a transformed ancestor always does.
- `body { position: fixed }` (mobile-styles.css) takes body out of flow, so `<html>` has no in-flow content and collapses to a 0px-tall box.

Every fixed element therefore positions against a zero-height box at the top of the page instead of the viewport. Top-anchored elements land in the right place by accident; bottom-anchored ones (`#toast-container.toast-bottom-right` with `bottom: 12px`) resolve above the screen. The app itself is unaffected because body pins itself with explicit `top`/`height`.

Fix: give `<html>` an explicit `height: 100dvh` so the containing block matches the viewport. Verified in a 375×812 viewport: toast container moves from top −60px (invisible) to bottom 12px, renders above the composer, and top bar/sheld/send form geometry is unchanged. Desktop is unaffected — with body in flow the html box already spans the viewport.