### PR TITLE
fix(termux): fix the ordering of what is installed first on start-termux-bun.sh

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -140,9 +140,11 @@ bash start-termux-node.sh
 
 - `bash start.sh` also defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
 - To force Node.js explicitly: `bash start-termux-node.sh`
-- To force Bun explicitly: `bash start-termux-bun.sh` (this bootstraps `bun-termux` automatically on first run)
+- To force Bun explicitly: `bash start-termux-bun.sh` (this installs glibc and bootstraps `bun-termux` automatically on first run)
 - Keep the repo inside Termux home (for example `~/SillyBunny`), not `~/storage/shared` or `/storage/emulated/0`; Android shared storage blocks the `node_modules` links Bun and npm need
 - Run `termux-setup-storage` once only to grant SillyBunny access to shared files; do not clone the repo into shared storage
+
+Bun on Termux runs through glibc, which the launcher installs via `glibc-repo` and `glibc-runner`. If `start-termux-bun.sh` reports that those packages are unavailable, run `pkg update && pkg install glibc-repo glibc-runner` to see the underlying error. Set `GLIBC_ROOT` if your glibc lives outside `$PREFIX/glibc`. Node.js needs none of this, so `bash start-termux-node.sh` always works as a fallback.
   
 ### How to Update
 

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -144,7 +144,7 @@ bash start-termux-node.sh
 - Keep the repo inside Termux home (for example `~/SillyBunny`), not `~/storage/shared` or `/storage/emulated/0`; Android shared storage blocks the `node_modules` links Bun and npm need
 - Run `termux-setup-storage` once only to grant SillyBunny access to shared files; do not clone the repo into shared storage
 
-Bun on Termux runs through glibc, which the launcher installs via `glibc-repo` and `glibc-runner`. If `start-termux-bun.sh` reports that those packages are unavailable, run `pkg update && pkg install glibc-repo glibc-runner` to see the underlying error. Set `GLIBC_ROOT` if your glibc lives outside `$PREFIX/glibc`. Node.js needs none of this, so `bash start-termux-node.sh` always works as a fallback.
+Bun on Termux runs through glibc, which the launcher installs via `glibc-repo` and `glibc-runner`. If `start-termux-bun.sh` reports that those packages are unavailable, run `pkg update && pkg install -y glibc-repo && pkg install -y glibc-runner` to see the underlying error. Set `GLIBC_ROOT` if your glibc lives outside `$PREFIX/glibc`. Node.js needs none of this, so `bash start-termux-node.sh` always works as a fallback.
   
 ### How to Update
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ bash start-termux-node.sh
 
 - `bash start.sh` also defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
 - To force Node.js explicitly: `bash start-termux-node.sh`
-- To force Bun explicitly: `bash start-termux-bun.sh` (this bootstraps `bun-termux` automatically on first run)
+- To force Bun explicitly: `bash start-termux-bun.sh` (this installs glibc and bootstraps `bun-termux` automatically on first run)
 - Keep the repo inside Termux home (for example `~/SillyBunny`), not `~/storage/shared` or `/storage/emulated/0`; Android shared storage blocks the `node_modules` links Bun and npm need
 - Run `termux-setup-storage` once only to grant SillyBunny access to shared files; do not clone the repo into shared storage
+
+Bun on Termux runs through glibc, which the launcher installs via `glibc-repo` and `glibc-runner`. If `start-termux-bun.sh` reports that those packages are unavailable, run `pkg update && pkg install glibc-repo glibc-runner` to see the underlying error. Set `GLIBC_ROOT` if your glibc lives outside `$PREFIX/glibc`. Node.js needs none of this, so `bash start-termux-node.sh` always works as a fallback.
   
 ### How to Update
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ bash start-termux-node.sh
 - Keep the repo inside Termux home (for example `~/SillyBunny`), not `~/storage/shared` or `/storage/emulated/0`; Android shared storage blocks the `node_modules` links Bun and npm need
 - Run `termux-setup-storage` once only to grant SillyBunny access to shared files; do not clone the repo into shared storage
 
-Bun on Termux runs through glibc, which the launcher installs via `glibc-repo` and `glibc-runner`. If `start-termux-bun.sh` reports that those packages are unavailable, run `pkg update && pkg install glibc-repo glibc-runner` to see the underlying error. Set `GLIBC_ROOT` if your glibc lives outside `$PREFIX/glibc`. Node.js needs none of this, so `bash start-termux-node.sh` always works as a fallback.
+Bun on Termux runs through glibc, which the launcher installs via `glibc-repo` and `glibc-runner`. If `start-termux-bun.sh` reports that those packages are unavailable, run `pkg update && pkg install -y glibc-repo && pkg install -y glibc-runner` to see the underlying error. Set `GLIBC_ROOT` if your glibc lives outside `$PREFIX/glibc`. Node.js needs none of this, so `bash start-termux-node.sh` always works as a fallback.
   
 ### How to Update
 

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -233,9 +233,20 @@ install_termux_glibc_runner() {
         pkg update -y || true
         if ! pkg install -y glibc-repo || ! pkg install -y glibc-runner; then
             echo "Termux could not install the glibc packages Bun depends on." >&2
-            echo "Run 'pkg update && pkg install glibc-repo glibc-runner' manually to see why, then rerun this launcher." >&2
+            echo "Run 'pkg update && pkg install -y glibc-repo && pkg install -y glibc-runner' manually to see why, then rerun this launcher." >&2
             echo "To start now without Bun, use Node.js instead: bash start-termux-node.sh" >&2
             exit 1
+        fi
+
+        refresh_known_paths
+        if ! termux_glibc_ready; then
+            echo "The glibc packages are registered but incomplete. Reinstalling their runtime files..."
+            if ! pkg install -y --reinstall glibc glibc-runner; then
+                echo "Termux could not repair the glibc runtime Bun depends on." >&2
+                echo "Run 'pkg install -y --reinstall glibc glibc-runner' manually to see why, then rerun this launcher." >&2
+                echo "To start now without Bun, use Node.js instead: bash start-termux-node.sh" >&2
+                exit 1
+            fi
         fi
     else
         install_linux_packages glibc-repo
@@ -249,7 +260,7 @@ install_termux_glibc_runner() {
             echo "'grun' is unavailable on PATH." >&2
         else
             echo "'grun' resolves, but no glibc dynamic linker was found in '$TERMUX_GLIBC_ROOT/lib'." >&2
-            echo "Reinstall with 'pkg install --reinstall glibc-runner', or set GLIBC_ROOT if your glibc lives elsewhere." >&2
+            echo "Reinstall with 'pkg install -y --reinstall glibc glibc-runner', or set GLIBC_ROOT if your glibc lives elsewhere." >&2
         fi
         echo "To start now without Bun, use Node.js instead: bash start-termux-node.sh" >&2
         exit 1

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -32,8 +32,12 @@ OS_NAME="$(uname -s 2>/dev/null || echo unknown)"
 BUN_INSTALL_DIR="${BUN_INSTALL:-$HOME/.bun}"
 TERMUX_PREFIX_DEFAULT='/data/data/com.termux/files/usr'
 TERMUX_PREFIX="${PREFIX:-$TERMUX_PREFIX_DEFAULT}"
+TERMUX_GLIBC_ROOT="${GLIBC_ROOT:-$TERMUX_PREFIX/glibc}"
 TERMUX_BUN_WRAPPER_MARKER='SillyBunny Termux Bun wrapper'
-TERMUX_BUN_MANAGER_URL='https://raw.githubusercontent.com/Happ1ness-dev/bun-termux/main/helper_scripts/bun-termux-manager'
+# Pinned to bun-termux-manager v1.0.1. This script is piped into bash, so it is
+# tracked by commit rather than by branch.
+TERMUX_BUN_MANAGER_COMMIT='b9f47733b0198d59dc9775a487a8a731cde322cb'
+TERMUX_BUN_MANAGER_URL="https://raw.githubusercontent.com/Happ1ness-dev/bun-termux/$TERMUX_BUN_MANAGER_COMMIT/helper_scripts/bun-termux-manager"
 TERMUX_BUN_SOURCE_DIR="${TERMUX_BUN_SOURCE_DIR:-$HOME/bun-termux}"
 TERMUX_BUN_SHIM_PATH="$BUN_INSTALL_DIR/lib/bun-shim.so"
 
@@ -206,27 +210,48 @@ termux_glibc_runner_path() {
     return 1
 }
 
+# bun-termux needs the glibc dynamic linker, not just the 'grun' launcher, and it
+# aborts on a missing linker with an error that names glibc-repo/glibc-runner as
+# unavailable even when 'grun' resolves fine. Check both signals so a half
+# provisioned glibc is repaired here instead of failing later inside bun-termux.
+termux_glibc_ready() {
+    termux_glibc_runner_path >/dev/null 2>&1 \
+        && compgen -G "$TERMUX_GLIBC_ROOT/lib/ld-linux-*.so.*" >/dev/null 2>&1
+}
+
 install_termux_glibc_runner() {
     if ! is_termux; then
         return 0
     fi
 
-    if termux_glibc_runner_path >/dev/null 2>&1; then
+    if termux_glibc_ready; then
         return 0
     fi
 
     echo "Termux detected. Installing glibc support for Bun..."
     if have_command pkg; then
-        pkg install -y glibc-repo
-        pkg install -y glibc-runner
+        pkg update -y || true
+        if ! pkg install -y glibc-repo || ! pkg install -y glibc-runner; then
+            echo "Termux could not install the glibc packages Bun depends on." >&2
+            echo "Run 'pkg update && pkg install glibc-repo glibc-runner' manually to see why, then rerun this launcher." >&2
+            echo "To start now without Bun, use Node.js instead: bash start-termux-node.sh" >&2
+            exit 1
+        fi
     else
         install_linux_packages glibc-repo
         install_linux_packages glibc-runner
     fi
     refresh_known_paths
 
-    if ! termux_glibc_runner_path >/dev/null 2>&1; then
-        echo "Termux glibc support installation finished, but 'grun' is still unavailable in this session." >&2
+    if ! termux_glibc_ready; then
+        echo "Termux glibc support installation finished, but Bun still cannot run through it in this session." >&2
+        if ! termux_glibc_runner_path >/dev/null 2>&1; then
+            echo "'grun' is unavailable on PATH." >&2
+        else
+            echo "'grun' resolves, but no glibc dynamic linker was found in '$TERMUX_GLIBC_ROOT/lib'." >&2
+            echo "Reinstall with 'pkg install --reinstall glibc-runner', or set GLIBC_ROOT if your glibc lives elsewhere." >&2
+        fi
+        echo "To start now without Bun, use Node.js instead: bash start-termux-node.sh" >&2
         exit 1
     fi
 }
@@ -240,9 +265,9 @@ install_termux_bun_manager() {
     ensure_download_tool
 
     if have_command curl; then
-        curl -fsSL "$TERMUX_BUN_MANAGER_URL" | BUN_INSTALL="$BUN_INSTALL_DIR" bash -s install --source "$TERMUX_BUN_SOURCE_DIR"
+        curl -fsSL "$TERMUX_BUN_MANAGER_URL" | BUN_INSTALL="$BUN_INSTALL_DIR" GLIBC_ROOT="$TERMUX_GLIBC_ROOT" bash -s install --source "$TERMUX_BUN_SOURCE_DIR"
     else
-        wget -qO- "$TERMUX_BUN_MANAGER_URL" | BUN_INSTALL="$BUN_INSTALL_DIR" bash -s install --source "$TERMUX_BUN_SOURCE_DIR"
+        wget -qO- "$TERMUX_BUN_MANAGER_URL" | BUN_INSTALL="$BUN_INSTALL_DIR" GLIBC_ROOT="$TERMUX_GLIBC_ROOT" bash -s install --source "$TERMUX_BUN_SOURCE_DIR"
     fi
 }
 
@@ -306,12 +331,16 @@ repair_termux_bun() {
         return 0
     fi
 
+    # Provision glibc first. bun-termux bails out early when the dynamic linker
+    # is missing, so delegating this to it turns a fixable glibc problem into an
+    # opaque wrapper failure.
+    install_termux_glibc_runner
+
     if install_termux_bun_manager; then
         refresh_known_paths
         have_working_termux_bun && return 0
     fi
 
-    install_termux_glibc_runner
     configure_termux_bun_wrapper || return 1
     refresh_known_paths
     have_working_bun
@@ -419,21 +448,14 @@ install_bun() {
         exit 1
     fi
 
+    # Everything below is the non-Termux path; the branch above always returns or exits.
     if have_working_bun; then
-        return
-    fi
-
-    if repair_termux_bun; then
         return
     fi
 
     echo "Bun was not found. Installing it automatically..."
 
     ensure_download_tool
-
-    if is_termux; then
-        install_termux_glibc_runner
-    fi
 
     if have_command curl; then
         curl -fsSL https://bun.sh/install | bash
@@ -443,17 +465,8 @@ install_bun() {
 
     refresh_known_paths
 
-    if is_termux; then
-        configure_termux_bun_wrapper || true
-        refresh_known_paths
-    fi
-
     if ! have_working_bun; then
         echo "Bun installation finished, but 'bun' is still unavailable in this session." >&2
-        if is_termux; then
-            echo "Termux needs Bun to run through glibc-runner. The launcher tried to install and wire that up automatically." >&2
-            echo "If it still fails, verify 'pkg install glibc-repo glibc-runner' works in this Termux session, then rerun the launcher." >&2
-        fi
         echo "Install Bun manually from https://bun.sh/" >&2
         exit 1
     fi

--- a/tests/termux-bun-bootstrap.test.js
+++ b/tests/termux-bun-bootstrap.test.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const prerequisitesSource = readFileSync(path.join(repoRoot, 'scripts', 'install-prerequisites.sh'), 'utf8');
+const readmeSource = readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
 
 /**
  * Lifts a top-level shell function out of install-prerequisites.sh so it can be
@@ -28,6 +29,7 @@ function extractShellFunction(source, name) {
 
 const harnessDir = mkdtempSync(path.join(tmpdir(), 'sb-termux-bun-'));
 const harnessPath = path.join(harnessDir, 'harness.sh');
+const repairHarnessPath = path.join(harnessDir, 'repair-harness.sh');
 const fakeBinDir = path.join(harnessDir, 'fakebin');
 
 mkdirSync(fakeBinDir, { recursive: true });
@@ -43,6 +45,27 @@ writeFileSync(harnessPath, [
     extractShellFunction(prerequisitesSource, 'termux_glibc_runner_path'),
     extractShellFunction(prerequisitesSource, 'termux_glibc_ready'),
     'if termux_glibc_ready; then echo ready; else echo not-ready; fi',
+    '',
+].join('\n\n'));
+
+writeFileSync(repairHarnessPath, [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    'ready=0',
+    'pkg_calls=()',
+    'is_termux() { return 0; }',
+    'have_command() { [[ "$1" == pkg ]]; }',
+    'refresh_known_paths() { :; }',
+    'termux_glibc_runner_path() { return 0; }',
+    'termux_glibc_ready() { (( ready == 1 )); }',
+    'pkg() {',
+    '    pkg_calls+=("$*")',
+    '    if [[ "$*" == *"--reinstall glibc glibc-runner"* ]]; then ready=1; fi',
+    '    return 0',
+    '}',
+    extractShellFunction(prerequisitesSource, 'install_termux_glibc_runner'),
+    'install_termux_glibc_runner >/dev/null 2>&1',
+    'printf "%s\\n" "${pkg_calls[@]}"',
     '',
 ].join('\n\n'));
 
@@ -66,20 +89,52 @@ afterAll(() => {
  */
 function resolveBash() {
     const probePath = path.join(harnessDir, 'probe.sh');
-    writeFileSync(probePath, 'set -euo pipefail\nprintf %s "$BASH"\n');
+    writeFileSync(probePath, 'set -euo pipefail\nprintf ready\n');
+    const candidates = [];
 
-    try {
-        const stdout = execFileSync('bash', [probePath], {
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore'],
-        });
-        return stdout.trim() || null;
-    } catch {
-        return null;
+    if (process.platform === 'win32') {
+        try {
+            const gitExecPath = execFileSync('git', ['--exec-path'], { encoding: 'utf8' }).trim();
+            candidates.push(path.resolve(gitExecPath, '..', '..', '..', 'bin', 'bash.exe'));
+        } catch {
+            // Git is optional for this test probe.
+        }
+        try {
+            candidates.push(...execFileSync('where.exe', ['bash'], { encoding: 'utf8' }).split(/\r?\n/));
+        } catch {
+            // Fall through to the generic candidates below.
+        }
+    } else {
+        candidates.push(process.env.BASH);
     }
+    candidates.push('bash');
+
+    for (const candidate of [...new Set(candidates.filter(Boolean))]) {
+        try {
+            const stdout = execFileSync(candidate, [probePath], {
+                encoding: 'utf8',
+                stdio: ['ignore', 'pipe', 'ignore'],
+            });
+            if (stdout.trim() === 'ready') {
+                return candidate;
+            }
+        } catch {
+            // Try the next bash candidate.
+        }
+    }
+
+    return null;
 }
 
 const bashPath = resolveBash();
+
+function toBashPath(filePath) {
+    if (process.platform !== 'win32' || !bashPath) {
+        return filePath;
+    }
+
+    return execFileSync(bashPath, ['-lc', 'cygpath -u "$1"', 'bash', filePath], { encoding: 'utf8' }).trim();
+}
 
 // CI runs unit tests on ubuntu-latest, so this only spares Windows contributors
 // a wall of failures that say nothing about the bootstrap. The source-level
@@ -109,9 +164,9 @@ function glibcReady({ grun, linker }) {
     // bash builtin, so nothing here depends on PATH being populated.
     const env = {
         ...process.env,
-        PATH: grun ? fakeBinDir : '',
-        TERMUX_PREFIX: path.join(glibcRoot, 'no-such-prefix'),
-        TERMUX_GLIBC_ROOT: glibcRoot,
+        PATH: grun ? toBashPath(fakeBinDir) : '',
+        TERMUX_PREFIX: toBashPath(path.join(glibcRoot, 'no-such-prefix')),
+        TERMUX_GLIBC_ROOT: toBashPath(glibcRoot),
     };
 
     return execFileSync(bashPath, [harnessPath], { env, encoding: 'utf8' }).trim();
@@ -175,8 +230,8 @@ describe('install-prerequisites.sh Termux Bun bootstrap wiring', () => {
         const glibcRunner = extractShellFunction(prerequisitesSource, 'install_termux_glibc_runner');
         const fallbackHints = glibcRunner.match(/bash start-termux-node\.sh/g) ?? [];
 
-        // One per failure exit: the package install failure and the final probe.
-        expect(fallbackHints).toHaveLength(2);
+        // One per failure exit: package install, package repair and the final probe.
+        expect(fallbackHints).toHaveLength(3);
     });
 
     test('a stale package index is refreshed before installing glibc', () => {
@@ -186,6 +241,23 @@ describe('install-prerequisites.sh Termux Bun bootstrap wiring', () => {
 
         expect(updateStep).toBeGreaterThanOrEqual(0);
         expect(installStep).toBeGreaterThan(updateStep);
+    });
+
+    test('repairs a half-installed glibc instead of repeating no-op installs', () => {
+        expect(bashPath).not.toBeNull();
+        const calls = execFileSync(bashPath, [repairHarnessPath], { encoding: 'utf8' }).trim().split(/\r?\n/);
+
+        expect(calls).toEqual([
+            'update -y',
+            'install -y glibc-repo',
+            'install -y glibc-runner',
+            'install -y --reinstall glibc glibc-runner',
+        ]);
+    });
+
+    test('documents the repository and runner installs as separate transactions', () => {
+        expect(readmeSource).toContain('pkg update && pkg install -y glibc-repo && pkg install -y glibc-runner');
+        expect(readmeSource).not.toContain('pkg install glibc-repo glibc-runner');
     });
 
     // install_bun's is_termux branch always returns or exits, so any further

--- a/tests/termux-bun-bootstrap.test.js
+++ b/tests/termux-bun-bootstrap.test.js
@@ -111,12 +111,18 @@ function resolveBash() {
 
     for (const candidate of [...new Set(candidates.filter(Boolean))]) {
         try {
-            const stdout = execFileSync(candidate, [probePath], {
+            const executable = process.platform === 'win32' || path.isAbsolute(candidate)
+                ? candidate
+                : execFileSync(candidate, ['-lc', 'command -v -- "$0"', candidate], {
+                    encoding: 'utf8',
+                    stdio: ['ignore', 'pipe', 'ignore'],
+                }).trim();
+            const stdout = execFileSync(executable, [probePath], {
                 encoding: 'utf8',
                 stdio: ['ignore', 'pipe', 'ignore'],
             });
             if (stdout.trim() === 'ready') {
-                return candidate;
+                return executable;
             }
         } catch {
             // Try the next bash candidate.
@@ -173,6 +179,10 @@ function glibcReady({ grun, linker }) {
 }
 
 describeShell('install-prerequisites.sh termux_glibc_ready', () => {
+    test('resolves bash before fixtures narrow PATH', () => {
+        expect(path.isAbsolute(bashPath)).toBe(true);
+    });
+
     test('reports ready only when grun and the dynamic linker are both present', () => {
         expect(glibcReady({ grun: true, linker: true })).toBe('ready');
     });

--- a/tests/termux-bun-bootstrap.test.js
+++ b/tests/termux-bun-bootstrap.test.js
@@ -51,31 +51,40 @@ afterAll(() => {
 });
 
 /**
- * Whether `bash` on PATH can actually run a script living in the temp dir. On
- * Windows `bash` resolves to the WSL app-execution alias ahead of Git Bash, and
- * that alias either has no distribution installed or cannot see the Windows temp
- * path — so probe the exact mechanism these tests use rather than inferring
+ * Resolves the absolute path of a `bash` that can run a script living in the
+ * temp dir, or null when there is none.
+ *
+ * The absolute path matters because the fixtures below run with a narrowed PATH
+ * to keep a real `grun` from deciding the outcome. Relying on PATH to find bash
+ * would then break wherever bash does not happen to sit next to the Node
+ * binary, which is the case on the CI runners.
+ *
+ * On Windows `bash` also resolves to the WSL app-execution alias ahead of Git
+ * Bash, and that alias either has no distribution installed or cannot see the
+ * Windows temp path — so probe the real mechanism rather than inferring
  * capability from process.platform.
  */
-function hasUsableBash() {
+function resolveBash() {
     const probePath = path.join(harnessDir, 'probe.sh');
-    writeFileSync(probePath, '#!/usr/bin/env bash\nset -euo pipefail\necho ok\n');
+    writeFileSync(probePath, 'set -euo pipefail\nprintf %s "$BASH"\n');
 
     try {
         const stdout = execFileSync('bash', [probePath], {
             encoding: 'utf8',
             stdio: ['ignore', 'pipe', 'ignore'],
         });
-        return stdout.trim() === 'ok';
+        return stdout.trim() || null;
     } catch {
-        return false;
+        return null;
     }
 }
+
+const bashPath = resolveBash();
 
 // CI runs unit tests on ubuntu-latest, so this only spares Windows contributors
 // a wall of failures that say nothing about the bootstrap. The source-level
 // checks below still run everywhere.
-const describeShell = hasUsableBash() ? describe : describe.skip;
+const describeShell = bashPath ? describe : describe.skip;
 
 let glibcRootCounter = 0;
 
@@ -95,16 +104,17 @@ function glibcReady({ grun, linker }) {
         writeFileSync(path.join(glibcRoot, 'lib', 'ld-linux-aarch64.so.1'), '');
     }
 
-    // A bare PATH keeps a real grun on the developer's machine from deciding the
-    // outcome, and keeps `command -v` available via bash's builtin lookup.
+    // An empty PATH keeps a real grun on the developer's machine from deciding
+    // the outcome. termux_glibc_runner_path only needs `command -v`, which is a
+    // bash builtin, so nothing here depends on PATH being populated.
     const env = {
         ...process.env,
-        PATH: grun ? `${fakeBinDir}:${path.dirname(process.execPath)}` : path.dirname(process.execPath),
+        PATH: grun ? fakeBinDir : '',
         TERMUX_PREFIX: path.join(glibcRoot, 'no-such-prefix'),
         TERMUX_GLIBC_ROOT: glibcRoot,
     };
 
-    return execFileSync('bash', [harnessPath], { env, encoding: 'utf8' }).trim();
+    return execFileSync(bashPath, [harnessPath], { env, encoding: 'utf8' }).trim();
 }
 
 describeShell('install-prerequisites.sh termux_glibc_ready', () => {

--- a/tests/termux-bun-bootstrap.test.js
+++ b/tests/termux-bun-bootstrap.test.js
@@ -1,0 +1,189 @@
+import { describe, test, expect, afterAll } from '@jest/globals';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const prerequisitesSource = readFileSync(path.join(repoRoot, 'scripts', 'install-prerequisites.sh'), 'utf8');
+
+/**
+ * Lifts a top-level shell function out of install-prerequisites.sh so it can be
+ * exercised in isolation. Sourcing the script directly is not an option: it
+ * would try to install Bun, Node.js and git on the way past.
+ *
+ * Terminates on the first closing brace at column 0, which matches how every
+ * function in the script is written. A mis-extraction fails the behavioural
+ * assertions below rather than passing quietly.
+ */
+function extractShellFunction(source, name) {
+    const lines = source.split('\n');
+    const start = lines.findIndex(line => line.startsWith(`${name}() {`));
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = lines.findIndex((line, index) => index > start && line === '}');
+    expect(end).toBeGreaterThan(start);
+    return lines.slice(start, end + 1).join('\n');
+}
+
+const harnessDir = mkdtempSync(path.join(tmpdir(), 'sb-termux-bun-'));
+const harnessPath = path.join(harnessDir, 'harness.sh');
+const fakeBinDir = path.join(harnessDir, 'fakebin');
+
+mkdirSync(fakeBinDir, { recursive: true });
+writeFileSync(path.join(fakeBinDir, 'grun'), '#!/usr/bin/env bash\nexit 0\n');
+chmodSync(path.join(fakeBinDir, 'grun'), 0o755);
+
+// Mirrors install-prerequisites.sh's own `set -euo pipefail` so the probe is
+// exercised under the same strictness it runs under in production.
+writeFileSync(harnessPath, [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    extractShellFunction(prerequisitesSource, 'have_command'),
+    extractShellFunction(prerequisitesSource, 'termux_glibc_runner_path'),
+    extractShellFunction(prerequisitesSource, 'termux_glibc_ready'),
+    'if termux_glibc_ready; then echo ready; else echo not-ready; fi',
+    '',
+].join('\n\n'));
+
+afterAll(() => {
+    rmSync(harnessDir, { recursive: true, force: true });
+});
+
+/**
+ * Whether `bash` on PATH can actually run a script living in the temp dir. On
+ * Windows `bash` resolves to the WSL app-execution alias ahead of Git Bash, and
+ * that alias either has no distribution installed or cannot see the Windows temp
+ * path — so probe the exact mechanism these tests use rather than inferring
+ * capability from process.platform.
+ */
+function hasUsableBash() {
+    const probePath = path.join(harnessDir, 'probe.sh');
+    writeFileSync(probePath, '#!/usr/bin/env bash\nset -euo pipefail\necho ok\n');
+
+    try {
+        const stdout = execFileSync('bash', [probePath], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        return stdout.trim() === 'ok';
+    } catch {
+        return false;
+    }
+}
+
+// CI runs unit tests on ubuntu-latest, so this only spares Windows contributors
+// a wall of failures that say nothing about the bootstrap. The source-level
+// checks below still run everywhere.
+const describeShell = hasUsableBash() ? describe : describe.skip;
+
+let glibcRootCounter = 0;
+
+/**
+ * Runs termux_glibc_ready against a synthetic glibc root.
+ *
+ * @param {object} options Fixture shape.
+ * @param {boolean} options.grun Whether `grun` resolves on PATH.
+ * @param {boolean} options.linker Whether a glibc dynamic linker exists under lib/.
+ * @returns {string} Either 'ready' or 'not-ready'.
+ */
+function glibcReady({ grun, linker }) {
+    const glibcRoot = path.join(harnessDir, `glibc-${glibcRootCounter++}`);
+    mkdirSync(path.join(glibcRoot, 'lib'), { recursive: true });
+
+    if (linker) {
+        writeFileSync(path.join(glibcRoot, 'lib', 'ld-linux-aarch64.so.1'), '');
+    }
+
+    // A bare PATH keeps a real grun on the developer's machine from deciding the
+    // outcome, and keeps `command -v` available via bash's builtin lookup.
+    const env = {
+        ...process.env,
+        PATH: grun ? `${fakeBinDir}:${path.dirname(process.execPath)}` : path.dirname(process.execPath),
+        TERMUX_PREFIX: path.join(glibcRoot, 'no-such-prefix'),
+        TERMUX_GLIBC_ROOT: glibcRoot,
+    };
+
+    return execFileSync('bash', [harnessPath], { env, encoding: 'utf8' }).trim();
+}
+
+describeShell('install-prerequisites.sh termux_glibc_ready', () => {
+    test('reports ready only when grun and the dynamic linker are both present', () => {
+        expect(glibcReady({ grun: true, linker: true })).toBe('ready');
+    });
+
+    // The bug this guards: bun-termux aborts with "glibc-repo/glibc-runner
+    // unavailable" when the linker is missing, even though grun resolves. A probe
+    // that only checks grun short-circuits the repair and leaves the user stuck.
+    test('reports not ready when grun resolves but no dynamic linker exists', () => {
+        expect(glibcReady({ grun: true, linker: false })).toBe('not-ready');
+    });
+
+    test('reports not ready when the linker exists but grun is missing', () => {
+        expect(glibcReady({ grun: false, linker: true })).toBe('not-ready');
+    });
+
+    test('reports not ready when neither is present', () => {
+        expect(glibcReady({ grun: false, linker: false })).toBe('not-ready');
+    });
+});
+
+describe('install-prerequisites.sh Termux Bun bootstrap wiring', () => {
+    // bun-termux bails out early on a missing dynamic linker, so glibc has to be
+    // provisioned before it runs. The reverse order turns a fixable glibc problem
+    // into an opaque wrapper failure.
+    test('repair_termux_bun provisions glibc before invoking bun-termux', () => {
+        const repair = extractShellFunction(prerequisitesSource, 'repair_termux_bun');
+        const glibcStep = repair.indexOf('install_termux_glibc_runner');
+        const managerStep = repair.indexOf('install_termux_bun_manager');
+
+        expect(glibcStep).toBeGreaterThanOrEqual(0);
+        expect(managerStep).toBeGreaterThan(glibcStep);
+    });
+
+    test('bun-termux is told which glibc root to use', () => {
+        const manager = extractShellFunction(prerequisitesSource, 'install_termux_bun_manager');
+        const invocations = manager.match(/GLIBC_ROOT="\$TERMUX_GLIBC_ROOT"/g) ?? [];
+
+        // One for the curl path, one for the wget fallback.
+        expect(invocations).toHaveLength(2);
+    });
+
+    test('the glibc root honours a caller-supplied GLIBC_ROOT', () => {
+        expect(prerequisitesSource).toContain('TERMUX_GLIBC_ROOT="${GLIBC_ROOT:-$TERMUX_PREFIX/glibc}"');
+    });
+
+    // The manager is piped straight into bash, so tracking a branch would let an
+    // upstream push change what runs on a user's device without review.
+    test('the bun-termux manager URL is pinned to a commit', () => {
+        expect(prerequisitesSource).toMatch(/^TERMUX_BUN_MANAGER_COMMIT='[0-9a-f]{40}'$/m);
+        expect(prerequisitesSource).toContain('/$TERMUX_BUN_MANAGER_COMMIT/helper_scripts/bun-termux-manager');
+        expect(prerequisitesSource).not.toContain('bun-termux/main/helper_scripts');
+    });
+
+    test('glibc failures point at Node.js as the way to start now', () => {
+        const glibcRunner = extractShellFunction(prerequisitesSource, 'install_termux_glibc_runner');
+        const fallbackHints = glibcRunner.match(/bash start-termux-node\.sh/g) ?? [];
+
+        // One per failure exit: the package install failure and the final probe.
+        expect(fallbackHints).toHaveLength(2);
+    });
+
+    test('a stale package index is refreshed before installing glibc', () => {
+        const glibcRunner = extractShellFunction(prerequisitesSource, 'install_termux_glibc_runner');
+        const updateStep = glibcRunner.indexOf('pkg update -y');
+        const installStep = glibcRunner.indexOf('pkg install -y glibc-repo');
+
+        expect(updateStep).toBeGreaterThanOrEqual(0);
+        expect(installStep).toBeGreaterThan(updateStep);
+    });
+
+    // install_bun's is_termux branch always returns or exits, so any further
+    // is_termux handling below it is unreachable.
+    test('install_bun keeps all Termux handling in one branch', () => {
+        const installBun = extractShellFunction(prerequisitesSource, 'install_bun');
+        const termuxChecks = installBun.match(/is_termux/g) ?? [];
+
+        expect(termuxChecks).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
To set up Bun using start-termux-bun.sh, there's an error where it was out of order. It looks for glibc first then just fails because if grun is installed, then it thinks that the existence of grun means the glibc libraries exist and then it does nothing. Makes the launcher fail on Termux Android.

Now it installs glibc first, checks for both grun and glibc libraries, does a pkg update first, improved error messages, and deleted dead code.

Also includes tests.

Note: Android will still default to Node, since there's an ARM memory/CPU leak issue upstream.

Best way to test is trying this on a real Android device which I don't have.