### PR TITLE
chore: add deepseek reasoning efforts on the backend UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2056,7 +2056,7 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,linkapi">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,linkapi,deepseek">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>
@@ -2088,6 +2088,9 @@
                                                 <span data-i18n="Allocates a portion of the response length for thinking (Flash 2.5/Pro 2.5) (min: 0/128 tokens, low: 10%, medium: 25%, high: 50%, max: 24576/32768 tokens). Auto lets the model decide.">
                                                     Allocates a portion of the response length for thinking (Flash 2.5/Pro 2.5) (min: 0/128 tokens, low: 10%, medium: 25%, high: 50%, max: 24576/32768 tokens). Auto lets the model decide.
                                                 </span>
+                                            </div>
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="deepseek" data-i18n="DeepSeek only accepts low, high, and max reasoning efforts. Medium and xhigh alias to high. Minimum aliases to low.">
+                                                DeepSeek only accepts low, high, and max reasoning efforts. Medium and xhigh alias to high. Minimum aliases to low.
                                             </div>
                                         </div>
                                     </div>
@@ -3660,8 +3663,8 @@
                             <div>
                                 <h4 data-i18n="DeepSeek Model">DeepSeek Model</h4>
                                 <select id="model_deepseek_select">
-                                    <option value="deepseek-chat">deepseek-chat</option>
-                                    <option value="deepseek-reasoner">deepseek-reasoner</option>
+                                    <option value="deepseek-v4-flash">deepseek-v4-flash</option>
+                                    <option value="deepseek-v4-pro">deepseek-v4-pro</option>
                                 </select>
                             </div>
                         </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -590,7 +590,7 @@ const default_settings = {
     electronhub_sort_models: 'alphabetically',
     electronhub_group_models: false,
     nanogpt_model: 'gpt-4o-mini',
-    deepseek_model: 'deepseek-chat',
+    deepseek_model: 'deepseek-v4-flash',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
     pollinations_model: 'openai',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1185,6 +1185,11 @@ async function sendDeepSeekRequest(request, response) {
             bodyParams['logprobs'] = true;
         }
 
+        // DeepSeek accepts low/high/max and aliases medium/xhigh to high itself; min has no DeepSeek meaning.
+        if (isThinkingModel && request.body.reasoning_effort && !['auto', 'none'].includes(request.body.reasoning_effort)) {
+            bodyParams['reasoning_effort'] = request.body.reasoning_effort === 'min' ? 'low' : request.body.reasoning_effort;
+        }
+
         if (Array.isArray(request.body.tools) && request.body.tools.length > 0) {
             bodyParams['tools'] = request.body.tools;
             bodyParams['tool_choice'] = request.body.tool_choice;

--- a/tests/deepseek-reasoning-effort.test.js
+++ b/tests/deepseek-reasoning-effort.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const readSource = (relativePath) => fs.readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const indexSource = readSource('../public/index.html');
+const openAiSource = readSource('../public/scripts/openai.js');
+const chatCompletionsSource = readSource('../src/endpoints/backends/chat-completions.js');
+
+describe('DeepSeek reasoning effort', () => {
+    test('exposes the reasoning effort control and a DeepSeek-specific hint', () => {
+        const wrapper = indexSource.match(/<div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="([^"]*)">\s*<div class="flex-container oneline-dropdown"[^>]*>\s*<label for="openai_reasoning_effort">/);
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper[1].split(',')).toContain('deepseek');
+        expect(indexSource).toMatch(/data-source="deepseek"[^>]*>\s*DeepSeek only accepts low, high, and max reasoning efforts\./);
+
+        // The generic OpenAI-style caption describes tiers DeepSeek does not have, so it must not claim DeepSeek.
+        const genericCaption = indexSource.match(/data-source="([^"]*)"[^>]*>\s*OpenAI-style options: low, medium, high, xhigh\./);
+        expect(genericCaption).not.toBeNull();
+        expect(genericCaption[1].split(',')).not.toContain('deepseek');
+    });
+
+    test('keeps DeepSeek out of the string-effort resolver so max is not collapsed to high', () => {
+        const sources = openAiSource.match(/const reasoningEffortSources = \[([\s\S]*?)\];/);
+
+        expect(sources).not.toBeNull();
+        expect(sources[1]).not.toContain('DEEPSEEK');
+    });
+
+    test('forwards the effort to DeepSeek for thinking models only, mapping min to low', () => {
+        const handler = chatCompletionsSource.match(/async function sendDeepSeekRequest\(request, response\) \{([\s\S]*?)\n\}/);
+
+        expect(handler).not.toBeNull();
+        expect(handler[1]).toContain('const isThinkingModel = /(?:^|-)reasoner$|deepseek-v4/i.test(String(request.body.model || \'\'));');
+        expect(handler[1]).toContain('if (isThinkingModel && request.body.reasoning_effort && ![\'auto\', \'none\'].includes(request.body.reasoning_effort)) {');
+        expect(handler[1]).toContain('bodyParams[\'reasoning_effort\'] = request.body.reasoning_effort === \'min\' ? \'low\' : request.body.reasoning_effort;');
+    });
+
+    test('offers the current V4 model ids, both of which the server treats as thinking models', () => {
+        const picker = indexSource.match(/<select id="model_deepseek_select">([\s\S]*?)<\/select>/);
+
+        expect(picker).not.toBeNull();
+        const modelIds = [...picker[1].matchAll(/value="([^"]*)"/g)].map(m => m[1]);
+        expect(modelIds).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro']);
+        expect(openAiSource).toContain('deepseek_model: \'deepseek-v4-flash\',');
+
+        // Every shipped default must satisfy the handler's isThinkingModel test, or the dropdown silently does nothing.
+        for (const model of modelIds) {
+            expect(/(?:^|-)reasoner$|deepseek-v4/i.test(model)).toBe(true);
+        }
+    });
+});


### PR DESCRIPTION
The new Deepseek V4 models on the official Deepseek API now have reasoning efforts. The UI of the Deepseek backend doesn't allow sending of reasoning effort, so now this does.

Fixes the model id to deepseek-v4-flash and deepseek-v4-pro.