### PR TITLE
fix(popup): stop dialog action buttons from being clipped

### DIFF
--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -182,8 +182,17 @@ body.no-blur .popup[open]::backdrop {
 }
 
 .popup-controls {
-    margin-top: 10px;
+    margin-top: 8px;
     display: flex;
+
+    /* SillyBunny: '.popup-body' clips overflow, so the control row must never leave it.
+       'max-width' stops 'align-self: center' from sizing the row past the popup, wrapping
+       replaces the horizontal overflow it used to produce, and the padding is the room the
+       focus ring and '.menu_button_default' glow need, since both paint outside the border box. */
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 100%;
+    padding: 6px;
     align-self: center;
     gap: var(--spacing-md, 12px);
 }
@@ -206,6 +215,15 @@ body.no-blur .popup[open]::backdrop {
 .popup-controls .menu_button {
     /* Popup buttons should not scale to smallest size, otherwise they will always break to multiline if multiple words */
     width: unset;
+
+    /* SillyBunny: row spacing comes from the row gap, so the row padding stays available as
+       focus ring room. 'flex-grow' only has free space to consume once the row hits its
+       'max-width', which is exactly the wrapped case, so unwrapped popups are unaffected.
+       'white-space' lets a label that cannot fit a line on its own wrap instead of overflowing. */
+    margin: 0;
+    max-width: 100%;
+    flex-grow: 1;
+    white-space: normal;
 
     /* Fix weird animation issue with fonts on brightness filter */
     backface-visibility: hidden;

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
             background-color: #1d2128;
         }
     </style>
-    <link rel="preload" as="style" href="style.css?v=20260610a">
+    <link rel="preload" as="style" href="style.css?v=20260803a">
     <link rel="modulepreload" href="script.js">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js">
     <link rel="modulepreload" href="scripts/sillybunny-conversation.js">
@@ -42,7 +42,7 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260610a">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260803a">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 @import url(css/animations.css);
-@import url(css/popup.css);
+@import url(css/popup.css?v=20260803a);
 @import url(css/promptmanager.css?v=20260507a);
 @import url(css/loader.css);
 @import url(css/character-group-overlay.css);
@@ -4149,6 +4149,13 @@ grammarly-extension {
 #dialogue_popup_controls {
     margin-top: 10px;
     display: flex;
+
+    /* SillyBunny: same clipping as '.popup-controls' -- '#dialogue_popup_holder' hides overflow,
+       so the row wraps rather than spilling past it, and the padding keeps the focus ring visible. */
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 100%;
+    padding: 6px;
     align-self: center;
     gap: 20px;
 }

--- a/tests/popup-controls-css.test.js
+++ b/tests/popup-controls-css.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const popupCss = readFileSync(path.join(repoRoot, 'public', 'css', 'popup.css'), 'utf8').replace(/\r\n/g, '\n');
+const styleCss = readFileSync(path.join(repoRoot, 'public', 'style.css'), 'utf8').replace(/\r\n/g, '\n');
+
+function getRuleBody(cssSource, selector) {
+    const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const matches = [...cssSource.matchAll(new RegExp(`${escapedSelector}\\s*\\{(?<body>[^}]*)\\}`, 'gs'))];
+    const match = matches.at(-1);
+
+    return match?.groups?.body ?? '';
+}
+
+// '.popup-body' and '#dialogue_popup_holder' both clip overflow, so a popup action row that
+// sizes itself to its content gets sliced at the popup edges once the labels are long enough,
+// and the focus ring plus the '.menu_button_default' glow -- which paint outside the button
+// border box -- get cut off along the bottom. The row therefore has to stay inside its parent
+// and carry its own padding as ring room.
+describe('popup controls css', () => {
+    test('keeps the modern popup action row inside the clipped popup body', () => {
+        const controlsRule = getRuleBody(popupCss, '.popup-controls');
+
+        expect(controlsRule).toContain('flex-wrap: wrap;');
+        expect(controlsRule).toContain('max-width: 100%;');
+        expect(controlsRule).toContain('padding: 6px;');
+    });
+
+    test('sizes modern popup buttons from the row gap so the row padding stays ring room', () => {
+        const buttonRule = getRuleBody(popupCss, '.popup-controls .menu_button');
+
+        expect(buttonRule).toContain('margin: 0;');
+        expect(buttonRule).toContain('max-width: 100%;');
+        expect(buttonRule).toContain('white-space: normal;');
+    });
+
+    test('keeps the legacy popup action row inside the clipped popup holder', () => {
+        const legacyControlsRule = getRuleBody(styleCss, '#dialogue_popup_controls');
+
+        expect(legacyControlsRule).toContain('flex-wrap: wrap;');
+        expect(legacyControlsRule).toContain('max-width: 100%;');
+        expect(legacyControlsRule).toContain('padding: 6px;');
+    });
+
+    test('cache-busts the popup sheet import so returning users get the fix', () => {
+        expect(styleCss).toMatch(/@import url\(css\/popup\.css\?v=[0-9a-z]+\);/);
+    });
+});


### PR DESCRIPTION
This pull request was created for archival reasons to correct an earlier commit policy mistake. The associated commit had already been applied to staging before this pull request was opened.