### PR TITLE
fix(ica): fix memory shard completely hiding the previous shard

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -998,7 +998,9 @@ export function normalizeCompanionConfig(raw = {}) {
         rawPrompt: Boolean(rawConfig.rawPrompt),
         inlinePhase: ['pre', 'post', 'both'].includes(String(rawConfig.inlinePhase)) ? String(rawConfig.inlinePhase) : '',
         minContextTokens: clampNumber(rawConfig.minContextTokens, defaults.minContextTokens, 0, 200000),
-        contextMessages: clampNumber(rawConfig.contextMessages, defaults.contextMessages, 1, 50),
+        // SillyBunny: no upper bound. These are "how far back to look" dials, and a hard ceiling
+        // silently rewrote whatever the user saved (200 came back as 50) with no way to tell.
+        contextMessages: clampNumber(rawConfig.contextMessages, defaults.contextMessages, 1, Infinity),
         includeCharacterCard: rawConfig.includeCharacterCard === undefined ? defaults.includeCharacterCard : Boolean(rawConfig.includeCharacterCard),
         includePersona: rawConfig.includePersona === undefined ? defaults.includePersona : Boolean(rawConfig.includePersona),
         includeWorldInfo: rawConfig.includeWorldInfo === undefined ? defaults.includeWorldInfo : Boolean(rawConfig.includeWorldInfo),
@@ -1006,7 +1008,7 @@ export function normalizeCompanionConfig(raw = {}) {
         includeSystemPrompt: rawConfig.includeSystemPrompt === undefined ? defaults.includeSystemPrompt : Boolean(rawConfig.includeSystemPrompt),
         includeHistory: rawConfig.includeHistory === undefined ? defaults.includeHistory : Boolean(rawConfig.includeHistory),
         includeInChatHistory: Boolean(rawConfig.includeInChatHistory),
-        chatHistoryDepth: clampNumber(rawConfig.chatHistoryDepth, defaults.chatHistoryDepth, 1, 50),
+        chatHistoryDepth: clampNumber(rawConfig.chatHistoryDepth, defaults.chatHistoryDepth, 1, Infinity),
         includeAllChatHistory: rawConfig.includeAllChatHistory === undefined ? defaults.includeAllChatHistory : Boolean(rawConfig.includeAllChatHistory),
         keepInChatHistoryWhenHostHidden: Boolean(rawConfig.keepInChatHistoryWhenHostHidden),
         historyDepth: clampNumber(rawConfig.historyDepth, defaults.historyDepth, 1, 10),

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -36,11 +36,11 @@ import {
     MEMORY_SHARD_TEMPLATE_ID,
     PLOT_COMPASS_OBJECTIVE_MAX_CHARS,
     appendChatOnlyUserMessage,
+    holdsReadableCompanionResults,
     isAssistantMessage,
     isChatOnlyAgent,
     isChatroomAgent,
     isPlotCompassAgent,
-    isValidCompanionMessage,
     normalizeChatOnlyInput,
     normalizeChatroomReply,
     normalizePlotCompassObjective,
@@ -439,7 +439,9 @@ export function collectPanelAgentStates() {
 
     for (let messageIndex = chat.length - 1; messageIndex >= 0; messageIndex--) {
         const message = chat[messageIndex];
-        if (!isValidCompanionMessage(message)) {
+        // Notes on hidden hosts stay listed: "hide story above this shard" hides every earlier
+        // shard's message, and skipping them here wiped those shards out of the panel entirely.
+        if (!holdsReadableCompanionResults(message)) {
             continue;
         }
 
@@ -467,7 +469,7 @@ export function collectPanelAgentStates() {
                 byAgentId.set(agentId, state);
             }
 
-            const entry = { messageIndex, result };
+            const entry = { messageIndex, result, hostHidden: Boolean(message.is_system) };
             if (!state.latest) {
                 state.latest = entry;
             } else if (state.history.length < PANEL_HISTORY_LIMIT) {
@@ -598,6 +600,13 @@ function buildPanelEntryControls(state) {
     ].filter(Boolean).join('');
 }
 
+/** Marks a note whose host message is hidden from prompts - the note itself still counts. */
+function buildAbsorbedPillHtml(entry) {
+    return entry?.hostHidden
+        ? '<span class="ica--card-pill ica--card-pill--absorbed" title="This message is hidden from prompts. The note itself is kept.">Absorbed</span>'
+        : '';
+}
+
 function buildPanelAgentSection(state) {
     const agentId = state.agentId ?? state.agent?.id ?? '';
     const latest = state.latest;
@@ -638,9 +647,10 @@ function buildPanelAgentSection(state) {
             <details class="ica--tpanel-history">
                 <summary>Previous states (${state.history.length})</summary>
                 ${state.history.map(entry => `
-                    <div class="ica--tpanel-history-entry" data-message-index="${entry.messageIndex}">
+                    <div class="ica--tpanel-history-entry" data-message-index="${entry.messageIndex}" data-host-hidden="${Boolean(entry.hostHidden)}">
                         <div class="ica--tpanel-history-head">
                             <span>Message #${entry.messageIndex}</span>
+                            ${buildAbsorbedPillHtml(entry)}
                             ${buildCompanionTokenUsagePillsHtml(entry.result)}
                             <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text" aria-label="Edit history entry"><i class="fa-solid fa-pen-to-square"></i></button>
                         </div>
@@ -651,18 +661,25 @@ function buildPanelAgentSection(state) {
         `
         : '';
 
+    // A hidden host cannot be re-run: runSingleCompanionAgent rejects system messages, so the
+    // rerun controls would silently do nothing. Editing the stored text and jumping still work.
+    const rerunButtons = latest.hostHidden
+        ? ''
+        : `
+                    <button type="button" class="ica--cdash-action" data-action="panel-regenerate" title="Regenerate this state" aria-label="Regenerate state"><i class="fa-solid fa-rotate-right"></i></button>
+                    <button type="button" class="ica--cdash-action" data-action="panel-fix" title="Fix: re-run with strict output enforcement (use when the model wrote roleplay instead)" aria-label="Fix state"><i class="fa-solid fa-wrench"></i></button>`;
+
     return `
-        <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}" data-message-index="${latest.messageIndex}" data-hidden="${isHidden}">
+        <section class="ica--tpanel-agent" data-agent-id="${escapeHtml(agentId)}" data-message-index="${latest.messageIndex}" data-hidden="${isHidden}" data-host-hidden="${Boolean(latest.hostHidden)}">
             <div class="ica--tpanel-agent-head">
                 <span class="ica--tpanel-agent-name"><i class="fa-solid ${escapeHtml(icon)}"></i><span>${escapeHtml(name)}</span></span>
                 <span class="ica--tpanel-agent-when">#${latest.messageIndex}</span>
+                ${buildAbsorbedPillHtml(latest)}
                 ${buildCompanionTokenUsagePillsHtml(latest.result)}
                 <span class="ica--tpanel-agent-actions">
                     ${dragHandleButton}
                     ${hiddenButton}
-                    ${runLatestButton}
-                    <button type="button" class="ica--cdash-action" data-action="panel-regenerate" title="Regenerate this state" aria-label="Regenerate state"><i class="fa-solid fa-rotate-right"></i></button>
-                    <button type="button" class="ica--cdash-action" data-action="panel-fix" title="Fix: re-run with strict output enforcement (use when the model wrote roleplay instead)" aria-label="Fix state"><i class="fa-solid fa-wrench"></i></button>
+                    ${runLatestButton}${rerunButtons}
                     <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text by hand (e.g. type your Plot Compass objective)" aria-label="Edit state text"><i class="fa-solid fa-pen-to-square"></i></button>
                     ${settingsButton}
                     <button type="button" class="ica--cdash-action" data-action="panel-jump" title="Scroll to the source message" aria-label="Scroll to source message"><i class="fa-solid fa-comment-dots"></i></button>
@@ -676,11 +693,22 @@ function buildPanelAgentSection(state) {
     `;
 }
 
+function countVisibleStoryAbove(messageIndex) {
+    return chat.slice(0, messageIndex).filter(message => message && !message.is_system).length;
+}
+
 /** The memory shard can replace the history it summarizes: offer hiding everything above it. */
 function buildCompactionButton(state) {
     const isMemoryShard = state.agent?.sourceTemplateId === MEMORY_SHARD_TEMPLATE_ID
         || /memory shard/i.test(String(state.agent?.name ?? state.latest?.result?.agentName ?? ''));
     if (!isMemoryShard || !state.latest || state.latest.messageIndex < 1 || state.latest.result?.status !== 'done') {
+        return '';
+    }
+
+    // Nothing left to absorb: either the shard's own host sits inside an already-hidden range,
+    // or a previous compaction already hid everything above it. Offering the button again would
+    // re-hide hidden messages and report a count of work it did not do.
+    if (state.latest.hostHidden || countVisibleStoryAbove(state.latest.messageIndex) === 0) {
         return '';
     }
 
@@ -992,7 +1020,10 @@ async function handlePanelAction(event) {
 
         const inputField = section.find('[data-role="plot-compass-objective"]');
         const objective = normalizePlotCompassObjective(inputField.val());
-        const runIndex = Number.isInteger(messageIndex) ? messageIndex : getLatestAssistantIndex();
+        // The section can be anchored to a hidden host now that hidden hosts keep their notes;
+        // a companion cannot run on one, so fall back to the newest visible reply.
+        const canRunOnSection = Number.isInteger(messageIndex) && !chat[messageIndex]?.is_system;
+        const runIndex = canRunOnSection ? messageIndex : getLatestAssistantIndex();
         if (runIndex < 0) {
             toastr.warning('No assistant reply yet to plan from.');
             return;
@@ -1015,6 +1046,12 @@ async function handlePanelAction(event) {
     }
 
     if (action === 'panel-hide-before' && Number.isInteger(messageIndex) && messageIndex > 0) {
+        const hideCount = countVisibleStoryAbove(messageIndex);
+        if (hideCount === 0) {
+            toastr.info('Everything above this shard is already hidden from prompts.');
+            return;
+        }
+
         const result = await new Popup(
             `Exclude messages #0–#${messageIndex - 1} from prompts? The shard carries that history from here on; messages stay visible in the chat and can be unhidden later.`,
             POPUP_TYPE.CONFIRM,
@@ -1024,7 +1061,7 @@ async function handlePanelAction(event) {
         }
 
         await hideChatMessageRange(0, messageIndex - 1, false);
-        toastr.success(`Hid ${messageIndex} message(s) from prompts.`);
+        toastr.success(`Hid ${hideCount} message(s) from prompts.`);
         if (panelOpen) {
             renderPanel();
         }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -603,7 +603,7 @@ function buildPanelEntryControls(state) {
 /** Marks a note whose host message is hidden from prompts - the note itself still counts. */
 function buildAbsorbedPillHtml(entry) {
     return entry?.hostHidden
-        ? '<span class="ica--card-pill ica--card-pill--absorbed" title="This message is hidden from prompts. The note itself is kept.">Absorbed</span>'
+        ? '<span class="ica--card-pill ica--card-pill--absorbed" title="This message is hidden from chat history, but this note will remain in this particular agent\'s history.">Absorbed</span>'
         : '';
 }
 

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -603,7 +603,7 @@ function buildPanelEntryControls(state) {
 /** Marks a note whose host message is hidden from prompts - the note itself still counts. */
 function buildAbsorbedPillHtml(entry) {
     return entry?.hostHidden
-        ? '<span class="ica--card-pill ica--card-pill--absorbed" title="This message is hidden from chat history, but this note will remain in this particular agent\'s history.">Absorbed</span>'
+        ? '<span class="ica--card-pill ica--card-pill--absorbed" title="The messages associated with this note are hidden from chat history, but this note remains as context seen by the LLM.">Absorbed</span>'
         : '';
 }
 

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -47,6 +47,7 @@ import {
     DIRECTORS_COMMENTARY_TEMPLATE_ID,
     PLOT_COMPASS_TEMPLATE_ID,
     getCompanionReferenceIds,
+    holdsReadableCompanionResults,
     isAssistantMessage,
     isEmptyOutputSentinel,
     isValidCompanionMessage,
@@ -708,7 +709,10 @@ export function collectRecentCompanionResults(agentId, { beforeMessageIndex = ch
 
     for (let index = Math.min(beforeMessageIndex - 1, chat.length - 1); index >= 0 && results.length < maxDepth; index--) {
         const message = chat[index];
-        if (!isAssistantMessage(message)) {
+        // Hidden hosts still count: "hide story above this shard" turns every earlier shard's
+        // message into a system note, and dropping those here left the shard with no prior
+        // shards to consolidate and trackers with no last known state.
+        if (!holdsReadableCompanionResults(message, { allowUserMessage: false })) {
             continue;
         }
 

--- a/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
@@ -145,6 +145,22 @@ export function isValidCompanionMessage(message) {
     return Boolean(message && !message.is_system);
 }
 
+/**
+ * Whether stored companion results on this message should still be listed and fed back.
+ *
+ * Hiding is a prompt-side decision: `is_system` drops the story text from context, but the
+ * notes an agent wrote about that story still exist. Memory Shard depends on this - its own
+ * "hide story above this shard" button hides every earlier shard's host message, so gating on
+ * `is_system` here would erase every previous shard from the panel and from the shard's own
+ * prior-notes window. Context selection keeps using isValidCompanionMessage / isAssistantMessage.
+ * @param {object} message
+ * @param {{ allowUserMessage?: boolean }} [options]
+ * @returns {boolean}
+ */
+export function holdsReadableCompanionResults(message, { allowUserMessage = true } = {}) {
+    return Boolean(message && (allowUserMessage || !message.is_user));
+}
+
 export function normalizeCompanionMacroSyntax(content = '') {
     return String(content ?? '')
         .replace(ESCAPED_MACRO_OPEN_RE, '{{')
@@ -228,7 +244,7 @@ export function selectCompanionChatHistory(messages = [], { policyMessages = mes
     const selections = new Map();
     for (const [agentId, candidates] of candidatesByAgent) {
         const policy = policyByAgent.get(agentId) ?? candidates.at(-1)?.result ?? {};
-        const depth = Math.max(1, Math.min(50, Math.floor(Number(policy.chatHistoryDepth) || 1)));
+        const depth = Math.max(1, Math.floor(Number(policy.chatHistoryDepth) || 1));
         const selected = policy.includeAllChatHistory === false
             ? candidates.slice(-depth)
             : candidates;

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -184,7 +184,7 @@
                 </select>
             </label>
             <label>Context Messages
-                <input type="number" id="ica--editor-companion-contextMessages" class="text_pole" min="1" max="50" value="10" />
+                <input type="number" id="ica--editor-companion-contextMessages" class="text_pole" min="1" value="10" />
             </label>
             <label title="Only auto-run once the chat reaches roughly this many tokens. 0 runs always.">Min Context Tokens
                 <input type="number" id="ica--editor-companion-minContextTokens" class="text_pole" min="0" max="200000" step="1000" value="0" />
@@ -209,7 +209,7 @@
         </div>
         <div class="ica--editor-row" id="ica--companion-chat-history-row">
             <label>Notes to keep
-                <input type="number" id="ica--editor-companion-chatHistoryDepth" class="text_pole" min="1" max="50" value="1" />
+                <input type="number" id="ica--editor-companion-chatHistoryDepth" class="text_pole" min="1" value="1" />
             </label>
             <div class="ica--regex-note">Keeps this agent's most recent notes in the AI's context. Only notes that finished generating are counted.</div>
             <label class="checkbox_label"><input type="checkbox" id="ica--editor-companion-includeAllChatHistory" /><span>Keep all notes instead</span></label>

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -641,6 +641,13 @@ button.ica--card-pill--version-update {
     font-weight: 700;
 }
 
+/* The note's host message is hidden from prompts; the note itself is still live. */
+.ica--card-pill--absorbed {
+    background: color-mix(in srgb, var(--SmartThemeBorderColor, #555) 28%, transparent);
+    border: 1px dashed color-mix(in srgb, var(--SmartThemeBorderColor, #555) 62%, transparent);
+    opacity: 0.6;
+}
+
 @keyframes ica--version-pulse {
     0%, 100% {
         box-shadow: 0 0 0 0 color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 0%, transparent);

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -585,7 +585,11 @@ describe('chat integrity rotation', () => {
         await fs.mkdir(path.dirname(chatFile), { recursive: true });
         await fs.mkdir(backupDir);
         const recoveryTarget = createCharacterChatTarget({ chatsDirectory, backupDirectory: backupDir, owner, filename: fileName });
-        await fs.writeFile(chatFile, chatWithIntegrity('existing-integrity', 'before').map(JSON.stringify).join('\n'));
+        // The saved chat has to shrink for the write to reach a resize at all: resizeFileSync
+        // skips ftruncateSync when writing already produced the target size, so an existing chat
+        // shorter than the new one never enters the step this test interrupts.
+        const existingMessage = 'before, and long enough that saving the new chat shrinks the file';
+        await fs.writeFile(chatFile, chatWithIntegrity('existing-integrity', existingMessage).map(JSON.stringify).join('\n'));
         const truncateSpy = jest.spyOn(fsSync, 'ftruncateSync').mockImplementationOnce(() => {
             throw Object.assign(new Error('I/O failure'), { code: 'EIO' });
         });

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -390,6 +390,69 @@ describe('companion tracker panel', () => {
         expect(panel.buildPanelHtml()).not.toContain('data-action="panel-hide-before"');
     });
 
+    test('keeps earlier shards listed after their host messages are hidden', async () => {
+        agents = [
+            { id: 'memory-shard', name: 'Memory Shard', sourceTemplateId: 'tpl-memory-shard-companion', execution: 'companion', enabled: true },
+        ];
+        const panel = await importPanel();
+
+        const olderShardHost = { is_user: false, is_system: false, mes: 'reply the first shard absorbed' };
+        const filler = { is_user: true, is_system: false, mes: 'keep going' };
+        const newerShardHost = { is_user: false, is_system: false, mes: 'latest reply' };
+        chat.push(olderShardHost, filler, newerShardHost);
+        companionResultsByMessage.set(olderShardHost, {
+            'memory-shard': { status: 'done', content: '# MEMORY SHARD: A-1', agentName: 'Memory Shard' },
+        });
+        companionResultsByMessage.set(newerShardHost, {
+            'memory-shard': { status: 'done', content: '# MEMORY SHARD: A-2', agentName: 'Memory Shard' },
+        });
+
+        expect(panel.buildPanelHtml()).toContain('Previous states (1)');
+
+        // "Hide story above this shard" only flips is_system on the absorbed range.
+        olderShardHost.is_system = true;
+        filler.is_system = true;
+
+        const html = panel.buildPanelHtml();
+        expect(html).toContain('Previous states (1)');
+        expect(html).toMatch(/ica--tpanel-history-entry[\s\S]*?data-message-index="0"/);
+        expect(html).toContain('# MEMORY SHARD: A-1');
+        expect(html).toContain('ica--card-pill--absorbed');
+        // The newest shard is still on a visible host, so it keeps its rerun controls.
+        expect(html).toContain('data-action="panel-regenerate"');
+        // Everything above the newest shard is already hidden, so there is nothing left to absorb.
+        expect(html).not.toContain('data-action="panel-hide-before"');
+    });
+
+    test('drops rerun controls and compaction once the newest note sits on a hidden host', async () => {
+        agents = [
+            { id: 'memory-shard', name: 'Memory Shard', sourceTemplateId: 'tpl-memory-shard-companion', execution: 'companion', enabled: true },
+        ];
+        const panel = await importPanel();
+
+        const filler = { is_user: true, is_system: false, mes: 'opening' };
+        const shardHost = { is_user: false, is_system: false, mes: 'absorbed reply' };
+        chat.push(filler, shardHost);
+        companionResultsByMessage.set(shardHost, {
+            'memory-shard': { status: 'done', content: '# MEMORY SHARD: A-1', agentName: 'Memory Shard' },
+        });
+
+        expect(panel.buildPanelHtml()).toContain('data-action="panel-regenerate"');
+
+        shardHost.is_system = true;
+
+        const html = panel.buildPanelHtml();
+        // The note survives, but it cannot be re-run and cannot compact a range it sits inside.
+        expect(html).toContain('# MEMORY SHARD: A-1');
+        expect(html).toContain('data-host-hidden="true"');
+        expect(html).not.toContain('data-action="panel-regenerate"');
+        expect(html).not.toContain('data-action="panel-fix"');
+        expect(html).not.toContain('data-action="panel-hide-before"');
+        // Editing the stored text and jumping to the message still work.
+        expect(html).toContain('data-action="panel-edit-note"');
+        expect(html).toContain('data-action="panel-jump"');
+    });
+
     test('shows the panel empty state when nothing is enabled or stored', async () => {
         const panel = await importPanel();
 

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -2434,6 +2434,33 @@ describe('in-chat agent post-processing runner', () => {
         ]);
     });
 
+    test('keeps notes on hidden hosts in the prior-notes window so shards can consolidate', async () => {
+        const shard = createCompanionAgent({
+            id: 'memory-shard',
+            name: 'Memory Shard',
+            companion: { includeHistory: true, historyDepth: 3, contextMessages: 1 },
+        });
+        enabledAgents = [shard];
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        const olderShardHost = { mes: 'Absorbed reply.', name: 'Assistant', is_user: false, is_system: false, extra: {} };
+        const latestReply = { mes: 'Fresh visible reply.', name: 'Assistant', is_user: false, is_system: false, extra: {} };
+        chat.push(olderShardHost, latestReply);
+        companionRunner.setCompanionResult(olderShardHost, shard, { status: 'done', content: '# MEMORY SHARD: A-1' });
+
+        // "Hide story above this shard" only flips is_system; the shard note itself is untouched.
+        olderShardHost.is_system = true;
+
+        const prompt = (await companionRunner.buildCompanionPromptMessages(shard, 1))[1].content;
+
+        // The earlier shard is still available to consolidate against...
+        expect(prompt).toContain('Your previous notes');
+        expect(prompt).toContain('# MEMORY SHARD: A-1');
+        // ...while the story it absorbed stays out of the conversation window.
+        expect(prompt).not.toContain('Absorbed reply.');
+        expect(prompt).toContain('Fresh visible reply.');
+    });
+
     test('appends the repair instruction on fix runs', async () => {
         const fixCompanion = createCompanionAgent({ id: 'fix-companion' });
         enabledAgents = [fixCompanion];

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -417,13 +417,15 @@ describe('in-chat agent scoped enabled state', () => {
             trigger: 'manual',
             displayMode: 'hidden',
             format: 'html',
-            contextMessages: 50,
+            // Context Messages and Notes to keep have no upper bound: they are look-back dials,
+            // and a ceiling silently rewrote whatever the user saved.
+            contextMessages: 999,
             includeCharacterCard: true,
             includePersona: true,
             includeWorldInfo: true,
             includeHistory: true,
             includeInChatHistory: true,
-            chatHistoryDepth: 50,
+            chatHistoryDepth: 999,
             includeAllChatHistory: false,
             keepInChatHistoryWhenHostHidden: true,
             historyDepth: 1,
@@ -449,6 +451,24 @@ describe('in-chat agent scoped enabled state', () => {
             feedback: { depth: 'never' },
             maxTokens: 'never',
         })).toEqual(store.createDefaultCompanionConfig());
+
+        // The reported case: 200 survives a save/load round trip instead of snapping back to 50.
+        expect(store.normalizeCompanionConfig({
+            contextMessages: 200,
+            chatHistoryDepth: 200,
+        })).toEqual(expect.objectContaining({
+            contextMessages: 200,
+            chatHistoryDepth: 200,
+        }));
+
+        // The lower bound still holds.
+        expect(store.normalizeCompanionConfig({
+            contextMessages: 0,
+            chatHistoryDepth: -5,
+        })).toEqual(expect.objectContaining({
+            contextMessages: 1,
+            chatHistoryDepth: 1,
+        }));
     });
 
     test('normalizes category and execution independently for companion agents', async () => {

--- a/tests/server-plugin-manager.test.js
+++ b/tests/server-plugin-manager.test.js
@@ -101,6 +101,10 @@ function createReleaseRepository({ markerSymlinkTarget = '' } = {}) {
     runGit(sourcePath, 'remote', 'add', 'origin', repositoryUrl);
     runGit(sourcePath, 'push', 'origin', 'main', '--tags');
     runGit(root, 'clone', '--branch', 'v1.0.0', '--single-branch', repositoryUrl, pluginPath);
+    // The clone inherits nothing from sourcePath, so tests that commit into it need their own
+    // identity: CI runners have no global user.name/user.email and git refuses to author there.
+    runGit(pluginPath, 'config', 'user.name', 'SillyBunny Tests');
+    runGit(pluginPath, 'config', 'user.email', 'tests@example.invalid');
     fs.writeFileSync(path.join(pluginPath, '.cursor-key'), 'persistent-secret\n', { mode: 0o600 });
 
     return { root, pluginsRoot, pluginPath, repositoryUrl };

--- a/tests/util-write-atomic-fallback.test.js
+++ b/tests/util-write-atomic-fallback.test.js
@@ -220,7 +220,10 @@ describe('tryWriteFileSync atomic fallback', () => {
 
     test('keeps an interrupted guarded write invalid for recovery', () => {
         const filePath = createTargetPath();
-        fs.writeFileSync(filePath, '{"old":true}\n', 'utf8');
+        // The new bytes have to be shorter than the old ones for the write to reach a resize at
+        // all: resizeFileSync skips ftruncateSync when writing already produced the target size,
+        // which the sibling test above pins. A same-size payload never enters the failing step.
+        fs.writeFileSync(filePath, '{"old":true,"padding":"shrunk away by the new write"}\n', 'utf8');
         const checked = fs.statSync(filePath, { bigint: true });
         jest.spyOn(fs, 'ftruncateSync').mockImplementationOnce(() => {
             throw Object.assign(new Error('I/O failure'), { code: 'EIO' });


### PR DESCRIPTION
Memory Shard is bugged. When you click Hide story above this shard, it completely hides the previous shard state. It's still there but you can't see it anymore, which is annoying.
Context Messages is also visually bugged. Even after saving something around 200 messages, it reverts back to two digits (e.g. 50) but it can be confirmed that 200 messages are considered.

Added "Absorbed" pill with tooltip: "The messages associated with this note are hidden from chat history, but this note remains as context seen by the LLM." for clarity's sake.