### PR TITLE
feat: reuse Start Reply With for Kimi K3 partial prefill

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2091,7 +2091,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="custom,moonshot,nanogpt">
+                                    <div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">
                                         <label for="openai_start_reply_with" class="range-block-title justifyLeft">
                                             <span data-i18n="Start Reply With">Start Reply With</span>
                                         </label>

--- a/public/index.html
+++ b/public/index.html
@@ -3894,6 +3894,7 @@
                             </div>
                             <h4 data-i18n="Moonshot AI Model">Moonshot AI Model</h4>
                             <select id="model_moonshot_select">
+                                <option value="kimi-k3">kimi-k3</option>
                                 <option value="moonshot-v1-8k">moonshot-v1-8k</option>
                                 <option value="moonshot-v1-32k">moonshot-v1-32k</option>
                                 <option value="moonshot-v1-128k">moonshot-v1-128k</option>

--- a/public/index.html
+++ b/public/index.html
@@ -2091,6 +2091,12 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="range-block" data-source="custom,moonshot,nanogpt">
+                                        <label for="openai_start_reply_with" class="range-block-title justifyLeft">
+                                            <span data-i18n="Start Reply With">Start Reply With</span>
+                                        </label>
+                                        <textarea id="openai_start_reply_with" data-macros class="start-reply-with-input text_pole textarea_compact autoSetHeight" rows="2" aria-label="Start Reply With" data-i18n="[aria-label]Start Reply With"></textarea>
+                                    </div>
                                     <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,openrouter,claude,linkapi">
                                         <div class="flex-container oneline-dropdown sb-setting-inline-help sb-setting-inline-center">
                                             <div class="sb-setting-inline-copy sb-setting-inline-copy-center">
@@ -4692,7 +4698,7 @@
                                         </span>
                                     </small>
                                     <div>
-                                        <textarea id="start_reply_with" data-macros class="text_pole textarea_compact autoSetHeight" aria-label="Start Reply With" data-i18n="[aria-label]Start Reply With"></textarea>
+                                        <textarea id="start_reply_with" data-macros class="start-reply-with-input text_pole textarea_compact autoSetHeight" aria-label="Start Reply With" data-i18n="[aria-label]Start Reply With"></textarea>
                                     </div>
                                     <label class="checkbox_label" for="chat-show-reply-prefix-checkbox">
                                         <input id="chat-show-reply-prefix-checkbox" type="checkbox" />

--- a/public/scripts/openai-model-capabilities.js
+++ b/public/scripts/openai-model-capabilities.js
@@ -26,3 +26,35 @@ export function applyClaudeModelParameterConstraints(generateData, { preserveRea
 
     return generateData;
 }
+
+/**
+ * Checks whether a model ID targets Kimi K3, including provider-prefixed IDs.
+ *
+ * @param {unknown} model Model identifier
+ * @returns {boolean} Whether the model is Kimi K3
+ */
+export function isKimiK3Model(model) {
+    const normalizedModel = String(model ?? '').trim().toLowerCase();
+    return /(?:^|[/:])kimi-k3(?:[-/:]|$)/.test(normalizedModel);
+}
+
+/**
+ * Removes request parameters fixed by the Kimi K3 API.
+ *
+ * @param {Record<string, any>} generateData Chat Completion request data
+ * @returns {Record<string, any>} The request data
+ */
+export function applyKimiK3ModelParameterConstraints(generateData) {
+    if (!isKimiK3Model(generateData?.model)) {
+        return generateData;
+    }
+
+    delete generateData.temperature;
+    delete generateData.top_p;
+    delete generateData.frequency_penalty;
+    delete generateData.presence_penalty;
+    delete generateData.n;
+    delete generateData.thinking;
+
+    return generateData;
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3628,6 +3628,7 @@ function groupOpenAISettingsIntoDrawers() {
                 '#openai_settings > div > .range-block:has(#openai_show_thoughts)',
                 '#openai_settings > div > .range-block:has(#openai_auto_append_reasoning_tags)',
                 '#openai_settings > div > .flex-container:has(#openai_reasoning_effort)',
+                '#openai_settings > div > .range-block:has(#openai_start_reply_with)',
                 '#openai_settings > div > .range-block:has(#openai_reasoning_tag_style)',
                 '#openai_settings > div > .flex-container:has(#openai_verbosity)',
                 '#openai_settings > div > .range-block:has(#claude_assistant_prefill)',
@@ -5211,7 +5212,7 @@ export async function createGenerationParameters(settings, model, type, messages
 
     const isO1 = gptSources.includes(settings.chat_completion_source) && ['o1-2024-12-17', 'o1'].includes(model);
     const isWorkersAIJsonMode = settings.chat_completion_source === chat_completion_sources.WORKERS_AI && jsonSchema;
-    const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT].includes(settings.chat_completion_source)
+    const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT].includes(settings.chat_completion_source)
         && isKimiK3Model(model);
     const stream = settings.stream_openai && type !== 'quiet' && !isO1 && !isWorkersAIJsonMode;
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -98,7 +98,7 @@ import {
     normalizeReverseProxyPreset,
     shouldIncludeSamplingFieldsInPreset,
 } from './openai-preset-utils.js';
-import { applyClaudeModelParameterConstraints } from './openai-model-capabilities.js';
+import { applyClaudeModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model } from './openai-model-capabilities.js';
 import { TOOL_CALL_RECURSE_LIMIT_DEFAULT, normalizeToolCallRecurseLimit } from './tool-call-recurse-limit.js';
 import { LINKAPI_ENDPOINT, getLinkApiRequestFormat } from './linkapi-utils.js';
 import { IN_CHAT_AGENT_PROMPT_KEY_PREFIX, RUNTIME_AGENTS_IDENTIFIER, collectInChatAgentInspectionRecords, getInChatAgentContributionKind, isInChatAgentPromptIdentifier, trimOldestRetainedContribution } from './in-chat-agent-inspection.js';
@@ -5211,10 +5211,12 @@ export async function createGenerationParameters(settings, model, type, messages
 
     const isO1 = gptSources.includes(settings.chat_completion_source) && ['o1-2024-12-17', 'o1'].includes(model);
     const isWorkersAIJsonMode = settings.chat_completion_source === chat_completion_sources.WORKERS_AI && jsonSchema;
+    const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT].includes(settings.chat_completion_source)
+        && isKimiK3Model(model);
     const stream = settings.stream_openai && type !== 'quiet' && !isO1 && !isWorkersAIJsonMode;
 
     const noMultiSwipeTypes = ['quiet', 'impersonate', 'continue'];
-    const canMultiSwipe = settings.n > 1 && !noMultiSwipeTypes.includes(type) && multiswipeSources.includes(settings.chat_completion_source);
+    const canMultiSwipe = settings.n > 1 && !noMultiSwipeTypes.includes(type) && multiswipeSources.includes(settings.chat_completion_source) && !isKimiK3Request;
 
     let logit_bias = {};
     if (settings.bias_preset_selected
@@ -5551,6 +5553,9 @@ export async function createGenerationParameters(settings, model, type, messages
     applyClaudeModelParameterConstraints(generate_data, {
         preserveReasoning: [chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source),
     });
+    if (isKimiK3Request) {
+        applyKimiK3ModelParameterConstraints(generate_data);
+    }
 
     if (jsonSchema) {
         generate_data.json_schema = jsonSchema;
@@ -8117,6 +8122,7 @@ function getMoonshotMaxContext(model, isUnlocked) {
         'kimi-k2-turbo-preview': max_256k,
         'kimi-k2-thinking': max_256k,
         'kimi-k2-thinking-turbo': max_256k,
+        'kimi-k3': max_1mil,
     };
 
     // Return context size if model found, otherwise default to 32k

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3698,7 +3698,7 @@ function updateOpenAISettingsGroupVisibility() {
 }
 
 function updateKimiK3PrefillVisibility() {
-    const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT];
+    const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT, chat_completion_sources.OPENROUTER];
     const isSupportedSource = supportedSources.includes(oai_settings.chat_completion_source);
     $('#openai_start_reply_with').closest('.range-block').toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()));
 }
@@ -5218,7 +5218,7 @@ export async function createGenerationParameters(settings, model, type, messages
 
     const isO1 = gptSources.includes(settings.chat_completion_source) && ['o1-2024-12-17', 'o1'].includes(model);
     const isWorkersAIJsonMode = settings.chat_completion_source === chat_completion_sources.WORKERS_AI && jsonSchema;
-    const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT].includes(settings.chat_completion_source)
+    const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT, chat_completion_sources.OPENROUTER].includes(settings.chat_completion_source)
         && isKimiK3Model(model);
     const stream = settings.stream_openai && type !== 'quiet' && !isO1 && !isWorkersAIJsonMode;
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3697,6 +3697,12 @@ function updateOpenAISettingsGroupVisibility() {
     });
 }
 
+function updateKimiK3PrefillVisibility() {
+    const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT];
+    const isSupportedSource = supportedSources.includes(oai_settings.chat_completion_source);
+    $('#openai_start_reply_with').closest('.range-block').toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()));
+}
+
 function updateServerChatCompletionConfigSourceVisibility() {
     const currentSource = oai_settings.chat_completion_source;
 
@@ -8878,6 +8884,7 @@ async function onModelChange() {
 
     saveSettingsDebounced();
     updateFeatureSupportFlags();
+    updateKimiK3PrefillVisibility();
     updateAdvancedFormattingVisibility();
     updateOpenAIModelFavoriteButton();
     refreshModelIdSearchControlsForSource(oai_settings.chat_completion_source);
@@ -9064,6 +9071,7 @@ function toggleChatCompletionForms() {
 
     setToolReasoningControls();
     updateAdvancedFormattingVisibility();
+    updateKimiK3PrefillVisibility();
     updateOpenAISettingsGroupVisibility();
     updateOpenAIModelFavoriteButton();
 }
@@ -10655,6 +10663,8 @@ export function initOpenAI() {
 
     $('#custom_model_id').on('input', function () {
         oai_settings.custom_model = String($(this).val());
+        updateKimiK3PrefillVisibility();
+        updateOpenAISettingsGroupVisibility();
         saveSettingsDebounced();
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2474,7 +2474,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#noShadowsmode').prop('checked', power_user.noShadows);
     $('#google_font_preset').val(power_user.google_font);
     $('#google_font_custom').val(power_user.google_font);
-    $('#start_reply_with').text(power_user.user_prompt_bias);
+    $('.start-reply-with-input').val(power_user.user_prompt_bias);
     $('#chat-show-reply-prefix-checkbox').prop('checked', power_user.show_user_prompt_bias);
     $('#auto_continue_enabled').prop('checked', power_user.auto_continue.enabled);
     $('#auto_continue_allow_chat_completions').prop('checked', power_user.auto_continue.allow_chat_completions);
@@ -4186,8 +4186,10 @@ jQuery(async () => {
         reloadMarkdownProcessor();
     });
 
-    $('#start_reply_with').on('input', function () {
-        power_user.user_prompt_bias = String($(this).val());
+    $('.start-reply-with-input').on('input', function () {
+        const value = String($(this).val());
+        power_user.user_prompt_bias = value;
+        $('.start-reply-with-input').not(this).val(value);
         saveSettingsDebounced();
     });
 
@@ -5589,7 +5591,7 @@ jQuery(async () => {
             }
 
             power_user.user_prompt_bias = String(value ?? '');
-            $('#start_reply_with').val(power_user.user_prompt_bias);
+            $('.start-reply-with-input').val(power_user.user_prompt_bias);
             saveSettingsDebounced();
 
             return power_user.user_prompt_bias;

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -304,7 +304,7 @@ class PresetManager {
             setData: (data) => {
                 power_user.user_prompt_bias = data.value ?? '';
                 power_user.show_user_prompt_bias = data.show ?? false;
-                $('#start_reply_with').val(power_user.user_prompt_bias);
+                $('.start-reply-with-input').val(power_user.user_prompt_bias);
                 $('#chat-show-reply-prefix-checkbox').prop('checked', power_user.show_user_prompt_bias);
                 return saveSettingsDebounced();
             },

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -3251,7 +3251,7 @@ export async function handleChatCompletionsGenerate(request, response) {
         };
 
         const isKimiK3Request = !isTextCompletion
-            && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.MOONSHOT, CHAT_COMPLETION_SOURCES.NANOGPT].includes(request.body.chat_completion_source)
+            && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.MOONSHOT, CHAT_COMPLETION_SOURCES.NANOGPT, CHAT_COMPLETION_SOURCES.OPENROUTER].includes(request.body.chat_completion_source)
             && isKimiK3Model(requestBody.model);
 
         if (isKimiK3Request) {
@@ -3266,7 +3266,7 @@ export async function handleChatCompletionsGenerate(request, response) {
             const responseFormatType = requestBody.response_format?.type;
             const usesStructuredOutput = Boolean(request.body.json_schema)
                 || Boolean(requestBody.response_format && responseFormatType !== 'text');
-            if ([CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.NANOGPT].includes(request.body.chat_completion_source)
+            if ([CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.NANOGPT, CHAT_COMPLETION_SOURCES.OPENROUTER].includes(request.body.chat_completion_source)
                 && !usesStructuredOutput
                 && Array.isArray(requestBody.messages)) {
                 addAssistantPrefix(requestBody.messages, [], 'partial');

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 import urlJoin from 'url-join';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
 import { getLinkApiBaseUrl, getLinkApiRequestFormat } from '../../../public/scripts/linkapi-utils.js';
+import { applyKimiK3ModelParameterConstraints, isKimiK3Model } from '../../../public/scripts/openai-model-capabilities.js';
 
 import {
     AIMLAPI_HEADERS,
@@ -3097,7 +3098,7 @@ export async function handleChatCompletionsGenerate(request, response) {
             apiUrl = new URL(request.body.reverse_proxy || API_MOONSHOT).toString();
             apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.MOONSHOT);
             headers = {};
-            bodyParams = {
+            bodyParams = isKimiK3Model(request.body.model) ? {} : {
                 thinking: {
                     type: request.body.include_reasoning ? 'enabled' : 'disabled',
                 },
@@ -3249,8 +3250,27 @@ export async function handleChatCompletionsGenerate(request, response) {
             ...bodyParams,
         };
 
+        const isKimiK3Request = !isTextCompletion
+            && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.MOONSHOT].includes(request.body.chat_completion_source)
+            && isKimiK3Model(requestBody.model);
+
+        if (isKimiK3Request) {
+            applyKimiK3ModelParameterConstraints(requestBody);
+        }
+
         if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
             excludeKeysByYaml(requestBody, request.body.custom_exclude_body);
+        }
+
+        if (isKimiK3Request) {
+            const responseFormatType = requestBody.response_format?.type;
+            const usesStructuredOutput = Boolean(request.body.json_schema)
+                || Boolean(requestBody.response_format && responseFormatType !== 'text');
+            if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM
+                && !usesStructuredOutput
+                && Array.isArray(requestBody.messages)) {
+                addAssistantPrefix(requestBody.messages, [], 'partial');
+            }
         }
 
         /** @type {import('node-fetch').RequestInit} */

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -3251,7 +3251,7 @@ export async function handleChatCompletionsGenerate(request, response) {
         };
 
         const isKimiK3Request = !isTextCompletion
-            && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.MOONSHOT].includes(request.body.chat_completion_source)
+            && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.MOONSHOT, CHAT_COMPLETION_SOURCES.NANOGPT].includes(request.body.chat_completion_source)
             && isKimiK3Model(requestBody.model);
 
         if (isKimiK3Request) {
@@ -3266,7 +3266,7 @@ export async function handleChatCompletionsGenerate(request, response) {
             const responseFormatType = requestBody.response_format?.type;
             const usesStructuredOutput = Boolean(request.body.json_schema)
                 || Boolean(requestBody.response_format && responseFormatType !== 'text');
-            if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM
+            if ([CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.NANOGPT].includes(request.body.chat_completion_source)
                 && !usesStructuredOutput
                 && Array.isArray(requestBody.messages)) {
                 addAssistantPrefix(requestBody.messages, [], 'partial');

--- a/tests/kimi-k3-chat-completions.test.js
+++ b/tests/kimi-k3-chat-completions.test.js
@@ -1,0 +1,213 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
+import { setConfigFilePath } from '../src/util.js';
+
+const actualNodeFetch = (await import('node-fetch')).default;
+const nodeFetchMock = jest.fn((url, options) => actualNodeFetch(url, options));
+await jest.unstable_mockModule('node-fetch', () => ({
+    default: nodeFetchMock,
+}));
+
+describe('Kimi K3 chat completion requests', () => {
+    /** @type {import('http').Server} */
+    let appServer;
+    let baseUrl;
+    let capturedBody;
+    const tempDirs = [];
+
+    beforeAll(async () => {
+        const configRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-kimi-k3-config-'));
+        const configPath = path.join(configRoot, 'config.yaml');
+        const defaultConfig = fs.readFileSync(fileURLToPath(new URL('../default/config.yaml', import.meta.url)), 'utf8');
+        fs.writeFileSync(configPath, defaultConfig);
+        tempDirs.push(configRoot);
+        setConfigFilePath(configPath);
+
+        const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
+        const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-kimi-k3-user-'));
+        tempDirs.push(userRoot);
+
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            req.user = { directories: { root: userRoot, backups: userRoot } };
+            next();
+        });
+        app.use('/api/backends/chat-completions', chatCompletionsRouter);
+
+        await new Promise((resolve) => {
+            appServer = app.listen(0, '127.0.0.1', resolve);
+        });
+        const address = appServer.address();
+        baseUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    beforeEach(() => {
+        capturedBody = undefined;
+        nodeFetchMock.mockClear();
+        nodeFetchMock.mockImplementation(async (_url, options) => {
+            capturedBody = JSON.parse(options?.body ?? '{}');
+            return new Response(JSON.stringify({
+                choices: [{ message: { role: 'assistant', content: ' continuation' }, finish_reason: 'stop' }],
+            }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        });
+    });
+
+    afterAll(async () => {
+        if (appServer) {
+            await new Promise((resolve, reject) => {
+                appServer.close((error) => error ? reject(error) : resolve());
+            });
+        }
+        for (const dir of tempDirs.splice(0)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+        nodeFetchMock.mockImplementation((url, options) => actualNodeFetch(url, options));
+    });
+
+    function makeRequest(source, overrides = {}) {
+        return fetch(`${baseUrl}/api/backends/chat-completions/generate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                chat_completion_source: source,
+                custom_url: 'https://custom.kimi.test/v1',
+                reverse_proxy: 'https://api.moonshot.test/v1',
+                proxy_password: 'test-key',
+                model: 'kimi-k3',
+                stream: false,
+                temperature: 1,
+                top_p: 0.95,
+                presence_penalty: 0,
+                frequency_penalty: 0,
+                n: 3,
+                max_tokens: 4096,
+                messages: [
+                    { role: 'user', content: 'Question' },
+                    { role: 'assistant', content: 'Prefill' },
+                ],
+                ...overrides,
+            }),
+        });
+    }
+
+    function expectFixedParametersOmitted() {
+        expect(capturedBody.temperature).toBeUndefined();
+        expect(capturedBody.top_p).toBeUndefined();
+        expect(capturedBody.presence_penalty).toBeUndefined();
+        expect(capturedBody.frequency_penalty).toBeUndefined();
+        expect(capturedBody.n).toBeUndefined();
+    }
+
+    test('marks native Moonshot K3 prefill as partial and omits unsupported parameters', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT);
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1)).toEqual({
+            role: 'assistant',
+            content: 'Prefill',
+            partial: true,
+        });
+        expect(capturedBody.thinking).toBeUndefined();
+        expectFixedParametersOmitted();
+    });
+
+    test('marks namespaced Custom K3 prefill as partial', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            model: 'moonshotai/Kimi-K3',
+            custom_include_body: 'thinking:\n  type: enabled',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1).partial).toBe(true);
+        expect(capturedBody.thinking).toBeUndefined();
+        expectFixedParametersOmitted();
+    });
+
+    test('marks the final assistant message supplied by Custom YAML', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            custom_include_body: [
+                'messages:',
+                '  - role: user',
+                '    content: YAML question',
+                '  - role: assistant',
+                '    content: YAML prefill',
+            ].join('\n'),
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1)).toEqual({
+            role: 'assistant',
+            content: 'YAML prefill',
+            partial: true,
+        });
+    });
+
+    test('does not use Partial Mode with structured output', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            json_schema: {
+                name: 'answer',
+                value: { type: 'object', properties: { answer: { type: 'string' } } },
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.response_format.type).toBe('json_schema');
+        expect(capturedBody.messages.at(-1).partial).toBeUndefined();
+    });
+
+    test('allows Partial Mode with an explicit text response format', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            custom_include_body: 'response_format:\n  type: text',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.response_format).toEqual({ type: 'text' });
+        expect(capturedBody.messages.at(-1).partial).toBe(true);
+    });
+
+    test('does not mark a prefill after tool history', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            messages: [
+                { role: 'assistant', content: null, tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'lookup', arguments: '{}' } }] },
+                { role: 'tool', tool_call_id: 'call-1', content: 'result' },
+                { role: 'assistant', content: 'Prefill' },
+            ],
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1).partial).toBeUndefined();
+    });
+
+    test('leaves non-K3 Custom requests unchanged', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            model: 'kimi-k2.5',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1).partial).toBeUndefined();
+        expect(capturedBody.temperature).toBe(1);
+        expect(capturedBody.top_p).toBe(0.95);
+        expect(capturedBody.n).toBe(3);
+    });
+
+    test('retains K2 thinking controls for native Moonshot', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT, {
+            model: 'kimi-k2.5',
+            include_reasoning: true,
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.thinking).toEqual({ type: 'enabled' });
+        expect(capturedBody.messages.at(-1).partial).toBe(true);
+    });
+});

--- a/tests/kimi-k3-chat-completions.test.js
+++ b/tests/kimi-k3-chat-completions.test.js
@@ -30,8 +30,10 @@ describe('Kimi K3 chat completion requests', () => {
         setConfigFilePath(configPath);
 
         const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
+        const { SecretManager, SECRET_KEYS } = await import('../src/endpoints/secrets.js');
         const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-kimi-k3-user-'));
         tempDirs.push(userRoot);
+        new SecretManager({ root: userRoot, backups: userRoot }).writeSecret(SECRET_KEYS.NANOGPT, 'nanogpt-test-key');
 
         const app = express();
         app.use(express.json());
@@ -186,6 +188,31 @@ describe('Kimi K3 chat completion requests', () => {
 
         expect(response.status).toBe(200);
         expect(capturedBody.messages.at(-1).partial).toBeUndefined();
+    });
+
+    test('marks NanoGPT K3 prefill as partial and omits unsupported parameters', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, {
+            model: 'moonshotai/kimi-k3',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1)).toEqual({
+            role: 'assistant',
+            content: 'Prefill',
+            partial: true,
+        });
+        expectFixedParametersOmitted();
+    });
+
+    test('leaves non-K3 NanoGPT requests unchanged', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, {
+            model: 'moonshotai/kimi-k2',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1).partial).toBeUndefined();
+        expect(capturedBody.temperature).toBe(1);
+        expect(capturedBody.n).toBe(3);
     });
 
     test('leaves non-K3 Custom requests unchanged', async () => {

--- a/tests/kimi-k3-chat-completions.test.js
+++ b/tests/kimi-k3-chat-completions.test.js
@@ -33,7 +33,9 @@ describe('Kimi K3 chat completion requests', () => {
         const { SecretManager, SECRET_KEYS } = await import('../src/endpoints/secrets.js');
         const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-kimi-k3-user-'));
         tempDirs.push(userRoot);
-        new SecretManager({ root: userRoot, backups: userRoot }).writeSecret(SECRET_KEYS.NANOGPT, 'nanogpt-test-key');
+        const secretManager = new SecretManager({ root: userRoot, backups: userRoot });
+        secretManager.writeSecret(SECRET_KEYS.NANOGPT, 'nanogpt-test-key');
+        secretManager.writeSecret(SECRET_KEYS.OPENROUTER, 'openrouter-test-key');
 
         const app = express();
         app.use(express.json());
@@ -206,6 +208,31 @@ describe('Kimi K3 chat completion requests', () => {
 
     test('leaves non-K3 NanoGPT requests unchanged', async () => {
         const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, {
+            model: 'moonshotai/kimi-k2',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1).partial).toBeUndefined();
+        expect(capturedBody.temperature).toBe(1);
+        expect(capturedBody.n).toBe(3);
+    });
+
+    test('marks OpenRouter K3 prefill as partial and omits unsupported parameters', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.OPENROUTER, {
+            model: 'moonshotai/kimi-k3',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.messages.at(-1)).toEqual({
+            role: 'assistant',
+            content: 'Prefill',
+            partial: true,
+        });
+        expectFixedParametersOmitted();
+    });
+
+    test('leaves non-K3 OpenRouter requests unchanged', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.OPENROUTER, {
             model: 'moonshotai/kimi-k2',
         });
 

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -9,6 +9,9 @@ import {
 } from '../public/scripts/openai-model-capabilities.js';
 
 const openAiSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/openai.js', import.meta.url)), 'utf8');
+const indexSource = fs.readFileSync(fileURLToPath(new URL('../public/index.html', import.meta.url)), 'utf8');
+const powerUserSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/power-user.js', import.meta.url)), 'utf8');
+const presetManagerSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/preset-manager.js', import.meta.url)), 'utf8');
 
 describe('OpenAI-compatible Claude model capabilities', () => {
     test('removes unsupported parameters from provider-prefixed Claude 5 requests', () => {
@@ -109,9 +112,19 @@ describe('Kimi K3 model capabilities', () => {
         });
     });
 
-    test('applies K3 constraints while building Custom and Moonshot generation parameters', () => {
-        expect(openAiSource).toContain('const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT]');
+    test('applies K3 constraints while building Custom, Moonshot and NanoGPT generation parameters', () => {
+        expect(openAiSource).toContain('const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT]');
         expect(openAiSource).toContain('applyKimiK3ModelParameterConstraints(generate_data);');
         expect(openAiSource).toContain('&& !isKimiK3Request;');
+    });
+
+    test('exposes a synchronized Start Reply With control for Custom, Moonshot and NanoGPT', () => {
+        expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt">[\s\S]*?id="openai_start_reply_with"/);
+        expect(indexSource).toContain('for="openai_start_reply_with" class="range-block-title justifyLeft"');
+        expect(indexSource.match(/class="start-reply-with-input [^"]*"/g)).toHaveLength(2);
+        expect(openAiSource).toContain('.range-block:has(#openai_start_reply_with)');
+        expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.on\('input', function \(\) \{/);
+        expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.not\(this\)\.val\(value\);/);
+        expect(presetManagerSource).toMatch(/\$\('\.start-reply-with-input'\)\.val\(power_user\.user_prompt_bias\);/);
     });
 });

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -2,7 +2,11 @@ import { describe, expect, test } from '@jest/globals';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import { applyClaudeModelParameterConstraints } from '../public/scripts/openai-model-capabilities.js';
+import {
+    applyClaudeModelParameterConstraints,
+    applyKimiK3ModelParameterConstraints,
+    isKimiK3Model,
+} from '../public/scripts/openai-model-capabilities.js';
 
 const openAiSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/openai.js', import.meta.url)), 'utf8');
 
@@ -48,8 +52,66 @@ describe('OpenAI-compatible Claude model capabilities', () => {
     });
 
     test('applies Claude model constraints while building generation parameters', () => {
-        expect(openAiSource).toContain('import { applyClaudeModelParameterConstraints } from \'./openai-model-capabilities.js\';');
+        expect(openAiSource).toContain('applyClaudeModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model');
         expect(openAiSource).toContain('applyClaudeModelParameterConstraints(generate_data, {');
         expect(openAiSource).toContain('preserveReasoning: [chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source)');
+    });
+});
+
+describe('Kimi K3 model capabilities', () => {
+    test('recognizes native and provider-prefixed K3 model IDs', () => {
+        for (const model of ['kimi-k3', 'KIMI-K3', 'moonshotai/kimi-k3', 'models:moonshotai/kimi-k3']) {
+            expect(isKimiK3Model(model)).toBe(true);
+        }
+    });
+
+    test('rejects unrelated model IDs', () => {
+        for (const model of ['kimi-k2.5', 'moonshotai/kimi-k2', 'not-kimi-k3', '', undefined]) {
+            expect(isKimiK3Model(model)).toBe(false);
+        }
+    });
+
+    test('removes parameters fixed by the Kimi K3 API', () => {
+        const payload = {
+            model: 'moonshotai/Kimi-K3',
+            temperature: 1,
+            top_p: 0.95,
+            frequency_penalty: 0,
+            presence_penalty: 0,
+            n: 3,
+            max_tokens: 4096,
+            reasoning_effort: 'max',
+            thinking: { type: 'enabled' },
+        };
+
+        applyKimiK3ModelParameterConstraints(payload);
+
+        expect(payload).toEqual({
+            model: 'moonshotai/Kimi-K3',
+            max_tokens: 4096,
+            reasoning_effort: 'max',
+        });
+    });
+
+    test('leaves non-K3 payloads unchanged', () => {
+        const payload = {
+            model: 'kimi-k2.5',
+            temperature: 0.7,
+            n: 2,
+        };
+
+        applyKimiK3ModelParameterConstraints(payload);
+
+        expect(payload).toEqual({
+            model: 'kimi-k2.5',
+            temperature: 0.7,
+            n: 2,
+        });
+    });
+
+    test('applies K3 constraints while building Custom and Moonshot generation parameters', () => {
+        expect(openAiSource).toContain('const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT]');
+        expect(openAiSource).toContain('applyKimiK3ModelParameterConstraints(generate_data);');
+        expect(openAiSource).toContain('&& !isKimiK3Request;');
     });
 });

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -112,19 +112,19 @@ describe('Kimi K3 model capabilities', () => {
         });
     });
 
-    test('applies K3 constraints while building Custom, Moonshot and NanoGPT generation parameters', () => {
-        expect(openAiSource).toContain('const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT]');
+    test('applies K3 constraints while building Custom, Moonshot, NanoGPT and OpenRouter generation parameters', () => {
+        expect(openAiSource).toContain('const isKimiK3Request = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT, chat_completion_sources.OPENROUTER]');
         expect(openAiSource).toContain('applyKimiK3ModelParameterConstraints(generate_data);');
         expect(openAiSource).toContain('&& !isKimiK3Request;');
     });
 
     test('exposes a synchronized Start Reply With control only for K3 models', () => {
-        expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt">[\s\S]*?id="openai_start_reply_with"/);
+        expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">[\s\S]*?id="openai_start_reply_with"/);
         expect(indexSource).toContain('for="openai_start_reply_with" class="range-block-title justifyLeft"');
         expect(indexSource.match(/class="start-reply-with-input [^"]*"/g)).toHaveLength(2);
         expect(openAiSource).toContain('.range-block:has(#openai_start_reply_with)');
-        expect(openAiSource).toContain("const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT];");
-        expect(openAiSource).toContain(".toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()))");
+        expect(openAiSource).toContain('const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT, chat_completion_sources.OPENROUTER];');
+        expect(openAiSource).toContain('.toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()))');
         expect(openAiSource.match(/updateKimiK3PrefillVisibility\(\);/g)).toHaveLength(3);
         expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.on\('input', function \(\) \{/);
         expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.not\(this\)\.val\(value\);/);

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -118,11 +118,14 @@ describe('Kimi K3 model capabilities', () => {
         expect(openAiSource).toContain('&& !isKimiK3Request;');
     });
 
-    test('exposes a synchronized Start Reply With control for Custom, Moonshot and NanoGPT', () => {
+    test('exposes a synchronized Start Reply With control only for K3 models', () => {
         expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt">[\s\S]*?id="openai_start_reply_with"/);
         expect(indexSource).toContain('for="openai_start_reply_with" class="range-block-title justifyLeft"');
         expect(indexSource.match(/class="start-reply-with-input [^"]*"/g)).toHaveLength(2);
         expect(openAiSource).toContain('.range-block:has(#openai_start_reply_with)');
+        expect(openAiSource).toContain("const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT];");
+        expect(openAiSource).toContain(".toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()))");
+        expect(openAiSource.match(/updateKimiK3PrefillVisibility\(\);/g)).toHaveLength(3);
         expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.on\('input', function \(\) \{/);
         expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.not\(this\)\.val\(value\);/);
         expect(presetManagerSource).toMatch(/\$\('\.start-reply-with-input'\)\.val\(power_user\.user_prompt_bias\);/);

--- a/tests/openai-static-models.test.js
+++ b/tests/openai-static-models.test.js
@@ -184,6 +184,15 @@ test('Other provider pickers omit confirmed-retired model IDs', () => {
     expect(mainHtml).toEqual(expect.not.stringContaining('value="kimi-thinking-preview"'));
 });
 
+test('Moonshot picker includes Kimi K3 with its one-million-token context', () => {
+    const mainSource = readSource('../public/index.html');
+    const openAiScript = readSource('../public/scripts/openai.js');
+    const moonshotPicker = getSelectOptionIds(mainSource, 'model_moonshot_select');
+
+    expect(moonshotPicker).toContain('kimi-k3');
+    expect(openAiScript).toContain('\'kimi-k3\': max_1mil');
+});
+
 test('Google AI Studio pickers include current models and omit all retired Gemini/Gemma models', () => {
     const mainSource = readSource('../public/index.html');
     const captionSource = readSource('../public/scripts/extensions/caption/settings.html');


### PR DESCRIPTION
Kimi K3 supports Partial Prefill, and it already considers it so when using Start Reply With, so just reusing that an exposing it in the UI. Parameter ends up being partial: true, by default.

Under Advanced & Reasoning:
<img width="722" height="1280" alt="image" src="https://github.com/user-attachments/assets/052e98f1-7498-4adf-a5a3-e5e123d2819c" />

For NanoGPT, Moonshot, OpenRouter and Custom backends.
Also, Advanced Formatting has Start Reply With which works too.

Gated to only Kimi K3 on all relevant backends.