### PR TITLE
fix: fix CharacterLibrary and ST-CoPilot incompatibilities

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1013,6 +1013,7 @@
         min-height: var(--sb-mobile-touch-target, 44px);
     }
 
+    /* SillyBunny divergence: text-labelled icon controls may expand beyond upstream square sizing. */
     .menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
     .menu_button_icon:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
     .right_menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1021,13 +1021,11 @@
     .menu_button:not(.sb-server-action):not(.api_button):not(.openrouter_authorize):not(#bg_selection_mode_button):not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child),
     .menu_button:not(.sb-server-action):not(.api_button):not(.openrouter_authorize):not(#bg_selection_mode_button):not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> input[hidden] + :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):last-child),
     .right_menu_button:not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child) {
-        width: var(--sb-control-icon-physical-size, 44px);
+        width: auto;
         min-width: var(--sb-control-icon-physical-size, 44px);
-        max-width: var(--sb-control-icon-physical-size, 44px);
-        height: var(--sb-control-icon-physical-size, 44px);
+        height: auto;
         min-height: var(--sb-control-icon-physical-size, 44px);
-        max-height: var(--sb-control-icon-physical-size, 44px);
-        padding: 0 !important;
+        padding: 0 6px !important;
     }
 
     .menu_button.sb-accent-preset,

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -128,15 +128,15 @@
         gap: 3px !important;
     }
 
-    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#qig-input-btn):not(.stscript_btn) {
-        display: none !important;
-    }
-
-    /* SillyBunny: the STscript execution play/pause/stop controls (.stscript_btn)
-       are unused by this fork's roleplay-focused audience. mobile-styles.css
-       forces them to display:flex (see #533), which lets them overlap the
-       composer textarea on mobile. Hide them unconditionally here -- this sheet
-       loads after mobile-styles.css so the !important wins. */
+    /* SillyBunny: name what the phone composer hides instead of allow-listing what it keeps.
+       The old allow-list also swallowed every third-party button injected into the right rail;
+       those are now relocated into the scrollable left rail by placeComposerControls().
+       The STscript play/pause/stop controls are unused by this fork's roleplay-focused audience
+       and mobile-styles.css forces them to display:flex (see #533), where they overlap the
+       textarea -- this sheet loads after it so the !important wins. */
+    #rightSendForm > #mes_impersonate,
+    #rightSendForm > #mes_continue,
+    #rightSendForm > #sb_prose_polisher_but,
     #rightSendForm > .stscript_btn {
         display: none !important;
     }
@@ -1322,6 +1322,15 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         width: var(--sb-mobile-toggle-size);
         height: var(--sb-mobile-toggle-size);
         min-height: var(--sb-mobile-toggle-size);
+    }
+
+    /* Adopted third-party buttons follow the same target size as everything else in the bar.
+       This sheet loads after sillybunny-tabs.css, so the equal-specificity tie goes here. */
+    #sb-topbar-extension-slot .drawer-icon,
+    #sb-topbar-extension-slot .menu_button {
+        width: var(--sb-mobile-toggle-size);
+        height: var(--sb-mobile-toggle-size);
+        min-width: var(--sb-mobile-toggle-size);
     }
 
     /* Visibility and seam handling live in sillybunny-tabs.css; the phone bar only shortens

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1324,17 +1324,23 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         min-height: var(--sb-mobile-toggle-size);
     }
 
-    /* Adopted third-party buttons follow the same target size as everything else in the bar.
+    /* Adopted third-party buttons keep the same minimum target size as the rest of the bar.
+       Icon-only controls stay square while text-bearing controls can grow to fit their label.
        This sheet loads after sillybunny-tabs.css, so the equal-specificity tie goes here. */
     #sb-topbar-extension-slot .drawer-icon,
-    #sb-topbar-extension-slot .menu_button {
-        width: var(--sb-mobile-toggle-size);
+    #sb-topbar-extension-slot .menu_button,
+    #top-bar #sb-topbar-extension-slot .drawer-icon,
+    #top-bar #sb-topbar-extension-slot .menu_button {
+        width: auto;
+        inline-size: auto;
         height: var(--sb-mobile-toggle-size);
+        min-height: var(--sb-mobile-toggle-size);
         min-width: var(--sb-mobile-toggle-size);
+        min-inline-size: var(--sb-mobile-toggle-size);
     }
 
     /* Visibility and seam handling live in sillybunny-tabs.css; the phone bar only shortens
-       the rule to match its smaller squares. */
+       the icon-only target to match its smaller squares. */
     .sb-topbar-cluster-divider {
         height: calc(var(--sb-mobile-toggle-size) * 0.5);
     }

--- a/public/css/sillybunny-paper-theme.css
+++ b/public/css/sillybunny-paper-theme.css
@@ -64,9 +64,10 @@ body::after {
 }
 
 #top-bar .drawer-toggle,
-#top-bar .menu_button,
+#top-bar .menu_button:not(#sb-topbar-extension-slot .menu_button),
 #topBar .drawer-toggle,
-#topBar .menu_button {
+#topBar .menu_button:not(#sb-topbar-extension-slot .menu_button) {
+    /* Adopted controls use the slot's own minimum-size contract so text labels can expand. */
     min-height: var(--topBarIconSize) !important;
     height: var(--topBarIconSize) !important;
     width: var(--topBarIconSize) !important;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1534,12 +1534,25 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 #sb-topbar-extension-slot .drawer-icon,
-#sb-topbar-extension-slot .menu_button {
-    width: var(--sb-proxy-button-height);
+#sb-topbar-extension-slot .menu_button,
+#top-bar #sb-topbar-extension-slot .drawer-icon,
+#top-bar #sb-topbar-extension-slot .menu_button {
+    width: auto;
+    inline-size: auto;
     height: var(--sb-proxy-button-height);
+    min-height: var(--sb-proxy-button-height);
     min-width: var(--sb-proxy-button-height);
+    min-inline-size: var(--sb-proxy-button-height);
     padding: 0;
     margin: 0;
+}
+
+#sb-topbar-extension-slot .menu_button,
+#top-bar #sb-topbar-extension-slot .menu_button {
+    max-width: none;
+    max-inline-size: min(12rem, 45vw);
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 /* .sb-proxy-button clips itself with overflow:hidden, which would eat a mirrored badge. */

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -13,6 +13,9 @@
     --sb-topbar-scale-active: var(--sb-topbar-scale-desktop);
     --sb-chatbar-scale-active: calc(var(--sb-topbar-scale-active) * var(--sb-bottom-bar-scale));
     --sb-topbar-primary-height-base: var(--topBarBlockSize);
+    /* Snapshot of the upstream bar height under a name this fork never overrides, so a rule can
+       scope --topBarBlockSize on an element without a self-reference cycle. */
+    --sb-host-topbar-block-size: var(--topBarBlockSize);
     --sb-topbar-padding-x-base: 10px;
     --sb-topbar-stack-gap-base: 4px;
     --sb-topbar-bottom-padding-base: 4px;
@@ -248,9 +251,19 @@
     pointer-events: auto;
 }
 
-/* SillyBunny: allow extension drawers (non-native) to be clickable despite parent pointer-events: none. */
+/*
+ * SillyBunny: allow extension drawers (non-native) to be clickable despite parent pointer-events: none.
+ * The box normalization matters as much as the pointer-events: upstream's bare `.drawer { width: 100% }`
+ * makes an injected drawer the only non-zero flex child of this fixed full-width strip, which then paints
+ * over the whole top bar and swallows every click. adoptTopbarExtensionNodes() moves these into the bar
+ * proper, so this is the pre-adoption frame and the opt-out path; the nine :not(#id) each contribute an
+ * ID, so the selector outranks `.drawer` on specificity alone.
+ */
 #top-settings-holder > .drawer:not(#ai-config-button):not(#sys-settings-button):not(#advanced-formatting-button):not(#WI-SP-button):not(#user-settings-button):not(#backgrounds-button):not(#extensions-settings-button):not(#persona-management-button):not(#rightNavHolder) {
     pointer-events: auto;
+    width: auto;
+    min-width: 0;
+    flex: 0 0 auto;
 }
 
 #top-bar {
@@ -1486,6 +1499,64 @@ body:not(.movingUI) .drawer-content.maximized {
 #top-settings-holder .popup,
 #top-settings-holder .popup * {
     pointer-events: auto;
+}
+
+/*
+ * SillyBunny: third-party top-bar buttons are adopted into this slot by
+ * adoptTopbarExtensionNodes() so they become real members of the bar rather than overlays
+ * floating above it. Every selector here carries the slot id, which outranks upstream's bare
+ * `.drawer` / `.drawer-icon` / `.menu_button` rules on specificity alone.
+ */
+#sb-topbar-extension-slot {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    gap: var(--sb-topbar-group-gap);
+    min-width: 0;
+}
+
+/*
+ * display:none rather than zero width: syncTopbarBrandFit() adds one inline gap per visible
+ * child, so an empty-but-visible slot would inflate the overflow verdict by a gap.
+ */
+#sb-topbar-extension-slot[data-sb-topbar-slot-empty='true'] {
+    display: none;
+}
+
+#sb-topbar-extension-slot > * {
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
+#sb-topbar-extension-slot > .drawer {
+    width: auto;
+    max-width: 100%;
+}
+
+#sb-topbar-extension-slot .drawer-icon,
+#sb-topbar-extension-slot .menu_button {
+    width: var(--sb-proxy-button-height);
+    height: var(--sb-proxy-button-height);
+    min-width: var(--sb-proxy-button-height);
+    padding: 0;
+    margin: 0;
+}
+
+/* .sb-proxy-button clips itself with overflow:hidden, which would eat a mirrored badge. */
+.sb-proxy-button.sb-has-adopted-badge {
+    overflow: visible;
+}
+
+/*
+ * SillyBunny: CharacterLibrary anchors its embedded panel to --topBarBlockSize, which only
+ * covers the primary row; when the chat bar row is showing, the panel painted over the bottom
+ * of the bar. Scoping the variable to the container re-anchors both its inline top and height.
+ * The max() is needed because neither input alone clears the bar in every state: on phones the
+ * layout offset sits just above the bar's bottom edge, and on desktop the upstream height stops
+ * short of the chat bar row. Both operands are substituted at :root, so there is no cycle.
+ */
+#charlib-embedded-container {
+    --topBarBlockSize: max(var(--sb-host-topbar-block-size), var(--sb-topbar-layout-offset));
 }
 
 #left-nav-panel select {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -939,7 +939,8 @@ h3:not(.popup h3):not(#chat h3) {
      * -- matched this rule and had its label squashed out of a 38px box. A genuinely icon-only
      * button still lands exactly on the square, because its content never reaches the minimum.
      * The hardcoded :not() exclusions on the selectors above are older, per-case patches for the
-     * same over-match.
+     * same over-match. Horizontal padding stays at zero so an oversized svg or img child cannot
+     * push a genuinely icon-only control wider than it is tall.
      */
     width: auto;
     inline-size: auto;
@@ -956,7 +957,7 @@ h3:not(.popup h3):not(#chat h3) {
     justify-content: center;
     gap: 6px;
     flex: 0 0 auto;
-    padding: 0 10px !important;
+    padding: 0 !important;
     margin: 0;
     border-radius: var(--sb-icon-control-radius);
     box-sizing: border-box;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -964,6 +964,24 @@ h3:not(.popup h3):not(#chat h3) {
     overflow: visible;
 }
 
+/*
+ * SillyBunny: the rule above is sized by a minimum so a bare-text label can grow the pill. An
+ * :empty element has no children at all, not even a text node, so it can never carry such a label
+ * -- re-pin the square for those three selectors. aspect-ratio is the load-bearing one:
+ * connection-manager's mobile rule sets the block axis from a width-derived percentage that never
+ * resolves there, and it outweighs anything this sheet can say, so with height: auto and nothing
+ * else holding the box up the button collapses to the height of the glyph's line box.
+ */
+.menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
+.menu_button_icon:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
+.right_menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty {
+    max-width: var(--sb-control-icon-physical-size);
+    max-inline-size: var(--sb-control-icon-physical-size);
+    max-height: var(--sb-control-icon-physical-size);
+    max-block-size: var(--sb-control-icon-physical-size);
+    aspect-ratio: 1 / 1;
+}
+
 .menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty::before,
 .menu_button_icon:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty::before,
 .right_menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty::before {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -932,26 +932,33 @@ h3:not(.popup h3):not(#chat h3) {
 .menu_button:not(.sb-server-action):not(.api_button):not(.openrouter_authorize):not(#bg_selection_mode_button):not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child),
 .menu_button:not(.sb-server-action):not(.api_button):not(.openrouter_authorize):not(#bg_selection_mode_button):not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> input[hidden] + :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):last-child),
 .right_menu_button:not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child) {
-    width: var(--sb-control-icon-physical-size);
-    inline-size: var(--sb-control-icon-physical-size);
+    /*
+     * SillyBunny: sized by a minimum rather than a fixed square. The :only-child test above sees
+     * element children only, so a button whose label is a bare text node -- the common
+     * third-party shape, e.g. <button class="menu_button"><i class="fa-solid fa-x"></i>Open</button>
+     * -- matched this rule and had its label squashed out of a 38px box. A genuinely icon-only
+     * button still lands exactly on the square, because its content never reaches the minimum.
+     * The hardcoded :not() exclusions on the selectors above are older, per-case patches for the
+     * same over-match.
+     */
+    width: auto;
+    inline-size: auto;
     height: var(--sb-control-icon-physical-size);
     block-size: var(--sb-control-icon-physical-size);
     min-width: var(--sb-control-icon-physical-size);
     min-inline-size: var(--sb-control-icon-physical-size);
     min-height: var(--sb-control-icon-physical-size);
     min-block-size: var(--sb-control-icon-physical-size);
-    max-width: var(--sb-control-icon-physical-size);
-    max-inline-size: var(--sb-control-icon-physical-size);
     max-height: var(--sb-control-icon-physical-size);
     max-block-size: var(--sb-control-icon-physical-size);
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     flex: 0 0 auto;
-    padding: 0 !important;
+    padding: 0 10px !important;
     margin: 0;
     border-radius: var(--sb-icon-control-radius);
-    aspect-ratio: 1 / 1;
     box-sizing: border-box;
     line-height: 1;
     text-align: center;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -939,25 +939,23 @@ h3:not(.popup h3):not(#chat h3) {
      * -- matched this rule and had its label squashed out of a 38px box. A genuinely icon-only
      * button still lands exactly on the square, because its content never reaches the minimum.
      * The hardcoded :not() exclusions on the selectors above are older, per-case patches for the
-     * same over-match. Horizontal padding stays at zero so an oversized svg or img child cannot
-     * push a genuinely icon-only control wider than it is tall.
+     * same over-match. The block axis is a minimum too: a narrow container can wrap such a label
+     * onto a second line, and a fixed height would push it outside the border.
      */
     width: auto;
     inline-size: auto;
-    height: var(--sb-control-icon-physical-size);
-    block-size: var(--sb-control-icon-physical-size);
+    height: auto;
+    block-size: auto;
     min-width: var(--sb-control-icon-physical-size);
     min-inline-size: var(--sb-control-icon-physical-size);
     min-height: var(--sb-control-icon-physical-size);
     min-block-size: var(--sb-control-icon-physical-size);
-    max-height: var(--sb-control-icon-physical-size);
-    max-block-size: var(--sb-control-icon-physical-size);
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 6px;
     flex: 0 0 auto;
-    padding: 0 !important;
+    padding: 0 6px !important;
     margin: 0;
     border-radius: var(--sb-icon-control-radius);
     box-sizing: border-box;
@@ -2077,19 +2075,15 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     .menu_button:not(.sb-server-action):not(.api_button):not(.openrouter_authorize):not(#bg_selection_mode_button):not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child),
     .menu_button:not(.sb-server-action):not(.api_button):not(.openrouter_authorize):not(#bg_selection_mode_button):not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> input[hidden] + :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):last-child),
     .right_menu_button:not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child) {
-        width: var(--sb-control-icon-physical-size);
-        inline-size: var(--sb-control-icon-physical-size);
-        height: var(--sb-control-icon-physical-size);
-        block-size: var(--sb-control-icon-physical-size);
+        width: auto;
+        inline-size: auto;
+        height: auto;
+        block-size: auto;
         min-width: var(--sb-control-icon-physical-size);
         min-inline-size: var(--sb-control-icon-physical-size);
         min-height: var(--sb-control-icon-physical-size);
         min-block-size: var(--sb-control-icon-physical-size);
-        max-width: var(--sb-control-icon-physical-size);
-        max-inline-size: var(--sb-control-icon-physical-size);
-        max-height: var(--sb-control-icon-physical-size);
-        max-block-size: var(--sb-control-icon-physical-size);
-        padding: 0 !important;
+        padding: 0 6px !important;
     }
 
     #chat .mes_edit_buttons {

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260727b" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260727b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260727c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725g">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725g" media="(max-width: 768px)">

--- a/public/index.html
+++ b/public/index.html
@@ -46,8 +46,8 @@
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260724a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260727a">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260727b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260727b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725g">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725g" media="(max-width: 768px)">

--- a/public/scripts/sillybunny-settings-tabs.js
+++ b/public/scripts/sillybunny-settings-tabs.js
@@ -73,11 +73,14 @@
             }
         }
 
-        /* Declarative visibility rules based on active tab */
-        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="appearance"] .inline-drawer:not([data-settings-tab="appearance"]),
-        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="chat-writing"] .inline-drawer:not([data-settings-tab="chat-writing"]),
-        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="system-device"] .inline-drawer:not([data-settings-tab="system-device"]),
-        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="cache-account"] .inline-drawer:not([data-settings-tab="cache-account"]) {
+        /* Declarative visibility rules based on active tab.
+           Only drawers that carry a tag are hidden. An untagged drawer -- a third-party one that
+           landed here after tagDrawersWithCategories() last ran -- stays visible rather than
+           vanishing from all four tabs; tagUntaggedDrawers() then settles it into one. */
+        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="appearance"] .inline-drawer[data-settings-tab]:not([data-settings-tab="appearance"]),
+        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="chat-writing"] .inline-drawer[data-settings-tab]:not([data-settings-tab="chat-writing"]),
+        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="system-device"] .inline-drawer[data-settings-tab]:not([data-settings-tab="system-device"]),
+        #user-settings-block-content:not([data-search-active="true"])[data-active-tab="cache-account"] .inline-drawer[data-settings-tab]:not([data-settings-tab="cache-account"]) {
             display: none !important;
         }
 
@@ -377,6 +380,39 @@
         }
     }
 
+    // Third-party extensions append their settings drawers long after initialize() runs, and the
+    // map above only knows this fork's own drawers. Give the leftovers a home so they show up in
+    // exactly one tab instead of every tab.
+    const DEFAULT_SETTINGS_TAB = 'system-device';
+
+    function tagUntaggedDrawers() {
+        const content = document.getElementById('user-settings-block-content');
+        if (!content) return;
+
+        content.querySelectorAll('.inline-drawer:not([data-settings-tab])').forEach(drawer => {
+            // A drawer nested inside an already-tagged section rides its parent's visibility.
+            if (drawer.parentElement?.closest('.inline-drawer[data-settings-tab]')) return;
+            drawer.setAttribute('data-settings-tab', DEFAULT_SETTINGS_TAB);
+        });
+    }
+
+    function watchForLateDrawers() {
+        const content = document.getElementById('user-settings-block-content');
+        if (!content || typeof MutationObserver === 'undefined') return;
+
+        let queued = 0;
+        const observer = new MutationObserver(() => {
+            if (queued) return;
+            queued = requestAnimationFrame(() => {
+                queued = 0;
+                tagDrawersWithCategories();
+                tagUntaggedDrawers();
+            });
+        });
+
+        observer.observe(content, { childList: true, subtree: true });
+    }
+
     function createTabBar() {
         const userSettingsContent = document.getElementById('user-settings-block-content');
         if (!userSettingsContent) return;
@@ -455,8 +491,10 @@
             promoteNestedDrawers();
             promoteCacheAccount();
             tagDrawersWithCategories();
+            tagUntaggedDrawers();
             createTabBar();
             setupSearchIntegration();
+            watchForLateDrawers();
         } catch (error) {
             console.error('[SillyBunny Settings Tabs] Initialization failed:', error);
         }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -15,6 +15,13 @@ import {
     PERSONA_APPENDICES_SELECTIONS_KEY,
 } from './sillybunny-conversation/constants.js';
 import { conversationState } from './sillybunny-conversation/state.js';
+import {
+    resolveCharacterBadgeMirrorPlan,
+    resolveTopbarAdoptionPlan,
+    TOPBAR_ADOPTED_MARKER_ATTRIBUTE,
+    TOPBAR_ADOPTION_ATTRIBUTE,
+    TOPBAR_EXTENSION_SLOT_ID,
+} from './topbar-extension-slot/index.js';
 import { escapeRegex } from './util/escape-regex.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
 import { flushCharacterSaveDebounced, getOneCharacter, getThumbnailUrl, parseAvatarSource, refreshCsrfToken, saveSettingsDebounced } from '../script.js';
@@ -821,6 +828,11 @@ const sbState = {
         syncFrame: 0,
         fitFrame: 0,
         brandWidth: 0,
+    },
+    topbarExtensions: {
+        syncFrame: 0,
+        adopting: false,
+        observer: null,
     },
     bottomBarScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.bottomBarScale)),
     desktopButtonScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.desktopButtonScale)),
@@ -1881,6 +1893,52 @@ function moveElementAfter(element, referenceElement, parent) {
     parent.insertBefore(element, referenceElement.nextSibling);
 }
 
+/*
+ * Everything upstream (plus the bundled palette button) ships in #rightSendForm. The phone
+ * composer sizes that rail for exactly two buttons, so anything else there is third-party.
+ */
+const SB_COMPOSER_NATIVE_RIGHT_RAIL_IDS = Object.freeze([
+    'stscript_continue',
+    'stscript_pause',
+    'stscript_stop',
+    'mes_stop',
+    'mes_impersonate',
+    'mes_continue',
+    'sb_prose_polisher_but',
+    'send_but',
+    'qig-input-btn',
+]);
+
+const SB_COMPOSER_ADOPTED_ATTRIBUTE = 'data-sb-composer-adopted';
+
+/**
+ * Relocates third-party composer buttons between the rails. The right rail is a fixed two-button
+ * grid column with no overflow, so extension buttons there used to be hidden outright on phones;
+ * the left rail already scrolls, so it can hold any number of them. Desktop keeps them where the
+ * extension put them.
+ */
+function placeComposerExtensionButtons(leftForm, rightForm) {
+    const mobile = isMobileViewport();
+
+    if (mobile) {
+        for (const child of Array.from(rightForm.children)) {
+            if (!(child instanceof HTMLElement) || SB_COMPOSER_NATIVE_RIGHT_RAIL_IDS.includes(child.id)) {
+                continue;
+            }
+
+            child.setAttribute(SB_COMPOSER_ADOPTED_ATTRIBUTE, 'right');
+            leftForm.appendChild(child);
+        }
+
+        return;
+    }
+
+    for (const child of Array.from(leftForm.querySelectorAll(`:scope > [${SB_COMPOSER_ADOPTED_ATTRIBUTE}='right']`))) {
+        child.removeAttribute(SB_COMPOSER_ADOPTED_ATTRIBUTE);
+        rightForm.appendChild(child);
+    }
+}
+
 function placeComposerControls() {
     const leftForm = document.getElementById('leftSendForm');
     const rightForm = document.getElementById('rightSendForm');
@@ -1903,6 +1961,7 @@ function placeComposerControls() {
     }
 
     moveElementBefore(paletteButton, rightForm, sendButton);
+    placeComposerExtensionButtons(leftForm, rightForm);
 }
 
 function queueComposerControlPlacement() {
@@ -2058,8 +2117,22 @@ function setCharacterDrawerRightLock(enabled, { persist = true } = {}) {
     syncCharacterDrawerLockButton();
 }
 
+/*
+ * Identity-based ownership for the top-bar adoption pass. An id prefix is spoofable and absent
+ * on id-less nodes, so registering what our own factory built is the only reliable test. Any
+ * future SillyBunny element that becomes a direct child of #top-bar or #top-settings-holder
+ * must come from createElement() or it will be adopted as if it were third-party markup.
+ */
+const sbOwnedElements = new WeakSet();
+
+function isSillyBunnyOwnedElement(node) {
+    return node instanceof Element && sbOwnedElements.has(node);
+}
+
 function createElement(tagName, { id = '', className = '', text = '', html = '', attrs = {} } = {}) {
     const element = document.createElement(tagName);
+
+    sbOwnedElements.add(element);
 
     if (id) {
         element.id = id;
@@ -4935,7 +5008,11 @@ function getTopbarGroupOrder({ iconsOnly, mobile }) {
         customize.leadId,
         customize.railId,
     ];
-    const right = [];
+    // The extension slot leads the right group in every mode: syncTopbarGroupOrder() re-appends
+    // every listed id, so an unlisted element would be pushed to the front of the group as a side
+    // effect. It stays out of the left group because that one scrolls in cramped mode, which would
+    // clip an adopted extension's dropdown.
+    const right = [TOPBAR_EXTENSION_SLOT_ID];
 
     if (iconsOnly) {
         right.push(...quickAccessIds);
@@ -8893,6 +8970,8 @@ window.matchMedia(SB_MOBILE_MEDIA_QUERY).addEventListener('change', () => {
     // whole preference re-applies rather than just the group order.
     applyTopbarIconsOnlyPreference();
     queueTopbarBrandFit();
+    // Crossing the breakpoint also decides which rail third-party composer buttons belong in.
+    queueComposerControlPlacement();
 });
 
 document.addEventListener('click', (e) => {
@@ -9356,10 +9435,10 @@ function buildTopBar() {
     }
 
     // SillyBunny: preserve children injected by third-party extensions before wiping
-    // the bar. Re-append them after the shell layout is built so extensions targeting
-    // #top-bar (e.g. CharacterLibrary in standalone mode) aren't orphaned.
+    // the bar. They are adopted into the extension slot once the shell layout exists, so
+    // extensions targeting #top-bar (e.g. CharacterLibrary in standalone mode) aren't orphaned.
     const preservedExtensionChildren = Array.from(topBar.children)
-        .filter(child => !(child instanceof HTMLElement) || !child.id.startsWith('sb-'));
+        .filter(child => child instanceof HTMLElement && !isSillyBunnyOwnedElement(child));
 
     topBar.replaceChildren();
 
@@ -9370,6 +9449,10 @@ function buildTopBar() {
     const leftGroup = createElement('div', { className: 'sb-topbar-group sb-topbar-group-left' });
     const centerGroup = createElement('div', { className: 'sb-topbar-brand' });
     const rightGroup = createElement('div', { className: 'sb-topbar-group sb-topbar-group-right' });
+    const extensionSlot = createElement('div', {
+        id: TOPBAR_EXTENSION_SLOT_ID,
+        attrs: { 'data-sb-topbar-slot-empty': 'true' },
+    });
 
     const mobileButton = createElement('button', {
         id: 'sb-hamburger',
@@ -9488,12 +9571,13 @@ function buildTopBar() {
     const charactersDivider = createTopbarClusterDivider('sb-topbar-divider-characters');
 
     leftGroup.append(mobileButton, leftButton, workspaceRail, customizeDivider, rightButton, customizeRail, leftShortcut, desktopShortcutButtons.slot3, desktopShortcutButtons.slot4);
-    rightGroup.append(desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, homeDivider, charactersDivider, charactersButton, charactersRail);
+    rightGroup.append(extensionSlot, desktopShortcutButtons.slot6, desktopShortcutButtons.slot5, rightShortcut, homeButton, homeDivider, charactersDivider, charactersButton, charactersRail);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);
 
     stack.append(primaryRow, searchRow);
-    topBar.append(stack, ...preservedExtensionChildren);
+    topBar.append(stack);
+    adoptTopbarExtensionNodes(preservedExtensionChildren);
 
     // The anchor that leads a cluster carries the wider seam that separates the clusters.
     for (const cluster of SB_TOPBAR_CLUSTERS) {
@@ -9503,6 +9587,7 @@ function buildTopBar() {
     observeProxyButton('sb-left-shell-toggle', getShellConfig('left').hostIconSelector);
     observeProxyButton('sb-right-shell-toggle', getShellConfig('right').hostIconSelector);
     observeProxyButton('sb-character-toggle', '#rightNavDrawerIcon');
+    bindTopbarExtensionAdoption();
     bindTopBarBrand();
     updateTopBarBrand();
     updateTopbarUtilityButtons();
@@ -9546,6 +9631,189 @@ function hideHostToggles() {
     const worldInfoDrawer = document.getElementById('WI-SP-button');
     worldInfoDrawer?.classList.add('sb-drawer-host');
     worldInfoDrawer?.querySelector(':scope > .drawer-toggle')?.classList.add('sb-hidden-toggle');
+}
+
+function getTopbarExtensionSlot() {
+    const slot = document.getElementById(TOPBAR_EXTENSION_SLOT_ID);
+
+    return slot instanceof HTMLElement ? slot : null;
+}
+
+function getNativeCharacterDrawerIcon() {
+    const icon = getCharacterDrawerHost()?.querySelector(':scope #rightNavDrawerIcon')
+        ?? document.getElementById('rightNavDrawerIcon');
+
+    return icon instanceof HTMLElement ? icon : null;
+}
+
+/**
+ * Describes a DOM node for the pure adoption rules. Keeping the DOM reads here lets the
+ * decision logic in topbar-extension-slot/index.js stay importable and unit testable.
+ */
+function describeTopbarNode(node, index) {
+    const isElement = node instanceof Element;
+
+    return {
+        node,
+        key: isElement && node.id ? `id:${node.id}` : `index:${index}`,
+        isElement,
+        id: isElement ? node.id : '',
+        tagName: isElement ? node.tagName : '',
+        classNames: isElement ? Array.from(node.classList) : [],
+        adoptAttribute: isElement ? node.getAttribute(TOPBAR_ADOPTION_ATTRIBUTE) : null,
+        isSillyBunnyOwned: isSillyBunnyOwnedElement(node),
+    };
+}
+
+function describeCharacterBadge(node, index) {
+    const descriptor = describeTopbarNode(node, index);
+
+    return {
+        ...descriptor,
+        key: `badge:${index}`,
+        signature: `${descriptor.tagName}:${descriptor.classNames.join(' ')}`,
+    };
+}
+
+/**
+ * Mirrors extension badges from the ghosted native Characters icon onto the visible proxy
+ * button. CharacterLibrary appends its chevron to #rightNavDrawerIcon, which lives inside
+ * .sb-ghost-toggle and is therefore invisible, so the affordance never reaches the user.
+ * The badges are moved rather than copied: the extension flips visibility through a global
+ * document.querySelector, which only ever reaches the first copy.
+ */
+function syncCharacterToggleBadges() {
+    const drawerIcon = getNativeCharacterDrawerIcon();
+    const proxyButton = document.getElementById('sb-character-toggle');
+
+    if (!(drawerIcon instanceof HTMLElement) || !(proxyButton instanceof HTMLElement)) {
+        return;
+    }
+
+    const iconNodes = Array.from(drawerIcon.children);
+    const hostNodes = Array.from(proxyButton.querySelectorAll(`:scope > [${TOPBAR_ADOPTED_MARKER_ATTRIBUTE}='true']`));
+    const iconBadges = iconNodes.map((node, index) => describeCharacterBadge(node, index));
+    const hostBadges = hostNodes.map((node, index) => describeCharacterBadge(node, `host-${index}`));
+    const plan = resolveCharacterBadgeMirrorPlan({ iconBadges, hostBadges });
+    const byKey = new Map([...iconBadges, ...hostBadges].map(badge => [badge.key, badge.node]));
+
+    for (const key of plan.removeKeys) {
+        byKey.get(key)?.remove();
+    }
+
+    for (const key of plan.moveKeys) {
+        const badge = byKey.get(key);
+
+        if (badge instanceof HTMLElement) {
+            badge.setAttribute(TOPBAR_ADOPTED_MARKER_ATTRIBUTE, 'true');
+            proxyButton.appendChild(badge);
+        }
+    }
+
+    proxyButton.classList.toggle(
+        'sb-has-adopted-badge',
+        proxyButton.querySelector(`:scope > [${TOPBAR_ADOPTED_MARKER_ATTRIBUTE}='true']`) !== null,
+    );
+}
+
+function syncTopbarExtensionSlotEmptyState() {
+    const slot = getTopbarExtensionSlot();
+
+    if (!slot) {
+        return;
+    }
+
+    slot.dataset.sbTopbarSlotEmpty = String(slot.children.length === 0);
+}
+
+/**
+ * Moves third-party top-bar controls into the shell's own bar. Upstream's bare
+ * `.drawer { width: 100% }` plus this fork's fixed, click-through #top-settings-holder means an
+ * injected button otherwise stretches across the whole strip and eats every click meant for the
+ * bar underneath it (Sillyanonymous/SillyTavern-CharacterLibrary).
+ */
+function adoptTopbarExtensionNodes(extraNodes = []) {
+    const slot = getTopbarExtensionSlot();
+
+    if (!slot || sbState.topbarExtensions.adopting) {
+        return;
+    }
+
+    sbState.topbarExtensions.adopting = true;
+
+    try {
+        const candidates = [...extraNodes];
+
+        for (const source of [getCanonicalTopSettingsHolder(), document.getElementById('top-bar')]) {
+            if (source instanceof HTMLElement) {
+                candidates.push(...source.children);
+            }
+        }
+
+        const descriptors = candidates.map((node, index) => describeTopbarNode(node, index));
+        // Only id-bearing slot children can be matched by key; id-less descriptors fall back to a
+        // per-pass index, which would collide across the two lists. Those are covered by the
+        // parentElement check below instead.
+        const slotChildKeys = Array.from(slot.children)
+            .filter(node => node instanceof Element && node.id)
+            .map(node => `id:${node.id}`);
+        const plan = resolveTopbarAdoptionPlan({ nodes: descriptors, slotChildKeys });
+        const byKey = new Map(descriptors.map(descriptor => [descriptor.key, descriptor.node]));
+
+        for (const key of plan.adoptKeys) {
+            const node = byKey.get(key);
+
+            // The parent check -- not a "already in place" helper -- is what terminates repeated
+            // passes: appendChild on a node the slot already holds still mutates childList.
+            if (node instanceof HTMLElement && node.parentElement !== slot) {
+                slot.appendChild(node);
+            }
+        }
+
+        syncCharacterToggleBadges();
+        syncTopbarExtensionSlotEmptyState();
+    } finally {
+        sbState.topbarExtensions.adopting = false;
+        // Drop the records our own moves just produced before they reach the callback.
+        sbState.topbarExtensions.observer?.takeRecords();
+    }
+
+    queueTopbarBrandFit();
+}
+
+function queueTopbarExtensionAdoption() {
+    if (sbState.topbarExtensions.syncFrame) {
+        return;
+    }
+
+    sbState.topbarExtensions.syncFrame = window.requestAnimationFrame(() => {
+        sbState.topbarExtensions.syncFrame = 0;
+        adoptTopbarExtensionNodes();
+    });
+}
+
+function bindTopbarExtensionAdoption() {
+    if (!getTopbarExtensionSlot()) {
+        return;
+    }
+
+    if (!(sbState.topbarExtensions.observer instanceof MutationObserver)) {
+        sbState.topbarExtensions.observer = new MutationObserver(() => queueTopbarExtensionAdoption());
+    }
+
+    const observer = sbState.topbarExtensions.observer;
+
+    observer.disconnect();
+
+    // childList only: extensions inject direct children, and subtree on #top-bar would fire on
+    // every chatbar and search re-render inside #sb-topbar-stack.
+    for (const target of [getCanonicalTopSettingsHolder(), document.getElementById('top-bar'), getNativeCharacterDrawerIcon()]) {
+        if (target instanceof HTMLElement) {
+            observer.observe(target, { childList: true });
+        }
+    }
+
+    queueTopbarExtensionAdoption();
 }
 
 function createShellPanel(tabConfig) {

--- a/public/scripts/topbar-extension-slot/index.js
+++ b/public/scripts/topbar-extension-slot/index.js
@@ -169,36 +169,28 @@ export function resolveTopbarAdoptionPlan({ nodes = [], slotChildKeys = [] } = {
  * @returns {{moveKeys: string[], removeKeys: string[]}} Keys to move and stale keys to drop.
  */
 export function resolveCharacterBadgeMirrorPlan({ iconBadges = [], hostBadges = [] } = {}) {
-    const moveKeys = [];
-    const newest = new Map();
+    const adoptable = iconBadges.filter(badge => resolveTopbarNodeAdoption(badge).shouldAdopt);
+    const adoptableKeys = new Set(adoptable.map(badge => String(badge?.key ?? '')));
+    const winnerBySignature = new Map();
     const removeKeys = [];
 
-    for (const badge of hostBadges) {
+    // Host badges first, then the ones on the native icon, so a freshly appended badge always
+    // wins over whatever is already mirrored. Only the winner is moved: an earlier duplicate
+    // appearing in the same batch must not end up in both lists, or the executor would remove
+    // it and then immediately re-append it.
+    for (const badge of [...hostBadges, ...adoptable]) {
         const signature = String(badge?.signature ?? '');
         const key = String(badge?.key ?? '');
+        const previous = winnerBySignature.get(signature);
 
-        if (newest.has(signature)) {
-            removeKeys.push(newest.get(signature));
+        if (previous !== undefined) {
+            removeKeys.push(previous);
         }
 
-        newest.set(signature, key);
+        winnerBySignature.set(signature, key);
     }
 
-    for (const badge of iconBadges) {
-        if (!resolveTopbarNodeAdoption(badge).shouldAdopt) {
-            continue;
-        }
-
-        const signature = String(badge?.signature ?? '');
-        const key = String(badge?.key ?? '');
-
-        if (newest.has(signature)) {
-            removeKeys.push(newest.get(signature));
-        }
-
-        newest.set(signature, key);
-        moveKeys.push(key);
-    }
+    const moveKeys = Array.from(winnerBySignature.values()).filter(key => adoptableKeys.has(key));
 
     return { moveKeys, removeKeys };
 }

--- a/public/scripts/topbar-extension-slot/index.js
+++ b/public/scripts/topbar-extension-slot/index.js
@@ -1,0 +1,204 @@
+export const TOPBAR_EXTENSION_SLOT_ID = 'sb-topbar-extension-slot';
+
+export const TOPBAR_ADOPTION_ATTRIBUTE = 'data-sb-topbar-adopt';
+
+export const TOPBAR_ADOPTED_MARKER_ATTRIBUTE = 'data-sb-topbar-adopted';
+
+/**
+ * The nine upstream drawers that live in #top-settings-holder. SillyBunny relocates or
+ * ghost-hides each of them, so they must never be treated as third-party markup. The same
+ * nine ids are enumerated in the hide/inert rules in sillybunny-tabs.css; keep both in sync.
+ */
+export const TOPBAR_NATIVE_DRAWER_IDS = Object.freeze([
+    'ai-config-button',
+    'sys-settings-button',
+    'advanced-formatting-button',
+    'WI-SP-button',
+    'user-settings-button',
+    'backgrounds-button',
+    'extensions-settings-button',
+    'persona-management-button',
+    'rightNavHolder',
+]);
+
+/** Tags that are never buttons, so adopting them into the bar would only break layout. */
+export const TOPBAR_ADOPTION_EXCLUDED_TAGS = Object.freeze([
+    'SCRIPT',
+    'STYLE',
+    'TEMPLATE',
+    'LINK',
+    'META',
+    'DIALOG',
+]);
+
+/**
+ * Panels an extension parked in the top strip rather than a control. These are positioned
+ * against the strip and would be mangled by the slot's flex layout.
+ */
+export const TOPBAR_ADOPTION_EXCLUDED_CLASSES = Object.freeze([
+    'drawer-content',
+    'popup',
+    'popup-holder',
+]);
+
+export const TOPBAR_ADOPTION_SKIP_REASON = Object.freeze({
+    NOT_ELEMENT: 'not-element',
+    NATIVE_DRAWER: 'native-drawer',
+    SILLYBUNNY_OWNED: 'sillybunny-owned',
+    OPTED_OUT: 'opted-out',
+    EXCLUDED_TAG: 'excluded-tag',
+    EXCLUDED_CLASS: 'excluded-class',
+});
+
+function normalizeClassNames(classNames) {
+    if (Array.isArray(classNames)) {
+        return classNames.map(name => String(name));
+    }
+
+    return String(classNames || '').split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Checks whether an element id belongs to one of the upstream top-bar drawers.
+ * @param {unknown} id Element id.
+ * @returns {boolean} True when the id is a native drawer.
+ */
+export function isNativeTopbarDrawerId(id) {
+    return TOPBAR_NATIVE_DRAWER_IDS.includes(String(id || ''));
+}
+
+/**
+ * Decides whether a node found in #top-bar or #top-settings-holder should be adopted into
+ * the SillyBunny top bar's extension slot.
+ * @param {object} descriptor Descriptor produced by describeTopbarNode().
+ * @param {boolean} [descriptor.isElement=false] Whether the node is an Element.
+ * @param {string} [descriptor.id=''] Element id.
+ * @param {string} [descriptor.tagName=''] Uppercase tag name.
+ * @param {string|string[]} [descriptor.classNames=[]] Class list.
+ * @param {string|null} [descriptor.adoptAttribute=null] Value of data-sb-topbar-adopt.
+ * @param {boolean} [descriptor.isSillyBunnyOwned=false] Whether SillyBunny created the node.
+ * @returns {{shouldAdopt: boolean, reason: string}} Verdict and, when skipped, why.
+ */
+export function resolveTopbarNodeAdoption({
+    isElement = false,
+    id = '',
+    tagName = '',
+    classNames = [],
+    adoptAttribute = null,
+    isSillyBunnyOwned = false,
+} = {}) {
+    if (!isElement) {
+        return { shouldAdopt: false, reason: TOPBAR_ADOPTION_SKIP_REASON.NOT_ELEMENT };
+    }
+
+    const normalizedAdoptAttribute = adoptAttribute === null || adoptAttribute === undefined
+        ? null
+        : String(adoptAttribute).trim().toLowerCase();
+
+    if (normalizedAdoptAttribute === 'false') {
+        return { shouldAdopt: false, reason: TOPBAR_ADOPTION_SKIP_REASON.OPTED_OUT };
+    }
+
+    if (isNativeTopbarDrawerId(id)) {
+        return { shouldAdopt: false, reason: TOPBAR_ADOPTION_SKIP_REASON.NATIVE_DRAWER };
+    }
+
+    if (isSillyBunnyOwned) {
+        return { shouldAdopt: false, reason: TOPBAR_ADOPTION_SKIP_REASON.SILLYBUNNY_OWNED };
+    }
+
+    // An explicit opt-in overrides only the heuristic exclusions below; an extension cannot
+    // claim a native drawer or one of our own elements.
+    if (normalizedAdoptAttribute === 'true') {
+        return { shouldAdopt: true, reason: '' };
+    }
+
+    if (TOPBAR_ADOPTION_EXCLUDED_TAGS.includes(String(tagName || '').toUpperCase())) {
+        return { shouldAdopt: false, reason: TOPBAR_ADOPTION_SKIP_REASON.EXCLUDED_TAG };
+    }
+
+    const names = normalizeClassNames(classNames);
+
+    if (names.some(name => TOPBAR_ADOPTION_EXCLUDED_CLASSES.includes(name))) {
+        return { shouldAdopt: false, reason: TOPBAR_ADOPTION_SKIP_REASON.EXCLUDED_CLASS };
+    }
+
+    return { shouldAdopt: true, reason: '' };
+}
+
+/**
+ * Builds the adoption plan for one pass. Nodes already parented by the slot are omitted, which
+ * is what makes repeated passes terminate instead of re-appending their own work forever.
+ * @param {object} options Options.
+ * @param {Array<object>} [options.nodes=[]] Descriptors, each carrying a stable `key`.
+ * @param {Iterable<string>} [options.slotChildKeys=[]] Keys already parented by the slot.
+ * @returns {{adoptKeys: string[], skipped: Array<{key: string, reason: string}>}} Plan.
+ */
+export function resolveTopbarAdoptionPlan({ nodes = [], slotChildKeys = [] } = {}) {
+    const presentKeys = new Set(Array.from(slotChildKeys, key => String(key)));
+    const adoptKeys = [];
+    const skipped = [];
+
+    for (const node of nodes) {
+        const key = String(node?.key ?? '');
+        const verdict = resolveTopbarNodeAdoption(node);
+
+        if (!verdict.shouldAdopt) {
+            skipped.push({ key, reason: verdict.reason });
+            continue;
+        }
+
+        if (presentKeys.has(key)) {
+            continue;
+        }
+
+        presentKeys.add(key);
+        adoptKeys.push(key);
+    }
+
+    return { adoptKeys, skipped };
+}
+
+/**
+ * Plans the mirror of extension badges from the ghosted native Characters icon onto the visible
+ * proxy button. Extensions append their badge unconditionally on every setup pass, so older
+ * copies with the same signature are dropped rather than stacking.
+ * @param {object} options Options.
+ * @param {Array<object>} [options.iconBadges=[]] Descriptors of children of #rightNavDrawerIcon.
+ * @param {Array<object>} [options.hostBadges=[]] Descriptors of already mirrored badges.
+ * @returns {{moveKeys: string[], removeKeys: string[]}} Keys to move and stale keys to drop.
+ */
+export function resolveCharacterBadgeMirrorPlan({ iconBadges = [], hostBadges = [] } = {}) {
+    const moveKeys = [];
+    const newest = new Map();
+    const removeKeys = [];
+
+    for (const badge of hostBadges) {
+        const signature = String(badge?.signature ?? '');
+        const key = String(badge?.key ?? '');
+
+        if (newest.has(signature)) {
+            removeKeys.push(newest.get(signature));
+        }
+
+        newest.set(signature, key);
+    }
+
+    for (const badge of iconBadges) {
+        if (!resolveTopbarNodeAdoption(badge).shouldAdopt) {
+            continue;
+        }
+
+        const signature = String(badge?.signature ?? '');
+        const key = String(badge?.key ?? '');
+
+        if (newest.has(signature)) {
+            removeKeys.push(newest.get(signature));
+        }
+
+        newest.set(signature, key);
+        moveKeys.push(key);
+    }
+
+    return { moveKeys, removeKeys };
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -516,18 +516,20 @@ export const OPENAI_FIXED_REASONING_EFFORT = {
 };
 
 /**
- * NanoGPT's vocabulary is the ladder none < minimal < low < medium < high, so every level is
- * translated one notch down and the top two share the ceiling.
- * SillyBunny divergence: upstream omits `xhigh`, which left "Extra High" sending an empty
- * reasoning object. Values absent here are omitted entirely by the caller.
+ * NanoGPT's vocabulary is the ladder none < minimal < low < medium < high < xhigh, which has
+ * exactly as many rungs as this fork's own min < low < medium < high < xhigh < max, so every
+ * level translates one notch down with no collisions.
+ * SillyBunny divergence: upstream stops at `max: 'high'`, leaving NanoGPT's `xhigh` ceiling
+ * unreachable and this fork's "Extra High" sending an empty reasoning object. Values absent
+ * here are omitted entirely by the caller.
  */
 export const NANOGPT_REASONING_EFFORT_MAP = {
     min: 'none',
     low: 'minimal',
     medium: 'low',
     high: 'medium',
-    max: 'high',
     xhigh: 'high',
+    max: 'xhigh',
 };
 
 export const LOG_LEVELS = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -515,12 +515,19 @@ export const OPENAI_FIXED_REASONING_EFFORT = {
     'gpt-5.3-chat-latest': 'medium',
 };
 
+/**
+ * NanoGPT's vocabulary is the ladder none < minimal < low < medium < high, so every level is
+ * translated one notch down and the top two share the ceiling.
+ * SillyBunny divergence: upstream omits `xhigh`, which left "Extra High" sending an empty
+ * reasoning object. Values absent here are omitted entirely by the caller.
+ */
 export const NANOGPT_REASONING_EFFORT_MAP = {
     min: 'none',
     low: 'minimal',
     medium: 'low',
     high: 'medium',
     max: 'high',
+    xhigh: 'high',
 };
 
 export const LOG_LEVELS = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -60,6 +60,7 @@ import {
     cachingSystemPromptForOpenRouter,
     addOpenRouterSignatures,
 } from '../../prompt-converters.js';
+import { applyReasoningEffortNormalization } from '../../reasoning-effort.js';
 
 import { readSecret, SECRET_KEYS } from '../secrets.js';
 import {
@@ -2815,6 +2816,12 @@ export async function handleChatCompletionsGenerate(request, response) {
     try {
         if (!request.body) return response.status(400).send({ error: true });
 
+        // SillyBunny divergence: normalize here, before the source switch, so every provider
+        // branch below inherits it. Extensions and hand-edited connection profiles can supply a
+        // reasoning effort the frontend never validated, and the pass-through sources forward it
+        // to the provider verbatim.
+        applyReasoningEffortNormalization(request.body);
+
         console.log(`[ChatCompletions] generate: type=${request.body.type} source=${request.body.chat_completion_source} model=${request.body.model} stream=${request.body.stream}`);
 
         const postProcessingType = request.body.custom_prompt_post_processing;
@@ -3066,9 +3073,11 @@ export async function handleChatCompletionsGenerate(request, response) {
             if (request.body.repetition_penalty !== undefined) {
                 bodyParams['repetition_penalty'] = request.body.repetition_penalty;
             }
-            if (request.body.reasoning_effort) {
-                const effort = NANOGPT_REASONING_EFFORT_MAP[request.body.reasoning_effort];
-                bodyParams['reasoning'] = { effort: effort };
+            // SillyBunny divergence: gate on the map rather than on the raw value being truthy.
+            // 'none' and 'auto' are truthy but have no NanoGPT equivalent, so upstream sent a
+            // bare `"reasoning": {}` for them -- and for anything else it could not translate.
+            if (Object.hasOwn(NANOGPT_REASONING_EFFORT_MAP, request.body.reasoning_effort)) {
+                bodyParams['reasoning'] = { effort: NANOGPT_REASONING_EFFORT_MAP[request.body.reasoning_effort] };
             }
 
             const isClaude = /(?:^|\/)claude[-_]/.test(request.body.model);

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1,19 +1,10 @@
 import crypto from 'node:crypto';
+// SillyBunny divergence: the effort vocabulary moved to its own leaf module so the
+// chat-completions backend can normalize incoming values against the same source of truth.
+import { REASONING_EFFORT } from './reasoning-effort.js';
 import { getConfigValue, tryParse } from './util.js';
 
 const PROMPT_PLACEHOLDER = getConfigValue('promptPlaceholder', 'Let\'s get started.');
-
-const REASONING_EFFORT = {
-    // 'auto' kept for backward-compat: backend may receive it from non-migrated external callers
-    auto: 'auto',
-    none: 'none',
-    low: 'low',
-    medium: 'medium',
-    high: 'high',
-    min: 'min',
-    max: 'max',
-    xhigh: 'xhigh',
-};
 
 export const PROMPT_PROCESSING_TYPE = {
     NONE: '',

--- a/src/reasoning-effort.js
+++ b/src/reasoning-effort.js
@@ -21,9 +21,9 @@ export const REASONING_EFFORT = {
 
 /**
  * Normalizes a reasoning effort value to the casing every provider table expects.
- * Unrecognized values are still returned (lowercased) rather than dropped: several
- * OpenAI-compatible endpoints take vocabulary of their own, and the backend forwards those
- * deliberately.
+ * Only canonical values are case-folded. An unrecognized value belongs to a custom endpoint
+ * whose vocabulary this fork does not own, and JSON enums are case-sensitive, so it is passed
+ * on with its original casing rather than lowercased into something the provider may reject.
  * @param {unknown} value Raw reasoning effort.
  * @returns {string} Normalized value, or an empty string when there is nothing usable.
  */
@@ -32,7 +32,15 @@ export function normalizeReasoningEffort(value) {
         return '';
     }
 
-    return value.trim().toLowerCase();
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        return '';
+    }
+
+    const canonical = trimmed.toLowerCase();
+
+    return isKnownReasoningEffort(canonical) ? canonical : trimmed;
 }
 
 /**
@@ -48,8 +56,7 @@ export function isKnownReasoningEffort(value) {
 
 /**
  * Normalizes `reasoning_effort` on an outgoing chat completion request body, in place.
- * Never adds the field when it is absent and never removes it, so this is a superset of the
- * previous behavior for every value that already worked.
+ * Never adds the field when it is absent, and never touches a non-string value.
  * @param {any} requestBody Chat completion request body.
  * @returns {void}
  */
@@ -65,11 +72,18 @@ export function applyReasoningEffortNormalization(requestBody) {
     const original = requestBody.reasoning_effort;
     const normalized = normalizeReasoningEffort(original);
 
+    if (!normalized) {
+        // Several provider branches assign this key unconditionally, so an empty string would
+        // ship as `"reasoning_effort": ""`. Removing it lets those branches omit the field.
+        delete requestBody.reasoning_effort;
+        return;
+    }
+
     if (normalized !== original) {
         console.debug(`[ReasoningEffort] normalized ${JSON.stringify(original)} to ${JSON.stringify(normalized)}`);
     }
 
-    if (normalized && !isKnownReasoningEffort(normalized)) {
+    if (!isKnownReasoningEffort(normalized)) {
         console.warn(`[ReasoningEffort] forwarding unrecognized value ${JSON.stringify(normalized)}; provider may reject it.`);
     }
 

--- a/src/reasoning-effort.js
+++ b/src/reasoning-effort.js
@@ -1,0 +1,77 @@
+/**
+ * SillyBunny: canonical reasoning-effort vocabulary and request normalization.
+ *
+ * Deliberately import-free. Every per-provider lookup table in the codebase is keyed on the
+ * exact lowercase strings below, so a value that reaches a provider with different casing
+ * misses every table silently. Keeping this a leaf module lets both prompt-converters.js and
+ * the chat-completions backend share it without any risk of an import cycle.
+ */
+
+export const REASONING_EFFORT = {
+    // 'auto' kept for backward-compat: backend may receive it from non-migrated external callers
+    auto: 'auto',
+    none: 'none',
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    min: 'min',
+    max: 'max',
+    xhigh: 'xhigh',
+};
+
+/**
+ * Normalizes a reasoning effort value to the casing every provider table expects.
+ * Unrecognized values are still returned (lowercased) rather than dropped: several
+ * OpenAI-compatible endpoints take vocabulary of their own, and the backend forwards those
+ * deliberately.
+ * @param {unknown} value Raw reasoning effort.
+ * @returns {string} Normalized value, or an empty string when there is nothing usable.
+ */
+export function normalizeReasoningEffort(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    return value.trim().toLowerCase();
+}
+
+/**
+ * Reports whether a normalized value is one this fork knows about.
+ * @param {string} value Normalized reasoning effort.
+ * @returns {boolean} True when the value is a canonical effort.
+ */
+export function isKnownReasoningEffort(value) {
+    // Object.hasOwn, not a bare index: 'constructor' and 'toString' would otherwise resolve
+    // through the prototype and report as known.
+    return Object.hasOwn(REASONING_EFFORT, value);
+}
+
+/**
+ * Normalizes `reasoning_effort` on an outgoing chat completion request body, in place.
+ * Never adds the field when it is absent and never removes it, so this is a superset of the
+ * previous behavior for every value that already worked.
+ * @param {any} requestBody Chat completion request body.
+ * @returns {void}
+ */
+export function applyReasoningEffortNormalization(requestBody) {
+    if (!requestBody || typeof requestBody !== 'object') {
+        return;
+    }
+
+    if (typeof requestBody.reasoning_effort !== 'string') {
+        return;
+    }
+
+    const original = requestBody.reasoning_effort;
+    const normalized = normalizeReasoningEffort(original);
+
+    if (normalized !== original) {
+        console.debug(`[ReasoningEffort] normalized ${JSON.stringify(original)} to ${JSON.stringify(normalized)}`);
+    }
+
+    if (normalized && !isKnownReasoningEffort(normalized)) {
+        console.warn(`[ReasoningEffort] forwarding unrecognized value ${JSON.stringify(normalized)}; provider may reject it.`);
+    }
+
+    requestBody.reasoning_effort = normalized;
+}

--- a/tests/icon-control-sizing-css.test.js
+++ b/tests/icon-control-sizing-css.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const ICON_CONTROL_ANCHOR = '.right_menu_button:not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child)';
+
+function getIconControlRuleBodies(fileName) {
+    const css = readFileSync(path.join(repoRoot, 'public', 'css', fileName), 'utf8').replace(/\r\n/g, '\n');
+    const escapedAnchor = ICON_CONTROL_ANCHOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const matches = [...css.matchAll(new RegExp(`${escapedAnchor}\\s*\\{(?<body>[^}]*)\\}`, 'gs'))];
+
+    return matches.map(match => match.groups?.body ?? '');
+}
+
+const themeRules = getIconControlRuleBodies('sillybunny-theme.css');
+const mobileRules = getIconControlRuleBodies('mobile-styles.css');
+const allRules = [...themeRules, ...mobileRules];
+
+describe('icon control sizing css', () => {
+    test('both sheets still carry the shared icon control rule', () => {
+        expect(themeRules.length).toBeGreaterThan(0);
+        expect(mobileRules.length).toBeGreaterThan(0);
+    });
+
+    test('every copy sizes icon controls by a minimum, never a fixed box', () => {
+        // A third-party button whose label is a bare text node matches this selector, so a fixed
+        // width/height would squash the label out of the box instead of letting the pill grow.
+        const fixedBoxRules = allRules.filter(body => /(?<!min-|max-)\b(width|height|inline-size|block-size):\s*var\(--sb-control-icon-physical-size/.test(body)
+            || /\bmax-(width|inline-size|height|block-size):/.test(body));
+
+        expect(fixedBoxRules).toEqual([]);
+    });
+
+    test('every copy keeps the minimum touch target on both axes', () => {
+        const missingFloor = allRules.filter(body => !/min-width:\s*var\(--sb-control-icon-physical-size/.test(body)
+            || !/min-height:\s*var\(--sb-control-icon-physical-size/.test(body));
+
+        expect(missingFloor).toEqual([]);
+    });
+
+    test('every copy keeps horizontal padding for a text label', () => {
+        const flushRules = allRules.filter(body => !/padding:\s*0 6px !important/.test(body));
+
+        expect(flushRules).toEqual([]);
+    });
+});

--- a/tests/icon-control-sizing-css.test.js
+++ b/tests/icon-control-sizing-css.test.js
@@ -46,4 +46,18 @@ describe('icon control sizing css', () => {
 
         expect(flushRules).toEqual([]);
     });
+
+    test('label-less glyph controls keep their square', () => {
+        // An :empty element has no children at all, so it can never carry the bare-text label the
+        // rule above is relaxed for. Without aspect-ratio a container that pins the width with
+        // !important (connection-manager's mobile profile actions) collapses the block axis to the
+        // height of the glyph, which is what the relaxation regressed.
+        const css = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-theme.css'), 'utf8').replace(/\r\n/g, '\n');
+        const emptyGlyphRule = css.match(/\.menu_button:is\(\.fa, \.fa-solid, \.fa-regular, \.fa-brands\):empty,\n\.menu_button_icon:is\([^)]*\):empty,\n\.right_menu_button:is\([^)]*\):empty\s*\{(?<body>[^}]*)\}/);
+
+        expect(emptyGlyphRule).not.toBeNull();
+        expect(emptyGlyphRule.groups.body).toMatch(/aspect-ratio:\s*1 \/ 1/);
+        expect(emptyGlyphRule.groups.body).toMatch(/max-width:\s*var\(--sb-control-icon-physical-size\)/);
+        expect(emptyGlyphRule.groups.body).toMatch(/max-height:\s*var\(--sb-control-icon-physical-size\)/);
+    });
 });

--- a/tests/nanogpt-reasoning-effort.test.js
+++ b/tests/nanogpt-reasoning-effort.test.js
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
+import { setConfigFilePath } from '../src/util.js';
+
+const actualNodeFetch = (await import('node-fetch')).default;
+const nodeFetchMock = jest.fn((url, options) => actualNodeFetch(url, options));
+await jest.unstable_mockModule('node-fetch', () => ({
+    default: nodeFetchMock,
+}));
+
+describe('reasoning effort on outgoing chat completions', () => {
+    /** @type {import('http').Server} */
+    let appServer;
+    let baseUrl;
+    let capturedBody;
+    const tempDirs = [];
+
+    beforeAll(async () => {
+        const configRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-effort-config-'));
+        const configPath = path.join(configRoot, 'config.yaml');
+        const defaultConfig = fs.readFileSync(fileURLToPath(new URL('../default/config.yaml', import.meta.url)), 'utf8');
+        fs.writeFileSync(configPath, defaultConfig);
+        tempDirs.push(configRoot);
+        setConfigFilePath(configPath);
+
+        const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
+        const { SecretManager, SECRET_KEYS } = await import('../src/endpoints/secrets.js');
+        const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-effort-user-'));
+        tempDirs.push(userRoot);
+        const secretManager = new SecretManager({ root: userRoot, backups: userRoot });
+        secretManager.writeSecret(SECRET_KEYS.NANOGPT, 'nanogpt-test-key');
+        secretManager.writeSecret(SECRET_KEYS.OPENROUTER, 'openrouter-test-key');
+        secretManager.writeSecret(SECRET_KEYS.PERPLEXITY, 'perplexity-test-key');
+
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            req.user = { directories: { root: userRoot, backups: userRoot } };
+            next();
+        });
+        app.use('/api/backends/chat-completions', chatCompletionsRouter);
+
+        await new Promise((resolve) => {
+            appServer = app.listen(0, '127.0.0.1', resolve);
+        });
+        const address = appServer.address();
+        baseUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    beforeEach(() => {
+        capturedBody = undefined;
+        nodeFetchMock.mockClear();
+        nodeFetchMock.mockImplementation(async (_url, options) => {
+            capturedBody = JSON.parse(options?.body ?? '{}');
+            return new Response(JSON.stringify({
+                choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+            }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        });
+    });
+
+    afterAll(async () => {
+        if (appServer) {
+            await new Promise((resolve, reject) => {
+                appServer.close((error) => error ? reject(error) : resolve());
+            });
+        }
+        for (const dir of tempDirs.splice(0)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+        nodeFetchMock.mockImplementation((url, options) => actualNodeFetch(url, options));
+    });
+
+    function makeRequest(source, overrides = {}) {
+        return fetch(`${baseUrl}/api/backends/chat-completions/generate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                chat_completion_source: source,
+                model: 'test-model',
+                stream: false,
+                max_tokens: 128,
+                messages: [{ role: 'user', content: 'Question' }],
+                ...overrides,
+            }),
+        });
+    }
+
+    test.each([
+        ['min', 'none'],
+        ['low', 'minimal'],
+        ['medium', 'low'],
+        ['high', 'medium'],
+        ['max', 'high'],
+        ['xhigh', 'high'],
+    ])('NanoGPT sends %s as %s', async (effort, expected) => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.reasoning).toEqual({ effort: expected });
+    });
+
+    test.each(['none', 'auto', 'banana', '   '])('NanoGPT omits the reasoning key entirely for %p', async (effort) => {
+        // Upstream emitted a bare `"reasoning": {}` for all of these, because the value is
+        // truthy but has no NanoGPT equivalent. hasOwn, not toBeUndefined: an empty object
+        // would also read as undefined on the nested effort.
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
+
+        expect(response.status).toBe(200);
+        expect(Object.hasOwn(capturedBody, 'reasoning')).toBe(false);
+    });
+
+    test('NanoGPT omits the reasoning key when no effort is supplied', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT);
+
+        expect(response.status).toBe(200);
+        expect(Object.hasOwn(capturedBody, 'reasoning')).toBe(false);
+    });
+
+    test.each(['XHigh', ' Max ', 'MAX'])('NanoGPT normalizes %p before the table lookup', async (effort) => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.reasoning).toEqual({ effort: 'high' });
+    });
+
+    test('OpenRouter receives a lowercased effort instead of the raw value', async () => {
+        // OpenRouter forwards whatever it is given, so a hand-edited profile containing
+        // "Medium" produced `invalid value for reasoning.effort "Medium"` from the provider.
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.OPENROUTER, { reasoning_effort: 'Medium' });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.reasoning.effort).toBe('medium');
+    });
+
+    test('Perplexity receives a lowercased effort', async () => {
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.PERPLEXITY, { reasoning_effort: 'HIGH' });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.reasoning_effort).toBe('high');
+    });
+
+    test('an unrecognized value still reaches an OpenAI-compatible endpoint', async () => {
+        // Several proxies take vocabulary of their own; dropping unknowns would regress them.
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            reasoning_effort: 'Minimal',
+            custom_url: 'https://custom.test/v1',
+            model: 'gpt-5',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.reasoning_effort).toBe('minimal');
+    });
+});

--- a/tests/nanogpt-reasoning-effort.test.js
+++ b/tests/nanogpt-reasoning-effort.test.js
@@ -37,6 +37,8 @@ describe('reasoning effort on outgoing chat completions', () => {
         secretManager.writeSecret(SECRET_KEYS.NANOGPT, 'nanogpt-test-key');
         secretManager.writeSecret(SECRET_KEYS.OPENROUTER, 'openrouter-test-key');
         secretManager.writeSecret(SECRET_KEYS.PERPLEXITY, 'perplexity-test-key');
+        secretManager.writeSecret(SECRET_KEYS.POLLINATIONS, 'pollinations-test-key');
+        secretManager.writeSecret(SECRET_KEYS.COMETAPI, 'cometapi-test-key');
 
         const app = express();
         app.use(express.json());
@@ -94,13 +96,16 @@ describe('reasoning effort on outgoing chat completions', () => {
         });
     }
 
+    // NanoGPT documents none < minimal < low < medium < high < xhigh, the same number of rungs
+    // as this fork's min < low < medium < high < xhigh < max, so the ladder maps one-to-one and
+    // Maximum reaches NanoGPT's real ceiling rather than stopping a rung short at high.
     test.each([
         ['min', 'none'],
         ['low', 'minimal'],
         ['medium', 'low'],
         ['high', 'medium'],
-        ['max', 'high'],
         ['xhigh', 'high'],
+        ['max', 'xhigh'],
     ])('NanoGPT sends %s as %s', async (effort, expected) => {
         const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
 
@@ -125,11 +130,16 @@ describe('reasoning effort on outgoing chat completions', () => {
         expect(Object.hasOwn(capturedBody, 'reasoning')).toBe(false);
     });
 
-    test.each(['XHigh', ' Max ', 'MAX'])('NanoGPT normalizes %p before the table lookup', async (effort) => {
+    test.each([
+        ['XHigh', 'high'],
+        [' xhigh ', 'high'],
+        [' Max ', 'xhigh'],
+        ['MAX', 'xhigh'],
+    ])('NanoGPT normalizes %p before the table lookup and sends %s', async (effort, expected) => {
         const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
 
         expect(response.status).toBe(200);
-        expect(capturedBody.reasoning).toEqual({ effort: 'high' });
+        expect(capturedBody.reasoning).toEqual({ effort: expected });
     });
 
     test('OpenRouter receives a lowercased effort instead of the raw value', async () => {
@@ -148,15 +158,30 @@ describe('reasoning effort on outgoing chat completions', () => {
         expect(capturedBody.reasoning_effort).toBe('high');
     });
 
-    test('an unrecognized value still reaches an OpenAI-compatible endpoint', async () => {
-        // Several proxies take vocabulary of their own; dropping unknowns would regress them.
+    test('an unrecognized value reaches an OpenAI-compatible endpoint with its casing intact', async () => {
+        // Several proxies take vocabulary of their own. Dropping unknowns would regress them, and
+        // case-folding one would too, since JSON enum values are case-sensitive.
         const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
-            reasoning_effort: 'Minimal',
+            reasoning_effort: 'UltraFast',
             custom_url: 'https://custom.test/v1',
             model: 'gpt-5',
         });
 
         expect(response.status).toBe(200);
-        expect(capturedBody.reasoning_effort).toBe('minimal');
+        expect(capturedBody.reasoning_effort).toBe('UltraFast');
+    });
+
+    // Two representatives of the branches that assign this key unconditionally (CometAPI and
+    // Chutes are the others). A value that trims to nothing has to be removed from the body
+    // rather than blanked, or they ship `"reasoning_effort": ""`. The removal happens once at
+    // the shared entry point, so these two cover the whole class.
+    test.each([
+        ['Perplexity', CHAT_COMPLETION_SOURCES.PERPLEXITY],
+        ['Pollinations', CHAT_COMPLETION_SOURCES.POLLINATIONS],
+    ])('%s omits the field entirely for a whitespace-only effort', async (_name, source) => {
+        const response = await makeRequest(source, { reasoning_effort: '   ' });
+
+        expect(response.status).toBe(200);
+        expect(Object.hasOwn(capturedBody, 'reasoning_effort')).toBe(false);
     });
 });

--- a/tests/reasoning-effort.test.js
+++ b/tests/reasoning-effort.test.js
@@ -34,10 +34,12 @@ describe('normalizeReasoningEffort', () => {
         expect(normalizeReasoningEffort('')).toBe('');
     });
 
-    test('preserves unrecognized values instead of dropping them', () => {
-        // OpenAI-compatible proxies take vocabulary of their own; the backend forwards it.
+    test('preserves unrecognized values, casing and all', () => {
+        // OpenAI-compatible proxies take vocabulary of their own and JSON enums are
+        // case-sensitive, so case-folding an unknown value could break a working setup.
         expect(normalizeReasoningEffort('minimal')).toBe('minimal');
-        expect(normalizeReasoningEffort('Ultra')).toBe('ultra');
+        expect(normalizeReasoningEffort('UltraFast')).toBe('UltraFast');
+        expect(normalizeReasoningEffort('  UltraFast  ')).toBe('UltraFast');
     });
 
     test('returns an empty string for anything that is not a string', () => {
@@ -90,13 +92,25 @@ describe('applyReasoningEffortNormalization', () => {
         expect(body.reasoning_effort).toBe(42);
     });
 
-    test('keeps an unrecognized value rather than deleting it', () => {
-        const body = { reasoning_effort: 'Ultra' };
+    test('keeps an unrecognized value, with its casing, rather than deleting it', () => {
+        const body = { reasoning_effort: 'UltraFast' };
         applyReasoningEffortNormalization(body);
 
         expect(Object.hasOwn(body, 'reasoning_effort')).toBe(true);
-        expect(body.reasoning_effort).toBe('ultra');
+        expect(body.reasoning_effort).toBe('UltraFast');
     });
+
+    for (const [label, value] of [['spaces', '   '], ['empty', ''], ['tab and newline', '\t\n']]) {
+        test(`removes the field for a ${label} value rather than blanking it`, () => {
+            // Provider branches that assign the key unconditionally would otherwise emit
+            // `"reasoning_effort": ""`, which is not a legal value anywhere.
+            const body = { reasoning_effort: value, model: 'test' };
+            applyReasoningEffortNormalization(body);
+
+            expect(Object.hasOwn(body, 'reasoning_effort')).toBe(false);
+            expect(body.model).toBe('test');
+        });
+    }
 
     test('tolerates a missing or non-object body', () => {
         expect(() => applyReasoningEffortNormalization(null)).not.toThrow();

--- a/tests/reasoning-effort.test.js
+++ b/tests/reasoning-effort.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+    applyReasoningEffortNormalization,
+    isKnownReasoningEffort,
+    normalizeReasoningEffort,
+    REASONING_EFFORT,
+} from '../src/reasoning-effort.js';
+
+describe('normalizeReasoningEffort', () => {
+    test('leaves every canonical value untouched', () => {
+        for (const value of Object.values(REASONING_EFFORT)) {
+            expect(normalizeReasoningEffort(value)).toBe(value);
+        }
+    });
+
+    test('lowercases values that arrive with UI casing', () => {
+        // The reasoning effort <select> shows Title Case labels over lowercase values, so an
+        // extension reading textContent instead of value ships "Medium" to the provider.
+        expect(normalizeReasoningEffort('Medium')).toBe('medium');
+        expect(normalizeReasoningEffort('HIGH')).toBe('high');
+        expect(normalizeReasoningEffort('XHigh')).toBe('xhigh');
+        expect(normalizeReasoningEffort('MiN')).toBe('min');
+    });
+
+    test('trims surrounding whitespace', () => {
+        expect(normalizeReasoningEffort(' high ')).toBe('high');
+        expect(normalizeReasoningEffort('\tmax\n')).toBe('max');
+        expect(normalizeReasoningEffort(' Medium ')).toBe('medium');
+    });
+
+    test('reduces a whitespace-only value to an empty string', () => {
+        // Every provider branch guards on truthiness, so this is what makes '  ' skip them.
+        expect(normalizeReasoningEffort('   ')).toBe('');
+        expect(normalizeReasoningEffort('')).toBe('');
+    });
+
+    test('preserves unrecognized values instead of dropping them', () => {
+        // OpenAI-compatible proxies take vocabulary of their own; the backend forwards it.
+        expect(normalizeReasoningEffort('minimal')).toBe('minimal');
+        expect(normalizeReasoningEffort('Ultra')).toBe('ultra');
+    });
+
+    test('returns an empty string for anything that is not a string', () => {
+        for (const value of [null, undefined, 42, {}, [], true]) {
+            expect(normalizeReasoningEffort(value)).toBe('');
+        }
+    });
+});
+
+describe('isKnownReasoningEffort', () => {
+    test('accepts every canonical value', () => {
+        for (const value of Object.values(REASONING_EFFORT)) {
+            expect(isKnownReasoningEffort(value)).toBe(true);
+        }
+    });
+
+    test('rejects unrecognized values', () => {
+        expect(isKnownReasoningEffort('ultra')).toBe(false);
+        expect(isKnownReasoningEffort('')).toBe(false);
+    });
+
+    test('rejects inherited prototype keys', () => {
+        // A bare index would resolve these through Object.prototype and report them as known.
+        for (const key of ['constructor', 'toString', 'valueOf', '__proto__', 'hasOwnProperty']) {
+            expect(isKnownReasoningEffort(key)).toBe(false);
+        }
+    });
+});
+
+describe('applyReasoningEffortNormalization', () => {
+    test('normalizes the field in place', () => {
+        const body = { reasoning_effort: 'Medium', model: 'test' };
+        applyReasoningEffortNormalization(body);
+
+        expect(body.reasoning_effort).toBe('medium');
+        expect(body.model).toBe('test');
+    });
+
+    test('never adds the field when it is absent', () => {
+        const body = { model: 'test' };
+        applyReasoningEffortNormalization(body);
+
+        expect(Object.hasOwn(body, 'reasoning_effort')).toBe(false);
+    });
+
+    test('leaves non-string values untouched', () => {
+        const body = { reasoning_effort: 42 };
+        applyReasoningEffortNormalization(body);
+
+        expect(body.reasoning_effort).toBe(42);
+    });
+
+    test('keeps an unrecognized value rather than deleting it', () => {
+        const body = { reasoning_effort: 'Ultra' };
+        applyReasoningEffortNormalization(body);
+
+        expect(Object.hasOwn(body, 'reasoning_effort')).toBe(true);
+        expect(body.reasoning_effort).toBe('ultra');
+    });
+
+    test('tolerates a missing or non-object body', () => {
+        expect(() => applyReasoningEffortNormalization(null)).not.toThrow();
+        expect(() => applyReasoningEffortNormalization(undefined)).not.toThrow();
+        expect(() => applyReasoningEffortNormalization('body')).not.toThrow();
+    });
+});

--- a/tests/topbar-extension-adoption.e2e.js
+++ b/tests/topbar-extension-adoption.e2e.js
@@ -1,4 +1,4 @@
-/* global document, window */
+/* global document, HTMLElement, window */
 import { expect, test } from '@playwright/test';
 import { dismissOpenDialogIfPresent, openQuietChatForSmoke, waitForAnimationFrames } from './chat-scroll-regression-helpers.js';
 
@@ -12,14 +12,30 @@ test.describe.configure({ mode: 'serial' });
 
 const IPHONE_VIEWPORT = { width: 390, height: 844 };
 
-// Bundled extensions raise their own first-run surfaces after the chat settles, and a full-screen
-// overlay owns every elementFromPoint hit. Quick Image Gen's wizard is a plain div rather than a
-// <dialog>, so dismissOpenDialogIfPresent alone does not clear it.
+// Extensions raise first-run surfaces after the chat settles, and a full-screen overlay owns
+// every elementFromPoint hit. Several are plain divs rather than <dialog>, so
+// dismissOpenDialogIfPresent alone does not clear them, and which ones appear depends on what is
+// installed. Clear them by shape rather than by name so this pack does not have to track them.
 async function openBarForTest(page) {
     await openQuietChatForSmoke(page);
     await dismissOpenDialogIfPresent(page);
     await page.evaluate(() => {
-        document.querySelectorAll('.qig-popup, #toast-container .toast').forEach(overlay => overlay.remove());
+        const shellIds = new Set(['top-bar', 'top-settings-holder', 'sheld', 'left-nav-panel', 'right-nav-panel', 'user-settings-block']);
+        const viewportArea = window.innerWidth * window.innerHeight;
+
+        for (const node of Array.from(document.body.children)) {
+            if (!(node instanceof HTMLElement) || shellIds.has(node.id) || node.id.startsWith('sb-')) {
+                continue;
+            }
+
+            const rect = node.getBoundingClientRect();
+
+            if (window.getComputedStyle(node).position === 'fixed' && rect.width * rect.height > viewportArea * 0.3) {
+                node.remove();
+            }
+        }
+
+        document.querySelectorAll('#toast-container .toast').forEach(toast => toast.remove());
     });
     await waitForAnimationFrames(page, 2);
 }

--- a/tests/topbar-extension-adoption.e2e.js
+++ b/tests/topbar-extension-adoption.e2e.js
@@ -170,6 +170,68 @@ test.describe('third-party top-bar button adoption', () => {
         expect(await page.evaluate(() => window.__sbPlainClicks)).toBe(1);
     });
 
+    test('lets a bare text-node label expand an adopted menu button on a phone', async ({ page }) => {
+        await page.setViewportSize(IPHONE_VIEWPORT);
+        await openBarForTest(page);
+
+        await page.evaluate(() => {
+            const button = document.createElement('button');
+            button.id = 'sb-e2e-bare-text-menu-button';
+            button.type = 'button';
+            button.className = 'menu_button';
+            button.innerHTML = '<i class="fa-solid fa-wand-magic-sparkles"></i> Copilot';
+            document.getElementById('top-settings-holder').appendChild(button);
+        });
+        await waitForAnimationFrames(page, 3);
+
+        const button = await page.evaluate(() => {
+            const element = document.getElementById('sb-e2e-bare-text-menu-button');
+            const slot = document.getElementById('sb-topbar-extension-slot');
+            return {
+                adopted: Boolean(slot && slot.contains(element)),
+                width: element.getBoundingClientRect().width,
+                height: element.getBoundingClientRect().height,
+                contentFits: element.scrollWidth <= element.clientWidth
+                    && element.scrollHeight <= element.clientHeight,
+            };
+        });
+
+        expect(button.adopted).toBe(true);
+        expect(button.width).toBeGreaterThan(button.height);
+        expect(button.contentFits).toBe(true);
+    });
+
+    test('lets a span label expand an adopted menu button on a phone', async ({ page }) => {
+        await page.setViewportSize(IPHONE_VIEWPORT);
+        await openBarForTest(page);
+
+        await page.evaluate(() => {
+            const button = document.createElement('button');
+            button.id = 'sb-e2e-span-text-menu-button';
+            button.type = 'button';
+            button.className = 'menu_button';
+            button.innerHTML = '<i class="fa-solid fa-wand-magic-sparkles"></i><span>Copilot</span>';
+            document.getElementById('top-settings-holder').appendChild(button);
+        });
+        await waitForAnimationFrames(page, 3);
+
+        const button = await page.evaluate(() => {
+            const element = document.getElementById('sb-e2e-span-text-menu-button');
+            const slot = document.getElementById('sb-topbar-extension-slot');
+            return {
+                adopted: Boolean(slot && slot.contains(element)),
+                width: element.getBoundingClientRect().width,
+                height: element.getBoundingClientRect().height,
+                contentFits: element.scrollWidth <= element.clientWidth
+                    && element.scrollHeight <= element.clientHeight,
+            };
+        });
+
+        expect(button.adopted).toBe(true);
+        expect(button.width).toBeGreaterThan(button.height);
+        expect(button.contentFits).toBe(true);
+    });
+
     test('keeps a third-party composer button visible on a phone', async ({ page }) => {
         await page.setViewportSize(IPHONE_VIEWPORT);
         await openBarForTest(page);

--- a/tests/topbar-extension-adoption.e2e.js
+++ b/tests/topbar-extension-adoption.e2e.js
@@ -1,0 +1,272 @@
+/* global document, window */
+import { expect, test } from '@playwright/test';
+import { dismissOpenDialogIfPresent, openQuietChatForSmoke, waitForAnimationFrames } from './chat-scroll-regression-helpers.js';
+
+// Regression pack for third-party top-bar buttons. CharacterLibrary injects a bare
+// `<div class="drawer">` after #rightNavHolder; upstream's global `.drawer { width: 100% }` made it
+// the only non-zero flex child of this fork's fixed, full-width #top-settings-holder, so it painted
+// over the whole SillyBunny bar and swallowed every click meant for it.
+// Run with: SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:<port> npx playwright test topbar-extension-adoption.e2e.js
+
+test.describe.configure({ mode: 'serial' });
+
+const IPHONE_VIEWPORT = { width: 390, height: 844 };
+
+// Bundled extensions raise their own first-run surfaces after the chat settles, and a full-screen
+// overlay owns every elementFromPoint hit. Quick Image Gen's wizard is a plain div rather than a
+// <dialog>, so dismissOpenDialogIfPresent alone does not clear it.
+async function openBarForTest(page) {
+    await openQuietChatForSmoke(page);
+    await dismissOpenDialogIfPresent(page);
+    await page.evaluate(() => {
+        document.querySelectorAll('.qig-popup, #toast-container .toast').forEach(overlay => overlay.remove());
+    });
+    await waitForAnimationFrames(page, 2);
+}
+
+async function injectCharacterLibraryButton(page) {
+    await page.evaluate(() => {
+        document.getElementById('st-gallery-btn')?.remove();
+        document.querySelector('#rightNavHolder').insertAdjacentHTML('afterend', [
+            '<div id="st-gallery-btn" class="drawer">',
+            '<div class="drawer-toggle drawer-header">',
+            '<div id="charlib-launcher-icon" class="drawer-icon fa-solid fa-layer-group fa-fw closedIcon"></div>',
+            '</div></div>',
+        ].join(''));
+
+        // Bind before adoption runs: if the slot cloned instead of moved, this never fires.
+        window.__sbGalleryClicks = 0;
+        document.getElementById('st-gallery-btn')
+            .addEventListener('click', () => { window.__sbGalleryClicks++; });
+    });
+
+    await waitForAnimationFrames(page, 3);
+}
+
+function getAdoptionSnapshot(page) {
+    return page.evaluate(() => {
+        const button = document.getElementById('st-gallery-btn');
+        const slot = document.getElementById('sb-topbar-extension-slot');
+        const title = document.getElementById('sb-topbar-title');
+        const titleRect = title.getBoundingClientRect();
+        const titleHit = document.elementFromPoint(
+            Math.round(titleRect.left + titleRect.width / 2),
+            Math.round(titleRect.top + titleRect.height / 2),
+        );
+
+        const hitTest = (id) => {
+            const element = document.getElementById(id);
+            const rect = element.getBoundingClientRect();
+            const hit = document.elementFromPoint(
+                Math.round(rect.left + rect.width / 2),
+                Math.round(rect.top + rect.height / 2),
+            );
+
+            return element.contains(hit);
+        };
+
+        return {
+            inSlot: Boolean(slot && button && slot.contains(button)),
+            slotEmpty: slot?.dataset.sbTopbarSlotEmpty,
+            buttonWidth: button.getBoundingClientRect().width,
+            viewportWidth: window.innerWidth,
+            titleBlocked: Boolean(button.contains(titleHit)),
+            homeHittable: hitTest('sb-home-toggle'),
+            charactersHittable: hitTest('sb-character-toggle'),
+        };
+    });
+}
+
+test.describe('third-party top-bar button adoption', () => {
+    test('adopts the CharacterLibrary button instead of letting it cover the bar', async ({ page }) => {
+        await openBarForTest(page);
+        await injectCharacterLibraryButton(page);
+
+        const snapshot = await getAdoptionSnapshot(page);
+
+        expect(snapshot.inSlot).toBe(true);
+        expect(snapshot.slotEmpty).toBe('false');
+        // The literal regression: the button used to stretch the full viewport width.
+        expect(snapshot.buttonWidth).toBeLessThan(80);
+        expect(snapshot.buttonWidth).toBeLessThan(snapshot.viewportWidth / 2);
+        expect(snapshot.titleBlocked).toBe(false);
+        expect(snapshot.homeHittable).toBe(true);
+        expect(snapshot.charactersHittable).toBe(true);
+    });
+
+    test('keeps listeners bound before adoption, so the node was moved and not cloned', async ({ page }) => {
+        await openBarForTest(page);
+        await injectCharacterLibraryButton(page);
+
+        await page.click('#charlib-launcher-icon');
+
+        expect(await page.evaluate(() => window.__sbGalleryClicks)).toBe(1);
+        expect(await page.evaluate(() => document.querySelectorAll('#st-gallery-btn').length)).toBe(1);
+    });
+
+    test('mirrors an extension badge onto the visible Characters button', async ({ page }) => {
+        await openBarForTest(page);
+
+        await page.evaluate(() => {
+            const chevron = document.createElement('i');
+            chevron.className = 'fa-solid fa-caret-down charlib-chevron-badge';
+            document.getElementById('rightNavDrawerIcon').appendChild(chevron);
+        });
+        await waitForAnimationFrames(page, 3);
+
+        const badge = await page.evaluate(() => {
+            const chevron = document.querySelector('.charlib-chevron-badge');
+            const proxy = document.getElementById('sb-character-toggle');
+            const rect = chevron.getBoundingClientRect();
+
+            return {
+                onProxy: proxy.contains(chevron),
+                proxyUnclipped: proxy.classList.contains('sb-has-adopted-badge'),
+                width: rect.width,
+                height: rect.height,
+                copies: document.querySelectorAll('.charlib-chevron-badge').length,
+            };
+        });
+
+        expect(badge.onProxy).toBe(true);
+        expect(badge.proxyUnclipped).toBe(true);
+        expect(badge.width).toBeGreaterThan(0);
+        expect(badge.height).toBeGreaterThan(0);
+        expect(badge.copies).toBe(1);
+    });
+
+    test('makes a plain non-drawer extension button clickable in the top strip', async ({ page }) => {
+        await openBarForTest(page);
+
+        await page.evaluate(() => {
+            window.__sbPlainClicks = 0;
+            const button = document.createElement('div');
+            button.id = 'sb-e2e-plain-ext-button';
+            button.className = 'menu_button';
+            button.innerHTML = '<i class="fa-solid fa-flask"></i>';
+            button.addEventListener('click', () => { window.__sbPlainClicks++; });
+            document.getElementById('top-settings-holder').appendChild(button);
+        });
+        await waitForAnimationFrames(page, 3);
+
+        await page.click('#sb-e2e-plain-ext-button');
+
+        expect(await page.evaluate(() => window.__sbPlainClicks)).toBe(1);
+    });
+
+    test('keeps a third-party composer button visible on a phone', async ({ page }) => {
+        await page.setViewportSize(IPHONE_VIEWPORT);
+        await openBarForTest(page);
+
+        await page.evaluate(() => {
+            const button = document.createElement('div');
+            button.id = 'sb-e2e-composer-ext-button';
+            button.className = 'fa-solid fa-dice interactable';
+            document.getElementById('rightSendForm').appendChild(button);
+        });
+        await waitForAnimationFrames(page, 3);
+
+        const composer = await page.evaluate(() => {
+            const button = document.getElementById('sb-e2e-composer-ext-button');
+            const rect = button.getBoundingClientRect();
+
+            return {
+                inLeftRail: document.getElementById('leftSendForm').contains(button),
+                display: window.getComputedStyle(button).display,
+                width: rect.width,
+                height: rect.height,
+            };
+        });
+
+        // The old allow-list rule hid every unrecognised right-rail child outright on phones.
+        expect(composer.display).not.toBe('none');
+        expect(composer.inLeftRail).toBe(true);
+        expect(composer.width).toBeGreaterThan(0);
+        expect(composer.height).toBeGreaterThan(0);
+    });
+
+    test('keeps a third-party settings drawer reachable in exactly one tab', async ({ page }) => {
+        await openBarForTest(page);
+
+        const visibility = await page.evaluate(async () => {
+            const content = document.getElementById('user-settings-block-content');
+            const drawer = document.createElement('div');
+            drawer.id = 'sb-e2e-ext-settings-drawer';
+            drawer.className = 'inline-drawer wide100p flexFlowColumn';
+            drawer.innerHTML = '<div class="inline-drawer-toggle inline-drawer-header"><b>E2E Ext</b></div>'
+                + '<div class="inline-drawer-content">body</div>';
+            content.appendChild(drawer);
+
+            await new Promise(resolve => setTimeout(resolve, 400));
+
+            const perTab = {};
+            const activeTab = content.getAttribute('data-active-tab');
+
+            for (const tab of ['appearance', 'chat-writing', 'system-device', 'cache-account']) {
+                content.setAttribute('data-active-tab', tab);
+                perTab[tab] = window.getComputedStyle(drawer).display;
+            }
+
+            content.setAttribute('data-active-tab', activeTab ?? 'appearance');
+
+            return { tagged: drawer.getAttribute('data-settings-tab'), perTab };
+        });
+
+        // Before the fix an untagged drawer matched the hide rule in all four tabs.
+        expect(Object.values(visibility.perTab).filter(display => display !== 'none')).toHaveLength(1);
+        expect(visibility.tagged).toBe('system-device');
+        expect(visibility.perTab['system-device']).not.toBe('none');
+    });
+
+    test('anchors a fixed extension panel below the whole bar, chat bar row included', async ({ page }) => {
+        await openBarForTest(page);
+
+        const measure = () => page.evaluate(() => {
+            // CharacterLibrary positions its embedded panel with exactly these inline styles.
+            const container = document.createElement('div');
+            container.id = 'charlib-embedded-container';
+            Object.assign(container.style, {
+                position: 'fixed',
+                top: 'var(--topBarBlockSize, 37px)',
+                left: '0',
+                right: '0',
+                bottom: '0',
+            });
+            document.body.appendChild(container);
+            const containerTop = container.getBoundingClientRect().top;
+            container.remove();
+
+            return { barBottom: document.getElementById('top-bar').getBoundingClientRect().bottom, containerTop };
+        });
+
+        const compact = await measure();
+        expect(compact.containerTop).toBeCloseTo(compact.barBottom, 0);
+
+        // The regression case: with the chat bar row showing, the bar is taller than
+        // --topBarBlockSize and the panel used to paint over the bottom of it.
+        await page.evaluate(() => document.body.classList.remove('sb-topbar-compact'));
+        await waitForAnimationFrames(page, 2);
+
+        const withChatBar = await measure();
+        expect(withChatBar.barBottom).toBeGreaterThan(compact.barBottom);
+        expect(withChatBar.containerTop).toBeCloseTo(withChatBar.barBottom, 0);
+    });
+
+    test('holds the same contract on a phone viewport with the icons-only bar', async ({ page }) => {
+        await page.setViewportSize(IPHONE_VIEWPORT);
+        await openBarForTest(page);
+
+        await page.evaluate(() => {
+            window.SillyBunnyShell?.setTopbarIconsOnly?.(true);
+        });
+        await waitForAnimationFrames(page, 3);
+        await injectCharacterLibraryButton(page);
+
+        const snapshot = await getAdoptionSnapshot(page);
+
+        expect(snapshot.inSlot).toBe(true);
+        expect(snapshot.buttonWidth).toBeLessThan(snapshot.viewportWidth / 2);
+        expect(snapshot.titleBlocked).toBe(false);
+        expect(snapshot.charactersHittable).toBe(true);
+    });
+});

--- a/tests/topbar-extension-slot-wiring.test.js
+++ b/tests/topbar-extension-slot-wiring.test.js
@@ -7,6 +7,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
 const tabsCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
 const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+const paperThemeCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-paper-theme.css'), 'utf8');
 const settingsTabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-settings-tabs.js'), 'utf8');
 
 function getFunctionSource(source, name) {
@@ -52,8 +53,8 @@ function getFunctionSource(source, name) {
     throw new Error(`Unable to find function source for ${name}`);
 }
 
-function getCssRule(css, selector) {
-    const start = css.indexOf(selector);
+function getCssRule(css, selector, fromIndex = 0) {
+    const start = css.indexOf(selector, fromIndex);
     expect(start).toBeGreaterThanOrEqual(0);
     const end = css.indexOf('}', start);
     expect(end).toBeGreaterThan(start);
@@ -172,10 +173,53 @@ describe('top-bar extension slot styling', () => {
         expect(tabsCss.match(/--sb-host-topbar-block-size:/g)).toHaveLength(1);
     });
 
-    test('sizes adopted buttons to the phone target size', () => {
-        expect(mobileShellCss).toContain('#sb-topbar-extension-slot .drawer-icon,');
-        expect(getCssRule(mobileShellCss, '#sb-topbar-extension-slot .drawer-icon,'))
-            .toContain('var(--sb-mobile-toggle-size)');
+    test('lets adopted buttons grow while preserving their target minimum size', () => {
+        const desktopRule = getCssRule(tabsCss, '#sb-topbar-extension-slot .drawer-icon,');
+
+        for (const declaration of [
+            'width: auto;',
+            'inline-size: auto;',
+            'height: var(--sb-proxy-button-height);',
+            'min-width: var(--sb-proxy-button-height);',
+            'min-inline-size: var(--sb-proxy-button-height);',
+            'min-height: var(--sb-proxy-button-height);',
+            'padding: 0;',
+            'margin: 0;',
+        ]) {
+            expect(desktopRule).toContain(declaration);
+        }
+
+        const sharedRuleStart = tabsCss.indexOf('#sb-topbar-extension-slot .drawer-icon,');
+        const labelRule = getCssRule(
+            tabsCss,
+            '#sb-topbar-extension-slot .menu_button,',
+            tabsCss.indexOf('}', sharedRuleStart) + 1,
+        );
+
+        expect(labelRule).toContain('max-width: none;');
+        expect(labelRule).toContain('max-inline-size: min(12rem, 45vw);');
+        expect(labelRule).toContain('white-space: nowrap;');
+        expect(labelRule).toContain('overflow: hidden;');
+
+        const mobileRule = getCssRule(mobileShellCss, '#sb-topbar-extension-slot .drawer-icon,');
+
+        for (const declaration of [
+            'width: auto;',
+            'inline-size: auto;',
+            'height: var(--sb-mobile-toggle-size);',
+            'min-width: var(--sb-mobile-toggle-size);',
+            'min-inline-size: var(--sb-mobile-toggle-size);',
+            'min-height: var(--sb-mobile-toggle-size);',
+        ]) {
+            expect(mobileRule).toContain(declaration);
+        }
+
+        expect(mobileRule).toContain('#sb-topbar-extension-slot .menu_button,');
+
+        // The phone-only paper theme uses !important for its square chrome. Its selector must
+        // leave adopted controls to the slot contract, or normal slot declarations can never win.
+        expect(paperThemeCss).toContain('#top-bar .menu_button:not(#sb-topbar-extension-slot .menu_button),');
+        expect(paperThemeCss).toContain('#topBar .menu_button:not(#sb-topbar-extension-slot .menu_button)');
     });
 
     test('adds no !important declarations to the new top-bar blocks', () => {

--- a/tests/topbar-extension-slot-wiring.test.js
+++ b/tests/topbar-extension-slot-wiring.test.js
@@ -1,0 +1,241 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+const tabsCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
+const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+const settingsTabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-settings-tabs.js'), 'utf8');
+
+function getFunctionSource(source, name) {
+    const marker = `function ${name}(`;
+    const start = source.indexOf(marker);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    // Skip the parameter list before hunting for the body brace: destructured parameters such as
+    // createElement(tagName, { id = '' }) would otherwise close the scan on the first argument.
+    let parenDepth = 0;
+    let bodyStart = -1;
+
+    for (let index = source.indexOf('(', start); index < source.length; index++) {
+        const char = source[index];
+        if (char === '(') {
+            parenDepth++;
+        } else if (char === ')') {
+            parenDepth--;
+            if (parenDepth === 0) {
+                bodyStart = source.indexOf('{', index);
+                break;
+            }
+        }
+    }
+
+    expect(bodyStart).toBeGreaterThan(start);
+
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index++) {
+        const char = source[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return source.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+function getCssRule(css, selector) {
+    const start = css.indexOf(selector);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = css.indexOf('}', start);
+    expect(end).toBeGreaterThan(start);
+    return css.slice(start, end + 1);
+}
+
+describe('top-bar extension slot wiring', () => {
+    test('imports the adoption decisions from the pure module', () => {
+        expect(tabsSource).toContain('from \'./topbar-extension-slot/index.js\';');
+        expect(tabsSource).toContain('resolveTopbarAdoptionPlan');
+        expect(tabsSource).toContain('resolveCharacterBadgeMirrorPlan');
+        expect(tabsSource).toContain('TOPBAR_EXTENSION_SLOT_ID');
+    });
+
+    test('tracks element ownership by identity rather than id prefix', () => {
+        expect(tabsSource).toContain('const sbOwnedElements = new WeakSet();');
+        expect(getFunctionSource(tabsSource, 'createElement')).toContain('sbOwnedElements.add(element);');
+
+        const buildTopBarSource = getFunctionSource(tabsSource, 'buildTopBar');
+        expect(buildTopBarSource).toContain('!isSillyBunnyOwnedElement(child)');
+        expect(buildTopBarSource).not.toContain('child.id.startsWith(\'sb-\')');
+    });
+
+    test('builds the slot and adopts into it instead of appending bare siblings', () => {
+        const buildTopBarSource = getFunctionSource(tabsSource, 'buildTopBar');
+
+        expect(buildTopBarSource).toContain('id: TOPBAR_EXTENSION_SLOT_ID,');
+        expect(buildTopBarSource).toContain('rightGroup.append(extensionSlot,');
+        expect(buildTopBarSource).toContain('topBar.append(stack);');
+        expect(buildTopBarSource).toContain('adoptTopbarExtensionNodes(preservedExtensionChildren);');
+        expect(buildTopBarSource).toContain('bindTopbarExtensionAdoption();');
+        expect(buildTopBarSource).not.toContain('topBar.append(stack, ...preservedExtensionChildren);');
+    });
+
+    test('pins the slot in the canonical right-group order', () => {
+        expect(getFunctionSource(tabsSource, 'getTopbarGroupOrder'))
+            .toContain('const right = [TOPBAR_EXTENSION_SLOT_ID];');
+    });
+
+    test('moves adopted nodes and guards the pass against re-entry', () => {
+        const adoptSource = getFunctionSource(tabsSource, 'adoptTopbarExtensionNodes');
+
+        expect(adoptSource).toContain('sbState.topbarExtensions.adopting');
+        expect(adoptSource).toContain('node.parentElement !== slot');
+        expect(adoptSource).toContain('sbState.topbarExtensions.observer?.takeRecords();');
+        // Cloning would defeat the extension's own "already injected" guard and drop its listeners;
+        // the position-specific move helpers would re-append every node but the last on each pass.
+        expect(adoptSource).not.toContain('cloneNode(');
+        expect(adoptSource).not.toContain('moveElementBefore(');
+        expect(adoptSource).not.toContain('moveElementToStart(');
+    });
+
+    test('observes only direct children of the containers extensions inject into', () => {
+        const bindSource = getFunctionSource(tabsSource, 'bindTopbarExtensionAdoption');
+
+        expect(bindSource).toContain('observer.disconnect();');
+        expect(bindSource).toContain('{ childList: true }');
+        expect(bindSource).not.toContain('subtree: true');
+        expect(bindSource).toContain('getCanonicalTopSettingsHolder()');
+        expect(bindSource).toContain('getNativeCharacterDrawerIcon()');
+    });
+
+    test('mirrors extension badges onto the visible Characters proxy button', () => {
+        const badgeSource = getFunctionSource(tabsSource, 'syncCharacterToggleBadges');
+
+        expect(badgeSource).toContain('resolveCharacterBadgeMirrorPlan');
+        expect(badgeSource).toContain('TOPBAR_ADOPTED_MARKER_ATTRIBUTE');
+        expect(badgeSource).toContain('sb-has-adopted-badge');
+        expect(badgeSource).not.toContain('cloneNode(');
+    });
+
+    test('leaves the proxy button state observer scoped to class changes', () => {
+        const observeSource = getFunctionSource(tabsSource, 'observeProxyButton');
+
+        expect(observeSource).toContain('attributeFilter: [\'class\']');
+        expect(observeSource).not.toContain('childList');
+    });
+});
+
+describe('top-bar extension slot styling', () => {
+    test('constrains a foreign drawer left in the top strip', () => {
+        const rule = getCssRule(tabsCss, '#top-settings-holder > .drawer:not(#ai-config-button)');
+
+        expect(rule).toContain('pointer-events: auto;');
+        expect(rule).toContain('width: auto;');
+        expect(rule).toContain('flex: 0 0 auto;');
+    });
+
+    test('overrides upstream .drawer sizing on specificity alone', () => {
+        const rule = getCssRule(tabsCss, '#sb-topbar-extension-slot > .drawer {');
+
+        expect(rule).toContain('width: auto;');
+        expect(rule).not.toContain('!important');
+    });
+
+    test('hides the slot when empty so the fit measurement is not inflated by a gap', () => {
+        const rule = getCssRule(tabsCss, '#sb-topbar-extension-slot[data-sb-topbar-slot-empty=\'true\']');
+
+        expect(rule).toContain('display: none;');
+    });
+
+    test('un-clips the proxy button only when it carries a mirrored badge', () => {
+        expect(getCssRule(tabsCss, '.sb-proxy-button.sb-has-adopted-badge')).toContain('overflow: visible;');
+    });
+
+    test('re-anchors the CharacterLibrary embedded panel to the real bar height', () => {
+        const rule = getCssRule(tabsCss, '#charlib-embedded-container {');
+
+        // Neither operand clears the bar on its own: the layout offset stops just short of the
+        // bar's bottom edge on phones, and the upstream height stops short of the chat bar row.
+        expect(rule).toContain('--topBarBlockSize: max(var(--sb-host-topbar-block-size), var(--sb-topbar-layout-offset));');
+        expect(rule).not.toContain('!important');
+
+        // The alias is what keeps the scoped override from being a self-referential cycle.
+        expect(tabsCss).toContain('--sb-host-topbar-block-size: var(--topBarBlockSize);');
+        expect(tabsCss.match(/--sb-host-topbar-block-size:/g)).toHaveLength(1);
+    });
+
+    test('sizes adopted buttons to the phone target size', () => {
+        expect(mobileShellCss).toContain('#sb-topbar-extension-slot .drawer-icon,');
+        expect(getCssRule(mobileShellCss, '#sb-topbar-extension-slot .drawer-icon,'))
+            .toContain('var(--sb-mobile-toggle-size)');
+    });
+
+    test('adds no !important declarations to the new top-bar blocks', () => {
+        const slotBlocks = tabsCss.slice(tabsCss.indexOf('#sb-topbar-extension-slot {'), tabsCss.indexOf('#charlib-embedded-container {'));
+
+        expect(slotBlocks).not.toContain('!important');
+    });
+});
+
+describe('mobile composer third-party buttons', () => {
+    test('names what the phone composer hides instead of allow-listing what it keeps', () => {
+        expect(mobileShellCss).not.toContain('#rightSendForm > div:not(#send_but)');
+
+        const rule = getCssRule(mobileShellCss, '#rightSendForm > #mes_impersonate,');
+
+        expect(rule).toContain('#rightSendForm > #mes_continue,');
+        expect(rule).toContain('#rightSendForm > #sb_prose_polisher_but,');
+        expect(rule).toContain('#rightSendForm > .stscript_btn');
+        expect(rule).toContain('display: none !important;');
+    });
+
+    test('relocates foreign right-rail buttons into the scrollable left rail on phones', () => {
+        expect(tabsSource).toContain('const SB_COMPOSER_NATIVE_RIGHT_RAIL_IDS = Object.freeze([');
+
+        for (const id of ['stscript_continue', 'stscript_pause', 'stscript_stop', 'mes_stop', 'mes_impersonate', 'mes_continue', 'sb_prose_polisher_but', 'send_but', 'qig-input-btn']) {
+            expect(tabsSource).toContain(`'${id}',`);
+        }
+
+        const placeSource = getFunctionSource(tabsSource, 'placeComposerExtensionButtons');
+
+        expect(placeSource).toContain('isMobileViewport()');
+        expect(placeSource).toContain('SB_COMPOSER_NATIVE_RIGHT_RAIL_IDS.includes(child.id)');
+        expect(placeSource).toContain('leftForm.appendChild(child);');
+        expect(placeSource).toContain('rightForm.appendChild(child);');
+
+        expect(getFunctionSource(tabsSource, 'placeComposerControls'))
+            .toContain('placeComposerExtensionButtons(leftForm, rightForm);');
+    });
+});
+
+describe('third-party settings drawers', () => {
+    test('only hides drawers that carry a tab tag, so untagged ones fail open', () => {
+        expect(settingsTabsSource).toContain('.inline-drawer[data-settings-tab]:not([data-settings-tab="appearance"])');
+        expect(settingsTabsSource).toContain('.inline-drawer[data-settings-tab]:not([data-settings-tab="cache-account"])');
+        expect(settingsTabsSource).not.toContain('[data-active-tab="appearance"] .inline-drawer:not(');
+    });
+
+    test('gives late third-party drawers a default tab and keeps watching for more', () => {
+        expect(settingsTabsSource).toContain('const DEFAULT_SETTINGS_TAB = \'system-device\';');
+
+        const tagSource = getFunctionSource(settingsTabsSource, 'tagUntaggedDrawers');
+        expect(tagSource).toContain('.inline-drawer:not([data-settings-tab])');
+        expect(tagSource).toContain('drawer.parentElement?.closest(\'.inline-drawer[data-settings-tab]\')');
+
+        const watchSource = getFunctionSource(settingsTabsSource, 'watchForLateDrawers');
+        expect(watchSource).toContain('new MutationObserver');
+        expect(watchSource).toContain('tagUntaggedDrawers();');
+
+        const initializeSource = getFunctionSource(settingsTabsSource, 'initialize');
+        expect(initializeSource).toContain('tagUntaggedDrawers();');
+        expect(initializeSource).toContain('watchForLateDrawers();');
+    });
+});

--- a/tests/topbar-extension-slot-wiring.test.js
+++ b/tests/topbar-extension-slot-wiring.test.js
@@ -4,282 +4,41 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
-const tabsCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
-const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
-const paperThemeCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-paper-theme.css'), 'utf8');
-const settingsTabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-settings-tabs.js'), 'utf8');
-
-function getFunctionSource(source, name) {
-    const marker = `function ${name}(`;
-    const start = source.indexOf(marker);
-
-    expect(start).toBeGreaterThanOrEqual(0);
-
-    // Skip the parameter list before hunting for the body brace: destructured parameters such as
-    // createElement(tagName, { id = '' }) would otherwise close the scan on the first argument.
-    let parenDepth = 0;
-    let bodyStart = -1;
-
-    for (let index = source.indexOf('(', start); index < source.length; index++) {
-        const char = source[index];
-        if (char === '(') {
-            parenDepth++;
-        } else if (char === ')') {
-            parenDepth--;
-            if (parenDepth === 0) {
-                bodyStart = source.indexOf('{', index);
-                break;
-            }
-        }
-    }
-
-    expect(bodyStart).toBeGreaterThan(start);
-
-    let depth = 0;
-
-    for (let index = bodyStart; index < source.length; index++) {
-        const char = source[index];
-        if (char === '{') {
-            depth++;
-        } else if (char === '}') {
-            depth--;
-            if (depth === 0) {
-                return source.slice(start, index + 1);
-            }
-        }
-    }
-
-    throw new Error(`Unable to find function source for ${name}`);
-}
-
-function getCssRule(css, selector, fromIndex = 0) {
-    const start = css.indexOf(selector, fromIndex);
-    expect(start).toBeGreaterThanOrEqual(0);
-    const end = css.indexOf('}', start);
-    expect(end).toBeGreaterThan(start);
-    return css.slice(start, end + 1);
-}
+const readRepoFile = (...segments) => readFileSync(path.join(repoRoot, ...segments), 'utf8');
+const tabsSource = readRepoFile('public', 'scripts', 'sillybunny-tabs.js');
+const tabsCss = readRepoFile('public', 'css', 'sillybunny-tabs.css');
+const mobileShellCss = readRepoFile('public', 'css', 'sillybunny-mobile-shell.css');
+const paperThemeCss = readRepoFile('public', 'css', 'sillybunny-paper-theme.css');
+const settingsTabsSource = readRepoFile('public', 'scripts', 'sillybunny-settings-tabs.js');
 
 describe('top-bar extension slot wiring', () => {
-    test('imports the adoption decisions from the pure module', () => {
+    test('connects the adoption module to the shell lifecycle', () => {
         expect(tabsSource).toContain('from \'./topbar-extension-slot/index.js\';');
-        expect(tabsSource).toContain('resolveTopbarAdoptionPlan');
-        expect(tabsSource).toContain('resolveCharacterBadgeMirrorPlan');
-        expect(tabsSource).toContain('TOPBAR_EXTENSION_SLOT_ID');
+        expect(tabsSource).toContain('resolveTopbarAdoptionPlan({');
+        expect(tabsSource).toContain('resolveCharacterBadgeMirrorPlan({');
+        expect(tabsSource).toContain('adoptTopbarExtensionNodes(preservedExtensionChildren);');
+        expect(tabsSource).toContain('bindTopbarExtensionAdoption();');
     });
 
-    test('tracks element ownership by identity rather than id prefix', () => {
-        expect(tabsSource).toContain('const sbOwnedElements = new WeakSet();');
-        expect(getFunctionSource(tabsSource, 'createElement')).toContain('sbOwnedElements.add(element);');
-
-        const buildTopBarSource = getFunctionSource(tabsSource, 'buildTopBar');
-        expect(buildTopBarSource).toContain('!isSillyBunnyOwnedElement(child)');
-        expect(buildTopBarSource).not.toContain('child.id.startsWith(\'sb-\')');
-    });
-
-    test('builds the slot and adopts into it instead of appending bare siblings', () => {
-        const buildTopBarSource = getFunctionSource(tabsSource, 'buildTopBar');
-
-        expect(buildTopBarSource).toContain('id: TOPBAR_EXTENSION_SLOT_ID,');
-        expect(buildTopBarSource).toContain('rightGroup.append(extensionSlot,');
-        expect(buildTopBarSource).toContain('topBar.append(stack);');
-        expect(buildTopBarSource).toContain('adoptTopbarExtensionNodes(preservedExtensionChildren);');
-        expect(buildTopBarSource).toContain('bindTopbarExtensionAdoption();');
-        expect(buildTopBarSource).not.toContain('topBar.append(stack, ...preservedExtensionChildren);');
-    });
-
-    test('pins the slot in the canonical right-group order', () => {
-        expect(getFunctionSource(tabsSource, 'getTopbarGroupOrder'))
-            .toContain('const right = [TOPBAR_EXTENSION_SLOT_ID];');
-    });
-
-    test('moves adopted nodes and guards the pass against re-entry', () => {
-        const adoptSource = getFunctionSource(tabsSource, 'adoptTopbarExtensionNodes');
-
-        expect(adoptSource).toContain('sbState.topbarExtensions.adopting');
-        expect(adoptSource).toContain('node.parentElement !== slot');
-        expect(adoptSource).toContain('sbState.topbarExtensions.observer?.takeRecords();');
-        // Cloning would defeat the extension's own "already injected" guard and drop its listeners;
-        // the position-specific move helpers would re-append every node but the last on each pass.
-        expect(adoptSource).not.toContain('cloneNode(');
-        expect(adoptSource).not.toContain('moveElementBefore(');
-        expect(adoptSource).not.toContain('moveElementToStart(');
-    });
-
-    test('observes only direct children of the containers extensions inject into', () => {
-        const bindSource = getFunctionSource(tabsSource, 'bindTopbarExtensionAdoption');
-
-        expect(bindSource).toContain('observer.disconnect();');
-        expect(bindSource).toContain('{ childList: true }');
-        expect(bindSource).not.toContain('subtree: true');
-        expect(bindSource).toContain('getCanonicalTopSettingsHolder()');
-        expect(bindSource).toContain('getNativeCharacterDrawerIcon()');
-    });
-
-    test('mirrors extension badges onto the visible Characters proxy button', () => {
-        const badgeSource = getFunctionSource(tabsSource, 'syncCharacterToggleBadges');
-
-        expect(badgeSource).toContain('resolveCharacterBadgeMirrorPlan');
-        expect(badgeSource).toContain('TOPBAR_ADOPTED_MARKER_ATTRIBUTE');
-        expect(badgeSource).toContain('sb-has-adopted-badge');
-        expect(badgeSource).not.toContain('cloneNode(');
-    });
-
-    test('leaves the proxy button state observer scoped to class changes', () => {
-        const observeSource = getFunctionSource(tabsSource, 'observeProxyButton');
-
-        expect(observeSource).toContain('attributeFilter: [\'class\']');
-        expect(observeSource).not.toContain('childList');
-    });
-});
-
-describe('top-bar extension slot styling', () => {
-    test('constrains a foreign drawer left in the top strip', () => {
-        const rule = getCssRule(tabsCss, '#top-settings-holder > .drawer:not(#ai-config-button)');
-
-        expect(rule).toContain('pointer-events: auto;');
-        expect(rule).toContain('width: auto;');
-        expect(rule).toContain('flex: 0 0 auto;');
-    });
-
-    test('overrides upstream .drawer sizing on specificity alone', () => {
-        const rule = getCssRule(tabsCss, '#sb-topbar-extension-slot > .drawer {');
-
-        expect(rule).toContain('width: auto;');
-        expect(rule).not.toContain('!important');
-    });
-
-    test('hides the slot when empty so the fit measurement is not inflated by a gap', () => {
-        const rule = getCssRule(tabsCss, '#sb-topbar-extension-slot[data-sb-topbar-slot-empty=\'true\']');
-
-        expect(rule).toContain('display: none;');
-    });
-
-    test('un-clips the proxy button only when it carries a mirrored badge', () => {
-        expect(getCssRule(tabsCss, '.sb-proxy-button.sb-has-adopted-badge')).toContain('overflow: visible;');
-    });
-
-    test('re-anchors the CharacterLibrary embedded panel to the real bar height', () => {
-        const rule = getCssRule(tabsCss, '#charlib-embedded-container {');
-
-        // Neither operand clears the bar on its own: the layout offset stops just short of the
-        // bar's bottom edge on phones, and the upstream height stops short of the chat bar row.
-        expect(rule).toContain('--topBarBlockSize: max(var(--sb-host-topbar-block-size), var(--sb-topbar-layout-offset));');
-        expect(rule).not.toContain('!important');
-
-        // The alias is what keeps the scoped override from being a self-referential cycle.
-        expect(tabsCss).toContain('--sb-host-topbar-block-size: var(--topBarBlockSize);');
-        expect(tabsCss.match(/--sb-host-topbar-block-size:/g)).toHaveLength(1);
-    });
-
-    test('lets adopted buttons grow while preserving their target minimum size', () => {
-        const desktopRule = getCssRule(tabsCss, '#sb-topbar-extension-slot .drawer-icon,');
-
-        for (const declaration of [
-            'width: auto;',
-            'inline-size: auto;',
-            'height: var(--sb-proxy-button-height);',
-            'min-width: var(--sb-proxy-button-height);',
-            'min-inline-size: var(--sb-proxy-button-height);',
-            'min-height: var(--sb-proxy-button-height);',
-            'padding: 0;',
-            'margin: 0;',
-        ]) {
-            expect(desktopRule).toContain(declaration);
-        }
-
-        const sharedRuleStart = tabsCss.indexOf('#sb-topbar-extension-slot .drawer-icon,');
-        const labelRule = getCssRule(
-            tabsCss,
-            '#sb-topbar-extension-slot .menu_button,',
-            tabsCss.indexOf('}', sharedRuleStart) + 1,
-        );
-
-        expect(labelRule).toContain('max-width: none;');
-        expect(labelRule).toContain('max-inline-size: min(12rem, 45vw);');
-        expect(labelRule).toContain('white-space: nowrap;');
-        expect(labelRule).toContain('overflow: hidden;');
-
-        const mobileRule = getCssRule(mobileShellCss, '#sb-topbar-extension-slot .drawer-icon,');
-
-        for (const declaration of [
-            'width: auto;',
-            'inline-size: auto;',
-            'height: var(--sb-mobile-toggle-size);',
-            'min-width: var(--sb-mobile-toggle-size);',
-            'min-inline-size: var(--sb-mobile-toggle-size);',
-            'min-height: var(--sb-mobile-toggle-size);',
-        ]) {
-            expect(mobileRule).toContain(declaration);
-        }
-
-        expect(mobileRule).toContain('#sb-topbar-extension-slot .menu_button,');
-
-        // The phone-only paper theme uses !important for its square chrome. Its selector must
-        // leave adopted controls to the slot contract, or normal slot declarations can never win.
+    test('declares the slot sizing and panel anchoring contracts', () => {
+        expect(tabsCss).toContain('#sb-topbar-extension-slot[data-sb-topbar-slot-empty=\'true\']');
+        expect(tabsCss).toContain('#sb-topbar-extension-slot .menu_button,');
+        expect(tabsCss).toContain('max-inline-size: min(12rem, 45vw);');
+        expect(tabsCss).toContain('--topBarBlockSize: max(var(--sb-host-topbar-block-size), var(--sb-topbar-layout-offset));');
+        expect(mobileShellCss).toContain('#sb-topbar-extension-slot .menu_button,');
         expect(paperThemeCss).toContain('#top-bar .menu_button:not(#sb-topbar-extension-slot .menu_button),');
-        expect(paperThemeCss).toContain('#topBar .menu_button:not(#sb-topbar-extension-slot .menu_button)');
     });
 
-    test('adds no !important declarations to the new top-bar blocks', () => {
-        const slotBlocks = tabsCss.slice(tabsCss.indexOf('#sb-topbar-extension-slot {'), tabsCss.indexOf('#charlib-embedded-container {'));
-
-        expect(slotBlocks).not.toContain('!important');
-    });
-});
-
-describe('mobile composer third-party buttons', () => {
-    test('names what the phone composer hides instead of allow-listing what it keeps', () => {
+    test('keeps third-party composer controls available on mobile', () => {
         expect(mobileShellCss).not.toContain('#rightSendForm > div:not(#send_but)');
-
-        const rule = getCssRule(mobileShellCss, '#rightSendForm > #mes_impersonate,');
-
-        expect(rule).toContain('#rightSendForm > #mes_continue,');
-        expect(rule).toContain('#rightSendForm > #sb_prose_polisher_but,');
-        expect(rule).toContain('#rightSendForm > .stscript_btn');
-        expect(rule).toContain('display: none !important;');
+        expect(mobileShellCss).toContain('#rightSendForm > #mes_impersonate,');
+        expect(tabsSource).toContain('placeComposerExtensionButtons(leftForm, rightForm);');
     });
 
-    test('relocates foreign right-rail buttons into the scrollable left rail on phones', () => {
-        expect(tabsSource).toContain('const SB_COMPOSER_NATIVE_RIGHT_RAIL_IDS = Object.freeze([');
-
-        for (const id of ['stscript_continue', 'stscript_pause', 'stscript_stop', 'mes_stop', 'mes_impersonate', 'mes_continue', 'sb_prose_polisher_but', 'send_but', 'qig-input-btn']) {
-            expect(tabsSource).toContain(`'${id}',`);
-        }
-
-        const placeSource = getFunctionSource(tabsSource, 'placeComposerExtensionButtons');
-
-        expect(placeSource).toContain('isMobileViewport()');
-        expect(placeSource).toContain('SB_COMPOSER_NATIVE_RIGHT_RAIL_IDS.includes(child.id)');
-        expect(placeSource).toContain('leftForm.appendChild(child);');
-        expect(placeSource).toContain('rightForm.appendChild(child);');
-
-        expect(getFunctionSource(tabsSource, 'placeComposerControls'))
-            .toContain('placeComposerExtensionButtons(leftForm, rightForm);');
-    });
-});
-
-describe('third-party settings drawers', () => {
-    test('only hides drawers that carry a tab tag, so untagged ones fail open', () => {
-        expect(settingsTabsSource).toContain('.inline-drawer[data-settings-tab]:not([data-settings-tab="appearance"])');
-        expect(settingsTabsSource).toContain('.inline-drawer[data-settings-tab]:not([data-settings-tab="cache-account"])');
-        expect(settingsTabsSource).not.toContain('[data-active-tab="appearance"] .inline-drawer:not(');
-    });
-
-    test('gives late third-party drawers a default tab and keeps watching for more', () => {
+    test('assigns late third-party drawers to a visible settings tab', () => {
         expect(settingsTabsSource).toContain('const DEFAULT_SETTINGS_TAB = \'system-device\';');
-
-        const tagSource = getFunctionSource(settingsTabsSource, 'tagUntaggedDrawers');
-        expect(tagSource).toContain('.inline-drawer:not([data-settings-tab])');
-        expect(tagSource).toContain('drawer.parentElement?.closest(\'.inline-drawer[data-settings-tab]\')');
-
-        const watchSource = getFunctionSource(settingsTabsSource, 'watchForLateDrawers');
-        expect(watchSource).toContain('new MutationObserver');
-        expect(watchSource).toContain('tagUntaggedDrawers();');
-
-        const initializeSource = getFunctionSource(settingsTabsSource, 'initialize');
-        expect(initializeSource).toContain('tagUntaggedDrawers();');
-        expect(initializeSource).toContain('watchForLateDrawers();');
+        expect(settingsTabsSource).toContain('.inline-drawer:not([data-settings-tab])');
+        expect(settingsTabsSource).toContain('tagUntaggedDrawers();');
+        expect(settingsTabsSource).toContain('watchForLateDrawers();');
     });
 });

--- a/tests/topbar-extension-slot.test.js
+++ b/tests/topbar-extension-slot.test.js
@@ -153,6 +153,49 @@ describe('character badge mirror plan', () => {
         expect(plan.removeKeys).toEqual(['badge:host-0']);
     });
 
+    test('moves only the newest when duplicates arrive in the same batch', () => {
+        // Two setup passes before the queued sync land both badges on the native icon at once.
+        // Listing the older one in both moveKeys and removeKeys would have the executor remove
+        // it and then immediately append it again, leaving two badges on the button.
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [
+                badge('badge:0', 'charlib-chevron-badge'),
+                badge('badge:1', 'charlib-chevron-badge'),
+            ],
+            hostBadges: [],
+        });
+
+        expect(plan.moveKeys).toEqual(['badge:1']);
+        expect(plan.removeKeys).toEqual(['badge:0']);
+    });
+
+    test('never lists a key in both moveKeys and removeKeys', () => {
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [
+                badge('badge:0', 'charlib-chevron-badge'),
+                badge('badge:1', 'charlib-chevron-badge'),
+                badge('badge:2', 'other-badge'),
+            ],
+            hostBadges: [badge('badge:host-0', 'charlib-chevron-badge')],
+        });
+
+        expect(plan.moveKeys.filter(key => plan.removeKeys.includes(key))).toEqual([]);
+        expect(plan.moveKeys).toEqual(['badge:1', 'badge:2']);
+    });
+
+    test('drops a stale duplicate already mirrored on the proxy button', () => {
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [],
+            hostBadges: [
+                badge('badge:host-0', 'charlib-chevron-badge'),
+                badge('badge:host-1', 'charlib-chevron-badge'),
+            ],
+        });
+
+        expect(plan.moveKeys).toEqual([]);
+        expect(plan.removeKeys).toEqual(['badge:host-0']);
+    });
+
     test('keeps badges with different signatures side by side', () => {
         const plan = resolveCharacterBadgeMirrorPlan({
             iconBadges: [badge('badge:0', 'charlib-chevron-badge'), badge('badge:1', 'other-badge')],

--- a/tests/topbar-extension-slot.test.js
+++ b/tests/topbar-extension-slot.test.js
@@ -1,0 +1,174 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+    isNativeTopbarDrawerId,
+    resolveCharacterBadgeMirrorPlan,
+    resolveTopbarAdoptionPlan,
+    resolveTopbarNodeAdoption,
+    TOPBAR_ADOPTION_SKIP_REASON,
+    TOPBAR_NATIVE_DRAWER_IDS,
+} from '../public/scripts/topbar-extension-slot/index.js';
+
+function describeNode(overrides = {}) {
+    return {
+        isElement: true,
+        id: '',
+        tagName: 'DIV',
+        classNames: [],
+        adoptAttribute: null,
+        isSillyBunnyOwned: false,
+        ...overrides,
+    };
+}
+
+describe('topbar extension adoption rules', () => {
+    test('covers every native top-bar drawer', () => {
+        expect(TOPBAR_NATIVE_DRAWER_IDS).toHaveLength(9);
+
+        for (const id of TOPBAR_NATIVE_DRAWER_IDS) {
+            expect(isNativeTopbarDrawerId(id)).toBe(true);
+            expect(resolveTopbarNodeAdoption(describeNode({ id, classNames: ['drawer'] }))).toEqual({
+                shouldAdopt: false,
+                reason: TOPBAR_ADOPTION_SKIP_REASON.NATIVE_DRAWER,
+            });
+        }
+    });
+
+    test('adopts an id that merely resembles a native drawer', () => {
+        expect(isNativeTopbarDrawerId('ai-config-button-2')).toBe(false);
+        expect(resolveTopbarNodeAdoption(describeNode({ id: 'ai-config-button-2' })).shouldAdopt).toBe(true);
+    });
+
+    test('adopts the CharacterLibrary standalone button', () => {
+        const verdict = resolveTopbarNodeAdoption(describeNode({ id: 'st-gallery-btn', classNames: ['drawer'] }));
+
+        expect(verdict).toEqual({ shouldAdopt: true, reason: '' });
+    });
+
+    test('adopts an extension that uses an sb- id prefix', () => {
+        // The previous filter keyed on the id prefix, so any extension picking one was treated as
+        // SillyBunny's own markup and left to stretch across the bar.
+        const verdict = resolveTopbarNodeAdoption(describeNode({ id: 'sb-third-party-button' }));
+
+        expect(verdict.shouldAdopt).toBe(true);
+    });
+
+    test('skips SillyBunny-owned elements regardless of id', () => {
+        const verdict = resolveTopbarNodeAdoption(describeNode({ id: 'anything', isSillyBunnyOwned: true }));
+
+        expect(verdict).toEqual({
+            shouldAdopt: false,
+            reason: TOPBAR_ADOPTION_SKIP_REASON.SILLYBUNNY_OWNED,
+        });
+    });
+
+    test('skips non-element nodes', () => {
+        expect(resolveTopbarNodeAdoption(describeNode({ isElement: false })).reason)
+            .toBe(TOPBAR_ADOPTION_SKIP_REASON.NOT_ELEMENT);
+    });
+
+    test('skips excluded tags and panel classes', () => {
+        expect(resolveTopbarNodeAdoption(describeNode({ tagName: 'SCRIPT' })).reason)
+            .toBe(TOPBAR_ADOPTION_SKIP_REASON.EXCLUDED_TAG);
+        expect(resolveTopbarNodeAdoption(describeNode({ classNames: ['drawer-content', 'openDrawer'] })).reason)
+            .toBe(TOPBAR_ADOPTION_SKIP_REASON.EXCLUDED_CLASS);
+        expect(resolveTopbarNodeAdoption(describeNode({ classNames: 'popup wide' })).reason)
+            .toBe(TOPBAR_ADOPTION_SKIP_REASON.EXCLUDED_CLASS);
+    });
+
+    test('honours the documented opt-out and opt-in attribute', () => {
+        expect(resolveTopbarNodeAdoption(describeNode({ id: 'st-gallery-btn', adoptAttribute: 'false' })).reason)
+            .toBe(TOPBAR_ADOPTION_SKIP_REASON.OPTED_OUT);
+        expect(resolveTopbarNodeAdoption(describeNode({ classNames: ['popup'], adoptAttribute: 'true' })).shouldAdopt)
+            .toBe(true);
+    });
+
+    test('an opt-in attribute cannot claim a native drawer or our own element', () => {
+        expect(resolveTopbarNodeAdoption(describeNode({ id: 'rightNavHolder', adoptAttribute: 'true' })).shouldAdopt)
+            .toBe(false);
+        expect(resolveTopbarNodeAdoption(describeNode({ isSillyBunnyOwned: true, adoptAttribute: 'true' })).shouldAdopt)
+            .toBe(false);
+    });
+});
+
+describe('topbar adoption plan', () => {
+    test('adopts foreign nodes and reports why the rest were skipped', () => {
+        const plan = resolveTopbarAdoptionPlan({
+            nodes: [
+                describeNode({ key: 'id:rightNavHolder', id: 'rightNavHolder' }),
+                describeNode({ key: 'id:st-gallery-btn', id: 'st-gallery-btn', classNames: ['drawer'] }),
+                describeNode({ key: 'id:sb-topbar-stack', id: 'sb-topbar-stack', isSillyBunnyOwned: true }),
+            ],
+            slotChildKeys: [],
+        });
+
+        expect(plan.adoptKeys).toEqual(['id:st-gallery-btn']);
+        expect(plan.skipped).toEqual([
+            { key: 'id:rightNavHolder', reason: TOPBAR_ADOPTION_SKIP_REASON.NATIVE_DRAWER },
+            { key: 'id:sb-topbar-stack', reason: TOPBAR_ADOPTION_SKIP_REASON.SILLYBUNNY_OWNED },
+        ]);
+    });
+
+    test('is idempotent: replaying a pass adopts nothing new', () => {
+        const nodes = [
+            describeNode({ key: 'id:st-gallery-btn', id: 'st-gallery-btn', classNames: ['drawer'] }),
+            describeNode({ key: 'id:other-ext-btn', id: 'other-ext-btn' }),
+        ];
+
+        const first = resolveTopbarAdoptionPlan({ nodes, slotChildKeys: [] });
+        expect(first.adoptKeys).toEqual(['id:st-gallery-btn', 'id:other-ext-btn']);
+
+        const second = resolveTopbarAdoptionPlan({ nodes, slotChildKeys: first.adoptKeys });
+        expect(second.adoptKeys).toEqual([]);
+    });
+
+    test('does not adopt the same key twice within one pass', () => {
+        const duplicate = describeNode({ key: 'id:st-gallery-btn', id: 'st-gallery-btn' });
+        const plan = resolveTopbarAdoptionPlan({ nodes: [duplicate, duplicate], slotChildKeys: [] });
+
+        expect(plan.adoptKeys).toEqual(['id:st-gallery-btn']);
+    });
+});
+
+describe('character badge mirror plan', () => {
+    function badge(key, className, overrides = {}) {
+        return describeNode({ key, signature: `I:${className}`, tagName: 'I', classNames: [className], ...overrides });
+    }
+
+    test('moves an extension badge onto the proxy button', () => {
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [badge('badge:0', 'charlib-chevron-badge')],
+            hostBadges: [],
+        });
+
+        expect(plan).toEqual({ moveKeys: ['badge:0'], removeKeys: [] });
+    });
+
+    test('replaces a previously mirrored badge instead of stacking duplicates', () => {
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [badge('badge:0', 'charlib-chevron-badge')],
+            hostBadges: [badge('badge:host-0', 'charlib-chevron-badge')],
+        });
+
+        expect(plan.moveKeys).toEqual(['badge:0']);
+        expect(plan.removeKeys).toEqual(['badge:host-0']);
+    });
+
+    test('keeps badges with different signatures side by side', () => {
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [badge('badge:0', 'charlib-chevron-badge'), badge('badge:1', 'other-badge')],
+            hostBadges: [],
+        });
+
+        expect(plan.moveKeys).toEqual(['badge:0', 'badge:1']);
+        expect(plan.removeKeys).toEqual([]);
+    });
+
+    test('ignores children that are not adoptable', () => {
+        const plan = resolveCharacterBadgeMirrorPlan({
+            iconBadges: [badge('badge:0', 'charlib-chevron-badge', { tagName: 'SCRIPT' })],
+            hostBadges: [],
+        });
+
+        expect(plan.moveKeys).toEqual([]);
+    });
+});


### PR DESCRIPTION
## CharacterLibrary
Third-party extension [CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) is a well-used extension, this PR involves making SB have full parity with it. Addresses the specific named issue: "If in embedded panel mode (possibly not just then) it seems to take over the entire top bar and blocks all of the other menus if you forget to turn on "Show launcher dropdown on Characters button". Easy enough to fix by turning it on, but I had to use the inspect console to dike out its button in order to reach the settings menu again."
Audits for other compatibility patches as well.

- Extensions adding a plain (non-drawer) button were getting one that was completely unclickable.
- CharacterLibrary's chevron marker was being attached to a hidden copy of the Characters button, so you never saw that the button had a menu. It's now mirrored onto the visible one.
- Its embedded panel was anchored to the height of only the top row, so it covered the chat bar row underneath. Now it's anchored to the whole bar.
- Third-party buttons in the composer were hidden outright on phones, and third-party settings panels were invisible in all four settings tabs. Both now show up.

## ST-Copilot
Another popular third-party extension, [ST-Copilot](https://github.com/Supker/ST-Copilot), also doesn't quite work correctly in SillyBunny.
SillyBunny doesn't resolve if there is a typo in reasoning effort (e.g. capital M Medium) so it fails. Should now resolve properly by automatically correcting capitalisation, and adds extra high, none, and auto properly into the NanoGPT backend. Previously it sent nothing at all and just picked a random effort.

### Others
Additionally, this also resolved other possible third-party extensions having problems with rendering buttons on the top bar in the future. If a button, similar to ST-Copilot had its own special CSS rules, SillyBunny didn't consider it a button with actual text, so it showed rendering issues with only an icon and text escaping the button bounds. Now it should grow to fit for similar CSS.

#### Testing
Tested both personally on my machine, any other errors I found (such as the search in CharacterLibrary) are bugged in the extension upstream due to my typically 4:3 browser size. ST-Copilot intercepts outgoing requests so it changes 'maximum' to 'high'. Any errors in that regard are on the extension upstream.