### PR TITLE
fix: character card metadata fixes (windows edition)

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -51,9 +51,9 @@ const EXTENSION_UNSET_VALUE = '__@@UNSET@@__';
 const forbiddenAvatarRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
 const CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE = 'allow_empty_definition_save';
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
-const getPngFileStem = fileName => path.extname(fileName).toLowerCase() === '.png'
-    ? fileName.slice(0, -path.extname(fileName).length)
-    : fileName;
+const getPngFileName = fileName => path.extname(fileName).toLowerCase() === '.png'
+    ? fileName
+    : `${fileName}.png`;
 const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.characters);
 const getCharacterDateAddedFallback = stat => [stat.ctimeMs, stat.birthtimeMs, stat.mtimeMs]
     .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
@@ -250,7 +250,7 @@ async function readCharacterData(inputFile, inputFormat = 'png') {
  * Writes the character card to the specified image file.
  * @param {string|Buffer} inputFile - Path to the image file or image buffer
  * @param {string} data - Character card data
- * @param {string} outputFile - Target image file name
+ * @param {string} outputFile - Target image file name, with or without a PNG extension
  * @param {import('express').Request} request - Express request obejct
  * @param {Crop|undefined} crop - Crop parameters
  * @param {{preserveDateAdded?: boolean, preserveFileIdentity?: boolean}} [writeOptions]
@@ -258,7 +258,7 @@ async function readCharacterData(inputFile, inputFormat = 'png') {
  */
 async function writeCharacterData(inputFile, data, outputFile, request, crop = undefined, { preserveDateAdded = false, preserveFileIdentity = false } = {}) {
     try {
-        const outputImageName = `${outputFile}.png`;
+        const outputImageName = getPngFileName(outputFile);
         const outputImagePath = path.join(request.user.directories.characters, outputImageName);
         const fileExists = fs.existsSync(outputImagePath);
         let expectedFileIdentity;
@@ -426,8 +426,7 @@ async function mergeCharacterUpdate(avatarPath, avatar, updateData, request, sho
         return { ok: false, error: validator.lastValidationError ?? 'Validation failed' };
     }
 
-    const targetImg = getPngFileStem(avatar);
-    const writeSucceeded = await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request, undefined, { preserveFileIdentity: true });
+    const writeSucceeded = await writeCharacterData(avatarPath, JSON.stringify(character), avatar, request, undefined, { preserveFileIdentity: true });
     if (!writeSucceeded) {
         return { ok: false, error: 'Failed to write character data.' };
     }
@@ -1394,7 +1393,7 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
     char.chat = request.body.chat;
     char.create_date = request.body.create_date;
     char = JSON.stringify(char);
-    let targetFile = getPngFileStem(request.body.avatar_url);
+    const targetFile = request.body.avatar_url;
 
     try {
         let writeSucceeded;
@@ -1440,7 +1439,7 @@ router.post('/edit-avatar', validateAvatarUrlMiddleware, async function (request
         }
 
         const crop = tryParse(request.query.crop);
-        const fileName = getPngFileStem(request.body.avatar_url);
+        const fileName = request.body.avatar_url;
         const writeSucceeded = await writeCharacterData(uploadPath, data, fileName, request, crop, { preserveFileIdentity: true });
 
         // Remove uploaded temp file
@@ -1499,7 +1498,7 @@ router.post('/edit-attribute', validateAvatarUrlMiddleware, async function (requ
         char[request.body.field] = request.body.value;
         char.data[request.body.field] = request.body.value;
         let newCharJSON = JSON.stringify(char);
-        const targetFile = getPngFileStem(request.body.avatar_url);
+        const targetFile = request.body.avatar_url;
         const writeSucceeded = await writeCharacterData(avatarPath, newCharJSON, targetFile, request, undefined, { preserveFileIdentity: true });
         if (!writeSucceeded) throw new Error('Failed to write character data.');
         return response.sendStatus(200);

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -51,13 +51,26 @@ const EXTENSION_UNSET_VALUE = '__@@UNSET@@__';
 const forbiddenAvatarRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
 const CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE = 'allow_empty_definition_save';
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
-const getPngFileStem = fileName => path.extname(fileName) === '.png'
+const getPngFileStem = fileName => path.extname(fileName).toLowerCase() === '.png'
     ? fileName.slice(0, -path.extname(fileName).length)
     : fileName;
 const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.characters);
 const getCharacterDateAddedFallback = stat => [stat.ctimeMs, stat.birthtimeMs, stat.mtimeMs]
     .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
 const isPngBuffer = buffer => buffer.length >= PNG_SIGNATURE.length && buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+const isSameFile = (firstPath, secondPath) => {
+    if (path.resolve(firstPath) === path.resolve(secondPath)) {
+        return true;
+    }
+
+    try {
+        const firstStats = fs.statSync(firstPath, { bigint: true });
+        const secondStats = fs.statSync(secondPath, { bigint: true });
+        return firstStats.dev === secondStats.dev && firstStats.ino !== 0n && firstStats.ino === secondStats.ino;
+    } catch {
+        return false;
+    }
+};
 
 class DiskCache {
     /**
@@ -272,7 +285,7 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
             try {
                 let rawImage;
                 // SillyBunny: metadata-only card edits must not rebuild an existing PNG through Jimp.
-                const editsExistingCard = typeof inputFile === 'string' && path.resolve(inputFile) === path.resolve(outputImagePath);
+                const editsExistingCard = typeof inputFile === 'string' && isSameFile(inputFile, outputImagePath);
                 if (editsExistingCard && (crop === undefined || crop === null)) {
                     rawImage = await fsPromises.readFile(inputFile);
                     if (isPngBuffer(rawImage)) {

--- a/src/util.js
+++ b/src/util.js
@@ -2106,6 +2106,13 @@ function writeAllSync(fileDescriptor, data, position = 0) {
     }
 }
 
+function resizeFileSync(fileDescriptor, size) {
+    // Windows can reject SetEndOfFile on a mapped file even when its size already matches.
+    if (fs.fstatSync(fileDescriptor, { bigint: true }).size !== BigInt(size)) {
+        fs.ftruncateSync(fileDescriptor, size);
+    }
+}
+
 function removeFileWriteRecovery(recoveryPath) {
     const retryDelaysMs = process.platform === 'win32' ? [0, 50, 125, 250] : [0];
     for (const delayMs of retryDelaysMs) {
@@ -2177,7 +2184,7 @@ function recoverFileWriteOnceSync(filePath) {
             restoreTempCreated = true;
             try {
                 writeAllSync(restoreDescriptor, originalData);
-                fs.ftruncateSync(restoreDescriptor, originalData.byteLength);
+                resizeFileSync(restoreDescriptor, originalData.byteLength);
                 fs.fsyncSync(restoreDescriptor);
             } finally {
                 fs.closeSync(restoreDescriptor);
@@ -2228,7 +2235,7 @@ function recoverFileWriteOnceSync(filePath) {
             throw Object.assign(new Error(`Refused to recover a replaced file: ${filePath}`), { code: 'ESTALE' });
         }
         writeAllSync(fileDescriptor, originalData);
-        fs.ftruncateSync(fileDescriptor, originalData.byteLength);
+        resizeFileSync(fileDescriptor, originalData.byteLength);
         fs.fsyncSync(fileDescriptor);
 
         const finalDescriptorStats = fs.fstatSync(fileDescriptor, { bigint: true });
@@ -2369,7 +2376,7 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
                     writeAllSync(fileDescriptor, Buffer.from([dataBuffer[0] ^ 0xFF]));
                     fs.fsyncSync(fileDescriptor);
                     writeAllSync(fileDescriptor, dataBuffer.subarray(1), 1);
-                    fs.ftruncateSync(fileDescriptor, dataLength);
+                    resizeFileSync(fileDescriptor, dataLength);
                     fs.fsyncSync(fileDescriptor);
                     writeAllSync(fileDescriptor, dataBuffer.subarray(0, 1));
                     fs.fsyncSync(fileDescriptor);
@@ -2387,7 +2394,7 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
 
                     targetMutated = true;
                     writeAllSync(fileDescriptor, dataBuffer);
-                    fs.ftruncateSync(fileDescriptor, dataLength);
+                    resizeFileSync(fileDescriptor, dataLength);
                     fs.fsyncSync(fileDescriptor);
                 }
 
@@ -2403,7 +2410,7 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
                 if (shouldRestoreOriginal && originalData) {
                     try {
                         writeAllSync(fileDescriptor, originalData);
-                        fs.ftruncateSync(fileDescriptor, originalData.byteLength);
+                        resizeFileSync(fileDescriptor, originalData.byteLength);
                         fs.fsyncSync(fileDescriptor);
                         removeFileWriteRecovery(recoveryPath);
                     } catch (rollbackError) {
@@ -2457,7 +2464,7 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
                     const encoding = typeof options === 'string' ? options : options?.encoding || 'utf8';
                     const dataBuffer = Buffer.isBuffer(data) ? data : Buffer.from(data, encoding);
                     writeAllSync(tempDescriptor, dataBuffer);
-                    fs.ftruncateSync(tempDescriptor, dataBuffer.byteLength);
+                    resizeFileSync(tempDescriptor, dataBuffer.byteLength);
                     fs.fsyncSync(tempDescriptor);
                 } finally {
                     fs.closeSync(tempDescriptor);

--- a/tests/character-card-metadata-preservation.test.js
+++ b/tests/character-card-metadata-preservation.test.js
@@ -3,6 +3,7 @@ import express from 'express';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import extract from 'png-chunks-extract';
@@ -18,6 +19,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const originalWorkingDirectory = process.cwd();
 const diskCacheEnvironmentKey = 'SILLYTAVERN_PERFORMANCE_USEDISKCACHE';
 const originalDiskCacheSetting = process.env[diskCacheEnvironmentKey];
+const describeWindows = process.platform === 'win32' ? describe : describe.skip;
 process.env[diskCacheEnvironmentKey] = 'false';
 process.chdir(repoRoot);
 setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
@@ -114,6 +116,37 @@ describe('character card metadata preservation', () => {
         expect(cardChunks[0].card.spec).toBe('chara_card_v2');
         expect(cardChunks[1].card.spec).toBe('chara_card_v3');
         expect(cardChunks.every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+    });
+
+    describeWindows('Windows card metadata', () => {
+        test('preserves NTFS metadata through a case-only card path alias', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            jest.spyOn(console, 'info').mockImplementation(() => {});
+            await createAlice();
+            const originalPath = path.join(directories.characters, 'Alice.png');
+            const uppercasePath = path.join(directories.characters, 'Alice.PNG');
+            fs.renameSync(originalPath, uppercasePath);
+            addAncillaryChunks(uppercasePath);
+            const alternateStreamPath = `${uppercasePath}:sillybunny-metadata-test`;
+            fs.writeFileSync(alternateStreamPath, 'preserve this stream', 'utf8');
+            const cardBefore = fs.readFileSync(uppercasePath);
+            const statBefore = fs.statSync(uppercasePath, { bigint: true });
+
+            const response = await postJson('/api/characters/merge-attributes', {
+                avatar: 'Alice.PNG',
+                creator: 'Somebody',
+            });
+
+            expect(response.status).toBe(200);
+            const cardAfter = fs.readFileSync(uppercasePath);
+            const statAfter = fs.statSync(uppercasePath, { bigint: true });
+            expect(nonCardChunks(cardAfter)).toEqual(nonCardChunks(cardBefore));
+            expect(statAfter.dev).toBe(statBefore.dev);
+            expect(statAfter.ino).toBe(statBefore.ino);
+            expect(statAfter.birthtimeNs).toBe(statBefore.birthtimeNs);
+            expect(fs.readFileSync(alternateStreamPath, 'utf8')).toBe('preserve this stream');
+            expect(decodeCardChunks(cardAfter).every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+        });
     });
 
     test('leaves the card untouched when a full editor save changes nothing', async () => {

--- a/tests/character-card-metadata-preservation.test.js
+++ b/tests/character-card-metadata-preservation.test.js
@@ -20,6 +20,7 @@ const originalWorkingDirectory = process.cwd();
 const diskCacheEnvironmentKey = 'SILLYTAVERN_PERFORMANCE_USEDISKCACHE';
 const originalDiskCacheSetting = process.env[diskCacheEnvironmentKey];
 const describeWindows = process.platform === 'win32' ? describe : describe.skip;
+const describeCaseSensitive = process.platform === 'win32' ? describe.skip : describe;
 process.env[diskCacheEnvironmentKey] = 'false';
 process.chdir(repoRoot);
 setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
@@ -204,6 +205,31 @@ describe('character card metadata preservation', () => {
         expect(fs.existsSync(cardPath)).toBe(true);
         expect(fs.existsSync(path.join(directories.characters, 'Alice.backup.png.png'))).toBe(false);
         expect(decodeCardChunks(fs.readFileSync(cardPath)).every(chunk => chunk.card.creator === 'Somebody')).toBe(true);
+    });
+
+    describeCaseSensitive('case-sensitive card filenames', () => {
+        test('updates the exact requested card when PNG filenames differ only by case', async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            jest.spyOn(console, 'info').mockImplementation(() => {});
+            await createAlice();
+            const lowercasePath = path.join(directories.characters, 'Alice.png');
+            const uppercasePath = path.join(directories.characters, 'Alice.PNG');
+            fs.copyFileSync(lowercasePath, uppercasePath);
+
+            const lowercaseResponse = await postJson('/api/characters/merge-attributes', {
+                avatar: 'Alice.png',
+                creator: 'Lowercase',
+            });
+            expect(lowercaseResponse.status).toBe(200);
+
+            const uppercaseResponse = await postJson('/api/characters/merge-attributes', {
+                avatar: 'Alice.PNG',
+                creator: 'Uppercase',
+            });
+            expect(uppercaseResponse.status).toBe(200);
+            expect(decodeCardChunks(fs.readFileSync(lowercasePath)).every(chunk => chunk.card.creator === 'Lowercase')).toBe(true);
+            expect(decodeCardChunks(fs.readFileSync(uppercasePath)).every(chunk => chunk.card.creator === 'Uppercase')).toBe(true);
+        });
     });
 
     test('replaces only the selected path when a card has a hard-link alias', async () => {

--- a/tests/util-write-atomic-fallback.test.js
+++ b/tests/util-write-atomic-fallback.test.js
@@ -104,6 +104,34 @@ describe('tryWriteFileSync atomic fallback', () => {
         expect(fs.readdirSync(tempRoot)).toEqual([path.basename(filePath)]);
     });
 
+    test('does not truncate when writing already produced the target size', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'before', 'utf8');
+        mockWritableTarget();
+        const truncateSpy = jest.spyOn(fs, 'ftruncateSync').mockImplementation(() => {
+            throw createWindowsFileLockError('EBUSY');
+        });
+
+        expect(() => tryWriteFileSync(filePath, 'after-is-longer', 'utf8', { preserveFileIdentity: true })).not.toThrow();
+
+        expect(truncateSpy).not.toHaveBeenCalled();
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('after-is-longer');
+    });
+
+    test('restores a shorter write when Windows keeps truncation locked', () => {
+        const filePath = createTargetPath();
+        fs.writeFileSync(filePath, 'original-card-content', 'utf8');
+        mockWritableTarget();
+        jest.spyOn(fs, 'ftruncateSync').mockImplementation(() => {
+            throw createWindowsFileLockError('EBUSY');
+        });
+
+        expect(() => tryWriteFileSync(filePath, 'short', 'utf8', { preserveFileIdentity: true })).toThrow('EBUSY');
+
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('original-card-content');
+        expect(fs.readdirSync(tempRoot)).toEqual([path.basename(filePath)]);
+    });
+
     test('recovers the original bytes from a durable interrupted-write record', () => {
         const filePath = createTargetPath();
         fs.writeFileSync(filePath, 'original-card-content', 'utf8');


### PR DESCRIPTION
Mirror's pura's work in https://github.com/SillyBunnyTeam/SillyBunny/pull/709 for the most part. Preserves case-aliased Windows cards by filesystem identity, avoids unnecessary truncation on mapped NTFS files, cleanly restores shorter failed writes, and proves PNG chunks, file ID, creation time, and alternate data streams survive.