### PR TITLE
fix(ios): fix iOS crash startup logs not being detailed enough

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8925,7 +8925,7 @@
     <div id="secrets_datalists" class="displayNone"></div>
 
     <!-- Script includes -->
-    <script src="scripts/sillybunny-boot-guard.js?v=20260730b"></script>
+    <script src="scripts/sillybunny-boot-guard.js?v=20260730c"></script>
     <script src="lib/polyfill.js" defer></script>
     <script src="lib/jquery-3.5.1.min.js" defer></script>
     <script src="lib/jquery-ui.min.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -8925,7 +8925,7 @@
     <div id="secrets_datalists" class="displayNone"></div>
 
     <!-- Script includes -->
-    <script src="scripts/sillybunny-boot-guard.js?v=20260730a"></script>
+    <script src="scripts/sillybunny-boot-guard.js?v=20260730b"></script>
     <script src="lib/polyfill.js" defer></script>
     <script src="lib/jquery-3.5.1.min.js" defer></script>
     <script src="lib/jquery-ui.min.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -8925,7 +8925,7 @@
     <div id="secrets_datalists" class="displayNone"></div>
 
     <!-- Script includes -->
-    <script src="scripts/sillybunny-boot-guard.js?v=20260611a"></script>
+    <script src="scripts/sillybunny-boot-guard.js?v=20260730a"></script>
     <script src="lib/polyfill.js" defer></script>
     <script src="lib/jquery-3.5.1.min.js" defer></script>
     <script src="lib/jquery-ui.min.js" defer></script>

--- a/public/lib/eventemitter.js
+++ b/public/lib/eventemitter.js
@@ -23,6 +23,20 @@ if (typeof Array.prototype.indexOf === 'function') {
 };
 
 
+/**
+ * Checks if event tracing is enabled.
+ * SillyBunny: iOS WebKit private browsing throws on localStorage access, which
+ * would otherwise abort the whole emit and every startup stage awaiting it.
+ * @returns {boolean} True if event tracing is enabled
+ */
+function isEventTracingEnabled() {
+    try {
+        return localStorage.getItem('eventTracing') === 'true';
+    } catch (error) {
+        return false;
+    }
+}
+
 /* Polyfill EventEmitter. */
 /**
  * Creates an event emitter.
@@ -129,7 +143,7 @@ EventEmitter.prototype.removeListener = function (event, listener) {
  */
 EventEmitter.prototype.emit = async function (event) {
     let args = [].slice.call(arguments, 1);
-    if (localStorage.getItem('eventTracing') === 'true') {
+    if (isEventTracingEnabled()) {
         console.trace('Event emitted: ' + event, args);
     } else {
         console.debug('Event emitted: ' + event);
@@ -159,7 +173,7 @@ EventEmitter.prototype.emit = async function (event) {
 
 EventEmitter.prototype.emitAndWait = function (event) {
     let args = [].slice.call(arguments, 1);
-    if (localStorage.getItem('eventTracing') === 'true') {
+    if (isEventTracingEnabled()) {
         console.trace('Event emitted: ' + event, args);
     } else {
         console.debug('Event emitted: ' + event);

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -509,7 +509,13 @@ function restoreUserInput() {
         return;
     }
 
-    const userInput = localStorage.getItem(getUserInputKey());
+    let userInput = null;
+    try {
+        userInput = localStorage.getItem(getUserInputKey());
+    } catch {
+        // Ignore storage read failures in Safari Private Browsing.
+    }
+
     if (userInput) {
         $('#send_textarea').val(userInput)[0].dispatchEvent(new Event('input', { bubbles: true }));
     }

--- a/public/scripts/extensions/quick-image-gen/index.js
+++ b/public/scripts/extensions/quick-image-gen/index.js
@@ -21321,10 +21321,10 @@ async function registerQigSlashCommands() {
 
     try {
         const [commandModule, parserModule, argumentModule, enumModule] = await Promise.all([
-            import("../../../slash-commands/SlashCommand.js"),
-            import("../../../slash-commands/SlashCommandParser.js"),
-            import("../../../slash-commands/SlashCommandArgument.js"),
-            import("../../../slash-commands/SlashCommandEnumValue.js"),
+            import("../../slash-commands/SlashCommand.js"),
+            import("../../slash-commands/SlashCommandParser.js"),
+            import("../../slash-commands/SlashCommandArgument.js"),
+            import("../../slash-commands/SlashCommandEnumValue.js"),
         ]);
         const { SlashCommand } = commandModule;
         const { SlashCommandParser } = parserModule;

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -302,7 +302,7 @@ function addLanguagesToDropdown() {
         uiLanguageSelects.append(option);
     }
 
-    const selectedLanguage = localStorage.getItem(storageKey);
+    const selectedLanguage = safeGetLocalStorageItem(storageKey);
     if (selectedLanguage) {
         uiLanguageSelects.val(selectedLanguage);
     }
@@ -335,7 +335,7 @@ export async function initLocales() {
         attributeFilter: ['data-i18n'],
     });
 
-    if (localStorage.getItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
+    if (safeGetLocalStorageItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
         trackMissingDynamicTranslate = new Set();
     }
 

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -15,6 +15,13 @@
     var THIRD_PARTY_EXTENSION_PATH = '/scripts/extensions/third-party/';
     var isBootGuardApplicable = isIOSWebKitBrowser();
 
+    // SillyBunny: jQuery rethrows whatever an async ready callback rejected with,
+    // so startup failures often arrive as message-less objects such as a jqXHR.
+    // These are the fields worth reading before falling back to enumeration.
+    var ERROR_DETAIL_KEYS = ['name', 'code', 'status', 'statusText', 'readyState', 'type', 'url', 'responseText'];
+    var MAX_ERROR_VALUE_LENGTH = 200;
+    var MAX_ERROR_DETAIL_LENGTH = 800;
+
     function isIOSWebKitBrowser() {
         try {
             if (typeof navigator === 'undefined') {
@@ -40,6 +47,77 @@
         }
     }
 
+    function truncate(value, limit) {
+        var text = String(value);
+        return text.length > limit ? text.slice(0, limit) + '...' : text;
+    }
+
+    function describeErrorValue(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        if (typeof value === 'object' || typeof value === 'function') {
+            return '';
+        }
+
+        return truncate(value, MAX_ERROR_VALUE_LENGTH);
+    }
+
+    // SillyBunny: `String(plainObject)` renders as "[object Object]", which hides
+    // every useful detail. Enumerate the value instead so iOS boot reports name the
+    // actual failure (for example an aborted jqXHR with status 0).
+    function describeErrorObject(error) {
+        var parts = [];
+        var seen = {};
+
+        function push(key, value) {
+            var text = describeErrorValue(value);
+
+            if (!text || seen[key]) {
+                return;
+            }
+
+            seen[key] = true;
+            parts.push(key + ': ' + text);
+        }
+
+        for (var index = 0; index < ERROR_DETAIL_KEYS.length; index++) {
+            try {
+                push(ERROR_DETAIL_KEYS[index], error[ERROR_DETAIL_KEYS[index]]);
+            } catch (_error) {
+                // Accessor properties can throw on cross-origin or revoked objects.
+            }
+        }
+
+        if (!parts.length) {
+            try {
+                var keys = Object.keys(error);
+
+                for (var keyIndex = 0; keyIndex < keys.length && parts.length < ERROR_DETAIL_KEYS.length; keyIndex++) {
+                    push(keys[keyIndex], error[keys[keyIndex]]);
+                }
+            } catch (_error) {
+                // Non-enumerable or exotic objects simply stay undescribed.
+            }
+        }
+
+        var constructorName = '';
+        try {
+            constructorName = String(error.constructor && error.constructor.name || '');
+        } catch (_error) {
+            constructorName = '';
+        }
+
+        var prefix = 'Thrown ' + (constructorName || 'object');
+
+        if (!parts.length) {
+            return prefix + ' with no readable details.';
+        }
+
+        return truncate(prefix + ' { ' + parts.join(', ') + ' }', MAX_ERROR_DETAIL_LENGTH);
+    }
+
     function describeError(error) {
         try {
             if (!error) {
@@ -56,6 +134,10 @@
 
             if (error.message) {
                 return String(error.message);
+            }
+
+            if (typeof error === 'object') {
+                return describeErrorObject(error);
             }
 
             return String(error);

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -22,6 +22,11 @@
     var MAX_ERROR_VALUE_LENGTH = 200;
     var MAX_ERROR_DETAIL_LENGTH = 800;
 
+    // SillyBunny: a rejected jqXHR does not carry its own URL, so failing requests are
+    // tracked separately to name the endpoint that broke startup.
+    var MAX_TRACKED_REQUEST_FAILURES = 5;
+    var failedRequests = [];
+
     function isIOSWebKitBrowser() {
         try {
             if (typeof navigator === 'undefined') {
@@ -146,6 +151,73 @@
         }
     }
 
+    function recordRequestFailure(method, url, status) {
+        if (failedRequests.length >= MAX_TRACKED_REQUEST_FAILURES) {
+            return;
+        }
+
+        failedRequests.push(truncate(String(method || 'GET') + ' ' + String(url) + ' -> ' + String(status), MAX_ERROR_VALUE_LENGTH));
+    }
+
+    function describeRequestFailures() {
+        if (!failedRequests.length) {
+            return '';
+        }
+
+        return truncate('Failed requests during startup:\n' + failedRequests.join('\n'), MAX_ERROR_DETAIL_LENGTH);
+    }
+
+    // SillyBunny: jQuery AJAX goes through XMLHttpRequest, so watching it here captures
+    // the URL and status of the request behind an otherwise anonymous jqXHR rejection.
+    function trackFailingRequests() {
+        try {
+            var XHR = window.XMLHttpRequest;
+
+            if (!XHR || !XHR.prototype || !XHR.prototype.open || !XHR.prototype.send) {
+                return;
+            }
+
+            var originalOpen = XHR.prototype.open;
+            var originalSend = XHR.prototype.send;
+
+            XHR.prototype.open = function (method, url) {
+                try {
+                    this.sillyBunnyBootMethod = method;
+                    this.sillyBunnyBootUrl = url;
+                } catch (_error) {
+                    // Exotic instances simply stay unlabeled.
+                }
+
+                return originalOpen.apply(this, arguments);
+            };
+
+            XHR.prototype.send = function () {
+                try {
+                    var request = this;
+                    request.addEventListener('loadend', function () {
+                        if (bootCompleted) {
+                            return;
+                        }
+
+                        var status = Number(request.status || 0);
+
+                        if (status !== 0 && status < 400) {
+                            return;
+                        }
+
+                        recordRequestFailure(request.sillyBunnyBootMethod, request.sillyBunnyBootUrl, status || 'network error');
+                    });
+                } catch (_error) {
+                    // Never let diagnostics break startup.
+                }
+
+                return originalSend.apply(this, arguments);
+            };
+        } catch (_error) {
+            // Never let diagnostics break startup.
+        }
+    }
+
     function recordFailure(message, error) {
         if (!isBootGuardApplicable) {
             return;
@@ -156,6 +228,12 @@
 
         if (errorDetails && details.indexOf(errorDetails) === -1) {
             details += '\n' + errorDetails;
+        }
+
+        var requestDetails = describeRequestFailures();
+
+        if (requestDetails && details.indexOf(requestDetails) === -1) {
+            details += '\n' + requestDetails;
         }
 
         lastFailure = details;
@@ -358,6 +436,8 @@
     if (!isBootGuardApplicable) {
         return;
     }
+
+    trackFailingRequests();
 
     window.addEventListener('error', function (event) {
         if (bootCompleted) {

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -12,7 +12,8 @@
     var MAX_BOOT_TIMEOUT_MS = 90000;
     var bootStartedAt = Date.now();
 
-    var THIRD_PARTY_EXTENSION_PATH = '/scripts/extensions/third-party/';
+    // SillyBunny: matched without a leading slash so relative extension URLs are recognised too.
+    var THIRD_PARTY_EXTENSION_PATH = 'scripts/extensions/third-party/';
     var isBootGuardApplicable = isIOSWebKitBrowser();
 
     // SillyBunny: jQuery rethrows whatever an async ready callback rejected with,
@@ -165,6 +166,27 @@
         }
 
         return truncate('Failed requests during startup:\n' + failedRequests.join('\n'), MAX_ERROR_DETAIL_LENGTH);
+    }
+
+    // SillyBunny: a rejected jqXHR carries no stack, message or URL, so jQuery rethrows it
+    // from its own source and the failure looks like a SillyBunny bug. When the only requests
+    // that failed belong to a third-party extension, blame the extension instead.
+    function isThirdPartyRequestFailure(error) {
+        if (!error || typeof error !== 'object' || error.stack || error.message) {
+            return false;
+        }
+
+        if (!failedRequests.length) {
+            return false;
+        }
+
+        for (var index = 0; index < failedRequests.length; index++) {
+            if (!isThirdPartyExtensionSource(failedRequests[index])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     // SillyBunny: jQuery AJAX goes through XMLHttpRequest, so watching it here captures
@@ -467,6 +489,11 @@
             return;
         }
 
+        if (isThirdPartyRequestFailure(event.error)) {
+            console.warn('SillyBunny boot guard ignored a third-party extension request failure.', failedRequests);
+            return;
+        }
+
         var source = event.filename ? ' at ' + event.filename + ':' + event.lineno + ':' + event.colno : '';
         recordFailure(String(event.message || 'Startup script error') + source, event.error);
     }, true);
@@ -478,6 +505,11 @@
 
         if (isThirdPartyExtensionSource(describeError(event.reason))) {
             console.warn('SillyBunny boot guard ignored a third-party extension startup rejection.', event.reason);
+            return;
+        }
+
+        if (isThirdPartyRequestFailure(event.reason)) {
+            console.warn('SillyBunny boot guard ignored a third-party extension request failure.', failedRequests);
             return;
         }
 

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -845,6 +845,35 @@ export function countTokensOpenAI(messages, full = false) {
 }
 
 /**
+ * Posts messages to the OpenAI token counting endpoint.
+ * SillyBunny: jQuery rejects with the jqXHR object, which has no message or stack.
+ * If that escapes into an async jQuery ready callback, jQuery rethrows it and the
+ * whole startup aborts with an unreadable "[object Object]" error, so failures are
+ * downgraded to the guesstimate fallback used everywhere else in this module.
+ * @param {string} endpoint Tokenizer endpoint URL.
+ * @param {object[]} messages Messages to count.
+ * @returns {Promise<number|null>} Token count, or null when the request failed.
+ */
+async function requestOpenAITokenCount(endpoint, messages) {
+    try {
+        const data = await jQuery.ajax({
+            async: true,
+            type: 'POST', //
+            url: endpoint,
+            data: JSON.stringify(messages),
+            dataType: 'json',
+            contentType: 'application/json',
+        });
+
+        const tokenCount = Number(data?.token_count);
+        return Number.isFinite(tokenCount) ? tokenCount : null;
+    } catch (error) {
+        console.error('Failed to count tokens with the OpenAI tokenizer.', error);
+        return null;
+    }
+}
+
+/**
  * Returns the token count for a message using the OpenAI tokenizer.
  * @param {object[]|object} messages
  * @param {boolean} full
@@ -874,17 +903,15 @@ export async function countTokensOpenAIAsync(messages, full = false) {
         if (typeof cachedCount === 'number') {
             token_count += cachedCount;
         } else {
-            const data = await jQuery.ajax({
-                async: true,
-                type: 'POST', //
-                url: tokenizerEndpoint,
-                data: JSON.stringify([message]),
-                dataType: 'json',
-                contentType: 'application/json',
-            });
+            const tokenCount = await requestOpenAITokenCount(tokenizerEndpoint, [message]);
 
-            token_count += Number(data.token_count);
-            cacheObject[cacheKey] = Number(data.token_count);
+            if (tokenCount === null) {
+                token_count += guesstimate(JSON.stringify(message));
+                continue;
+            }
+
+            token_count += tokenCount;
+            cacheObject[cacheKey] = tokenCount;
         }
     }
 
@@ -903,16 +930,9 @@ export async function countChatCompletionPayloadTokensOpenAIAsync(messages) {
 
     // SillyBunny: count post-intercept payloads in one request so backend-specific
     // per-payload padding is applied once instead of once per message.
-    const data = await jQuery.ajax({
-        async: true,
-        type: 'POST', //
-        url: tokenizerEndpoint,
-        data: JSON.stringify(messages),
-        dataType: 'json',
-        contentType: 'application/json',
-    });
+    const tokenCount = await requestOpenAITokenCount(tokenizerEndpoint, messages);
 
-    return Number(data.token_count);
+    return tokenCount === null ? guesstimate(JSON.stringify(messages)) : tokenCount;
 }
 
 /**

--- a/tests/event-emitter.test.js
+++ b/tests/event-emitter.test.js
@@ -30,4 +30,40 @@ describe('EventEmitter', () => {
 
         expect(calls).toEqual(['first', 'second', 'after']);
     });
+
+    describe('when localStorage access is blocked', () => {
+        beforeEach(() => {
+            globalThis.localStorage = {
+                getItem: () => {
+                    throw new Error('The operation is insecure.');
+                },
+            };
+        });
+
+        test('still runs emit listeners', async () => {
+            const emitter = new EventEmitter();
+            const calls = [];
+
+            emitter.on('boot', value => {
+                calls.push(value);
+            });
+
+            await emitter.emit('boot', 'payload');
+
+            expect(calls).toEqual(['payload']);
+        });
+
+        test('still runs emitAndWait listeners', () => {
+            const emitter = new EventEmitter();
+            const calls = [];
+
+            emitter.on('boot', value => {
+                calls.push(value);
+            });
+
+            emitter.emitAndWait('boot', 'payload');
+
+            expect(calls).toEqual(['payload']);
+        });
+    });
 });

--- a/tests/sillybunny-boot-guard.test.js
+++ b/tests/sillybunny-boot-guard.test.js
@@ -294,4 +294,37 @@ describe('SillyBunny boot guard', () => {
 
         expect(preloader.querySelector('button').textContent).toBe('Clear frontend cache and reload');
     });
+
+    test('describes message-less thrown objects instead of showing [object Object]', () => {
+        const { document, listeners, timers } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const initialTimerCount = timers.length;
+
+        listeners.get('error')({
+            filename: '/lib/jquery-3.5.1.min.js',
+            message: '[object Object]',
+            lineno: 2,
+            colno: 31677,
+            error: { readyState: 4, status: 0, statusText: 'error' },
+        });
+
+        timers.slice(initialTimerCount).forEach(timer => timer.callback());
+
+        const details = preloader.querySelector('pre').textContent;
+        expect(details).toContain('status: 0');
+        expect(details).toContain('statusText: error');
+        expect(details).toContain('readyState: 4');
+    });
+
+    test('describes rejected objects that only carry enumerable keys', () => {
+        const { document, listeners, timers } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const initialTimerCount = timers.length;
+
+        listeners.get('unhandledrejection')({ reason: { extensionId: 'quick-reply' } });
+
+        timers.slice(initialTimerCount).forEach(timer => timer.callback());
+
+        expect(preloader.querySelector('pre').textContent).toContain('extensionId: quick-reply');
+    });
 });

--- a/tests/sillybunny-boot-guard.test.js
+++ b/tests/sillybunny-boot-guard.test.js
@@ -140,6 +140,34 @@ function matchesSelector(element, selector) {
     return true;
 }
 
+function createFakeXMLHttpRequest() {
+    return class FakeXMLHttpRequest {
+        constructor() {
+            this.status = 0;
+            this.requestListeners = new Map();
+        }
+
+        open(method, url) {
+            this.requestMethod = method;
+            this.requestUrl = url;
+        }
+
+        send() {
+            this.sent = true;
+        }
+
+        addEventListener(type, listener) {
+            const existing = this.requestListeners.get(type) || [];
+            existing.push(listener);
+            this.requestListeners.set(type, existing);
+        }
+
+        dispatch(type) {
+            (this.requestListeners.get(type) || []).forEach(listener => listener());
+        }
+    };
+}
+
 function createBootGuardHarness({ userAgent = IOS_WEBKIT_USER_AGENT, platform = 'iPhone', maxTouchPoints = 5 } = {}) {
     const document = new FakeDocument();
     const timers = [];
@@ -156,6 +184,7 @@ function createBootGuardHarness({ userAgent = IOS_WEBKIT_USER_AGENT, platform = 
             timers.push({ callback, delay });
             return timers.length;
         },
+        XMLHttpRequest: createFakeXMLHttpRequest(),
     };
 
     vm.runInNewContext(bootGuardSource, {
@@ -314,6 +343,32 @@ describe('SillyBunny boot guard', () => {
         expect(details).toContain('status: 0');
         expect(details).toContain('statusText: error');
         expect(details).toContain('readyState: 4');
+    });
+
+    test('names the failing request behind an object-shaped startup failure', () => {
+        const { document, listeners, timers, window } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const initialTimerCount = timers.length;
+
+        const request = new window.XMLHttpRequest();
+        request.open('POST', '/api/tokenizers/openai/count?model=gpt-4-turbo');
+        request.send();
+        request.status = 404;
+        request.dispatch('loadend');
+
+        listeners.get('error')({
+            filename: '/lib/jquery-3.5.1.min.js',
+            message: '[object Object]',
+            lineno: 2,
+            colno: 31677,
+            error: { readyState: 4, status: 404, statusText: 'Not Found' },
+        });
+
+        timers.slice(initialTimerCount).forEach(timer => timer.callback());
+
+        const details = preloader.querySelector('pre').textContent;
+        expect(details).toContain('Failed requests during startup:');
+        expect(details).toContain('POST /api/tokenizers/openai/count?model=gpt-4-turbo -> 404');
     });
 
     test('describes rejected objects that only carry enumerable keys', () => {

--- a/tests/sillybunny-boot-guard.test.js
+++ b/tests/sillybunny-boot-guard.test.js
@@ -371,6 +371,60 @@ describe('SillyBunny boot guard', () => {
         expect(details).toContain('POST /api/tokenizers/openai/count?model=gpt-4-turbo -> 404');
     });
 
+    test('ignores object-shaped failures whose only failing request is a third-party extension file', () => {
+        const { document, listeners, timers, window } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const initialTimerCount = timers.length;
+
+        const request = new window.XMLHttpRequest();
+        request.open('GET', 'scripts/extensions/third-party/SB-GroupUtilities/html/group-note.html');
+        request.send();
+        request.status = 404;
+        request.dispatch('loadend');
+
+        listeners.get('error')({
+            filename: '/lib/jquery-3.5.1.min.js',
+            message: '[object Object]',
+            lineno: 2,
+            colno: 31677,
+            error: { readyState: 4, status: 404, statusText: 'Not Found', responseText: 'Not Found' },
+        });
+
+        timers.slice(initialTimerCount).forEach(timer => timer.callback());
+
+        expect(preloader.querySelector('pre')).toBeNull();
+    });
+
+    test('still blames SillyBunny when a core request failed alongside a third-party one', () => {
+        const { document, listeners, timers, window } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const initialTimerCount = timers.length;
+
+        const extensionRequest = new window.XMLHttpRequest();
+        extensionRequest.open('GET', 'scripts/extensions/third-party/SB-GroupUtilities/html/group-note.html');
+        extensionRequest.send();
+        extensionRequest.status = 404;
+        extensionRequest.dispatch('loadend');
+
+        const coreRequest = new window.XMLHttpRequest();
+        coreRequest.open('GET', '/api/settings/get');
+        coreRequest.send();
+        coreRequest.status = 500;
+        coreRequest.dispatch('loadend');
+
+        listeners.get('error')({
+            filename: '/lib/jquery-3.5.1.min.js',
+            message: '[object Object]',
+            lineno: 2,
+            colno: 31677,
+            error: { readyState: 4, status: 500, statusText: 'Internal Server Error' },
+        });
+
+        timers.slice(initialTimerCount).forEach(timer => timer.callback());
+
+        expect(preloader.querySelector('pre').textContent).toContain('GET /api/settings/get -> 500');
+    });
+
     test('describes rejected objects that only carry enumerable keys', () => {
         const { document, listeners, timers } = createBootGuardHarness();
         const preloader = addPreloader(document);

--- a/tests/tokenizers-openai-count-fallback.test.js
+++ b/tests/tokenizers-openai-count-fallback.test.js
@@ -1,0 +1,102 @@
+/* global globalThis */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const mockOaiSettings = {
+    chat_completion_source: 'openai',
+    openai_model: 'gpt-4-turbo',
+};
+
+await jest.unstable_mockModule('../public/lib.js', () => ({
+    localforage: {
+        createInstance: () => ({
+            getItem: jest.fn(async () => ({})),
+            setItem: jest.fn(async () => undefined),
+        }),
+    },
+}));
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    characters: [],
+    event_types: {},
+    eventSource: { on: jest.fn() },
+    main_api: 'openai',
+    nai_settings: {},
+    online_status: 'no_connection',
+    this_chid: undefined,
+}));
+
+await jest.unstable_mockModule('../public/scripts/power-user.js', () => ({
+    power_user: { tokenizer: 0 },
+    registerDebugFunction: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/openai.js', () => ({
+    chat_completion_sources: { OPENAI: 'openai' },
+    model_list: [],
+    oai_settings: mockOaiSettings,
+}));
+
+await jest.unstable_mockModule('../public/scripts/group-chats.js', () => ({
+    groups: [],
+    selected_group: null,
+}));
+
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    getStringHash: jest.fn(() => 1234),
+}));
+
+await jest.unstable_mockModule('../public/scripts/kai-settings.js', () => ({
+    kai_flags: {},
+    kai_settings: {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/textgen-settings.js', () => ({
+    textgen_types: {},
+    textgenerationwebui_settings: { type: 'ooba' },
+    getTextGenServer: jest.fn(() => ''),
+    getTextGenModel: jest.fn(() => ''),
+}));
+
+await jest.unstable_mockModule('../public/scripts/textgen-models.js', () => ({
+    getCurrentDreamGenModelTokenizer: jest.fn(),
+    getCurrentOpenRouterModelTokenizer: jest.fn(),
+    openRouterModels: [],
+}));
+
+const {
+    countChatCompletionPayloadTokensOpenAIAsync,
+    countTokensOpenAIAsync,
+    guesstimate,
+} = await import('../public/scripts/tokenizers.js');
+
+describe('OpenAI token counting resilience', () => {
+    beforeEach(() => {
+        globalThis.jQuery = { ajax: jest.fn() };
+    });
+
+    test('falls back to a guesstimate when the tokenizer endpoint rejects with a jqXHR', async () => {
+        const message = { role: 'system', content: 'Main prompt text' };
+        globalThis.jQuery.ajax.mockRejectedValue({ status: 404, statusText: 'Not Found', readyState: 4 });
+
+        const count = await countTokensOpenAIAsync(message, true);
+
+        expect(count).toBe(-1 + guesstimate(JSON.stringify(message)));
+    });
+
+    test('falls back to a guesstimate for finalized payloads when the request fails', async () => {
+        const messages = [{ role: 'user', content: 'Post-history instruction' }];
+        globalThis.jQuery.ajax.mockRejectedValue({ status: 404, statusText: 'Not Found', readyState: 4 });
+
+        const count = await countChatCompletionPayloadTokensOpenAIAsync(messages);
+
+        expect(count).toBe(guesstimate(JSON.stringify(messages)));
+    });
+
+    test('still returns the server count when the request succeeds', async () => {
+        globalThis.jQuery.ajax.mockResolvedValue({ token_count: 42 });
+
+        const count = await countChatCompletionPayloadTokensOpenAIAsync([{ role: 'user', content: 'hi' }]);
+
+        expect(count).toBe(42);
+    });
+});


### PR DESCRIPTION
First commit: on iPhone, when the browser blocks saved settings (private browsing), the app used to stop loading. Now it just carries on.
Second commit: the error box used to say [object Object], which means nothing. Now it says what actually failed, and names the exact request that broke it.
Third commit: if the tokenizer request fails, the app estimates instead of just crashing/dying.
Fourth commit: when a third-party extension's file is missing, the app no longer blames itself or gives a vague error, it now points at the extension.

The actual crash came from the SB-GroupUtilities extension asking for a file under the wrong folder name; fixed separately in a PR yet to be merged at the time of writing https://github.com/aracnai/SB-GroupUtilities/pull/1.

For reviewers: This is mostly just a fix for iOS startup diagnostics.