### PR TITLE
fix(characters): align favourites bar across tabs

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2061,8 +2061,8 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         align-items: center;
         width: 100%;
         min-width: 0;
-        min-height: 50px;
-        max-height: 50px;
+        min-height: 58px;
+        max-height: 58px;
         margin: 0;
         padding: 7px var(--sb-shell-panel-padding-inline);
         border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 76%, transparent);

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2319,16 +2319,22 @@ body.sb-shell-resizing * {
     display: none !important;
 }
 
+#right-nav-panel.openDrawer:is([data-menu-type="characters"], [data-menu-type="world-info"], [data-menu-type="persona"]) > #CharListButtonAndHotSwaps {
+    display: flex !important;
+    visibility: visible !important;
+}
+
 #right-nav-panel #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
     display: contents;
 }
 
 #right-nav-panel #CharListButtonAndHotSwaps {
-    /* Natural height: the favorites label sits above the avatar strip, and the
-       old 52px clamp clipped the strip's bottom edge */
-    min-height: 52px;
+    /* Reserve space for the favorites label, gap, and avatar strip together. */
+    flex: 0 0 auto;
+    min-height: 70px;
     max-height: none;
     padding: var(--sb-shell-space-sm) var(--sb-shell-panel-padding-inline);
+    box-sizing: border-box;
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 76%, transparent);
     overflow: hidden;
 }
@@ -2337,9 +2343,10 @@ body.sb-shell-resizing * {
     /* Deliberate two-row layout (label divider, then avatar strip); previously
        the strip only ended up below the label as a flex-wrap accident */
     flex-direction: column;
-    align-items: stretch;
+    align-items: center;
     gap: 5px;
     margin: 0 !important;
+    padding: 0 !important;
     min-height: 0;
     overflow: hidden;
 }
@@ -2509,8 +2516,11 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 #right-nav-panel .sb-character-create-bar #rm_button_group_chats::after {
-    content: none;
-    display: none;
+    content: 'Create New Chat Group';
+    font-family: var(--mainFontFamily);
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-compact);
 }
 
 #right-nav-panel .sb-character-create-bar #rm_print_characters_pagination {

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -42,10 +42,14 @@ function getMediaQueryPxValues(cssSource) {
 // chrome adjustment sheet is budgeted from introduction.
 // sillybunny-theme.css raised 158 -> 161: the mobile character list needs to
 // override upstream !important avatar alignment rules for missing avatars.
+// sillybunny-tabs.css raised 386 -> 389: the favourites bar fix re-shows the
+// bar on the character tabs with display:flex !important and
+// visibility:visible !important to beat the JS inline hide, and pins
+// #HotSwapWrapper padding:0 !important against the base flex-container rules.
 const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
     'sillybunny-mobile-shell.css': 685,
     'sillybunny-paper-theme.css': 55,
-    'sillybunny-tabs.css': 386,
+    'sillybunny-tabs.css': 389,
     'sillybunny-chat-styles.css': 225,
     'sillybunny-theme.css': 161,
 });


### PR DESCRIPTION
An earlier regression broke the spacing of the favourites bar between the different sub-tabs in the Characters menu. This PR fixes that by standardising the alignment and padding while removing the clipping caused by a prior patch. This also fixes another regression where the "Create New Chat Group" had its text hidden, inconsistent with the "Create New Character" button.

Should be checked on mobile, but works well on desktop.