### PR TITLE
fix(world_info): fix certain values being simplified, instead it now leaves values verbatim

### DIFF
--- a/public/scripts/slash-commands/SlashCommandRuntimeUtils.js
+++ b/public/scripts/slash-commands/SlashCommandRuntimeUtils.js
@@ -38,6 +38,41 @@ export function readVariableValue(value) {
     return Number(value);
 }
 
+/**
+ * Whether an operand can take part in a numeric comparison.
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+export function isNumericOperand(value) {
+    if (typeof value === 'number') {
+        return true;
+    }
+    return typeof value === 'string' && value.trim() !== '' && !isNaN(Number(value));
+}
+
+/**
+ * Whether an operand is a numeric representation of zero.
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+export function isNumericZero(value) {
+    return isNumericOperand(value) && Number(value) === 0;
+}
+
+/**
+ * Converts a boolean operand to the string spelling used before formatted
+ * numeric variable values were preserved on read.
+ *
+ * @param {any} value
+ * @returns {string}
+ */
+export function booleanOperandToString(value) {
+    const comparableValue = isNumericOperand(value) ? Number(value) : value;
+    return (typeof comparableValue === 'string' ? comparableValue : JSON.stringify(comparableValue)).toLowerCase();
+}
+
 export function uuidv4() {
     if ('randomUUID' in crypto) {
         return crypto.randomUUID();

--- a/public/scripts/slash-commands/SlashCommandRuntimeUtils.js
+++ b/public/scripts/slash-commands/SlashCommandRuntimeUtils.js
@@ -18,8 +18,9 @@ export function isTrueBoolean(arg) {
  * value is fine; only the read loses the text. Converting only when the number renders
  * back to the same characters keeps every genuinely numeric value behaving as before.
  *
- * Lives in this leaf module because both readers need it and variables.js imports
- * SlashCommandScope.js, so a shared helper in either of those would be circular.
+ * Lives in this leaf module because getLocalVariable, getGlobalVariable, and
+ * SlashCommandScope.getVariable all need it, while variables.js imports
+ * SlashCommandScope.js. A shared helper in either of those would be circular.
  *
  * @param {any} value Raw stored value.
  * @returns {any} The number, or the value unchanged.

--- a/public/scripts/slash-commands/SlashCommandRuntimeUtils.js
+++ b/public/scripts/slash-commands/SlashCommandRuntimeUtils.js
@@ -10,6 +10,34 @@ export function isTrueBoolean(arg) {
     return ['on', 'true', '1'].includes(arg?.trim?.()?.toLowerCase?.() ?? '');
 }
 
+/**
+ * Reads a stored variable value, converting it to a number where that is lossless.
+ *
+ * SillyBunny diverges from upstream here: upstream returns Number(value) for anything
+ * numeric-looking, which rewrites '00' to 0 and '0.50' to 0.5 on every read. The stored
+ * value is fine; only the read loses the text. Converting only when the number renders
+ * back to the same characters keeps every genuinely numeric value behaving as before.
+ *
+ * Lives in this leaf module because both readers need it and variables.js imports
+ * SlashCommandScope.js, so a shared helper in either of those would be circular.
+ *
+ * @param {any} value Raw stored value.
+ * @returns {any} The number, or the value unchanged.
+ */
+export function readVariableValue(value) {
+    if (value?.trim?.() === '' || isNaN(Number(value))) {
+        return value || '';
+    }
+
+    // Non-strings arrive from the index path via JSON.parse. Number(false) is 0 but
+    // Number('false') is NaN, so they must not be compared as text.
+    if (typeof value === 'string' && String(Number(value)) !== value.trim()) {
+        return value;
+    }
+
+    return Number(value);
+}
+
 export function uuidv4() {
     if ('randomUUID' in crypto) {
         return crypto.randomUUID();

--- a/public/scripts/slash-commands/SlashCommandScope.js
+++ b/public/scripts/slash-commands/SlashCommandScope.js
@@ -98,6 +98,8 @@ export class SlashCommandScope {
                 return v ?? '';
             } else {
                 const value = this.variables[key];
+                // SillyBunny preserves formatted numeric text for scoped variables;
+                // the shared reader keeps this fork-specific behavior in one place.
                 return readVariableValue(value);
             }
         }

--- a/public/scripts/slash-commands/SlashCommandScope.js
+++ b/public/scripts/slash-commands/SlashCommandScope.js
@@ -1,5 +1,5 @@
 import { SlashCommandClosure } from './SlashCommandClosure.js';
-import { convertValueType } from './SlashCommandRuntimeUtils.js';
+import { convertValueType, readVariableValue } from './SlashCommandRuntimeUtils.js';
 
 export class SlashCommandScope {
     /** @type {string[]} */ variableNames = [];
@@ -98,7 +98,7 @@ export class SlashCommandScope {
                 return v ?? '';
             } else {
                 const value = this.variables[key];
-                return (value?.trim?.() === '' || isNaN(Number(value))) ? (value || '') : Number(value);
+                return readVariableValue(value);
             }
         }
         if (this.parent) {

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -13,6 +13,7 @@ import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { slashCommandReturnHelper } from './slash-commands/SlashCommandReturnHelper.js';
 import { SlashCommandScope } from './slash-commands/SlashCommandScope.js';
 import { isFalseBoolean, convertValueType, isTrueBoolean } from './utils.js';
+import { readVariableValue } from './slash-commands/SlashCommandRuntimeUtils.js';
 
 /** @typedef {import('./slash-commands/SlashCommandParser.js').NamedArguments} NamedArguments */
 /** @typedef {import('./slash-commands/SlashCommand.js').UnnamedArguments} UnnamedArguments */
@@ -42,7 +43,7 @@ export function getLocalVariable(name, args = {}) {
         }
     }
 
-    return (localVariable?.trim?.() === '' || isNaN(Number(localVariable))) ? (localVariable || '') : Number(localVariable);
+    return readVariableValue(localVariable);
 }
 
 export function setLocalVariable(name, value, args = {}) {
@@ -99,7 +100,7 @@ export function getGlobalVariable(name, args = {}) {
         }
     }
 
-    return (globalVariable?.trim?.() === '' || isNaN(Number(globalVariable))) ? (globalVariable || '') : Number(globalVariable);
+    return readVariableValue(globalVariable);
 }
 
 export function setGlobalVariable(name, value, args = {}) {
@@ -491,6 +492,19 @@ export function parseBooleanOperands(args) {
  * @param {string|number?} b The right operand
  * @returns {boolean} True if the rule yields true, false otherwise
  */
+/**
+ * Whether an operand can take part in a numeric comparison.
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isNumericOperand(value) {
+    if (typeof value === 'number') {
+        return true;
+    }
+    return typeof value === 'string' && value.trim() !== '' && !isNaN(Number(value));
+}
+
 export function evalBoolean(rule, a, b) {
     if (a === undefined) {
         throw new Error('Left operand is not provided');
@@ -514,7 +528,11 @@ export function evalBoolean(rule, a, b) {
     // If no rule was provided, we are implicitly using 'eq', as defined for the slash commands
     rule ??= 'eq';
 
-    if (typeof a === 'number' && typeof b === 'number') {
+    // SillyBunny: upstream tests `typeof === 'number'` here, which relied on the variable
+    // readers coercing on the way out. They no longer do that for values whose text would
+    // change (see readVariableValue), so a padded '007' would reach the string switch and
+    // throw for gt/gte/lt/lte. Accept numeric-looking strings so the comparison still runs.
+    if (isNumericOperand(a) && isNumericOperand(b)) {
         // only do numeric comparison if both operands are numbers
         const aNumber = Number(a);
         const bNumber = Number(b);

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -13,7 +13,7 @@ import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { slashCommandReturnHelper } from './slash-commands/SlashCommandReturnHelper.js';
 import { SlashCommandScope } from './slash-commands/SlashCommandScope.js';
 import { isFalseBoolean, convertValueType, isTrueBoolean } from './utils.js';
-import { readVariableValue } from './slash-commands/SlashCommandRuntimeUtils.js';
+import { booleanOperandToString, isNumericOperand, isNumericZero, readVariableValue } from './slash-commands/SlashCommandRuntimeUtils.js';
 
 /** @typedef {import('./slash-commands/SlashCommandParser.js').NamedArguments} NamedArguments */
 /** @typedef {import('./slash-commands/SlashCommand.js').UnnamedArguments} UnnamedArguments */
@@ -492,19 +492,6 @@ export function parseBooleanOperands(args) {
  * @param {string|number?} b The right operand
  * @returns {boolean} True if the rule yields true, false otherwise
  */
-/**
- * Whether an operand can take part in a numeric comparison.
- *
- * @param {any} value
- * @returns {boolean}
- */
-function isNumericOperand(value) {
-    if (typeof value === 'number') {
-        return true;
-    }
-    return typeof value === 'string' && value.trim() !== '' && !isNaN(Number(value));
-}
-
 export function evalBoolean(rule, a, b) {
     if (a === undefined) {
         throw new Error('Left operand is not provided');
@@ -518,6 +505,10 @@ export function evalBoolean(rule, a, b) {
                 const resultOnTruthy = rule !== 'not';
                 if (isTrueBoolean(String(a))) return resultOnTruthy;
                 if (isFalseBoolean(String(a))) return !resultOnTruthy;
+                // Variable reads preserve numeric text such as "00" so formatted
+                // values survive round-trips. Keep upstream truthiness for those
+                // values: every numeric spelling of zero was previously read as 0.
+                if (isNumericZero(a)) return !resultOnTruthy;
                 return a ? resultOnTruthy : !resultOnTruthy;
             }
             default:
@@ -560,9 +551,11 @@ export function evalBoolean(rule, a, b) {
         }
     }
 
-    // otherwise do case-insensitive string comparsion, stringify non-strings
-    let aString = (typeof a === 'string') ? a.toLowerCase() : JSON.stringify(a).toLowerCase();
-    let bString = (typeof b === 'string') ? b.toLowerCase() : JSON.stringify(b).toLowerCase();
+    // Otherwise do case-insensitive string comparison. Numeric-looking strings
+    // must use their canonical numeric spelling, as upstream readers returned
+    // numbers before readVariableValue started preserving formatted text.
+    const aString = booleanOperandToString(a);
+    const bString = booleanOperandToString(b);
 
     switch (rule) {
         case 'in':

--- a/tests/variables-read-coercion.test.js
+++ b/tests/variables-read-coercion.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { readVariableValue } from '../public/scripts/slash-commands/SlashCommandRuntimeUtils.js';
+
+// readVariableValue backs all three variable readers: getLocalVariable and
+// getGlobalVariable in public/scripts/variables.js, and SlashCommandScope.getVariable
+// for scoped (/let, /var) variables. Those modules pull in browser-only code and cannot
+// be imported here, so the shared helper is what gets covered.
+
+/** The expression this replaced, verbatim, for parity checks. */
+const upstream = (value) =>
+    ((value?.trim?.() === '' || isNaN(Number(value))) ? (value || '') : Number(value));
+
+/** Values upstream rewrites on read; the whole point of the change. */
+const LOSSY = ['00', '007', '0.50', '1.10', '+5', '.5', '1e3', '0x10', '-0'];
+
+/** Values that must keep behaving exactly as they always have. */
+const UNCHANGED = [
+    ['5', 5],
+    ['12.5', 12.5],
+    ['-3', -3],
+    ['0', 0],
+    ['1000', 1000],
+    ['-0.25', -0.25],
+    ['  5  ', 5],
+    ['abc', 'abc'],
+    ['5 apples', '5 apples'],
+    ['true', 'true'],
+    ['', ''],
+];
+
+describe('reading a variable that is plainly numeric', () => {
+    test('numeric text still reads back as a number', () => {
+        for (const [stored, expected] of UNCHANGED) {
+            expect(readVariableValue(stored)).toBe(expected);
+        }
+    });
+
+    test('surrounding whitespace is still tolerated', () => {
+        expect(readVariableValue('  5  ')).toBe(5);
+    });
+});
+
+describe('reading a variable whose text a number would change', () => {
+    test('the stored text is returned unchanged', () => {
+        for (const stored of LOSSY) {
+            expect(readVariableValue(stored)).toBe(stored);
+        }
+    });
+
+    test('a zero-padded clock minute survives, which is the reported symptom', () => {
+        expect(readVariableValue('00')).toBe('00');
+        expect(`7:${readVariableValue('00')}`).toBe('7:00');
+    });
+});
+
+describe('reading a variable that is not numeric', () => {
+    test('a whitespace-only value is preserved, not turned into 0', () => {
+        // Guarded upstream since 4336253b2; Number('   ') is 0, which is what that
+        // commit was fixing. Kept exactly as it was.
+        expect(readVariableValue('   ')).toBe('   ');
+    });
+
+    test('unset and null keep their existing, differing results', () => {
+        // Not a distinction worth changing here: both are upstream behaviour and
+        // altering either would be a separate change with its own blast radius.
+        expect(readVariableValue(undefined)).toBe('');
+        expect(readVariableValue(null)).toBe(0);
+    });
+});
+
+describe('values arriving from the index path', () => {
+    // getLocalVariable/getGlobalVariable JSON.parse the value when args.index is set,
+    // so the helper can be handed a number or a boolean rather than a string. Those
+    // must keep their old behaviour: Number(false) is 0, but Number('false') is NaN.
+    test('numbers pass straight through', () => {
+        expect(readVariableValue(5)).toBe(5);
+        expect(readVariableValue(0)).toBe(0);
+        expect(readVariableValue(-2.5)).toBe(-2.5);
+    });
+
+    test('booleans still read as 1 and 0, as they did before', () => {
+        expect(readVariableValue(true)).toBe(1);
+        expect(readVariableValue(false)).toBe(0);
+    });
+});
+
+describe('parity with the upstream expression', () => {
+    test('every value except the lossy ones matches upstream exactly', () => {
+        const sameAsBefore = [
+            ...UNCHANGED.map(([stored]) => stored),
+            '   ', undefined, null, 5, 0, true, false,
+        ];
+        for (const value of sameAsBefore) {
+            expect(readVariableValue(value)).toBe(upstream(value));
+        }
+    });
+
+    test('the only differences are values upstream would rewrite', () => {
+        for (const value of LOSSY) {
+            expect(readVariableValue(value)).toBe(value);
+            expect(upstream(value)).not.toBe(value);
+        }
+    });
+});
+
+describe('arithmetic callers still work', () => {
+    // addLocalVariable/addGlobalVariable re-read through the helper and then apply
+    // Number() themselves, so a preserved string must still add up correctly.
+    test('a padded value still adds numerically', () => {
+        const current = readVariableValue('00');
+        expect(current).toBe('00');
+        expect(Number(current) + 5).toBe(5);
+    });
+
+    test('a padded counter increments to a plain number', () => {
+        expect(Number(readVariableValue('007')) + 1).toBe(8);
+    });
+
+    test('the || 0 fallback in addLocalVariable is unaffected', () => {
+        // '0' stays the number 0 (falsy), and '00' becomes a truthy string, but both
+        // yield 0 once Number() is applied, which is all the caller does with it.
+        expect(Number(readVariableValue('0') || 0)).toBe(0);
+        expect(Number(readVariableValue('00') || 0)).toBe(0);
+    });
+});

--- a/tests/variables-read-coercion.test.js
+++ b/tests/variables-read-coercion.test.js
@@ -1,8 +1,13 @@
 import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
     booleanOperandToString,
+    isNumericOperand,
     isNumericZero,
+    isTrueBoolean,
     readVariableValue,
 } from '../public/scripts/slash-commands/SlashCommandRuntimeUtils.js';
 
@@ -145,5 +150,76 @@ describe('boolean callers retain upstream semantics', () => {
         expect(booleanOperandToString(readVariableValue('0.50'))).toBe('0.5');
         expect(booleanOperandToString(readVariableValue('+Infinity'))).toBe('null');
         expect(booleanOperandToString('Needle')).toBe('needle');
+    });
+});
+
+// The helpers above only prove the pieces behave; they say nothing about evalBoolean
+// actually calling them. variables.js and utils.js both import script.js, so neither can
+// be imported here. Lift the two functions out as source and run them for real, the same
+// way the *-wiring tests reach logic stranded inside script.js.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function getFunctionSource(source, name) {
+    const start = source.indexOf(`function ${name}(`);
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index++) {
+        if (source[index] === '{') {
+            depth++;
+        } else if (source[index] === '}') {
+            depth--;
+            if (depth === 0) {
+                return source.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+const isFalseBoolean = new Function(`${getFunctionSource(
+    readFileSync(path.join(repoRoot, 'public', 'scripts', 'utils.js'), 'utf8'), 'isFalseBoolean',
+)}; return isFalseBoolean;`)();
+
+const evalBoolean = new Function(
+    'isTrueBoolean', 'isFalseBoolean', 'isNumericOperand', 'isNumericZero', 'booleanOperandToString',
+    `${getFunctionSource(
+        readFileSync(path.join(repoRoot, 'public', 'scripts', 'variables.js'), 'utf8'), 'evalBoolean',
+    )}; return evalBoolean;`,
+)(isTrueBoolean, isFalseBoolean, isNumericOperand, isNumericZero, booleanOperandToString);
+
+describe('evalBoolean is wired to those helpers', () => {
+    test('every numeric spelling of zero is still falsy', () => {
+        for (const stored of ['00', '-0', '+0', '0.0', '0e0', '0x0', '-00.0']) {
+            expect(evalBoolean(undefined, readVariableValue(stored), undefined)).toBe(false);
+            expect(evalBoolean('not', readVariableValue(stored), undefined)).toBe(true);
+        }
+    });
+
+    test('padded non-zero values stay truthy, so the zero guard does not overreach', () => {
+        for (const stored of ['007', '01', '0.50']) {
+            expect(evalBoolean(undefined, readVariableValue(stored), undefined)).toBe(true);
+            expect(evalBoolean('not', readVariableValue(stored), undefined)).toBe(false);
+        }
+    });
+
+    test('containment compares the canonical spelling, not the padding', () => {
+        // '007'.includes('0') was true while the reader preserved the text and the string
+        // branch did not canonicalise. Upstream read 7 and answered false.
+        expect(evalBoolean('in', readVariableValue('007'), 0)).toBe(false);
+        expect(evalBoolean('nin', readVariableValue('007'), 0)).toBe(true);
+        expect(evalBoolean('in', readVariableValue('1e3'), 100)).toBe(true);
+        expect(evalBoolean('eq', readVariableValue('0.50'), 'half')).toBe(false);
+    });
+
+    test('preserved text still takes the numeric branch instead of throwing', () => {
+        expect(evalBoolean('gt', readVariableValue('007'), 5)).toBe(true);
+        expect(evalBoolean('lte', readVariableValue('0.50'), 0.5)).toBe(true);
+        expect(evalBoolean('eq', readVariableValue('0.50'), 0.5)).toBe(true);
+        expect(evalBoolean('neq', readVariableValue('00'), 0)).toBe(false);
+        expect(() => evalBoolean('gt', readVariableValue('abc'), 5)).toThrow();
     });
 });

--- a/tests/variables-read-coercion.test.js
+++ b/tests/variables-read-coercion.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { readVariableValue } from '../public/scripts/slash-commands/SlashCommandRuntimeUtils.js';
+import {
+    booleanOperandToString,
+    isNumericZero,
+    readVariableValue,
+} from '../public/scripts/slash-commands/SlashCommandRuntimeUtils.js';
 
 // readVariableValue backs all three variable readers: getLocalVariable and
 // getGlobalVariable in public/scripts/variables.js, and SlashCommandScope.getVariable
@@ -122,5 +126,24 @@ describe('arithmetic callers still work', () => {
         // yield 0 once Number() is applied, which is all the caller does with it.
         expect(Number(readVariableValue('0') || 0)).toBe(0);
         expect(Number(readVariableValue('00') || 0)).toBe(0);
+    });
+});
+
+describe('boolean callers retain upstream semantics', () => {
+    test('alternate numeric spellings of zero stay falsy', () => {
+        for (const value of ['00', '-0', '+0', '0.0', '0e0', '0x0']) {
+            expect(readVariableValue(value)).toBe(value);
+            expect(isNumericZero(readVariableValue(value))).toBe(true);
+        }
+        expect(isNumericZero('0.01')).toBe(false);
+        expect(isNumericZero('off')).toBe(false);
+    });
+
+    test('containment uses the numeric spelling upstream readers produced', () => {
+        expect(booleanOperandToString(readVariableValue('007'))).toBe('7');
+        expect(booleanOperandToString(readVariableValue('1e3'))).toBe('1000');
+        expect(booleanOperandToString(readVariableValue('0.50'))).toBe('0.5');
+        expect(booleanOperandToString(readVariableValue('+Infinity'))).toBe('null');
+        expect(booleanOperandToString('Needle')).toBe('needle');
     });
 });


### PR DESCRIPTION
An upstream SillyTavern bug makes some specific features not work due to how it simplifies values. 00 comes back as 0, 007 as 7, 0.50 as 0.5. This is normal for regular use case, but it causes compatibility errors with https://github.com/SillyBunnyTeam/SillyBunny-MacroEnhanced which uses more advanced macros. The time/clock macro would show up as 7:0 PM instead of 7:00 PM for example.

This fix makes the numeric values be rendered verbatim rather than simplified.

Essentially this is a compatibility fix to help macro expansions without changing anything huge. Could be beneficial in fact to keep it verbatim.

For reviewers: Seeking if this is low-risk as it fixes an upstream ST bug.