### PR TITLE
fix: character metadata is preserved

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -50,9 +50,11 @@ const BULK_MERGE_CONCURRENCY = 8;
 const EXTENSION_UNSET_VALUE = '__@@UNSET@@__';
 const forbiddenAvatarRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
 const CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE = 'allow_empty_definition_save';
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
 const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.characters);
 const getCharacterDateAddedFallback = stat => [stat.ctimeMs, stat.birthtimeMs, stat.mtimeMs]
     .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
+const isPngBuffer = buffer => buffer.length >= PNG_SIGNATURE.length && buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
 
 class DiskCache {
     /**
@@ -234,32 +236,35 @@ async function readCharacterData(inputFile, inputFormat = 'png') {
  * @param {string} outputFile - Target image file name
  * @param {import('express').Request} request - Express request obejct
  * @param {Crop|undefined} crop - Crop parameters
- * @param {boolean} [preserveDateAdded] - Preserve preassigned metadata for rename operations
+ * @param {{preserveDateAdded?: boolean, preserveFileIdentity?: boolean}} [writeOptions]
  * @returns {Promise<boolean>} - True if the operation was successful
  */
-async function writeCharacterData(inputFile, data, outputFile, request, crop = undefined, preserveDateAdded = false) {
+async function writeCharacterData(inputFile, data, outputFile, request, crop = undefined, { preserveDateAdded = false, preserveFileIdentity = false } = {}) {
     try {
-        // Reset the cache
-        for (const key of memoryCache.keys()) {
-            if (Buffer.isBuffer(inputFile)) {
-                break;
-            }
-            if (key.startsWith(inputFile)) {
-                memoryCache.delete(key);
-                break;
-            }
-        }
-        if (useDiskCache && !Buffer.isBuffer(inputFile)) {
-            diskCache.syncQueue.add(request.user.profile.handle);
-        }
+        const outputImageName = `${outputFile}.png`;
+        const outputImagePath = path.join(request.user.directories.characters, outputImageName);
+
         /**
          * Read the image, resize, and save it as a PNG into the buffer.
          * @returns {Promise<Buffer>} Image buffer
          */
         const getInputImage = async () => {
             try {
+                let rawImage;
+                // SillyBunny: metadata-only card edits must not rebuild an existing PNG through Jimp.
+                const editsExistingCard = typeof inputFile === 'string' && path.resolve(inputFile) === path.resolve(outputImagePath);
+                if (editsExistingCard && (crop === undefined || crop === null)) {
+                    rawImage = await fsPromises.readFile(inputFile);
+                    if (isPngBuffer(rawImage)) {
+                        return rawImage;
+                    }
+                }
+
                 if (Buffer.isBuffer(inputFile)) {
                     return await parseImageBuffer(inputFile, crop);
+                }
+                if (rawImage) {
+                    return await parseImageBuffer(rawImage, crop);
                 }
 
                 return await tryReadImage(inputFile, crop);
@@ -274,16 +279,36 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
 
         // Get the chunks
         const outputImage = write(inputImage, data);
-        const outputImageName = `${outputFile}.png`;
-        const outputImagePath = path.join(request.user.directories.characters, outputImageName);
         const operationTime = Date.now();
         const fileExists = fs.existsSync(outputImagePath);
         const migrationFallback = fileExists ? getCharacterDateAddedFallback(fs.statSync(outputImagePath)) : operationTime;
 
+        if (preserveFileIdentity && !fileExists) {
+            throw new Error(`Character card does not exist: ${outputImageName}`);
+        }
+
+        if (preserveFileIdentity && fs.readFileSync(outputImagePath).equals(outputImage)) {
+            return true;
+        }
+
+        // Reset the cache only when the card actually changed.
+        for (const key of memoryCache.keys()) {
+            if (Buffer.isBuffer(inputFile)) {
+                break;
+            }
+            if (key.startsWith(inputFile)) {
+                memoryCache.delete(key);
+                break;
+            }
+        }
+        if (useDiskCache && !Buffer.isBuffer(inputFile)) {
+            diskCache.syncQueue.add(request.user.profile.handle);
+        }
+
         if (fileExists) {
             ensureEntityDateAdded(getEntityDateAddedRoot(request.user.directories), 'characters', outputImageName, migrationFallback, operationTime);
         }
-        tryWriteFileSync(outputImagePath, outputImage);
+        tryWriteFileSync(outputImagePath, outputImage, undefined, { preserveFileIdentity });
         if (!fileExists) {
             try {
                 if (preserveDateAdded) {
@@ -367,7 +392,7 @@ async function mergeCharacterUpdate(avatarPath, avatar, updateData, request, sho
     }
 
     const targetImg = avatar.replace('.png', '');
-    const writeSucceeded = await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request);
+    const writeSucceeded = await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request, undefined, { preserveFileIdentity: true });
     if (!writeSucceeded) {
         return { ok: false, error: 'Failed to write character data.' };
     }
@@ -1244,7 +1269,7 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
         const newData = JSON.stringify(oldData);
 
         // Write data to new location
-        const writeSucceeded = await writeCharacterData(oldAvatarPath, newData, newInternalName, request, undefined, true);
+        const writeSucceeded = await writeCharacterData(oldAvatarPath, newData, newInternalName, request, undefined, { preserveDateAdded: true });
         if (!writeSucceeded) {
             throw new Error('Failed to write renamed character data.');
         }
@@ -1339,12 +1364,12 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
     try {
         let writeSucceeded;
         if (!request.file) {
-            writeSucceeded = await writeCharacterData(avatarPath, char, targetFile, request);
+            writeSucceeded = await writeCharacterData(avatarPath, char, targetFile, request, undefined, { preserveFileIdentity: true });
         } else {
             const crop = tryParse(request.query.crop);
             const newAvatarPath = path.join(request.file.destination, request.file.filename);
             invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
-            writeSucceeded = await writeCharacterData(newAvatarPath, char, targetFile, request, crop);
+            writeSucceeded = await writeCharacterData(newAvatarPath, char, targetFile, request, crop, { preserveFileIdentity: true });
             fs.unlinkSync(newAvatarPath);
         }
         if (!writeSucceeded) throw new Error('Failed to write character data.');
@@ -1381,7 +1406,7 @@ router.post('/edit-avatar', validateAvatarUrlMiddleware, async function (request
 
         const crop = tryParse(request.query.crop);
         const fileName = request.body.avatar_url.replace('.png', '');
-        const writeSucceeded = await writeCharacterData(uploadPath, data, fileName, request, crop);
+        const writeSucceeded = await writeCharacterData(uploadPath, data, fileName, request, crop, { preserveFileIdentity: true });
 
         // Remove uploaded temp file
         fs.unlinkSync(uploadPath);
@@ -1440,7 +1465,7 @@ router.post('/edit-attribute', validateAvatarUrlMiddleware, async function (requ
         char.data[request.body.field] = request.body.value;
         let newCharJSON = JSON.stringify(char);
         const targetFile = (request.body.avatar_url).replace('.png', '');
-        const writeSucceeded = await writeCharacterData(avatarPath, newCharJSON, targetFile, request);
+        const writeSucceeded = await writeCharacterData(avatarPath, newCharJSON, targetFile, request, undefined, { preserveFileIdentity: true });
         if (!writeSucceeded) throw new Error('Failed to write character data.');
         return response.sendStatus(200);
     } catch (err) {

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -14,7 +14,7 @@ import storage from 'node-persist';
 
 import { AVATAR_WIDTH, AVATAR_HEIGHT, DEFAULT_AVATAR_PATH } from '../constants.js';
 import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction } from '../middleware/validateFileName.js';
-import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements, tryWriteFileSync } from '../util.js';
+import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, recoverFileWritesInDirectorySync, recoverFileWriteSync, sanitizeSafeCharacterReplacements, tryWriteFileSync } from '../util.js';
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
 import { readWorldInfoFile } from './worldinfo.js';
@@ -51,6 +51,9 @@ const EXTENSION_UNSET_VALUE = '__@@UNSET@@__';
 const forbiddenAvatarRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
 const CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE = 'allow_empty_definition_save';
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+const getPngFileStem = fileName => path.extname(fileName) === '.png'
+    ? fileName.slice(0, -path.extname(fileName).length)
+    : fileName;
 const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.characters);
 const getCharacterDateAddedFallback = stat => [stat.ctimeMs, stat.birthtimeMs, stat.mtimeMs]
     .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
@@ -200,6 +203,7 @@ function getCacheKey(inputFile) {
  * @returns {Promise<string | undefined>} - Character card data
  */
 async function readCharacterData(inputFile, inputFormat = 'png') {
+    recoverFileWriteSync(inputFile);
     const cacheKey = getCacheKey(inputFile);
     if (memoryCache.has(cacheKey)) {
         return memoryCache.get(cacheKey);
@@ -243,6 +247,22 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
     try {
         const outputImageName = `${outputFile}.png`;
         const outputImagePath = path.join(request.user.directories.characters, outputImageName);
+        const fileExists = fs.existsSync(outputImagePath);
+        let expectedFileIdentity;
+        let shouldPreserveFileIdentity = preserveFileIdentity;
+        let shouldReplaceFileOnly = false;
+
+        if (preserveFileIdentity && !fileExists) {
+            throw new Error(`Character card does not exist: ${outputImageName}`);
+        }
+
+        if (preserveFileIdentity) {
+            recoverFileWriteSync(outputImagePath);
+            const activeFileStats = fs.lstatSync(outputImagePath, { bigint: true });
+            shouldPreserveFileIdentity = activeFileStats.isFile() && activeFileStats.nlink === 1n;
+            shouldReplaceFileOnly = !activeFileStats.isFile() || activeFileStats.nlink !== 1n;
+            expectedFileIdentity = { dev: activeFileStats.dev, ino: activeFileStats.ino };
+        }
 
         /**
          * Read the image, resize, and save it as a PNG into the buffer.
@@ -280,15 +300,12 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
         // Get the chunks
         const outputImage = write(inputImage, data);
         const operationTime = Date.now();
-        const fileExists = fs.existsSync(outputImagePath);
         const migrationFallback = fileExists ? getCharacterDateAddedFallback(fs.statSync(outputImagePath)) : operationTime;
 
-        if (preserveFileIdentity && !fileExists) {
-            throw new Error(`Character card does not exist: ${outputImageName}`);
-        }
-
-        if (preserveFileIdentity && fs.readFileSync(outputImagePath).equals(outputImage)) {
-            return true;
+        if (preserveFileIdentity) {
+            if (fs.readFileSync(outputImagePath).equals(outputImage)) {
+                return true;
+            }
         }
 
         // Reset the cache only when the card actually changed.
@@ -308,7 +325,11 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
         if (fileExists) {
             ensureEntityDateAdded(getEntityDateAddedRoot(request.user.directories), 'characters', outputImageName, migrationFallback, operationTime);
         }
-        tryWriteFileSync(outputImagePath, outputImage, undefined, { preserveFileIdentity });
+        tryWriteFileSync(outputImagePath, outputImage, undefined, {
+            preserveFileIdentity: shouldPreserveFileIdentity,
+            expectedFileIdentity,
+            replaceFileOnly: shouldReplaceFileOnly,
+        });
         if (!fileExists) {
             try {
                 if (preserveDateAdded) {
@@ -373,6 +394,7 @@ async function mergeCharacterUpdate(avatarPath, avatar, updateData, request, sho
 
     const update = structuredClone(updateData);
     _.unset(update, 'json_data');
+    _.unset(update, 'avatar');
     _.unset(character, 'json_data');
 
     const beforeMerge = structuredClone(character);
@@ -391,7 +413,7 @@ async function mergeCharacterUpdate(avatarPath, avatar, updateData, request, sho
         return { ok: false, error: validator.lastValidationError ?? 'Validation failed' };
     }
 
-    const targetImg = avatar.replace('.png', '');
+    const targetImg = getPngFileStem(avatar);
     const writeSucceeded = await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request, undefined, { preserveFileIdentity: true });
     if (!writeSucceeded) {
         return { ok: false, error: 'Failed to write character data.' };
@@ -1359,7 +1381,7 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
     char.chat = request.body.chat;
     char.create_date = request.body.create_date;
     char = JSON.stringify(char);
-    let targetFile = (request.body.avatar_url).replace('.png', '');
+    let targetFile = getPngFileStem(request.body.avatar_url);
 
     try {
         let writeSucceeded;
@@ -1405,7 +1427,7 @@ router.post('/edit-avatar', validateAvatarUrlMiddleware, async function (request
         }
 
         const crop = tryParse(request.query.crop);
-        const fileName = request.body.avatar_url.replace('.png', '');
+        const fileName = getPngFileStem(request.body.avatar_url);
         const writeSucceeded = await writeCharacterData(uploadPath, data, fileName, request, crop, { preserveFileIdentity: true });
 
         // Remove uploaded temp file
@@ -1464,7 +1486,7 @@ router.post('/edit-attribute', validateAvatarUrlMiddleware, async function (requ
         char[request.body.field] = request.body.value;
         char.data[request.body.field] = request.body.value;
         let newCharJSON = JSON.stringify(char);
-        const targetFile = (request.body.avatar_url).replace('.png', '');
+        const targetFile = getPngFileStem(request.body.avatar_url);
         const writeSucceeded = await writeCharacterData(avatarPath, newCharJSON, targetFile, request, undefined, { preserveFileIdentity: true });
         if (!writeSucceeded) throw new Error('Failed to write character data.');
         return response.sendStatus(200);
@@ -1593,11 +1615,17 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
     }
 
     const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
+    try {
+        recoverFileWriteSync(avatarPath);
+    } catch (error) {
+        console.error('Could not recover character before deletion.', error);
+        return response.sendStatus(500);
+    }
     if (!fs.existsSync(avatarPath)) {
         return response.sendStatus(400);
     }
 
-    let dir_name = (request.body.avatar_url.replace('.png', ''));
+    let dir_name = request.body.avatar_url.replace('.png', '');
 
     if (!dir_name.length) {
         console.error('Malicious dirname prevented');
@@ -1721,6 +1749,7 @@ router.post('/regenerate-thumbnail', validateAvatarUrlMiddleware, async function
  */
 router.post('/all', async function (request, response) {
     try {
+        recoverFileWritesInDirectorySync(request.user.directories.characters);
         const files = fs.readdirSync(request.user.directories.characters);
         const pngFiles = files.filter(file => file.endsWith('.png'));
         const fileStats = new Map();
@@ -1897,6 +1926,10 @@ router.post('/import', async function (request, response) {
     const format = request.body.file_type;
     const preservedFileName = getPreservedName(request);
 
+    if (preservedFileName) {
+        recoverFileWriteSync(path.join(request.user.directories.characters, `${preservedFileName}.png`));
+    }
+
     const formatImportFunctions = {
         'yaml': importFromYaml,
         'yml': importFromYaml,
@@ -1970,6 +2003,7 @@ router.post('/duplicate', validateAvatarUrlMiddleware, async function (request, 
         const operationTime = Date.now();
         const dateAddedRoot = getEntityDateAddedRoot(request.user.directories);
         const newAvatarName = path.basename(newFilename);
+        recoverFileWriteSync(filename);
         fs.copyFileSync(filename, newFilename, fs.constants.COPYFILE_EXCL);
         try {
             createEntityDateAdded(dateAddedRoot, 'characters', newAvatarName, operationTime);
@@ -1998,6 +2032,7 @@ router.post('/export', validateAvatarUrlMiddleware, async function (request, res
 
         switch (request.body.format) {
             case 'png': {
+                recoverFileWriteSync(filename);
                 const rawBuffer = await fsPromises.readFile(filename);
                 const rawData = read(rawBuffer);
                 const mutatedData = mutateJsonString(rawData, unsetPrivateFields);

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -9,7 +9,7 @@ import fetch from 'node-fetch';
 import sanitize from 'sanitize-filename';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 
-import { getConfigValue, color, setPermissionsSync, isValidUrl } from '../util.js';
+import { getConfigValue, color, recoverFileWriteSync, setPermissionsSync, isValidUrl } from '../util.js';
 import { write } from '../character-card-parser.js';
 import { serverDirectory } from '../server-directory.js';
 import { Jimp, JimpMime } from '../jimp.js';
@@ -739,6 +739,9 @@ export function getContentOfType(type, format, scope = CONTENT_SCOPE.USER) {
         }
         try {
             const filePath = path.join(item.folder, item.filename);
+            if (item.type === CONTENT_TYPES.CHARACTER && path.extname(filePath).toLowerCase() === '.png') {
+                recoverFileWriteSync(filePath);
+            }
             const fileContent = fs.readFileSync(filePath);
             switch (format) {
                 case 'json':

--- a/src/endpoints/conversation-generation.js
+++ b/src/endpoints/conversation-generation.js
@@ -10,6 +10,7 @@ import { EventEmitter } from 'node:events';
 import sanitize from 'sanitize-filename';
 
 import { parse as parseCharacterCard } from '../character-card-parser.js';
+import { recoverFileWriteSync } from '../util.js';
 import { handleChatCompletionsGenerate } from './backends/chat-completions.js';
 import { handleTextCompletionsGenerate } from './backends/text-completions.js';
 import {
@@ -80,6 +81,7 @@ export async function getCharacterData(request, avatar, { allowOverride = true }
             return normalizeCharacterData({}, avatar);
         }
 
+        recoverFileWriteSync(avatarPath);
         const cardText = await parseCharacterCard(avatarPath, 'png');
         return normalizeCharacterData(JSON.parse(cardText), avatar);
     } catch (error) {

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -5,7 +5,7 @@ import express from 'express';
 import mime from 'mime-types';
 import { getSettingsBackupFilePrefix } from './settings.js';
 import { CHAT_BACKUPS_PREFIX } from './chats.js';
-import { isPathUnderParent, tryParse } from '../util.js';
+import { isPathUnderParent, recoverFileWriteSync, tryParse } from '../util.js';
 import { SETTINGS_FILE } from '../constants.js';
 
 const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
@@ -753,6 +753,11 @@ router.get('/view', async (req, res) => {
         }
 
         const pathToFile = fileEntry.path;
+        const isDirectCharacterCard = path.dirname(path.resolve(pathToFile)) === path.resolve(req.user.directories.characters)
+            && path.extname(pathToFile).toLowerCase() === '.png';
+        if (isDirectCharacterCard) {
+            recoverFileWriteSync(pathToFile);
+        }
         const fileExists = fs.existsSync(pathToFile);
 
         if (!fileExists) {

--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -7,7 +7,7 @@ import { Jimp, JimpMime } from '../jimp.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { imageSize as sizeOf } from 'image-size';
 
-import { getConfigValue, invalidateFirefoxCache } from '../util.js';
+import { getConfigValue, invalidateFirefoxCache, recoverFileWriteSync } from '../util.js';
 import {
     getThumbnailResolution,
     getThumbnailMobileResolution,
@@ -217,6 +217,10 @@ export async function generateThumbnail(directories, type, file, forceGenerate =
 
     try {
         const pathToOriginalFile = path.join(originalFolder, file);
+
+        if (type === 'avatar' && path.extname(pathToOriginalFile).toLowerCase() === '.png') {
+            recoverFileWriteSync(pathToOriginalFile);
+        }
 
         // Check if thumbnail already exists and return it if not forcing regeneration
         if (!forceGenerate && fs.existsSync(pathToCachedFile)) {

--- a/src/endpoints/users-private.js
+++ b/src/endpoints/users-private.js
@@ -12,7 +12,7 @@ import { getUserAvatar, toKey, getPasswordHash, getPasswordSalt, createBackupArc
 import { SETTINGS_FILE, USER_DIRECTORY_TEMPLATE } from '../constants.js';
 import { checkForNewContent, CONTENT_TYPES } from './content-manager.js';
 import { SECRETS_FILE } from './secrets.js';
-import { color, Cache, getConfigValue, ensureDirectory, normalizeZipEntryPath } from '../util.js';
+import { color, Cache, getConfigValue, ensureDirectory, normalizeZipEntryPath, recoverFileWritesInDirectorySync } from '../util.js';
 import { ENTITY_DATE_ADDED_FILE, importEntityDateAdded } from '../entity-date-added.js';
 import { ENTITY_LAST_CHAT_FILE, importEntityLastChat } from '../entity-last-chat.js';
 
@@ -837,6 +837,7 @@ router.post('/import-sillytavern/folder', async (request, response) => {
             return response.status(400).json({ error: 'That folder is already the current SillyBunny account.' });
         }
 
+        recoverFileWritesInDirectorySync(request.user.directories.characters);
         const copiedEntries = await copyAllowedFolderContents(sourceRoot, targetRoot);
         await checkForNewContent([request.user.directories]);
 
@@ -878,6 +879,7 @@ router.post('/import-sillytavern/zip', async (request, response) => {
             return response.status(400).json({ error: 'A SillyTavern backup ZIP is required.' });
         }
 
+        recoverFileWritesInDirectorySync(request.user.directories.characters);
         const importedFiles = await importZipContents(uploadedZipPath, request.user.directories.root);
         await checkForNewContent([request.user.directories]);
 

--- a/src/entity-date-added.js
+++ b/src/entity-date-added.js
@@ -144,7 +144,7 @@ function updateStore(userRoot, entityType, callback) {
         const result = callback(scope);
 
         if (state.writable && before !== JSON.stringify(state.store)) {
-            tryWriteFileSync(state.filePath, `${JSON.stringify(state.store, null, 4)}\n`, 'utf8');
+            tryWriteFileSync(state.filePath, `${JSON.stringify(state.store, null, 4)}\n`, 'utf8', { durable: true });
         }
 
         return result;
@@ -326,6 +326,6 @@ export function importEntityDateAdded(userRoot, value) {
             importedScope.initialized ||= currentScope.initialized;
         }
 
-        tryWriteFileSync(state.filePath, `${JSON.stringify(importedStore, null, 4)}\n`, 'utf8');
+        tryWriteFileSync(state.filePath, `${JSON.stringify(importedStore, null, 4)}\n`, 'utf8', { durable: true });
     });
 }

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -68,6 +68,7 @@ import {
     removeColorFormatting,
     getSeparator,
     safeReadFileSync,
+    recoverFileWritesInDirectorySync,
     setupLogLevel,
     setWindowTitle,
     getConfigValue,
@@ -482,6 +483,9 @@ async function preSetupTasks() {
     console.log();
 
     startupDirectories = await getUserDirectoriesList();
+    for (const directories of startupDirectories) {
+        recoverFileWritesInDirectorySync(directories.characters);
+    }
     await migrateGroupChatsMetadataFormat(startupDirectories);
     await migratePublicOverrides();
     await checkForNewContent(startupDirectories, PRESET_CONTENT_TYPES);

--- a/src/users.js
+++ b/src/users.js
@@ -17,7 +17,7 @@ import sanitize from 'sanitize-filename';
 import ipMatching from 'ip-matching';
 
 import { USER_DIRECTORY_TEMPLATE, DEFAULT_USER, PUBLIC_DIRECTORIES, SETTINGS_FILE, UPLOADS_DIRECTORY } from './constants.js';
-import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache, isPathUnderParent, setPermissionsSync } from './util.js';
+import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache, isPathUnderParent, recoverFileWriteSync, setPermissionsSync } from './util.js';
 import { allowKeysExposure, readSecret, writeSecret, SECRETS_FILE } from './endpoints/secrets.js';
 import { getContentOfType } from './endpoints/content-manager.js';
 import { serverDirectory } from './server-directory.js';
@@ -1084,9 +1084,10 @@ export async function loginPageMiddleware(request, response) {
 /**
  * Creates a route handler for serving files from a specific directory.
  * @param {(req: import('express').Request) => string} directoryFn A function that returns the directory path to serve files from
+ * @param {{recoverInterruptedWrites?: boolean}} [options] Route options
  * @returns {import('express').RequestHandler}
  */
-function createRouteHandler(directoryFn) {
+function createRouteHandler(directoryFn, { recoverInterruptedWrites = false } = {}) {
     return async (req, res) => {
         try {
             const directory = directoryFn(req);
@@ -1094,6 +1095,11 @@ function createRouteHandler(directoryFn) {
             const fullPath = path.join(directory, filePath);
             if (!isPathUnderParent(directory, path.resolve(fullPath))) {
                 return res.sendStatus(403);
+            }
+            const isDirectPng = path.dirname(path.resolve(fullPath)) === path.resolve(directory)
+                && path.extname(fullPath).toLowerCase() === '.png';
+            if (recoverInterruptedWrites && isDirectPng) {
+                recoverFileWriteSync(fullPath);
             }
             const exists = fs.existsSync(fullPath);
             if (!exists) {
@@ -1235,7 +1241,7 @@ export async function getAllEnabledUsers() {
  */
 export const router = express.Router();
 router.use('/backgrounds/*', createRouteHandler(req => req.user.directories.backgrounds));
-router.use('/characters/*', createRouteHandler(req => req.user.directories.characters));
+router.use('/characters/*', createRouteHandler(req => req.user.directories.characters, { recoverInterruptedWrites: true }));
 router.use('/User%20Avatars/*', createRouteHandler(req => req.user.directories.avatars));
 router.use('/assets/*', createRouteHandler(req => req.user.directories.assets));
 router.use('/user/images/*', createRouteHandler(req => req.user.directories.userImages));

--- a/src/util.js
+++ b/src/util.js
@@ -2066,14 +2066,238 @@ export function flattenSchema(schema, api) {
     return flattenedSchema;
 }
 
+const FILE_WRITE_RECOVERY_SUFFIX = '.sillybunny-write-recovery';
+
+function getFileWriteRecoveryPath(filePath) {
+    return `${filePath}${FILE_WRITE_RECOVERY_SUFFIX}`;
+}
+
+function hashFileWriteData(data) {
+    return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function fsyncDirectorySync(directory) {
+    if (process.platform === 'win32') {
+        return;
+    }
+
+    const directoryDescriptor = fs.openSync(directory, 'r');
+    try {
+        try {
+            fs.fsyncSync(directoryDescriptor);
+        } catch (error) {
+            if (!['EBADF', 'EINVAL', 'ENOTSUP'].includes(error?.code)) {
+                throw error;
+            }
+        }
+    } finally {
+        fs.closeSync(directoryDescriptor);
+    }
+}
+
+function writeAllSync(fileDescriptor, data, position = 0) {
+    let offset = 0;
+    while (offset < data.byteLength) {
+        const bytesWritten = fs.writeSync(fileDescriptor, data, offset, data.byteLength - offset, position + offset);
+        if (bytesWritten === 0) {
+            throw new Error('Could not finish writing the file.');
+        }
+        offset += bytesWritten;
+    }
+}
+
+function removeFileWriteRecovery(recoveryPath) {
+    const retryDelaysMs = process.platform === 'win32' ? [0, 50, 125, 250] : [0];
+    for (const delayMs of retryDelaysMs) {
+        if (delayMs) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+        }
+        try {
+            fs.unlinkSync(recoveryPath);
+            fsyncDirectorySync(path.dirname(recoveryPath));
+            return;
+        } catch (error) {
+            if (error?.code === 'ENOENT') {
+                return;
+            }
+            const isRetryable = ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
+            if (!isRetryable || delayMs === retryDelaysMs.at(-1)) {
+                throw Object.assign(new Error(`Failed to remove completed write recovery file ${recoveryPath}.`, { cause: error }), { code: 'ERECOVERYCLEANUP' });
+            }
+        }
+    }
+}
+
+function finishDurableWriteSync(filePath) {
+    const retryDelaysMs = process.platform === 'win32' ? [0, 50, 125, 250] : [0];
+    for (const delayMs of retryDelaysMs) {
+        if (delayMs) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+        }
+        try {
+            const fileDescriptor = fs.openSync(filePath, 'r+');
+            try {
+                fs.fsyncSync(fileDescriptor);
+            } finally {
+                fs.closeSync(fileDescriptor);
+            }
+            fsyncDirectorySync(path.dirname(filePath));
+            return;
+        } catch (error) {
+            const isRetryable = ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
+            if (!isRetryable || delayMs === retryDelaysMs.at(-1)) {
+                throw error;
+            }
+        }
+    }
+}
+
+/**
+ * Restores a file left partially updated by an interrupted identity-preserving write.
+ * @param {string} filePath
+ * @returns {boolean} Whether the original bytes were restored.
+ */
+function recoverFileWriteOnceSync(filePath) {
+    const recoveryPath = getFileWriteRecoveryPath(filePath);
+    if (!fs.existsSync(recoveryPath)) {
+        return false;
+    }
+
+    const record = JSON.parse(fs.readFileSync(recoveryPath, 'utf8'));
+    const originalData = Buffer.from(record.originalData, 'base64');
+    if (record.version !== 1 || hashFileWriteData(originalData) !== record.originalHash) {
+        throw new Error(`Invalid write recovery file: ${recoveryPath}`);
+    }
+
+    if (!fs.existsSync(filePath)) {
+        const restoreTempPath = `${filePath}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.restore`;
+        let restoreTempCreated = false;
+        try {
+            const restoreDescriptor = fs.openSync(restoreTempPath, 'wx');
+            restoreTempCreated = true;
+            try {
+                writeAllSync(restoreDescriptor, originalData);
+                fs.ftruncateSync(restoreDescriptor, originalData.byteLength);
+                fs.fsyncSync(restoreDescriptor);
+            } finally {
+                fs.closeSync(restoreDescriptor);
+            }
+            try {
+                fs.linkSync(restoreTempPath, filePath);
+            } catch (error) {
+                if (error?.code === 'EEXIST') {
+                    return recoverFileWriteOnceSync(filePath);
+                }
+                throw error;
+            }
+            fsyncDirectorySync(path.dirname(filePath));
+            removeFileWriteRecovery(recoveryPath);
+            return true;
+        } finally {
+            if (restoreTempCreated) {
+                try {
+                    fs.unlinkSync(restoreTempPath);
+                } catch (error) {
+                    if (error?.code !== 'ENOENT') {
+                        console.warn(`Failed to clean up recovery temp file for ${filePath}.`, error?.code);
+                    }
+                }
+            }
+        }
+    }
+
+    const currentData = fs.readFileSync(filePath);
+    const currentHash = hashFileWriteData(currentData);
+    if (currentHash === record.originalHash || currentHash === record.nextHash) {
+        removeFileWriteRecovery(recoveryPath);
+        return false;
+    }
+
+    const pathStats = fs.lstatSync(filePath, { bigint: true });
+    if (String(pathStats.dev) !== record.dev || String(pathStats.ino) !== record.ino) {
+        throw Object.assign(new Error(`Refused to recover a replaced file: ${filePath}`), { code: 'ESTALE' });
+    }
+    if (!pathStats.isFile() || pathStats.nlink !== 1n) {
+        throw Object.assign(new Error(`Refused to recover a hard-linked file: ${filePath}`), { code: 'EMLINK' });
+    }
+
+    const fileDescriptor = fs.openSync(filePath, 'r+');
+    try {
+        const descriptorStats = fs.fstatSync(fileDescriptor, { bigint: true });
+        if (descriptorStats.dev !== pathStats.dev || descriptorStats.ino !== pathStats.ino || descriptorStats.nlink !== 1n) {
+            throw Object.assign(new Error(`Refused to recover a replaced file: ${filePath}`), { code: 'ESTALE' });
+        }
+        writeAllSync(fileDescriptor, originalData);
+        fs.ftruncateSync(fileDescriptor, originalData.byteLength);
+        fs.fsyncSync(fileDescriptor);
+
+        const finalDescriptorStats = fs.fstatSync(fileDescriptor, { bigint: true });
+        const finalPathStats = fs.lstatSync(filePath, { bigint: true });
+        if (finalDescriptorStats.dev !== finalPathStats.dev || finalDescriptorStats.ino !== finalPathStats.ino
+            || finalDescriptorStats.nlink !== 1n || finalPathStats.nlink !== 1n) {
+            removeFileWriteRecovery(recoveryPath);
+            throw Object.assign(new Error(`Refused to finish recovering a replaced file: ${filePath}`), { code: 'ESTALE' });
+        }
+    } finally {
+        fs.closeSync(fileDescriptor);
+    }
+
+    removeFileWriteRecovery(recoveryPath);
+    return true;
+}
+
+/**
+ * Restores a file left partially updated by an interrupted identity-preserving write.
+ * @param {string} filePath
+ * @returns {boolean} Whether the original bytes were restored.
+ */
+export function recoverFileWriteSync(filePath) {
+    const retryDelaysMs = process.platform === 'win32' ? [0, 50, 125, 250] : [0];
+    for (const delayMs of retryDelaysMs) {
+        if (delayMs) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+        }
+        try {
+            return recoverFileWriteOnceSync(filePath);
+        } catch (error) {
+            const isRetryable = ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
+            if (!isRetryable || delayMs === retryDelaysMs.at(-1)) {
+                throw error;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Recovers every interrupted identity-preserving write in a directory.
+ * @param {string} directory
+ * @returns {number} Number of files restored.
+ */
+export function recoverFileWritesInDirectorySync(directory) {
+    if (!fs.existsSync(directory)) {
+        return 0;
+    }
+
+    let restored = 0;
+    for (const fileName of fs.readdirSync(directory)) {
+        if (!fileName.endsWith(FILE_WRITE_RECOVERY_SUFFIX)) {
+            continue;
+        }
+        const filePath = path.join(directory, fileName.slice(0, -FILE_WRITE_RECOVERY_SUFFIX.length));
+        restored += recoverFileWriteSync(filePath) ? 1 : 0;
+    }
+    return restored;
+}
+
 /**
  * Writes to a file, creating it's parent directories if needed.
  * @param {string} filePath
  * @param {string|Buffer} data
  * @param {import('node:fs').WriteFileOptions} [options]
- * @param {{preserveFileIdentity?: boolean}} [writeOptions]
+ * @param {{preserveFileIdentity?: boolean, expectedFileIdentity?: {dev: bigint, ino: bigint}, invalidateBeforeWrite?: boolean, replaceFileOnly?: boolean, durable?: boolean}} [writeOptions]
  */
-export function tryWriteFileSync(filePath, data, options = typeof data === 'string' ? 'utf8' : undefined, { preserveFileIdentity = false } = {}) {
+export function tryWriteFileSync(filePath, data, options = typeof data === 'string' ? 'utf8' : undefined, { preserveFileIdentity = false, expectedFileIdentity = undefined, invalidateBeforeWrite = false, replaceFileOnly = false, durable = false } = {}) {
     const isRetryableWindowsWriteError = (error) => process.platform === 'win32' && ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
     const sleepSync = (delayMs) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
     const retryDelaysMs = [50, 125, 250];
@@ -2103,19 +2327,102 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
         fs.mkdirSync(directory, { recursive: true });
     }
 
-    // SillyBunny: existing character cards must keep their filesystem identity and creation metadata.
+    // SillyBunny: some existing user data carries filesystem metadata that replacement would discard.
     if (preserveFileIdentity) {
-        const dataLength = typeof data === 'string'
-            ? Buffer.byteLength(data, typeof options === 'string' ? options : options?.encoding || 'utf8')
-            : data.byteLength;
+        if (!invalidateBeforeWrite) {
+            recoverFileWriteSync(filePath);
+        }
+
+        const encoding = typeof options === 'string' ? options : options?.encoding || 'utf8';
+        const dataBuffer = Buffer.isBuffer(data) ? data : Buffer.from(data, encoding);
+        const dataLength = dataBuffer.byteLength;
         const writeInPlace = () => {
             const fileDescriptor = fs.openSync(filePath, 'r+');
+            let operationFailed = false;
+            let recoveryPath;
+            let originalData;
+            let targetMutated = false;
             try {
-                fs.writeFileSync(fileDescriptor, data, options);
-                fs.ftruncateSync(fileDescriptor, dataLength);
-                fs.fsyncSync(fileDescriptor);
+                const descriptorStats = fs.fstatSync(fileDescriptor, { bigint: true });
+                const pathStats = fs.lstatSync(filePath, { bigint: true });
+                const matchesExpectedIdentity = !expectedFileIdentity
+                    || (descriptorStats.dev === expectedFileIdentity.dev && descriptorStats.ino === expectedFileIdentity.ino);
+                if (!descriptorStats.isFile() || !pathStats.isFile()
+                    || descriptorStats.dev !== pathStats.dev || descriptorStats.ino !== pathStats.ino
+                    || !matchesExpectedIdentity) {
+                    throw Object.assign(new Error(`Refused to overwrite a replaced file: ${filePath}`), { code: 'ESTALE' });
+                }
+                if (descriptorStats.nlink !== 1n || pathStats.nlink !== 1n) {
+                    throw Object.assign(new Error(`Refused to overwrite a hard-linked file: ${filePath}`), { code: 'EMLINK' });
+                }
+
+                originalData = Buffer.alloc(Number(descriptorStats.size));
+                let offset = 0;
+                while (offset < originalData.byteLength) {
+                    const bytesRead = fs.readSync(fileDescriptor, originalData, offset, originalData.byteLength - offset, offset);
+                    if (bytesRead === 0) break;
+                    offset += bytesRead;
+                }
+
+                if (invalidateBeforeWrite && dataLength > 0) {
+                    targetMutated = true;
+                    writeAllSync(fileDescriptor, Buffer.from([dataBuffer[0] ^ 0xFF]));
+                    fs.fsyncSync(fileDescriptor);
+                    writeAllSync(fileDescriptor, dataBuffer.subarray(1), 1);
+                    fs.ftruncateSync(fileDescriptor, dataLength);
+                    fs.fsyncSync(fileDescriptor);
+                    writeAllSync(fileDescriptor, dataBuffer.subarray(0, 1));
+                    fs.fsyncSync(fileDescriptor);
+                } else {
+                    recoveryPath = getFileWriteRecoveryPath(filePath);
+                    writeFileAtomicSync(recoveryPath, JSON.stringify({
+                        version: 1,
+                        dev: String(descriptorStats.dev),
+                        ino: String(descriptorStats.ino),
+                        originalHash: hashFileWriteData(originalData),
+                        nextHash: hashFileWriteData(dataBuffer),
+                        originalData: originalData.toString('base64'),
+                    }), 'utf8');
+                    fsyncDirectorySync(path.dirname(recoveryPath));
+
+                    targetMutated = true;
+                    writeAllSync(fileDescriptor, dataBuffer);
+                    fs.ftruncateSync(fileDescriptor, dataLength);
+                    fs.fsyncSync(fileDescriptor);
+                }
+
+                const finalDescriptorStats = fs.fstatSync(fileDescriptor, { bigint: true });
+                const finalPathStats = fs.lstatSync(filePath, { bigint: true });
+                if (finalDescriptorStats.dev !== finalPathStats.dev || finalDescriptorStats.ino !== finalPathStats.ino
+                    || finalDescriptorStats.nlink !== 1n || finalPathStats.nlink !== 1n) {
+                    throw Object.assign(new Error(`Refused to finish writing a replaced or hard-linked file: ${filePath}`), { code: 'ESTALE' });
+                }
+            } catch (error) {
+                operationFailed = true;
+                const shouldRestoreOriginal = targetMutated && (recoveryPath || ['EMLINK', 'ESTALE'].includes(error?.code));
+                if (shouldRestoreOriginal && originalData) {
+                    try {
+                        writeAllSync(fileDescriptor, originalData);
+                        fs.ftruncateSync(fileDescriptor, originalData.byteLength);
+                        fs.fsyncSync(fileDescriptor);
+                        removeFileWriteRecovery(recoveryPath);
+                    } catch (rollbackError) {
+                        throw new AggregateError([error, rollbackError], `Failed to write and restore ${filePath}.`);
+                    }
+                }
+                throw error;
             } finally {
-                fs.closeSync(fileDescriptor);
+                try {
+                    fs.closeSync(fileDescriptor);
+                } catch (error) {
+                    if (!operationFailed) {
+                        console.warn(`Failed to close ${filePath} after its data was flushed.`, error?.code);
+                    }
+                }
+            }
+
+            if (recoveryPath) {
+                removeFileWriteRecovery(recoveryPath);
             }
         };
 
@@ -2126,7 +2433,65 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
         throw lastError;
     }
 
+    const assertExpectedPathIdentity = () => {
+        if (!expectedFileIdentity) {
+            return;
+        }
+        const stats = fs.lstatSync(filePath, { bigint: true });
+        if (stats.dev !== expectedFileIdentity.dev || stats.ino !== expectedFileIdentity.ino) {
+            throw Object.assign(new Error(`Refused to replace a changed file: ${filePath}`), { code: 'ESTALE' });
+        }
+    };
+
+    if (replaceFileOnly) {
+        const tempFilePaths = new Set();
+        let tempFilePath;
+        try {
+            assertExpectedPathIdentity();
+            if (!runWithWindowsRetries(() => {
+                const candidatePath = `${filePath}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`;
+                const targetStats = fs.lstatSync(filePath, { bigint: true });
+                const tempDescriptor = fs.openSync(candidatePath, 'wx', Number(targetStats.mode & 0o777n));
+                tempFilePaths.add(candidatePath);
+                try {
+                    const encoding = typeof options === 'string' ? options : options?.encoding || 'utf8';
+                    const dataBuffer = Buffer.isBuffer(data) ? data : Buffer.from(data, encoding);
+                    writeAllSync(tempDescriptor, dataBuffer);
+                    fs.ftruncateSync(tempDescriptor, dataBuffer.byteLength);
+                    fs.fsyncSync(tempDescriptor);
+                } finally {
+                    fs.closeSync(tempDescriptor);
+                }
+                tempFilePath = candidatePath;
+            })) {
+                throw lastError;
+            }
+            assertExpectedPathIdentity();
+            if (!runWithWindowsRetries(() => {
+                assertExpectedPathIdentity();
+                fs.renameSync(tempFilePath, filePath);
+            })) {
+                throw lastError;
+            }
+            fsyncDirectorySync(directory);
+            return;
+        } finally {
+            for (const createdTempPath of tempFilePaths) {
+                try {
+                    fs.unlinkSync(createdTempPath);
+                } catch (error) {
+                    if (error?.code !== 'ENOENT') {
+                        console.warn(`Failed to clean up temp write file for ${filePath}.`, error?.code);
+                    }
+                }
+            }
+        }
+    }
+
     if (runWithWindowsRetries(() => writeFileAtomicSync(filePath, data, options))) {
+        if (durable) {
+            finishDurableWriteSync(filePath);
+        }
         return;
     }
 
@@ -2152,16 +2517,25 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
         }
 
         if (runWithWindowsRetries(() => fs.renameSync(tempFilePath, filePath))) {
+            if (durable) {
+                finishDurableWriteSync(filePath);
+            }
             return;
         }
 
         console.warn(`Temp file rename failed for ${filePath}. Falling back to a copy replacement.`, lastError?.code);
         if (runWithWindowsRetries(() => fs.copyFileSync(tempFilePath, filePath))) {
+            if (durable) {
+                finishDurableWriteSync(filePath);
+            }
             return;
         }
 
         console.warn(`Temp file copy failed for ${filePath}. Falling back to a direct write.`, lastError?.code);
         if (runWithWindowsRetries(() => fs.writeFileSync(filePath, data, options))) {
+            if (durable) {
+                finishDurableWriteSync(filePath);
+            }
             return;
         }
 

--- a/src/util.js
+++ b/src/util.js
@@ -2071,8 +2071,9 @@ export function flattenSchema(schema, api) {
  * @param {string} filePath
  * @param {string|Buffer} data
  * @param {import('node:fs').WriteFileOptions} [options]
+ * @param {{preserveFileIdentity?: boolean}} [writeOptions]
  */
-export function tryWriteFileSync(filePath, data, options = typeof data === 'string' ? 'utf8' : undefined) {
+export function tryWriteFileSync(filePath, data, options = typeof data === 'string' ? 'utf8' : undefined, { preserveFileIdentity = false } = {}) {
     const isRetryableWindowsWriteError = (error) => process.platform === 'win32' && ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
     const sleepSync = (delayMs) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
     const retryDelaysMs = [50, 125, 250];
@@ -2100,6 +2101,29 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
     //Ensure the directory exists.
     if (!fs.existsSync(directory)) {
         fs.mkdirSync(directory, { recursive: true });
+    }
+
+    // SillyBunny: existing character cards must keep their filesystem identity and creation metadata.
+    if (preserveFileIdentity) {
+        const dataLength = typeof data === 'string'
+            ? Buffer.byteLength(data, typeof options === 'string' ? options : options?.encoding || 'utf8')
+            : data.byteLength;
+        const writeInPlace = () => {
+            const fileDescriptor = fs.openSync(filePath, 'r+');
+            try {
+                fs.writeFileSync(fileDescriptor, data, options);
+                fs.ftruncateSync(fileDescriptor, dataLength);
+                fs.fsyncSync(fileDescriptor);
+            } finally {
+                fs.closeSync(fileDescriptor);
+            }
+        };
+
+        if (runWithWindowsRetries(writeInPlace)) {
+            return;
+        }
+
+        throw lastError;
     }
 
     if (runWithWindowsRetries(() => writeFileAtomicSync(filePath, data, options))) {

--- a/tests/character-card-metadata-preservation.test.js
+++ b/tests/character-card-metadata-preservation.test.js
@@ -1,0 +1,229 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import extract from 'png-chunks-extract';
+import PNGtext from 'png-chunk-text';
+
+import '../src/fetch-patch.js';
+import { AVATAR_HEIGHT, AVATAR_WIDTH } from '../src/constants.js';
+import { Jimp } from '../src/jimp.js';
+import { setConfigFilePath } from '../src/util.js';
+import encode from '../src/png/encode.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const originalWorkingDirectory = process.cwd();
+const diskCacheEnvironmentKey = 'SILLYTAVERN_PERFORMANCE_USEDISKCACHE';
+const originalDiskCacheSetting = process.env[diskCacheEnvironmentKey];
+process.env[diskCacheEnvironmentKey] = 'false';
+process.chdir(repoRoot);
+setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
+
+const { router: charactersRouter } = await import('../src/endpoints/characters.js');
+
+describe('character card metadata preservation', () => {
+    let baseUrl;
+    let directories;
+    let server;
+    let tempRoot;
+
+    beforeAll(async () => {
+        const app = express();
+        app.use(express.json({ limit: '10mb' }));
+        app.use((request, _response, next) => {
+            request.user = {
+                profile: { handle: 'card-metadata-test-user' },
+                directories,
+            };
+            next();
+        });
+        app.use('/api/characters', charactersRouter);
+
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-card-metadata-'));
+        directories = {
+            root: tempRoot,
+            backups: path.join(tempRoot, 'backups'),
+            chats: path.join(tempRoot, 'chats'),
+            characters: path.join(tempRoot, 'characters'),
+            groupChats: path.join(tempRoot, 'group chats'),
+            groups: path.join(tempRoot, 'groups'),
+            thumbnailsAvatar: path.join(tempRoot, 'thumbnails', 'avatar'),
+            thumbnailsAvatarMobile: path.join(tempRoot, 'thumbnails', 'avatar', 'mobile'),
+            worlds: path.join(tempRoot, 'worlds'),
+        };
+        for (const directory of Object.values(directories)) {
+            fs.mkdirSync(directory, { recursive: true });
+        }
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+        if (server) {
+            await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        }
+        if (originalDiskCacheSetting === undefined) {
+            delete process.env[diskCacheEnvironmentKey];
+        } else {
+            process.env[diskCacheEnvironmentKey] = originalDiskCacheSetting;
+        }
+        process.chdir(originalWorkingDirectory);
+    });
+
+    test('keeps the PNG container and file identity during a metadata edit', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        await createAlice();
+        const cardPath = path.join(directories.characters, 'Alice.png');
+        addAncillaryChunks(cardPath);
+        const cardBefore = fs.readFileSync(cardPath);
+        const statBefore = fs.statSync(cardPath);
+
+        await delay();
+        const response = await postJson('/api/characters/merge-attributes', {
+            avatar: 'Alice.png',
+            creator: 'Somebody',
+        });
+        expect(response.status).toBe(200);
+
+        const cardAfter = fs.readFileSync(cardPath);
+        const statAfter = fs.statSync(cardPath);
+        const decodedImage = await Jimp.fromBuffer(cardAfter);
+        expect(decodedImage.bitmap.width).toBe(AVATAR_WIDTH);
+        expect(decodedImage.bitmap.height).toBe(AVATAR_HEIGHT);
+        expect(nonCardChunks(cardAfter)).toEqual(nonCardChunks(cardBefore));
+        expect(statAfter.ino).toBe(statBefore.ino);
+        expect(statAfter.birthtimeMs).toBe(statBefore.birthtimeMs);
+        expect(statAfter.mtimeMs).toBeGreaterThan(statBefore.mtimeMs);
+
+        const cardChunks = decodeCardChunks(cardAfter);
+        expect(cardChunks.map(chunk => chunk.keyword)).toEqual(['chara', 'ccv3']);
+        expect(cardChunks[0].card.spec).toBe('chara_card_v2');
+        expect(cardChunks[1].card.spec).toBe('chara_card_v3');
+        expect(cardChunks.every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+    });
+
+    test('leaves the card untouched when a full editor save changes nothing', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        await createAlice();
+        const initialCharacter = await getCharacter('Alice.png');
+        expect((await saveCharacter(initialCharacter)).status).toBe(200);
+        const character = await getCharacter('Alice.png');
+        const cardPath = path.join(directories.characters, 'Alice.png');
+        const cardBefore = fs.readFileSync(cardPath);
+        const statBefore = fs.statSync(cardPath);
+
+        await delay();
+        const response = await saveCharacter(character);
+        expect(response.status).toBe(200);
+        const cardAfter = fs.readFileSync(cardPath);
+        expect(decodeCardChunks(cardAfter)).toEqual(decodeCardChunks(cardBefore));
+        expect(cardAfter.equals(cardBefore)).toBe(true);
+
+        const statAfter = fs.statSync(cardPath);
+        expect(statAfter.ino).toBe(statBefore.ino);
+        expect(statAfter.birthtimeMs).toBe(statBefore.birthtimeMs);
+        expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+    });
+
+    function saveCharacter(character) {
+        return postJson('/api/characters/edit', {
+            avatar_url: 'Alice.png',
+            ch_name: character.name,
+            description: character.description,
+            personality: character.personality,
+            scenario: character.scenario,
+            first_mes: character.first_mes,
+            mes_example: character.mes_example,
+            creator_notes: character.data.creator_notes,
+            system_prompt: character.data.system_prompt,
+            post_history_instructions: character.data.post_history_instructions,
+            creator: character.data.creator,
+            character_version: character.data.character_version,
+            alternate_greetings: character.data.alternate_greetings,
+            tags: character.tags.join(','),
+            talkativeness: character.talkativeness,
+            fav: String(character.fav),
+            world: character.data.extensions.world,
+            depth_prompt_prompt: character.data.extensions.depth_prompt.prompt,
+            depth_prompt_depth: character.data.extensions.depth_prompt.depth,
+            depth_prompt_role: character.data.extensions.depth_prompt.role,
+            chat: character.chat,
+            create_date: character.create_date,
+            json_data: character.json_data,
+        });
+    }
+
+    async function createAlice() {
+        const response = await postJson('/api/characters/create', {
+            ch_name: 'Alice',
+            file_name: 'Alice',
+        });
+        expect(response.status).toBe(200);
+    }
+
+    function postJson(resource, body = {}) {
+        return fetch(`${baseUrl}${resource}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+    }
+
+    async function getCharacter(avatarUrl) {
+        const response = await postJson('/api/characters/get', { avatar_url: avatarUrl });
+        expect(response.status).toBe(200);
+        return response.json();
+    }
+
+    function addAncillaryChunks(cardPath) {
+        const chunks = extract(new Uint8Array(fs.readFileSync(cardPath)));
+        const firstImageDataChunk = chunks.findIndex(chunk => chunk.name === 'IDAT');
+        chunks.splice(firstImageDataChunk, 0, PNGtext.encode('Comment', 'preserve this metadata'));
+        fs.writeFileSync(cardPath, Buffer.from(encode(chunks)));
+    }
+
+    function nonCardChunks(image) {
+        return extract(new Uint8Array(image))
+            .filter(chunk => !isCardChunk(chunk))
+            .map(chunk => ({ name: chunk.name, data: Buffer.from(chunk.data) }));
+    }
+
+    function decodeCardChunks(image) {
+        return extract(new Uint8Array(image))
+            .filter(isCardChunk)
+            .map(chunk => {
+                const decoded = PNGtext.decode(chunk.data);
+                return {
+                    keyword: decoded.keyword.toLowerCase(),
+                    card: JSON.parse(Buffer.from(decoded.text, 'base64').toString('utf8')),
+                };
+            });
+    }
+
+    function isCardChunk(chunk) {
+        if (chunk.name !== 'tEXt') {
+            return false;
+        }
+        const keyword = PNGtext.decode(chunk.data).keyword.toLowerCase();
+        return keyword === 'chara' || keyword === 'ccv3';
+    }
+
+    function delay() {
+        return new Promise(resolve => setTimeout(resolve, 25));
+    }
+});

--- a/tests/character-card-metadata-preservation.test.js
+++ b/tests/character-card-metadata-preservation.test.js
@@ -140,9 +140,142 @@ describe('character card metadata preservation', () => {
         expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
     });
 
-    function saveCharacter(character) {
+    test('does not persist the routing-only avatar field during a merge', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        await createAlice();
+        const cardPath = path.join(directories.characters, 'Alice.png');
+        const cardBefore = fs.readFileSync(cardPath);
+        const statBefore = fs.statSync(cardPath);
+
+        await delay();
+        const response = await postJson('/api/characters/merge-attributes', { avatar: 'Alice.png' });
+
+        expect(response.status).toBe(200);
+        expect(fs.readFileSync(cardPath).equals(cardBefore)).toBe(true);
+        expect(fs.statSync(cardPath).mtimeMs).toBe(statBefore.mtimeMs);
+    });
+
+    test('updates the original card when its filename stem contains .png', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        await createCharacter('Alice.png.backup');
+        const cardPath = path.join(directories.characters, 'Alice.png.backup.png');
+
+        const response = await postJson('/api/characters/merge-attributes', {
+            avatar: 'Alice.png.backup.png',
+            creator: 'Somebody',
+        });
+
+        expect(response.status).toBe(200);
+        expect(fs.existsSync(cardPath)).toBe(true);
+        expect(fs.existsSync(path.join(directories.characters, 'Alice.backup.png.png'))).toBe(false);
+        expect(decodeCardChunks(fs.readFileSync(cardPath)).every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+    });
+
+    test('replaces only the selected path when a card has a hard-link alias', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        await createAlice();
+        const cardPath = path.join(directories.characters, 'Alice.png');
+        const aliasPath = path.join(directories.characters, 'Alice-alias.png');
+        fs.linkSync(cardPath, aliasPath);
+        const aliasBefore = fs.readFileSync(aliasPath);
+
+        const response = await postJson('/api/characters/merge-attributes', {
+            avatar: 'Alice.png',
+            creator: 'Somebody',
+        });
+
+        expect(response.status).toBe(200);
+        expect(fs.readFileSync(aliasPath).equals(aliasBefore)).toBe(true);
+        expect(decodeCardChunks(fs.readFileSync(cardPath)).every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+        expect(fs.statSync(cardPath).ino).not.toBe(fs.statSync(aliasPath).ino);
+    });
+
+    test('keeps dotted filename stems on full and single-attribute edits', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        const avatar = 'Alice.png.backup.png';
+        await createCharacter('Alice.png.backup');
+        const character = await getCharacter(avatar);
+
+        expect((await saveCharacter(character, avatar)).status).toBe(200);
+        const attributeResponse = await postJson('/api/characters/edit-attribute', {
+            avatar_url: avatar,
+            ch_name: character.name,
+            field: 'creator',
+            value: 'Somebody',
+        });
+
+        expect(attributeResponse.status).toBe(200);
+        expect(fs.existsSync(path.join(directories.characters, avatar))).toBe(true);
+        expect(fs.existsSync(path.join(directories.characters, 'Alice.backup.png.png'))).toBe(false);
+        expect(decodeCardChunks(fs.readFileSync(path.join(directories.characters, avatar))).every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+    });
+
+    test('does not alias a non-PNG filename onto another card', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        await createAlice();
+        const alicePath = path.join(directories.characters, 'Alice.png');
+        const aliceBefore = fs.readFileSync(alicePath);
+        fs.copyFileSync(alicePath, path.join(directories.characters, 'Alice.jpg'));
+
+        const response = await postJson('/api/characters/merge-attributes', {
+            avatar: 'Alice.jpg',
+            creator: 'Somebody',
+        });
+
+        expect(response.status).toBe(400);
+        expect(fs.readFileSync(alicePath).equals(aliceBefore)).toBe(true);
+    });
+
+    test('replaces a symlinked card path without modifying its target', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        await createAlice();
+        const cardPath = path.join(directories.characters, 'Alice.png');
+        const outsidePath = path.join(tempRoot, 'outside.png');
+        fs.copyFileSync(cardPath, outsidePath);
+        const outsideBefore = fs.readFileSync(outsidePath);
+        fs.unlinkSync(cardPath);
+        fs.symlinkSync(outsidePath, cardPath);
+
+        const response = await postJson('/api/characters/merge-attributes', {
+            avatar: 'Alice.png',
+            creator: 'Somebody',
+        });
+
+        expect(response.status).toBe(200);
+        expect(fs.lstatSync(cardPath).isSymbolicLink()).toBe(false);
+        expect(fs.readFileSync(outsidePath).equals(outsideBefore)).toBe(true);
+        expect(decodeCardChunks(fs.readFileSync(cardPath)).every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+    });
+
+    test('deletes chats under the existing dotted-card owner name', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        const avatar = 'Alice.png.backup.png';
+        await createCharacter('Alice.png.backup');
+        const chatDirectory = path.join(directories.chats, 'Alice.backup.png');
+        fs.mkdirSync(chatDirectory, { recursive: true });
+        fs.writeFileSync(path.join(chatDirectory, 'chat.jsonl'), '{}\n');
+
+        const response = await postJson('/api/characters/delete', {
+            avatar_url: avatar,
+            delete_chats: true,
+        });
+
+        expect(response.status).toBe(200);
+        expect(fs.existsSync(path.join(directories.characters, avatar))).toBe(false);
+        expect(fs.existsSync(chatDirectory)).toBe(false);
+    });
+
+    function saveCharacter(character, avatarUrl = 'Alice.png') {
         return postJson('/api/characters/edit', {
-            avatar_url: 'Alice.png',
+            avatar_url: avatarUrl,
             ch_name: character.name,
             description: character.description,
             personality: character.personality,
@@ -169,9 +302,13 @@ describe('character card metadata preservation', () => {
     }
 
     async function createAlice() {
+        return createCharacter('Alice');
+    }
+
+    async function createCharacter(name) {
         const response = await postJson('/api/characters/create', {
-            ch_name: 'Alice',
-            file_name: 'Alice',
+            ch_name: name,
+            file_name: name,
         });
         expect(response.status).toBe(200);
     }

--- a/tests/default-preset-deletions.test.js
+++ b/tests/default-preset-deletions.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../src/util.js', () => ({
     },
     getConfigValue: jest.fn((_key, defaultValue) => defaultValue),
     isValidUrl: jest.fn(() => false),
+    recoverFileWriteSync: jest.fn(),
     setPermissionsSync: jest.fn(),
 }));
 

--- a/tests/util-durable-write.test.js
+++ b/tests/util-durable-write.test.js
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { tryWriteFileSync } from '../src/util.js';
+
+const describeDirectoryFsync = process.platform === 'win32' ? describe.skip : describe;
+let tempRoot;
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    if (tempRoot) {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+        tempRoot = undefined;
+    }
+});
+
+describeDirectoryFsync('tryWriteFileSync durable writes', () => {
+    test('flushes the parent directory after committing a durable write', () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-durable-'));
+        const filePath = path.join(tempRoot, 'metadata.json');
+        const fsyncSync = fs.fsyncSync.bind(fs);
+        let directoryFlushed = false;
+        jest.spyOn(fs, 'fsyncSync').mockImplementation((fileDescriptor) => {
+            if (fs.fstatSync(fileDescriptor).isDirectory()) {
+                directoryFlushed = true;
+            }
+            return fsyncSync(fileDescriptor);
+        });
+
+        tryWriteFileSync(filePath, '{}', 'utf8', { durable: true });
+
+        expect(directoryFlushed).toBe(true);
+    });
+
+    test('accepts filesystems that do not support directory fsync', () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-durable-'));
+        const filePath = path.join(tempRoot, 'metadata.json');
+        const fsyncSync = fs.fsyncSync.bind(fs);
+        jest.spyOn(fs, 'fsyncSync').mockImplementation((fileDescriptor) => {
+            if (fs.fstatSync(fileDescriptor).isDirectory()) {
+                throw Object.assign(new Error('unsupported'), { code: 'EINVAL' });
+            }
+            return fsyncSync(fileDescriptor);
+        });
+
+        expect(() => tryWriteFileSync(filePath, '{}', 'utf8', { durable: true })).not.toThrow();
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('{}');
+    });
+});

--- a/tests/util-write-atomic-fallback.test.js
+++ b/tests/util-write-atomic-fallback.test.js
@@ -39,6 +39,60 @@ afterEach(() => {
 });
 
 describe('tryWriteFileSync atomic fallback', () => {
+    test('writes directly when the target must keep its filesystem identity', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        const inodeBefore = fs.statSync(filePath).ino;
+        mockWritableTarget();
+        const writeFileSpy = jest.spyOn(fs, 'writeFileSync');
+        const renameSpy = jest.spyOn(fs, 'renameSync');
+
+        tryWriteFileSync(filePath, 'after', 'utf8', { preserveFileIdentity: true });
+
+        expect(writeFileSpy).toHaveBeenCalledTimes(1);
+        expect(writeFileSpy.mock.calls[0].slice(1)).toEqual(['after', 'utf8']);
+        expect(renameSpy).not.toHaveBeenCalled();
+        expect(fs.statSync(filePath).ino).toBe(inodeBefore);
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('after');
+    });
+
+    test('retries identity-preserving writes without replacing the target', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        mockWritableTarget();
+        const openSync = fs.openSync.bind(fs);
+        let failures = 0;
+        const openSpy = jest.spyOn(fs, 'openSync').mockImplementation((target, flags) => {
+            if (target === filePath && failures++ < 2) {
+                throw createWindowsFileLockError('EBUSY');
+            }
+            return openSync(target, flags);
+        });
+        const renameSpy = jest.spyOn(fs, 'renameSync');
+
+        tryWriteFileSync(filePath, 'after', 'utf8', { preserveFileIdentity: true });
+
+        expect(openSpy).toHaveBeenCalledTimes(3);
+        expect(renameSpy).not.toHaveBeenCalled();
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('after');
+    });
+
+    test('does not replace the target when direct retries are exhausted', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        mockWritableTarget();
+        jest.spyOn(fs, 'openSync').mockImplementation(() => {
+            throw createWindowsFileLockError('EPERM');
+        });
+        const renameSpy = jest.spyOn(fs, 'renameSync');
+        const copyFileSpy = jest.spyOn(fs, 'copyFileSync');
+
+        expect(() => tryWriteFileSync(filePath, 'after', 'utf8', { preserveFileIdentity: true })).toThrow('EPERM');
+
+        expect(renameSpy).not.toHaveBeenCalled();
+        expect(copyFileSpy).not.toHaveBeenCalled();
+    });
+
     test('replaces the target via a temp file when atomic writes keep failing on Windows', () => {
         const filePath = createTargetPath();
         mockWritableTarget();

--- a/tests/util-write-atomic-fallback.test.js
+++ b/tests/util-write-atomic-fallback.test.js
@@ -1,5 +1,6 @@
 /* global globalThis */
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -12,7 +13,7 @@ await jest.unstable_mockModule('node:process', () => ({
     default: mockedProcess,
 }));
 
-const { tryWriteFileSync } = await import('../src/util.js');
+const { recoverFileWritesInDirectorySync, recoverFileWriteSync, tryWriteFileSync } = await import('../src/util.js');
 
 let tempRoot;
 
@@ -44,14 +45,11 @@ describe('tryWriteFileSync atomic fallback', () => {
         fs.writeFileSync(filePath, 'before', 'utf8');
         const inodeBefore = fs.statSync(filePath).ino;
         mockWritableTarget();
-        const writeFileSpy = jest.spyOn(fs, 'writeFileSync');
         const renameSpy = jest.spyOn(fs, 'renameSync');
 
         tryWriteFileSync(filePath, 'after', 'utf8', { preserveFileIdentity: true });
 
-        expect(writeFileSpy).toHaveBeenCalledTimes(1);
-        expect(writeFileSpy.mock.calls[0].slice(1)).toEqual(['after', 'utf8']);
-        expect(renameSpy).not.toHaveBeenCalled();
+        expect(renameSpy.mock.calls.some(([, destination]) => destination === filePath)).toBe(false);
         expect(fs.statSync(filePath).ino).toBe(inodeBefore);
         expect(fs.readFileSync(filePath, 'utf8')).toBe('after');
     });
@@ -72,8 +70,8 @@ describe('tryWriteFileSync atomic fallback', () => {
 
         tryWriteFileSync(filePath, 'after', 'utf8', { preserveFileIdentity: true });
 
-        expect(openSpy).toHaveBeenCalledTimes(3);
-        expect(renameSpy).not.toHaveBeenCalled();
+        expect(openSpy.mock.calls.filter(([target]) => target === filePath)).toHaveLength(3);
+        expect(renameSpy.mock.calls.some(([, destination]) => destination === filePath)).toBe(false);
         expect(fs.readFileSync(filePath, 'utf8')).toBe('after');
     });
 
@@ -91,6 +89,203 @@ describe('tryWriteFileSync atomic fallback', () => {
 
         expect(renameSpy).not.toHaveBeenCalled();
         expect(copyFileSpy).not.toHaveBeenCalled();
+    });
+
+    test('restores the original bytes when an identity-preserving write fails after mutation', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'original-card-content', 'utf8');
+        jest.spyOn(fs, 'ftruncateSync').mockImplementationOnce(() => {
+            throw Object.assign(new Error('simulated truncate failure'), { code: 'EIO' });
+        });
+
+        expect(() => tryWriteFileSync(filePath, 'new', 'utf8', { preserveFileIdentity: true })).toThrow('simulated truncate failure');
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('original-card-content');
+        expect(fs.readdirSync(tempRoot)).toEqual([path.basename(filePath)]);
+    });
+
+    test('recovers the original bytes from a durable interrupted-write record', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'original-card-content', 'utf8');
+        const unlinkSync = fs.unlinkSync.bind(fs);
+        const unlinkSpy = jest.spyOn(fs, 'unlinkSync').mockImplementation((target) => {
+            if (String(target).endsWith('.sillybunny-write-recovery')) {
+                throw createWindowsFileLockError('EPERM');
+            }
+            return unlinkSync(target);
+        });
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        expect(() => tryWriteFileSync(filePath, 'new-card-content', 'utf8', { preserveFileIdentity: true })).toThrow(/write recovery file/i);
+        unlinkSpy.mockRestore();
+        fs.writeFileSync(filePath, 'partial', 'utf8');
+
+        expect(recoverFileWriteSync(filePath)).toBe(true);
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('original-card-content');
+        expect(fs.readdirSync(tempRoot)).toEqual([path.basename(filePath)]);
+    });
+
+    test('refuses to mutate a hard-linked target in place', () => {
+        const filePath = createTargetPath();
+        const aliasPath = path.join(tempRoot, 'alias.jsonl');
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        fs.linkSync(filePath, aliasPath);
+
+        expect(() => tryWriteFileSync(filePath, 'after', 'utf8', { preserveFileIdentity: true })).toThrow(/hard-linked/i);
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('before');
+        expect(fs.readFileSync(aliasPath, 'utf8')).toBe('before');
+    });
+
+    test('refuses an identity-preserving write after the checked file is replaced', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        const checked = fs.statSync(filePath, { bigint: true });
+        const replacementPath = `${filePath}.replacement`;
+        fs.writeFileSync(replacementPath, 'replacement', 'utf8');
+        fs.renameSync(replacementPath, filePath);
+
+        expect(() => tryWriteFileSync(filePath, 'after', 'utf8', {
+            preserveFileIdentity: true,
+            expectedFileIdentity: { dev: checked.dev, ino: checked.ino },
+        })).toThrow(/replaced file/i);
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('replacement');
+    });
+
+    test('never copies through a hard link when replacement renames stay locked', () => {
+        const filePath = createTargetPath();
+        const aliasPath = path.join(tempRoot, 'alias.jsonl');
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        fs.linkSync(filePath, aliasPath);
+        const checked = fs.statSync(filePath, { bigint: true });
+        mockWritableTarget();
+        jest.spyOn(fs, 'renameSync').mockImplementation(() => {
+            throw createWindowsFileLockError('EBUSY');
+        });
+
+        expect(() => tryWriteFileSync(filePath, 'after', 'utf8', {
+            expectedFileIdentity: { dev: checked.dev, ino: checked.ino },
+            replaceFileOnly: true,
+        })).toThrow('EBUSY');
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('before');
+        expect(fs.readFileSync(aliasPath, 'utf8')).toBe('before');
+        expect(fs.statSync(filePath).ino).toBe(fs.statSync(aliasPath).ino);
+    });
+
+    test('does not follow or delete a pre-existing replacement temp link', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        const checked = fs.statSync(filePath, { bigint: true });
+        jest.spyOn(crypto, 'randomBytes').mockReturnValue(Buffer.alloc(8, 1));
+        const tempPath = `${filePath}.${process.pid}.${Buffer.alloc(8, 1).toString('hex')}.tmp`;
+        fs.linkSync(filePath, tempPath);
+
+        expect(() => tryWriteFileSync(filePath, 'after', 'utf8', {
+            expectedFileIdentity: { dev: checked.dev, ino: checked.ino },
+            replaceFileOnly: true,
+        })).toThrow();
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('before');
+        expect(fs.existsSync(tempPath)).toBe(true);
+        expect(fs.statSync(filePath).ino).toBe(fs.statSync(tempPath).ino);
+    });
+
+    test('retries replace-only temp flushing with a fresh exclusive file', () => {
+        const filePath = createTargetPath();
+        const aliasPath = path.join(tempRoot, 'alias.jsonl');
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        fs.linkSync(filePath, aliasPath);
+        const checked = fs.statSync(filePath, { bigint: true });
+        const fsyncSync = fs.fsyncSync.bind(fs);
+        let failed = false;
+        jest.spyOn(fs, 'fsyncSync').mockImplementation((fileDescriptor) => {
+            if (!failed) {
+                failed = true;
+                throw createWindowsFileLockError('EPERM');
+            }
+            return fsyncSync(fileDescriptor);
+        });
+        mockWritableTarget();
+
+        tryWriteFileSync(filePath, 'after', 'utf8', {
+            expectedFileIdentity: { dev: checked.dev, ino: checked.ino },
+            replaceFileOnly: true,
+        });
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('after');
+        expect(fs.readFileSync(aliasPath, 'utf8')).toBe('before');
+        expect(fs.readdirSync(tempRoot).filter(file => file.endsWith('.tmp'))).toHaveLength(0);
+    });
+
+    test('recovers every interrupted identity write in a directory', () => {
+        const firstPath = createTargetPath();
+        const secondPath = path.join(tempRoot, 'second.png');
+        fs.writeFileSync(firstPath, 'first-original', 'utf8');
+        fs.writeFileSync(secondPath, 'second-original', 'utf8');
+        const unlinkSync = fs.unlinkSync.bind(fs);
+        const unlinkSpy = jest.spyOn(fs, 'unlinkSync').mockImplementation((target) => {
+            if (String(target).endsWith('.sillybunny-write-recovery')) {
+                throw createWindowsFileLockError('EPERM');
+            }
+            return unlinkSync(target);
+        });
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        expect(() => tryWriteFileSync(firstPath, 'first-next', 'utf8', { preserveFileIdentity: true })).toThrow(/write recovery file/i);
+        expect(() => tryWriteFileSync(secondPath, 'second-next', 'utf8', { preserveFileIdentity: true })).toThrow(/write recovery file/i);
+        unlinkSpy.mockRestore();
+        fs.writeFileSync(firstPath, 'first-partial', 'utf8');
+        fs.writeFileSync(secondPath, 'second-partial', 'utf8');
+
+        expect(recoverFileWritesInDirectorySync(tempRoot)).toBe(2);
+        expect(fs.readFileSync(firstPath, 'utf8')).toBe('first-original');
+        expect(fs.readFileSync(secondPath, 'utf8')).toBe('second-original');
+    });
+
+    test('restores an orphaned target from its interrupted-write record', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'original-card-content', 'utf8');
+        const unlinkSync = fs.unlinkSync.bind(fs);
+        const unlinkSpy = jest.spyOn(fs, 'unlinkSync').mockImplementation((target) => {
+            if (String(target).endsWith('.sillybunny-write-recovery')) {
+                throw createWindowsFileLockError('EPERM');
+            }
+            return unlinkSync(target);
+        });
+        expect(() => tryWriteFileSync(filePath, 'new-card-content', 'utf8', { preserveFileIdentity: true })).toThrow(/write recovery file/i);
+        unlinkSpy.mockRestore();
+        fs.unlinkSync(filePath);
+
+        expect(recoverFileWritesInDirectorySync(tempRoot)).toBe(1);
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('original-card-content');
+    });
+
+    test('does not overwrite a card recreated during orphan recovery', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'original-card-content', 'utf8');
+        const unlinkSync = fs.unlinkSync.bind(fs);
+        const unlinkSpy = jest.spyOn(fs, 'unlinkSync').mockImplementation((target) => {
+            if (String(target).endsWith('.sillybunny-write-recovery')) {
+                throw createWindowsFileLockError('EPERM');
+            }
+            return unlinkSync(target);
+        });
+        expect(() => tryWriteFileSync(filePath, 'new-card-content', 'utf8', { preserveFileIdentity: true })).toThrow(/write recovery file/i);
+        unlinkSpy.mockRestore();
+        fs.unlinkSync(filePath);
+        const linkSync = fs.linkSync.bind(fs);
+        let recreated = false;
+        jest.spyOn(fs, 'linkSync').mockImplementation((existingPath, newPath) => {
+            if (!recreated && newPath === filePath) {
+                recreated = true;
+                fs.writeFileSync(filePath, 'concurrent-card-content', 'utf8');
+            }
+            return linkSync(existingPath, newPath);
+        });
+
+        expect(() => recoverFileWritesInDirectorySync(tempRoot)).toThrow(/replaced file/i);
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('concurrent-card-content');
     });
 
     test('replaces the target via a temp file when atomic writes keep failing on Windows', () => {


### PR DESCRIPTION
## Issue
Stated in Issue #707, the character card seems to constantly resave despite not really changing, ruining the metadata.

## Fix
Similar to the chat fix, SB now skips writes/rewrites when nothing is changed, preserving the card and its metadata.

Confirmed fixed by user https://github.com/SillyBunnyTeam/SillyBunny/issues/707#issuecomment-5147738930