### PR TITLE
feat(home): rework home screen for v1.7.0 release

### DIFF
--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -15,7 +15,6 @@
     color: var(--welcome-strong-fg);
 }
 
-.welcomeHeroMedia,
 .welcomeActionCard,
 .welcomeRecentShell,
 .welcomePanel .recentChatList .noRecentChat,
@@ -41,38 +40,30 @@
     gap: 18px;
     width: 100%;
     padding: var(--panel-padding, 18px);
-    border-radius: 28px;
+    border-radius: 20px;
     container: welcome-home / inline-size;
-    --sb-welcome-panel-bg:
-        radial-gradient(circle at top right, color-mix(in srgb, var(--sb-accent) 16%, transparent), transparent 30%),
-        radial-gradient(circle at bottom left, color-mix(in srgb, var(--sb-accent-soft) 12%, transparent), transparent 32%),
-        var(--sb-card-bg, color-mix(in srgb, var(--SmartThemeBodyColor) 5%, transparent));
+    --sb-welcome-panel-bg: var(--sb-card-bg, color-mix(in srgb, var(--SmartThemeBodyColor) 5%, transparent));
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 88%, transparent);
-    box-shadow: 0 30px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 18%, transparent);
+    box-shadow: none;
 }
 
 :root[data-sb-surface-tone='light'] .welcomePanel {
-    --sb-welcome-panel-bg:
-        radial-gradient(circle at top right, color-mix(in srgb, var(--sb-accent) 12%, transparent), transparent 32%),
-        radial-gradient(circle at bottom left, color-mix(in srgb, var(--sb-accent-soft) 10%, transparent), transparent 32%),
-        linear-gradient(180deg, color-mix(in srgb, #ffffff 88%, var(--SmartThemeBlurTintColor)), color-mix(in srgb, var(--SmartThemeBlurTintColor) 84%, var(--SmartThemeBodyColor) 16%));
+    --sb-welcome-panel-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeChatTintColor) 8%);
 }
 
 :root[data-sb-surface-tone='light'] .welcomeActionCard,
 :root[data-sb-surface-tone='light'] .welcomeRecentShell,
 :root[data-sb-surface-tone='light'] .welcomeGuidePanel,
 :root[data-sb-surface-tone='light'] .welcomePromptPanel {
-    --sb-welcome-surface-bg: color-mix(in srgb, #ffffff 78%, var(--SmartThemeBlurTintColor));
+    --sb-welcome-surface-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeChatTintColor) 8%);
 }
 
 .welcomePanel::before {
     content: "";
     position: absolute;
     inset: 0;
-    background:
-        linear-gradient(135deg, color-mix(in srgb, var(--sb-accent) 10%, transparent), transparent 34%),
-        linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 26%);
+    background: none;
     pointer-events: none;
 }
 
@@ -87,13 +78,6 @@
     opacity: var(--sb-page-card-opacity, 1);
 }
 
-.welcomePanel.recentHidden:not(.welcomePanel--listOnly) .welcomeRecentShell,
-.welcomePanel.recentHidden .hideRecentChats,
-.welcomePanel.recentHidden .recentChatsSettings,
-.welcomePanel:not(.recentHidden) .showRecentChats {
-    display: none;
-}
-
 .welcomePanel--compact {
     gap: 12px;
     padding: var(--spacing-lg, 16px);
@@ -103,7 +87,6 @@
     display: block;
 }
 
-.welcomePanel--compact .welcomeHeroMedia,
 .welcomePanel--compact .welcomeHeroBlurb,
 .welcomePanel--compact .welcomeForkNotice,
 .welcomePanel--compact .welcomeActionGrid,
@@ -140,27 +123,17 @@
     font-size: calc(var(--mainFontSize) * 1.16);
 }
 
-.welcomePanel--compact .welcomeHeroTitleGroup::after {
-    content: "Home panel minimized. Recent chats stay below.";
-    display: block;
-    margin-top: 4px;
-    color: var(--welcome-muted-fg);
-    font-size: calc(var(--mainFontSize) * 0.76);
-    line-height: 1.35;
-}
-
 .welcomePanel--listOnly {
     gap: 0;
     padding: var(--spacing-md, 12px);
-    border-radius: 22px;
+    border-radius: 20px;
 }
 
 
-.welcomePanelModeToggle.is-active,
-.welcomePanelModeChip.is-active {
+.welcomePanelModeToggle.is-active {
     color: var(--welcome-strong-fg);
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border, var(--SmartThemeBorderColor)));
-    box-shadow: 0 10px 20px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
 }
 
 #chat:has(.welcomePanel) {
@@ -189,10 +162,6 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 
 .welcomeHero {
     position: relative;
-    display: grid;
-    grid-template-columns: minmax(0, 1.46fr) minmax(240px, 0.9fr);
-    gap: 18px;
-    align-items: stretch;
 }
 
 .welcomeHeroCopy {
@@ -205,10 +174,10 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 }
 
 .welcomeHeroEyebrow {
+    margin: 0;
     font-size: calc(var(--mainFontSize) * 0.78);
     font-weight: 700;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+    letter-spacing: 0.04em;
     color: var(--welcome-muted-fg);
 }
 
@@ -228,10 +197,10 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     object-fit: contain;
     image-rendering: pixelated;
     padding: 8px;
-    border-radius: 24px;
+    border-radius: 16px;
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 7%, transparent);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 82%, transparent);
-    box-shadow: 0 18px 30px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
 }
 
 .welcomeHeroTitleGroup {
@@ -243,8 +212,8 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 .welcomeHeaderVersionDisplay {
     display: block;
     font-size: calc(var(--mainFontSize) * 1.72);
-    font-weight: 800;
-    line-height: 1.05;
+    font-weight: 700;
+    line-height: 1.12;
     max-width: 100%;
     white-space: normal;
     text-wrap: balance;
@@ -272,7 +241,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     align-self: center;
     background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 9%, transparent);
     border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 28%, var(--sb-shell-border, var(--SmartThemeBorderColor)));
-    box-shadow: 0 12px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
+    box-shadow: none;
     text-align: center;
 }
 
@@ -290,10 +259,9 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 }
 
 .welcomePanelToggles {
-    display: flex;
+    display: none;
     justify-content: center;
     width: 100%;
-    margin-top: -6px;
 }
 
 .welcomePanel--compact .welcomePanelToggles,
@@ -302,14 +270,9 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
-    gap: 10px;
-    margin-bottom: 10px;
+    gap: 8px;
+    margin-bottom: 0;
     margin-top: 0;
-}
-
-.welcomePanel--compact .welcomePanelVisibilityControls,
-.welcomePanel--listOnly .welcomePanelVisibilityControls {
-    display: none;
 }
 
 .welcomePanelModeControls {
@@ -322,24 +285,6 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 
 .welcomePanelModeControls--listOnly {
     display: none;
-}
-
-.welcomePanelVisibilityControls {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.welcomePanelToggles .mes_button {
-    width: 40px;
-    height: 40px;
-    margin: 0;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--SmartThemeBodyColor) 9%, transparent);
-    border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 84%, transparent);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
 }
 
 .welcomePanel--compact .welcomeForkNotice .welcomePanelModeControls,
@@ -372,11 +317,11 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     justify-content: center;
     gap: 12px;
     text-align: center;
-    border-radius: 20px;
+    border-radius: 16px;
     text-decoration: none;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 86%, transparent);
-    box-shadow: 0 14px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
+    box-shadow: none;
 }
 
 .welcomeActionCard::before {
@@ -446,7 +391,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 .welcomeShortcut--compact {
     max-width: none;
     width: 100%;
-    min-height: 42px;
+    min-height: 44px;
     padding: 0 12px;
 }
 
@@ -464,248 +409,6 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     font-size: calc(var(--mainFontSize) * 0.92);
 }
 
-.welcomeHeroMedia {
-    --sb-welcome-media-bg:
-        radial-gradient(circle at top, color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 26%, transparent), transparent 46%),
-        radial-gradient(circle at 22% 78%, color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 16%, transparent), transparent 28%),
-        linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(11, 18, 14, 0.24));
-    position: relative;
-    min-height: clamp(224px, 30vw, 320px);
-    padding: var(--spacing-lg, 16px);
-    border-radius: 24px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    overflow: hidden;
-    background: transparent;
-    border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 88%, transparent);
-}
-
-.welcomeHeroBadge {
-    position: absolute;
-    top: 20px;
-    left: 18px;
-    padding: 8px 12px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 14%, transparent);
-    border: 1px solid color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 28%, transparent);
-    font-size: calc(var(--mainFontSize) * 0.72);
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    color: color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 72%, white);
-    z-index: 2;
-}
-
-:root[data-sb-surface-tone='light'] .welcomeHeroMedia {
-    --sb-welcome-media-bg:
-        radial-gradient(circle at top, color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 18%, transparent), transparent 44%),
-        radial-gradient(circle at 22% 78%, color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 12%, transparent), transparent 30%),
-        linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(242, 230, 220, 0.86));
-}
-
-.welcomeHeroMedia::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-    border-radius: inherit;
-    pointer-events: none;
-    background: var(--sb-welcome-media-bg);
-    opacity: var(--sb-page-card-opacity, 1);
-}
-
-.welcomeHeroScene {
-    position: relative;
-    display: grid;
-    place-items: center;
-    justify-items: center;
-    width: min(100%, 312px);
-    min-height: clamp(188px, 25vw, 248px);
-    padding: var(--spacing-md, 12px) var(--spacing-sm, 8px) var(--spacing-md, 12px);
-    margin-inline: auto;
-}
-
-.welcomeHeroScene::before,
-.welcomeHeroScene::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    pointer-events: none;
-}
-
-.welcomeHeroScene::before {
-    inset: 18px 18px auto;
-    height: 64%;
-    border-radius: 999px;
-    background:
-        radial-gradient(circle at 50% 38%, color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 28%, transparent), transparent 55%),
-        radial-gradient(circle at 65% 60%, color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 22%, transparent), transparent 52%);
-    filter: blur(12px);
-    opacity: 0.95;
-}
-
-.welcomeHeroScene::after {
-    bottom: 4px;
-    width: min(100%, 190px);
-    height: 28px;
-    border-radius: 999px;
-    background:
-        radial-gradient(circle at center, color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 28%, transparent), transparent 72%),
-        linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 6%, transparent), color-mix(in srgb, var(--SmartThemeBlurTintColor) 70%, transparent));
-    border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 78%, transparent);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-.welcomeHeroMascot {
-    position: relative;
-    z-index: 1;
-    width: clamp(110px, 16vw, 152px);
-    aspect-ratio: 1 / 1;
-    filter: drop-shadow(0 16px 22px rgba(0, 0, 0, 0.2));
-    animation: welcomeBunnyFloat 4.6s ease-in-out infinite;
-}
-
-.welcomeHeroFrame {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    opacity: 0;
-    animation: welcomeBunnyFrameCycle 920ms steps(1, end) infinite;
-}
-
-.welcomeHeroFrame--1 {
-    animation-delay: 0s;
-}
-
-.welcomeHeroFrame--2 {
-    animation-delay: -0.23s;
-}
-
-.welcomeHeroFrame--3 {
-    animation-delay: -0.46s;
-}
-
-.welcomeHeroFrame--4 {
-    animation-delay: -0.69s;
-}
-
-.welcomeHeroSpark,
-.welcomeHeroRing {
-    position: absolute;
-    pointer-events: none;
-    z-index: 0;
-}
-
-.welcomeHeroSpark {
-    width: 12px;
-    height: 12px;
-    border-radius: 4px;
-    background:
-        radial-gradient(circle at center, color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 88%, white), transparent 62%),
-        radial-gradient(circle at center, color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 36%, transparent), transparent 78%);
-    box-shadow: 0 0 18px color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 36%, transparent);
-    animation: welcomeSparkFloat 5.2s ease-in-out infinite;
-}
-
-.welcomeHeroSpark--1 {
-    top: 20%;
-    left: 18%;
-    animation-delay: -0.4s;
-}
-
-.welcomeHeroSpark--2 {
-    top: 16%;
-    right: 20%;
-    animation-delay: -1.9s;
-}
-
-.welcomeHeroSpark--3 {
-    bottom: 24%;
-    left: 24%;
-    animation-delay: -2.7s;
-}
-
-.welcomeHeroSpark--4 {
-    bottom: 20%;
-    right: 22%;
-    animation-delay: -1.1s;
-}
-
-.welcomeHeroRing {
-    border: 1px solid color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 22%, transparent);
-    border-radius: 999px;
-    opacity: 0.92;
-}
-
-.welcomeHeroRing--1 {
-    width: min(100%, 192px);
-    height: 100px;
-    bottom: 14px;
-    background: radial-gradient(circle at center, color-mix(in srgb, var(--sb-accent, var(--SmartThemeQuoteColor)) 6%, transparent), transparent 74%);
-}
-
-.welcomeHeroRing--2 {
-    width: min(100%, 132px);
-    height: 132px;
-    top: 18px;
-    border-style: dashed;
-    border-color: color-mix(in srgb, var(--sb-accent-soft, var(--SmartThemeUnderlineColor)) 18%, transparent);
-    animation: welcomeOrbitSpin 18s linear infinite;
-}
-
-@keyframes welcomeBunnyFloat {
-    0%,
-    100% {
-        transform: translateY(0) scale(1);
-    }
-    25% {
-        transform: translateY(-8px) scale(1.015);
-    }
-    55% {
-        transform: translateY(-14px) scale(1.03);
-    }
-    75% {
-        transform: translateY(-6px) scale(1.01);
-    }
-}
-
-@keyframes welcomeSparkFloat {
-    0%,
-    100% {
-        transform: translateY(0) scale(0.92);
-        opacity: 0.58;
-    }
-    50% {
-        transform: translateY(-12px) scale(1.08);
-        opacity: 1;
-    }
-}
-
-@keyframes welcomeBunnyFrameCycle {
-    0%,
-    24.99% {
-        opacity: 1;
-    }
-
-    25%,
-    100% {
-        opacity: 0;
-    }
-}
-
-@keyframes welcomeOrbitSpin {
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
-}
-
 .welcomeRecentShell {
     --sb-welcome-surface-bg: var(--sb-surface-elevated);
     display: flex;
@@ -713,7 +416,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     gap: 14px;
     min-height: 0;
     padding: 18px;
-    border-radius: 24px;
+    border-radius: 20px;
     overflow: hidden;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 82%, transparent);
@@ -743,25 +446,9 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     gap: 6px;
 }
 
-.welcomeRecentTitleRow {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    flex-wrap: wrap;
-}
-
 .recentChatsTitle {
     font-size: calc(var(--mainFontSize) * 1.12);
     font-weight: 700;
-}
-
-.welcomeRecentConversationButton {
-    min-height: 30px;
-    gap: 6px;
-    padding: 0 10px;
-    border-radius: 999px;
-    font-size: calc(var(--mainFontSize) * 0.76);
-    white-space: nowrap;
 }
 
 .welcomeHeaderText p {
@@ -772,19 +459,21 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 }
 
 .welcomeRecentTabs {
-    display: inline-flex;
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 6px;
     padding: 4px;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 72%, transparent);
-    border-radius: 999px;
+    border-radius: 14px;
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 38%, transparent);
 }
 
 .welcomeRecentTab {
     border: 0;
-    border-radius: 999px;
-    padding: 5px 10px;
+    border-radius: 10px;
+    min-height: 36px;
+    padding: 6px 10px;
     color: var(--SmartThemeBodyColor);
     background: transparent;
     cursor: pointer;
@@ -797,30 +486,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--SmartThemeQuoteColor) 45%, transparent) inset;
 }
 
-.welcomePanelModeChip {
-    min-height: 36px;
-    gap: 8px;
-    padding: 0 12px;
-    border-radius: 999px;
-    font-size: calc(var(--mainFontSize) * 0.78);
-    white-space: nowrap;
-}
-
-.welcomePanelModeChip i {
-    font-size: calc(var(--mainFontSize) * 0.82);
-}
-
-.welcomePanelModeChip.is-active {
-    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 18%, transparent);
-}
-
 @container welcome-home (max-width: 1320px) {
-    .welcomeHero {
-        grid-template-columns: 1fr;
-        gap: 16px;
-        justify-items: center;
-    }
-
     .welcomeHeroCopy {
         width: 100%;
     }
@@ -830,39 +496,6 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
         gap: 12px;
     }
 
-    .welcomeHeroMedia {
-        order: -1;
-        width: min(100%, 320px);
-        min-height: 184px;
-        padding: 14px 12px 12px;
-        align-self: center;
-    }
-
-    .welcomeHeroScene {
-        width: min(100%, 232px);
-        min-height: 164px;
-        padding: 6px 6px 18px;
-    }
-
-    .welcomeHeroMascot {
-        width: clamp(82px, 18vw, 108px);
-    }
-
-    .welcomeHeroRing--1 {
-        width: min(100%, 168px);
-        height: 86px;
-    }
-
-    .welcomeHeroRing--2 {
-        width: min(100%, 112px);
-        height: 112px;
-        top: 12px;
-    }
-
-    .welcomeHeroScene::after {
-        width: min(100%, 156px);
-        height: 24px;
-    }
 }
 
 @container welcome-home (max-width: 900px) {
@@ -950,8 +583,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     align-items: flex-start;
     gap: 14px;
     padding: 14px;
-    border-radius: 20px;
-    cursor: pointer;
+    border-radius: 16px;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 80%, transparent);
     background: transparent;
     transition: transform var(--sb-transition-fast), background-color var(--sb-transition-fast), border-color var(--sb-transition-fast), box-shadow var(--sb-transition-fast);
@@ -972,11 +604,33 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 .welcomeRecent .recentChatList .recentChat:hover {
     transform: translateY(-1px);
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 26%, var(--sb-shell-border, transparent));
-    box-shadow: 0 14px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
 }
 
 .welcomeRecent .recentChatList .recentChat:hover::before {
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 6%, transparent);
+}
+
+.welcomeRecent .recentChatList .recentChatOpen {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: inherit;
+    background: transparent;
+    cursor: pointer;
+}
+
+.welcomeRecent .recentChatList .recentChatOpen:focus-visible {
+    outline: none;
+}
+
+.welcomeRecent .recentChatList .recentChat:has(.recentChatOpen:focus-visible) {
+    border-color: color-mix(in srgb, var(--sb-focus-ring) 88%, var(--SmartThemeBorderColor));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 60%, transparent);
 }
 
 .welcomeRecent .recentChatList .recentChat .avatar {
@@ -986,7 +640,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     justify-content: center;
     width: 60px;
     height: 60px;
-    border-radius: 18px;
+    border-radius: 16px;
     overflow: hidden;
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 8%, transparent);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 78%, transparent);
@@ -1034,13 +688,11 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 }
 
 .welcomeRecent .recentChatList .recentChat .chatActions {
+    position: relative;
+    z-index: 2;
     display: inline-flex;
     align-items: center;
     gap: 6px;
-}
-
-.welcomeRecent .recentChatList .recentChat.conversation .chatActions {
-    display: none;
 }
 
 .welcomeRecent .recentChatList .recentChat .chatActions button {
@@ -1130,14 +782,15 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     --sb-welcome-surface-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 76%, transparent);
     align-self: center;
     min-width: 44px;
+    min-height: 44px;
     position: -webkit-sticky;
     position: sticky;
     bottom: 0;
     z-index: 1;
-    border-radius: 999px;
+    border-radius: 14px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 82%, transparent);
-    box-shadow: 0 10px 20px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
 }
 
 .welcomeRecent .recentChatList .showMoreChats::before {
@@ -1170,7 +823,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     justify-content: space-between;
     gap: 16px;
     padding: 16px 18px;
-    border-radius: 22px;
+    border-radius: 20px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 82%, transparent);
 }
@@ -1212,7 +865,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     flex-direction: column;
     gap: 16px;
     padding: 18px;
-    border-radius: 24px;
+    border-radius: 20px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 82%, transparent);
 }
@@ -1253,7 +906,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     gap: 10px;
     min-width: 0;
     padding: 16px;
-    border-radius: 18px;
+    border-radius: 16px;
     background: transparent;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 78%, transparent);
 }
@@ -1296,11 +949,9 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     gap: 14px;
 }
 
-.welcomeDeck.is-collapsed {
-    display: none;
-}
-
 .welcomeDeckIntro {
+    display: flex;
+    flex-direction: column;
     gap: 14px;
 }
 
@@ -1308,11 +959,6 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-}
-
-.welcomeDeckToggle {
-    flex: 0 0 auto;
-    white-space: nowrap;
 }
 
 .welcomeDeckTabs {
@@ -1329,7 +975,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     gap: 12px;
     padding: 14px 16px;
     text-align: left;
-    border-radius: 20px;
+    border-radius: 14px;
 }
 
 .welcomeDeckTabs > .welcomeDeckTab {
@@ -1353,7 +999,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
 .welcomeDeckTab.is-active {
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 40%, transparent);
-    box-shadow: 0 16px 28px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
 }
 
 .welcomeDeckTabMeta {
@@ -1381,6 +1027,8 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
 .welcomeDeckPanel {
     display: none;
+    flex-direction: column;
+    gap: 16px;
 }
 
 .welcomeDeckPanel.is-active {
@@ -1389,9 +1037,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 .welcomeAssistantButton {
-    background:
-        linear-gradient(135deg, color-mix(in srgb, var(--color-primary, var(--sb-accent)) 16%, transparent), transparent 86%),
-        color-mix(in srgb, var(--SmartThemeBodyColor) 6%, transparent);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 10%, transparent);
 }
 
 .welcomeGuideHeader,
@@ -1421,9 +1067,14 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 .welcomeGuideTitleBlock h3,
+.welcomeGuideTitleBlock h4,
 .welcomeTourStepHeader strong,
 .welcomeGuideCardHeader strong {
     margin: 0;
+}
+
+.welcomeStarterPackCategoryHeader {
+    margin-top: 16px;
 }
 
 .welcomeGuideTitleBlock p,
@@ -1500,8 +1151,8 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     max-width: min(100%, 28ch);
     overflow-wrap: anywhere;
     padding: 11px 12px;
-    border-radius: 18px;
-    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, white 4%);
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, var(--SmartThemeBodyColor) 4%);
     color: var(--welcome-strong-fg);
     font-size: calc(var(--mainFontSize) * 0.8);
     line-height: 1.45;
@@ -1530,23 +1181,27 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
 .welcomeTourProgress {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 10px;
 }
 
 .welcomeTourProgressButton {
+    width: 100%;
+    min-width: 0;
     min-height: 62px;
+    margin: 0;
+    box-sizing: border-box;
     justify-content: flex-start;
     align-items: center;
     gap: 10px;
     padding: 10px 12px;
     text-align: left;
-    border-radius: 18px;
+    border-radius: 14px;
 }
 
 .welcomeTourProgressButton.is-active {
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 46%, transparent);
-    box-shadow: 0 10px 20px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 18%, transparent);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 18%, transparent);
 }
 
 .welcomeTourProgressNumber {
@@ -1586,11 +1241,14 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 .welcomeTourStepCount {
-    font-size: calc(var(--mainFontSize) * 0.74);
+    font-size: calc(var(--mainFontSize) * 0.94);
     font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
+    letter-spacing: 0;
     color: var(--welcome-muted-fg);
+}
+
+.welcomeTourStepHeader strong {
+    font-size: calc(var(--mainFontSize) * 0.84);
 }
 
 .welcomeTourHint {
@@ -1605,6 +1263,29 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 .welcomeTourNav {
     display: flex;
     justify-content: flex-end;
+}
+
+.welcomeTourActions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.welcomeGuideActions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.welcomeTourActions > .menu_button,
+.welcomeGuideActions > .menu_button {
+    min-width: 0;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+.welcomeGuideActions > .menu_button {
+    width: 100%;
 }
 
 .welcomeTourNav .menu_button[disabled] {
@@ -1626,19 +1307,6 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-}
-
-.welcomeChip {
-    display: inline-flex;
-    align-items: center;
-    min-height: 30px;
-    padding: 0 10px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 84%, transparent);
-    border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 74%, transparent);
-    color: var(--welcome-muted-fg);
-    font-size: calc(var(--mainFontSize) * 0.72);
-    line-height: 1.2;
 }
 
 .welcomeGuideCard .welcomeActionButton,
@@ -1686,12 +1354,27 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 .welcomeBundledAssistantQuestions {
+    flex-direction: column;
+    flex-wrap: nowrap;
     margin-top: 2px;
+}
+
+.welcomeBundledAssistantQuestions > .menu_button {
+    width: 100%;
+    min-width: 0;
+    margin: 0;
+    box-sizing: border-box;
 }
 
 .welcomeBundledAssistantCard .welcomePromptActions {
     justify-content: flex-start;
-    margin-top: auto;
+}
+
+.welcomeBundledAssistantCard .welcomePromptActions > .menu_button {
+    width: 100%;
+    min-width: 0;
+    margin: 0;
+    box-sizing: border-box;
 }
 
 .welcomeAssistantGuideMedia {
@@ -1711,10 +1394,10 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 .welcomeQuestionChip {
-    min-height: 38px;
+    min-height: 44px;
     gap: 8px;
     padding: 0 12px;
-    border-radius: 999px;
+    border-radius: 14px;
     font-size: calc(var(--mainFontSize) * 0.76);
 }
 
@@ -1734,39 +1417,6 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
 .welcomeStarterPackCard {
     gap: 12px;
-    container: welcome-starter-pack / inline-size;
-}
-
-.welcomeStarterPackCard .welcomeChipRow {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 8px;
-}
-
-.welcomeStarterPackCard .welcomeChipRow[data-chip-columns='2'] {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.welcomeStarterPackCard .welcomeChipRow[data-chip-columns='3'] {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.welcomeStarterPackCard .welcomeChipRow[data-chip-columns='4'] {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.welcomeStarterPackCard .welcomeChip {
-    width: 100%;
-    min-width: 0;
-    justify-content: center;
-    text-align: center;
-    padding: 0 8px;
-}
-
-@container welcome-starter-pack (max-width: 460px) {
-    .welcomeChipRow[data-chip-columns='4'] {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
 }
 
 .welcomeStarterPackActions {
@@ -1779,7 +1429,18 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 .welcomeStarterPackActions .welcomeActionButton {
+    flex: 1 1 0;
     align-self: auto;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.welcomeActionButton.is-pending {
+    opacity: 0.65;
+    cursor: progress;
 }
 
 .welcomeStarterPackHeader {
@@ -1794,46 +1455,27 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     padding: 0 10px;
     border-radius: 999px;
     font-size: calc(var(--mainFontSize) * 0.74);
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    font-weight: 700;
+    letter-spacing: 0.04em;
     border: 1px solid transparent;
 }
 
-@media screen and (max-width: 900px) {
-    .welcomeStarterPackCard .welcomeChipRow {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-}
-
 .welcomeStatusBadge--good {
-    color: #effff2;
-    background: rgba(28, 102, 63, 0.66);
-    border-color: rgba(170, 238, 193, 0.58);
+    color: color-mix(in srgb, var(--color-success, var(--sb-accent)) 72%, var(--SmartThemeBodyColor));
+    background: color-mix(in srgb, var(--color-success, var(--sb-accent)) 24%, var(--SmartThemeBlurTintColor));
+    border-color: color-mix(in srgb, var(--color-success, var(--sb-accent)) 42%, var(--SmartThemeBorderColor));
 }
 
 .welcomeStatusBadge--warm {
-    color: #fff0d6;
-    background: rgba(130, 78, 24, 0.82);
-    border-color: rgba(255, 211, 160, 0.62);
+    color: color-mix(in srgb, var(--color-warning, var(--SmartThemeQuoteColor)) 72%, var(--SmartThemeBodyColor));
+    background: color-mix(in srgb, var(--color-warning, var(--SmartThemeQuoteColor)) 24%, var(--SmartThemeBlurTintColor));
+    border-color: color-mix(in srgb, var(--color-warning, var(--SmartThemeQuoteColor)) 42%, var(--SmartThemeBorderColor));
 }
 
 .welcomeStatusBadge--neutral {
     color: var(--welcome-muted-fg);
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 88%, transparent);
     border-color: color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 74%, transparent);
-}
-
-:root[data-sb-surface-tone='light'] .welcomeStatusBadge--good {
-    color: #1b5a37;
-    background: rgba(143, 225, 173, 0.32);
-    border-color: rgba(143, 225, 173, 0.46);
-}
-
-:root[data-sb-surface-tone='light'] .welcomeStatusBadge--warm {
-    color: #7a4a14;
-    background: rgba(255, 198, 138, 0.34);
-    border-color: rgba(255, 198, 138, 0.48);
 }
 
 @keyframes welcomeDeckFadeIn {
@@ -1900,57 +1542,12 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 }
 
 @media screen and (max-width: 1040px), screen and (max-height: 780px) {
-    .welcomeHero {
-        grid-template-columns: 1fr;
-        gap: 16px;
-        justify-items: center;
-    }
-
     .welcomeHeroCopy {
         width: 100%;
-    }
-
-    .welcomeHeroMedia {
-        order: -1;
-        width: min(100%, 320px);
-        min-height: 184px;
-        padding: 14px 12px 12px;
-        align-self: center;
-    }
-
-    .welcomeHeroScene {
-        width: min(100%, 232px);
-        min-height: 164px;
-        padding: 6px 6px 18px;
-    }
-
-    .welcomeHeroMascot {
-        width: clamp(82px, 18vw, 108px);
-    }
-
-    .welcomeHeroRing--1 {
-        width: min(100%, 168px);
-        height: 86px;
-    }
-
-    .welcomeHeroRing--2 {
-        width: min(100%, 112px);
-        height: 112px;
-        top: 12px;
-    }
-
-    .welcomeHeroScene::after {
-        width: min(100%, 156px);
-        height: 24px;
     }
 }
 
 @media screen and (max-width: 768px) {
-    .welcomeDeckToggle {
-        width: 100%;
-        justify-content: center;
-    }
-
     .welcomeDeckTabs {
         grid-template-columns: 1fr;
     }
@@ -1990,21 +1587,14 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     }
 
     .welcomePanelToggles .mes_button {
-        width: 36px;
-        height: 36px;
+        width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
     }
 
     .welcomeHero {
-        grid-template-columns: 1fr;
-        gap: 14px;
-    }
-
-    .welcomeHeroMedia {
-        width: min(100%, 226px);
-        min-height: 166px;
-        padding: 12px 10px 10px;
-        border-radius: 20px;
-        margin-inline: auto;
+        display: block;
     }
 
     .welcomeActionGrid,
@@ -2024,7 +1614,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
         max-width: none;
         padding: 10px 12px;
         gap: 10px;
-        border-radius: 18px;
+        border-radius: 16px;
         white-space: normal !important;
     }
 
@@ -2044,21 +1634,10 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     }
 
     .welcomeActionMeta span {
-        font-size: calc(var(--mainFontSize) * 0.68);
+        font-size: calc(var(--mainFontSize) * 0.82);
         line-height: 1.35;
         max-width: 100%;
         overflow-wrap: anywhere;
-    }
-
-    .welcomeHeroScene {
-        width: min(100%, 188px);
-        min-height: 136px;
-        padding-bottom: 14px;
-        margin-inline: auto;
-    }
-
-    .welcomeHeroMascot {
-        width: clamp(68px, 21vw, 88px);
     }
 
     .welcomeShortcuts {
@@ -2070,7 +1649,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
         flex-basis: 100%;
         max-width: none;
         width: 100%;
-        min-height: 42px;
+        min-height: var(--sb-mobile-touch-target, 44px);
         padding: 0 14px;
         border-radius: 16px;
         font-size: calc(var(--mainFontSize) * 0.82);
@@ -2087,8 +1666,16 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     }
 
     .welcomeRecentTabs {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         width: 100%;
-        justify-content: center;
+    }
+
+    .welcomeRecentTab {
+        min-width: 0;
+        min-height: var(--sb-mobile-touch-target, 44px);
+        white-space: normal;
+        overflow-wrap: anywhere;
     }
 
     .welcomeRecent .recentChatList .recentChat {
@@ -2231,19 +1818,8 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
         font-size: calc(var(--mainFontSize) * 1);
     }
 
-    .welcomePanel--compact .welcomeHeroTitleGroup::after {
-        content: "Home minimized.";
-    }
-
     .welcomeHeader {
         flex-wrap: wrap;
-    }
-
-    .welcomePanelModeChip {
-        flex: 1 1 auto;
-        justify-content: center;
-        min-height: 34px;
-        padding: 0 10px;
     }
 
     .recentChatsTitle {
@@ -2286,10 +1862,23 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     }
 
     .welcomeRecent .recentChatList .recentChat .chatActions button {
-        width: 28px;
-        height: 28px;
-        min-width: 28px;
-        border-radius: 10px;
+        width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
+        border-radius: 14px;
+    }
+
+    .welcomeDeckTab,
+    .welcomeTourActions > .menu_button,
+    .welcomeGuideActions > .menu_button,
+    .welcomeTourNav .menu_button,
+    .welcomePromptActions > .menu_button,
+    .welcomeStarterPackActions > .menu_button,
+    .welcomeBundledAssistantQuestions > .menu_button {
+        min-height: var(--sb-mobile-touch-target, 44px);
     }
 
     .welcomeRecent .recentChatList .recentChat .chatMessageContainer {
@@ -2317,43 +1906,6 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
         padding: 12px;
     }
 
-    .welcomeHero {
-        gap: 12px;
-    }
-
-    .welcomeHeroMedia {
-        width: min(100%, 198px);
-        min-height: 144px;
-        padding: 10px 8px 8px;
-    }
-
-    .welcomeHeroScene {
-        width: min(100%, 166px);
-        min-height: 116px;
-        padding-bottom: 12px;
-    }
-
-    .welcomeHeroScene::after {
-        width: min(100%, 132px);
-        height: 20px;
-    }
-
-    .welcomeHeroMascot {
-        width: 64px;
-    }
-
-    .welcomeHeroRing--1 {
-        width: min(100%, 140px);
-        height: 70px;
-        bottom: 10px;
-    }
-
-    .welcomeHeroRing--2 {
-        width: min(100%, 96px);
-        height: 96px;
-        top: 8px;
-    }
-
     .welcomeHeaderVersionDisplay {
         font-size: calc(var(--mainFontSize) * 1.24);
     }
@@ -2369,7 +1921,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     }
 
     .welcomeShortcut {
-        min-height: 40px;
+        min-height: var(--sb-mobile-touch-target, 44px);
     }
 
     .welcomeBundledAssistantHeader {
@@ -2398,23 +1950,9 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
         width: 100%;
     }
 
-    .welcomePanelModeChip span {
-        display: none;
-    }
-
-    .welcomePanelModeChip {
-        min-width: 42px;
-    }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .welcomeHeroMascot,
-    .welcomeHeroFrame,
-    .welcomeHeroSpark,
-    [class*="welcomeOrbit"] {
-        animation: none !important;
-    }
-
     .welcomeDeckPanel.is-active {
         animation: none !important;
         opacity: 1;

--- a/public/script.js
+++ b/public/script.js
@@ -1882,7 +1882,7 @@ async function delChat(chatfile) {
  * Deletes a character chat by its name.
  * @param {string} characterId Character ID to delete chat for
  * @param {string} fileName Name of the chat file to delete (without .jsonl extension)
- * @returns {Promise<void>} A promise that resolves when the chat is deleted.
+ * @returns {Promise<boolean>} Whether the chat was deleted.
  */
 export async function deleteCharacterChatByName(characterId, fileName) {
     // Make sure all the data is loaded.
@@ -1892,7 +1892,7 @@ export async function deleteCharacterChatByName(characterId, fileName) {
     const character = characters[characterId];
     if (!character) {
         console.warn(`Character with ID ${characterId} not found.`);
-        return;
+        return false;
     }
 
     const response = await fetch('/api/chats/delete', {
@@ -1906,7 +1906,7 @@ export async function deleteCharacterChatByName(characterId, fileName) {
 
     if (!response.ok) {
         console.error('Failed to delete chat for character.');
-        return;
+        return false;
     }
 
     if (fileName === character.chat) {
@@ -1922,6 +1922,8 @@ export async function deleteCharacterChatByName(characterId, fileName) {
     }
 
     await eventSource.emit(event_types.CHAT_DELETED, fileName);
+    // SillyBunny: Home only clears pinned state after a confirmed deletion.
+    return true;
 }
 
 export async function replaceCurrentChat() {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -571,7 +571,7 @@ function hasExtensionHook(extensionName, hookName) {
  * @param {string} externalId External ID of the extension (excluding or including the leading 'third-party/')
  * @returns {string} Type of the extension (global, local, system, or empty string if not found)
  */
-function getExtensionType(externalId) {
+export function getExtensionType(externalId) {
     const id = Object.keys(extensionTypes).find(id => id === externalId || (id.startsWith('third-party') && id.endsWith(externalId)));
     return id ? extensionTypes[id] : '';
 }
@@ -2040,6 +2040,9 @@ async function moveExtension(extensionName, source, destination) {
  */
 export async function deleteExtension(extensionName, shouldClean = false) {
     const fullExtensionName = getFullExtensionName(extensionName);
+    const apiExtensionName = fullExtensionName.startsWith('third-party/')
+        ? fullExtensionName.slice('third-party/'.length)
+        : extensionName;
     if (shouldClean) {
         await callExtensionHook(fullExtensionName, 'clean');
     }
@@ -2047,21 +2050,27 @@ export async function deleteExtension(extensionName, shouldClean = false) {
     await callExtensionHook(fullExtensionName, 'delete');
 
     try {
-        await fetch('/api/extensions/delete', {
+        const response = await fetch('/api/extensions/delete', {
             method: 'POST',
             headers: getRequestHeaders(),
             body: JSON.stringify({
-                extensionName,
+                extensionName: apiExtensionName,
                 global: getExtensionType(extensionName) === 'global',
             }),
         });
+        if (!response.ok) {
+            throw new Error(`Extension deletion failed with status ${response.status}.`);
+        }
     } catch (error) {
-        console.error('Error:', error);
+        console.error('Extension deletion failed:', error);
+        toastr.error(t`Failed to delete extension ${extensionName}.`);
+        return false;
     }
 
     await saveSettings();
     toastr.success(t`Extension ${extensionName} deleted`);
     delay(1000).then(() => location.reload());
+    return true;
 }
 
 /**

--- a/public/scripts/sillybunny-conversation.js
+++ b/public/scripts/sillybunny-conversation.js
@@ -1,6 +1,10 @@
 export {
     isConversationModeEnabled,
     getConversationWelcomeChats,
+    deleteConversationWelcomeBranch,
+    renameConversationBranch,
     openConversationWorkspaceForAvatar,
     openConversationWorkspaceFromWelcome,
+    getRoleplayAvatarForWelcome,
+    disableConversationModeForCurrentCharacter,
 } from './sillybunny-conversation/index.js';

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -1039,6 +1039,9 @@ export function openConversationWorkspaceForAvatar(avatar, { branchId = '', grou
     const character = avatar ? getCharacterForAvatar(avatar) : null;
     const targetAvatar = character?.avatar || null;
     const targetGroupId = groupId && targetAvatar && isAvatarInConversationGroup(targetAvatar, groupId) ? String(groupId) : null;
+    if (branchId && targetAvatar && !getConversationBranches(targetAvatar, { groupId: targetGroupId }).some(branch => branch.id === String(branchId))) {
+        return false;
+    }
     const wasWorkspaceOpen = Boolean(conversationState.conversationWorkspaceOpen);
     const threadChanged = conversationState.conversationSelectedAvatar !== targetAvatar || conversationState.conversationSelectedGroupId !== targetGroupId;
     conversationState.conversationWorkspaceOpen = true;
@@ -1095,6 +1098,10 @@ export function openConversationWorkspaceFromWelcome() {
     }
 
     return true;
+}
+
+export function getRoleplayAvatarForWelcome() {
+    return conversationState.conversationSelectedAvatar || getRoleplayCurrentCharacter()?.avatar || null;
 }
 
 export function disableConversationModeForCurrentCharacter({ focusRoleplay = true } = {}) {

--- a/public/scripts/sillybunny-conversation/context.js
+++ b/public/scripts/sillybunny-conversation/context.js
@@ -985,12 +985,13 @@ export function renameConversationBranch(avatar, branchId, name, { groupId = get
     const characterStore = getConversationThreadStore(avatar, { create: false, groupId });
     const branch = characterStore?.branches?.[branchId];
     if (!branch || !String(name || '').trim()) {
-        return;
+        return false;
     }
 
     branch.name = String(name).trim();
     branch.updatedAt = Date.now();
     persistConversationStore();
+    return true;
 }
 
 function createConversationResetBranch(characterStore, name, branchId) {
@@ -1022,6 +1023,15 @@ export function deleteConversationBranch(avatar, branchId, { groupId = getConver
     }
     persistConversationStore();
     return true;
+}
+
+export function deleteConversationWelcomeBranch(avatar, branchId, { groupId = getConversationGroupIdForAvatar(avatar), personaId = getConversationPersonaId() } = {}) {
+    const threadStore = getConversationThreadStore(avatar, { create: false, groupId, personaId });
+    const reset = Boolean(threadStore?.branches?.[branchId]) && Object.keys(threadStore.branches).length <= 1;
+    return {
+        deleted: deleteConversationBranch(avatar, branchId, { groupId, personaId }),
+        reset,
+    };
 }
 
 export function resetCharacterConversationBranches(avatar, { groupId = getConversationGroupIdForAvatar(avatar), personaId = getConversationPersonaId() } = {}) {

--- a/public/scripts/sillybunny-conversation/index.js
+++ b/public/scripts/sillybunny-conversation/index.js
@@ -5,6 +5,12 @@ export {
     getConversationWelcomeChats,
 } from './settings-store.js';
 export {
+    deleteConversationWelcomeBranch,
+    renameConversationBranch,
+} from './context.js';
+export {
     openConversationWorkspaceForAvatar,
     openConversationWorkspaceFromWelcome,
+    getRoleplayAvatarForWelcome,
+    disableConversationModeForCurrentCharacter,
 } from './chrome.js';

--- a/public/scripts/sillybunny-conversation/settings-store.js
+++ b/public/scripts/sillybunny-conversation/settings-store.js
@@ -221,6 +221,8 @@ export function getConversationWelcomeChats({ max = Infinity } = {}) {
             is_agent: false,
             is_conversation: true,
             recent_chat_type: 'conversation',
+            conversation_branch_id: branchId,
+            conversation_branch_name: branchName,
             hidden: false,
             pinned: false,
         });

--- a/public/scripts/templates/welcomePanelOnboarding.html
+++ b/public/scripts/templates/welcomePanelOnboarding.html
@@ -1,7 +1,7 @@
 <div class="welcomePanel {{#if welcomePanelCompact}}welcomePanel--compact{{/if}}{{#if welcomePanelListOnly}} welcomePanel--listOnly{{/if}}" data-active-deck-view="{{activeDeckView}}" data-home-panel-mode="{{welcomePanelMode}}">
-    <div class="welcomeHero">
+    <section class="welcomeHero" aria-labelledby="welcome-home-title">
         <div class="welcomeHeroCopy">
-            <div class="welcomeHeroEyebrow">Home</div>
+            <h1 id="welcome-home-title" class="welcomeHeroEyebrow">Home</h1>
             <div class="welcomeHeaderTitle">
                 <img src="img/sillybunny-pixel-logo-og.png" alt="SillyBunny badge" data-i18n="[alt]SillyBunny badge" class="welcomeHeaderLogo" data-sb-frontend-icon="true">
                 <div class="welcomeHeroTitleGroup">
@@ -36,11 +36,11 @@
                         <span>Open a quick, throwaway session for testing without any extra setup.</span>
                     </span>
                 </button>
-                <button class="menu_button menu_button_icon welcomeActionCard welcomeActionButton openLaunchpad" data-action="open-launchpad">
-                    <i class="fa-solid fa-compass"></i>
+                <button class="menu_button menu_button_icon welcomeActionCard welcomeActionButton" data-action="open-characters-menu">
+                    <i class="fa-solid fa-id-card"></i>
                     <span class="welcomeActionMeta">
-                        <strong>Open/Close Launchpad</strong>
-                        <span>View the Launchpad to browse our curated selection of tutorials, assistants, and recommended add-ons.</span>
+                        <strong>Open Characters</strong>
+                        <span>Open the character menu to directly interact with your character cards in roleplay or conversation modes.</span>
                     </span>
                 </button>
                 <button class="menu_button menu_button_icon welcomeActionCard welcomeAssistantButton welcomeActionButton" data-action="open-assistant" data-assistant-id="guide">
@@ -57,26 +57,26 @@
                         <span>Chat with Assistant Nahida, our alternative assistant, for a more gentle and philosophical lens!</span>
                     </span>
                 </button>
-                <button class="menu_button menu_button_icon welcomeActionCard welcomeActionButton" data-action="open-characters-menu">
-                    <i class="fa-solid fa-id-card"></i>
+                <button class="menu_button menu_button_icon welcomeActionCard welcomeActionButton" data-action="open-tab" data-action-value="left:agents">
+                    <i class="fa-solid fa-robot"></i>
                     <span class="welcomeActionMeta">
-                        <strong>Open Characters</strong>
-                        <span>Open the character menu for directly interacting with your character cards.</span>
+                        <strong>Open Agents</strong>
+                        <span>Open the agents menu to configure and set up your pre, sidecar, and post generation agents that go alongside the main chat.</span>
                     </span>
                 </button>
             </div>
             <div class="welcomeShortcuts" aria-label="Home shortcuts">
-                <button class="menu_button menu_button_icon welcomeShortcut open_characters_library">
-                    <i class="fa-solid fa-image-portrait"></i>
-                    <span data-i18n="Sample characters">Sample characters</span>
-                </button>
                 <button class="menu_button menu_button_icon welcomeShortcut external_import_button">
                     <i class="fa-solid fa-cloud-arrow-down"></i>
-                    <span data-i18n="Import Character">Import character</span>
+                    <span data-i18n="Import Characters">Import Characters</span>
+                </button>
+                <button class="menu_button menu_button_icon welcomeShortcut welcomeActionButton" data-action="open-tab" data-action-value="left:presets">
+                    <i class="fa-solid fa-sliders"></i>
+                    <span>Presets</span>
                 </button>
                 <button class="menu_button menu_button_icon welcomeShortcut welcomeActionButton" data-action="open-tab" data-action-value="left:api">
                     <i class="fa-solid fa-plug"></i>
-                    <span>Open API</span>
+                    <span>API</span>
                 </button>
                 <button class="menu_button menu_button_icon welcomeShortcut welcomeActionButton" data-action="open-tab" data-action-value="right:extensions">
                     <i class="fa-solid fa-cubes"></i>
@@ -93,23 +93,7 @@
             </div>
         </div>
 
-        <div class="welcomeHeroMedia">
-            <div class="welcomeHeroScene">
-                <span class="welcomeHeroSpark welcomeHeroSpark--1"></span>
-                <span class="welcomeHeroSpark welcomeHeroSpark--2"></span>
-                <span class="welcomeHeroSpark welcomeHeroSpark--3"></span>
-                <span class="welcomeHeroSpark welcomeHeroSpark--4"></span>
-                <span class="welcomeHeroRing welcomeHeroRing--1"></span>
-                <span class="welcomeHeroRing welcomeHeroRing--2"></span>
-                <div class="welcomeHeroMascot" role="img" aria-label="Animated SillyBunny bunny mascot">
-                    <img src="img/sillybunny-bunny-frame-1.svg" alt="" class="welcomeHeroFrame welcomeHeroFrame--1">
-                    <img src="img/sillybunny-bunny-frame-2.svg" alt="" class="welcomeHeroFrame welcomeHeroFrame--2">
-                    <img src="img/sillybunny-bunny-frame-3.svg" alt="" class="welcomeHeroFrame welcomeHeroFrame--3">
-                    <img src="img/sillybunny-bunny-frame-4.svg" alt="" class="welcomeHeroFrame welcomeHeroFrame--4">
-                </div>
-            </div>
-        </div>
-    </div>
+    </section>
     <div class="welcomePanelToggles">
         <div class="welcomePanelModeControls welcomePanelModeControls--listOnly welcomePanelPersistentControls" aria-label="Home panel display">
             <button class="menu_button menu_button_icon welcomePanelModeToggle welcomePanelModeToggle--full" title="Show full Home panel" aria-label="Show full Home panel" aria-pressed="{{#if welcomePanelFull}}true{{else}}false{{/if}}" data-i18n="[title]Show full Home panel;[aria-label]Show full Home panel" data-welcome-panel-mode-target="full">
@@ -125,30 +109,18 @@
                 <span>List Only</span>
             </button>
         </div>
-        <div class="welcomePanelVisibilityControls">
-            <button class="mes_button showRecentChats" title="Show recent chats" data-i18n="[title]Show recent chats">
-                <i class="fa-solid fa-list-ul fa-fw"></i>
-            </button>
-            <button class="mes_button hideRecentChats" title="Hide recent chats" data-i18n="[title]Hide recent chats">
-                <i class="fa-solid fa-xmark fa-fw"></i>
-            </button>
-        </div>
     </div>
-    <div class="welcomeDeck{{#if deckCollapsed}} is-collapsed{{/if}}" data-collapsed="{{#if deckCollapsed}}true{{else}}false{{/if}}">
-        <div class="welcomeGuidePanel welcomeDeckIntro">
+    <section class="welcomeGuidePanel welcomeDeck" aria-labelledby="welcome-launchpad-title">
+        <div class="welcomeDeckIntro">
             <div class="welcomeGuideHeader welcomeDeckIntroHeader">
                 <div class="welcomeGuideTitleBlock">
-                    <div class="welcomeHeroEyebrow">Launchpad</div>
+                    <h2 id="welcome-launchpad-title" class="welcomeHeroEyebrow">Launchpad</h2>
                     <h3>Getting Acquainted With Silly Bunny</h3>
                 </div>
-                <button class="menu_button menu_button_icon welcomeActionButton welcomeDeckToggle" data-action="close-guide" title="Close Launchpad" aria-expanded="{{#unless deckCollapsed}}true{{else}}false{{/unless}}">
-                    <i class="fa-solid fa-xmark"></i>
-                    <span>Close</span>
-                </button>
             </div>
-            <div class="welcomeDeckTabs">
+            <div class="welcomeDeckTabs" role="tablist" aria-label="Launchpad views">
                 {{#each deckTabs}}
-                    <button class="menu_button menu_button_icon welcomeDeckTab {{#if active}}is-active{{/if}}" data-deck-target="{{id}}">
+                    <button id="welcome-deck-tab-{{id}}" class="menu_button menu_button_icon welcomeDeckTab {{#if active}}is-active{{/if}}" role="tab" aria-selected="{{#if active}}true{{else}}false{{/if}}" aria-controls="welcome-deck-panel-{{id}}" tabindex="{{#if active}}0{{else}}-1{{/if}}" data-deck-target="{{id}}">
                         <i class="fa-solid {{icon}}"></i>
                         <span class="welcomeDeckTabMeta">
                             <strong>{{title}}</strong>
@@ -160,22 +132,22 @@
         </div>
 
         <div class="welcomeDeckFrame">
-            <div class="welcomeGuidePanel welcomeDeckPanel welcomeTourPanel{{#unless tutorialExpanded}} tutorialCollapsed{{/unless}}{{#if deckTourActive}} is-active{{/if}}" data-deck-panel="tour" data-tutorial-expanded="{{#if tutorialExpanded}}true{{else}}false{{/if}}" data-tutorial-index="{{tutorialIndex}}">
+            <div id="welcome-deck-panel-tour" class="welcomeDeckPanel welcomeTourPanel{{#unless tutorialExpanded}} tutorialCollapsed{{/unless}}{{#if deckTourActive}} is-active{{/if}}" role="tabpanel" aria-labelledby="welcome-deck-tab-tour"{{#unless deckTourActive}} hidden aria-hidden="true"{{/unless}} data-deck-panel="tour" data-tutorial-expanded="{{#if tutorialExpanded}}true{{else}}false{{/if}}" data-tutorial-index="{{tutorialIndex}}">
                 <div class="welcomeGuideHeader welcomeTourHeader">
                     <div class="welcomeGuideTitleBlock">
-                        <div class="welcomeHeroEyebrow">SillyBunny Tutorial</div>
-                        <h3>SillyBunny in five gentle steps</h3>
-                        <p>New to SillyBunny? This tutorial explains how to get started in five steps.</p>
+                        <div class="welcomeHeroEyebrow">Starting Tutorial</div>
+                        <h3>SillyBunny in five easy steps</h3>
+                        <p>If you're unsure what to do or how to get started, go through these five steps to get acquainted with our program.</p>
                     </div>
                     <div class="welcomeGuideMascot">
-                        <img src="img/sillybunny-guide-bunny.png" alt="Pixel-art bunny guide" class="welcomeGuideMascotImage">
+                        <img src="img/sillybunny-guide-bunny.png" alt="Pixel-art bunny guide" class="welcomeGuideMascotImage" width="256" height="256" loading="lazy" decoding="async">
                         <div class="welcomeGuideBubble">Don't worry; we all start somewhere!</div>
                     </div>
                 </div>
 
-                <div class="welcomeTourProgress">
+                <div class="welcomeTourProgress" role="group" aria-label="Tutorial steps">
                     {{#each tutorialSteps}}
-                        <button class="menu_button menu_button_icon welcomeTourProgressButton {{#if active}}is-active{{/if}}" data-step-target="{{@index}}">
+                        <button class="menu_button menu_button_icon welcomeTourProgressButton {{#if active}}is-active{{/if}}" aria-pressed="{{#if active}}true{{else}}false{{/if}}"{{#if active}} aria-current="step"{{/if}} data-step-target="{{@index}}">
                             <span class="welcomeTourProgressNumber">{{stepNumber}}</span>
                             <span class="welcomeTourProgressLabel">{{title}}</span>
                         </button>
@@ -184,7 +156,7 @@
 
                 <div class="welcomeTourSteps">
                     {{#each tutorialSteps}}
-                        <section class="welcomeGuideCard welcomeTourStep {{#if active}}is-active{{/if}}" data-step-index="{{@index}}">
+                        <section class="welcomeGuideCard welcomeTourStep {{#if active}}is-active{{/if}}"{{#unless active}} hidden aria-hidden="true"{{/unless}} data-step-index="{{@index}}">
                             <div class="welcomeTourStepHeader">
                                 <span class="welcomeTourStepCount">Step {{stepNumber}}</span>
                                 <strong>{{title}}</strong>
@@ -193,17 +165,14 @@
                             {{#if hint}}
                                 <div class="welcomeTourHint">{{hint}}</div>
                             {{/if}}
-                            <div class="welcomeChipRow" data-chip-columns="{{chipColumnCount}}">
-                                {{#each chips}}
-                                    <span class="welcomeChip">{{this}}</span>
+                            <div class="welcomeTourActions">
+                                {{#each actions}}
+                                    <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{type}}" data-action-value="{{value}}"{{#if assistantId}} data-assistant-id="{{assistantId}}"{{/if}}>
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                        <span>{{label}}</span>
+                                    </button>
                                 {{/each}}
                             </div>
-                            {{#if actionLabel}}
-                                <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{actionType}}" data-action-value="{{actionValue}}">
-                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                                    <span>{{actionLabel}}</span>
-                                </button>
-                            {{/if}}
                         </section>
                     {{/each}}
                 </div>
@@ -220,10 +189,10 @@
                 </div>
             </div>
 
-            <div class="welcomeGuidePanel welcomeDeckPanel welcomeBasicsPanel{{#if deckBasicsActive}} is-active{{/if}}" data-deck-panel="basics">
+            <div id="welcome-deck-panel-basics" class="welcomeDeckPanel welcomeBasicsPanel{{#if deckBasicsActive}} is-active{{/if}}" role="tabpanel" aria-labelledby="welcome-deck-tab-basics"{{#unless deckBasicsActive}} hidden aria-hidden="true"{{/unless}} data-deck-panel="basics">
                 <div class="welcomeGuideHeader">
                     <div class="welcomeGuideTitleBlock">
-                        <div class="welcomeHeroEyebrow">Graphical Shell</div>
+                        <div class="welcomeHeroEyebrow">UI Handbook</div>
                         <h3>SillyBunny Shell 101</h3>
                         <p>Refer to the documentation below for more information on SillyBunny's graphical shell. We've designed it to be intuitive and simple to use and understand.</p>
                     </div>
@@ -236,23 +205,20 @@
                                 <strong>{{title}}</strong>
                             </div>
                             <p>{{body}}</p>
-                            <div class="welcomeChipRow" style="--welcome-chip-columns: {{chipColumnCount}};">
-                                {{#each chips}}
-                                    <span class="welcomeChip">{{this}}</span>
+                            <div class="welcomeGuideActions">
+                                {{#each actions}}
+                                    <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{type}}" data-action-value="{{value}}"{{#if assistantId}} data-assistant-id="{{assistantId}}"{{/if}}{{#if isSearchTrigger}} data-sb-universal-search-trigger="true"{{/if}}>
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                        <span>{{label}}</span>
+                                    </button>
                                 {{/each}}
                             </div>
-                            {{#if actionLabel}}
-                                <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{actionType}}" data-action-value="{{actionValue}}"{{#if isSearchTrigger}} data-sb-universal-search-trigger="true"{{/if}}>
-                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                                    <span>{{actionLabel}}</span>
-                                </button>
-                            {{/if}}
                         </article>
                     {{/each}}
                 </div>
             </div>
 
-            <div class="welcomeGuidePanel welcomeDeckPanel welcomeAssistantGuidePanel{{#if deckGuideActive}} is-active{{/if}}" data-deck-panel="guide">
+            <div id="welcome-deck-panel-guide" class="welcomeDeckPanel welcomeAssistantGuidePanel{{#if deckGuideActive}} is-active{{/if}}" role="tabpanel" aria-labelledby="welcome-deck-tab-guide"{{#unless deckGuideActive}} hidden aria-hidden="true"{{/unless}} data-deck-panel="guide">
                 <div class="welcomeGuideHeader">
                     <div class="welcomeGuideTitleBlock">
                         <div class="welcomeHeroEyebrow">Bundled Assistants</div>
@@ -265,7 +231,7 @@
                         <article class="welcomeGuideCard welcomeBundledAssistantCard">
                             <div class="welcomeBundledAssistantHeader">
                                 <div class="welcomeAssistantGuideMedia">
-                                    <img src="{{portrait}}" alt="{{portraitAlt}}" class="welcomeAssistantGuideImage">
+                                    <img src="{{portrait}}" alt="{{portraitAlt}}" class="welcomeAssistantGuideImage" width="256" height="256" loading="lazy" decoding="async">
                                 </div>
                                 <div class="welcomeBundledAssistantCopy">
                                     <div class="welcomeGuideCardHeader">
@@ -276,10 +242,11 @@
                                     <span class="welcomeBundledAssistantCredit">{{credit}}</span>
                                 </div>
                             </div>
-                            <div class="welcomeChipRow" data-chip-columns="{{chipColumnCount}}">
-                                {{#each chips}}
-                                    <span class="welcomeChip">{{this}}</span>
-                                {{/each}}
+                            <div class="welcomePromptActions">
+                                <button class="menu_button menu_button_icon welcomeAssistantButton welcomeActionButton" data-action="open-assistant" data-assistant-id="{{id}}">
+                                    <i class="fa-solid {{actionIcon}}"></i>
+                                    <span>{{actionLabel}}</span>
+                                </button>
                             </div>
                             {{#if hasQuestions}}
                                 <div class="welcomeChipRow welcomeBundledAssistantQuestions">
@@ -291,23 +258,17 @@
                                     {{/each}}
                                 </div>
                             {{/if}}
-                            <div class="welcomePromptActions">
-                                <button class="menu_button menu_button_icon welcomeAssistantButton welcomeActionButton" data-action="open-assistant" data-assistant-id="{{id}}">
-                                    <i class="fa-solid {{actionIcon}}"></i>
-                                    <span>{{actionLabel}}</span>
-                                </button>
-                            </div>
                         </article>
                     {{/each}}
                 </div>
             </div>
 
-            <div class="welcomeGuidePanel welcomeDeckPanel welcomeStarterPackPanel{{#if deckStarterActive}} is-active{{/if}}" data-deck-panel="starter">
+            <div id="welcome-deck-panel-starter" class="welcomeDeckPanel welcomeStarterPackPanel{{#if deckStarterActive}} is-active{{/if}}" role="tabpanel" aria-labelledby="welcome-deck-tab-starter"{{#unless deckStarterActive}} hidden aria-hidden="true"{{/unless}} data-deck-panel="starter">
                 <div class="welcomeGuideHeader">
                     <div class="welcomeGuideTitleBlock">
                         <div class="welcomeHeroEyebrow">Bundled Add-ons</div>
                         <h3>Pre-installed</h3>
-                        <p>These presets and extensions ship with SillyBunny and are ready to use.</p>
+                        <p>Pre-bundled presets from SillyBunny's main dev team. You don't have to do anything; these are all included by default!</p>
                     </div>
                 </div>
                 <div class="welcomeGuideGrid welcomeStarterPackGrid">
@@ -321,11 +282,6 @@
                                 <span class="welcomeStatusBadge welcomeStatusBadge--{{statusTone}}">{{statusLabel}}</span>
                             </div>
                             <p>{{body}}</p>
-                            <div class="welcomeChipRow" data-chip-columns="{{chipColumnCount}}">
-                                {{#each chips}}
-                                    <span class="welcomeChip">{{this}}</span>
-                                {{/each}}
-                            </div>
                             <div class="welcomeStarterPackActions">
                                 <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{actionType}}" data-action-value="{{actionValue}}">
                                     <i class="fa-solid {{#if actionIcon}}{{actionIcon}}{{else}}fa-wand-magic-sparkles{{/if}}"></i>
@@ -337,18 +293,24 @@
                                         <span>{{secondaryActionLabel}}</span>
                                     </button>
                                 {{/if}}
+                                {{#if tertiaryActionLabel}}
+                                    <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{tertiaryActionType}}" data-action-value="{{tertiaryActionValue}}">
+                                        <i class="fa-solid {{#if tertiaryActionIcon}}{{tertiaryActionIcon}}{{else}}fa-arrow-up-right-from-square{{/if}}"></i>
+                                        <span>{{tertiaryActionLabel}}</span>
+                                    </button>
+                                {{/if}}
                             </div>
                         </article>
                     {{/each}}
                 </div>
                 <div class="welcomeGuideHeader" style="margin-top: 16px;">
                     <div class="welcomeGuideTitleBlock">
-                        <h3>Optional installs</h3>
-                        <p>These curated add-ons are not installed by default. Install them if you want extra functionality.</p>
+                        <h3>Official extensions</h3>
+                        <p>A list of optional add-ons developed by the SillyBunny team. These slot into SillyBunny perfectly and are fully tested and supported.</p>
                     </div>
                 </div>
                 <div class="welcomeGuideGrid welcomeStarterPackGrid">
-                    {{#each starterPackItems.optional}}
+                    {{#each starterPackItems.optionalOfficial}}
                         <article class="welcomeGuideCard welcomeStarterPackCard" data-launchpad-extension="{{actionValue}}">
                             <div class="welcomeStarterPackHeader">
                                 <div class="welcomeGuideCardHeader">
@@ -358,11 +320,38 @@
                                 <span class="welcomeStatusBadge welcomeStatusBadge--{{statusTone}}">{{statusLabel}}</span>
                             </div>
                             <p>{{body}}</p>
-                            <div class="welcomeChipRow" data-chip-columns="{{chipColumnCount}}">
-                                {{#each chips}}
-                                    <span class="welcomeChip">{{this}}</span>
-                                {{/each}}
+                            <div class="welcomeStarterPackActions">
+                                <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{actionType}}" data-action-value="{{actionValue}}">
+                                    <i class="fa-solid {{#if actionIcon}}{{actionIcon}}{{else}}fa-wand-magic-sparkles{{/if}}"></i>
+                                    <span>{{actionLabel}}</span>
+                                </button>
+                                {{#if secondaryActionLabel}}
+                                    <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{secondaryActionType}}" data-action-value="{{secondaryActionValue}}">
+                                        <i class="fa-solid {{#if secondaryActionIcon}}{{secondaryActionIcon}}{{else}}fa-arrow-up-right-from-square{{/if}}"></i>
+                                        <span>{{secondaryActionLabel}}</span>
+                                    </button>
+                                {{/if}}
                             </div>
+                        </article>
+                    {{/each}}
+                </div>
+                <div class="welcomeGuideHeader welcomeStarterPackCategoryHeader">
+                    <div class="welcomeGuideTitleBlock">
+                        <h3>Unofficial extensions</h3>
+                        <p>A curated list of useful, unofficial extensions that we strongly recommend. Please note that these third-party, and thus are not developed by the SillyBunny team.</p>
+                    </div>
+                </div>
+                <div class="welcomeGuideGrid welcomeStarterPackGrid">
+                    {{#each starterPackItems.optionalUnofficial}}
+                        <article class="welcomeGuideCard welcomeStarterPackCard" data-launchpad-extension="{{actionValue}}">
+                            <div class="welcomeStarterPackHeader">
+                                <div class="welcomeGuideCardHeader">
+                                    <i class="fa-solid {{icon}}"></i>
+                                    <strong>{{title}}</strong>
+                                </div>
+                                <span class="welcomeStatusBadge welcomeStatusBadge--{{statusTone}}">{{statusLabel}}</span>
+                            </div>
+                            <p>{{body}}</p>
                             <div class="welcomeStarterPackActions">
                                 <button class="menu_button menu_button_icon welcomeActionButton" data-action="{{actionType}}" data-action-value="{{actionValue}}">
                                     <i class="fa-solid {{#if actionIcon}}{{actionIcon}}{{else}}fa-wand-magic-sparkles{{/if}}"></i>
@@ -380,23 +369,17 @@
                 </div>
             </div>
         </div>
-    </div>
+    </section>
 
-    <div class="welcomeRecentShell">
+    <section class="welcomeRecentShell" aria-labelledby="welcome-recent-title">
         <div class="welcomeHeader">
             <div class="welcomeHeaderText">
-                <div class="welcomeRecentTitleRow">
-                    <div class="recentChatsTitle" data-i18n="Recent Chats">
-                        Recent Chats
-                    </div>
-                    <button type="button" class="menu_button menu_button_icon welcomeRecentConversationButton welcomeActionButton" data-action="open-conversation" title="Open Conversation Mode" aria-label="Open Conversation Mode">
-                        <i class="fa-solid fa-comments" aria-hidden="true"></i>
-                        <span>Open Conversation</span>
-                    </button>
-                </div>
+                <h2 id="welcome-recent-title" class="recentChatsTitle" data-i18n="Recent Chats">
+                    Recent Chats
+                </h2>
                 <p>Quickly jump back into your most recent conversations.</p>
             </div>
-            <div class="welcomeRecentTabs" role="tablist" aria-label="Recent chat type filter">
+            <div class="welcomeRecentTabs" role="group" aria-label="Recent chat type filter">
                 <button type="button" class="welcomeRecentTab active" data-recent-chat-filter="all" aria-pressed="true" data-i18n="All">All</button>
                 <button type="button" class="welcomeRecentTab" data-recent-chat-filter="individual" aria-pressed="false" data-i18n="Individual">Individual</button>
                 <button type="button" class="welcomeRecentTab" data-recent-chat-filter="group" aria-pressed="false" data-i18n="Groups">Groups</button>
@@ -405,7 +388,7 @@
             </div>
         </div>
         <div class="welcomeRecent">
-            <div class="recentChatList">
+            <div id="welcome-recent-chat-list" class="recentChatList">
             {{#if empty}}
                 <div class="noRecentChat">
                     <i class="fa-solid fa-comment-dots"></i>
@@ -424,14 +407,15 @@
                 </div>
             {{#each chats}}
                 {{#with this}}
-                <div class="recentChat {{#if hidden}}hidden{{/if}} {{#if is_group}}group{{else}}individual{{/if}} {{#if is_agent}}agent{{/if}} {{#if is_conversation}}conversation{{/if}}" data-recent-chat-type="{{recent_chat_type}}" data-file="{{chat_name}}" data-avatar="{{avatar}}" data-group="{{group}}">
+                <article class="recentChat {{#if hidden}}hidden{{/if}} {{#if is_group}}group{{else}}individual{{/if}} {{#if is_agent}}agent{{/if}} {{#if is_conversation}}conversation{{/if}}" data-recent-chat-type="{{recent_chat_type}}" data-file="{{chat_name}}" data-avatar="{{avatar}}" data-group="{{group}}" data-conversation-branch-id="{{conversation_branch_id}}" data-conversation-branch-name="{{conversation_branch_name}}">
+                    <button type="button" class="recentChatOpen"><span class="sr-only">{{char_name}} &ndash; {{chat_name}}</span></button>
                     {{#if pinned}}
                         <div class="recentChatPinned">
                             <i class="fa-solid fa-thumbtack fa-fw fa-xs" title="Pinned chat" data-i18n="[title]Pinned chat"></i>
                         </div>
                     {{/if}}
                     <div class="avatar" title="[Character] {{char_name}}&#10;File: {{avatar}}">
-                        <img src="{{char_thumbnail}}" alt="{{char_name}}">
+                        <img src="{{char_thumbnail}}" alt="{{char_name}}" width="64" height="64" loading="lazy" decoding="async">
                     </div>
                     <div class="recentChatInfo">
                         <div class="chatNameContainer">
@@ -442,13 +426,13 @@
                             </div>
                             <small class="chatDate" title="{{date_long}}">{{date_short}}</small>
                             <div class="chatActions">
-                                <button class="menu_button menu_button_icon pinChat {{#if pinned}}active{{/if}}" title="Pin chat" data-i18n="[title]Pin chat">
+                                <button class="menu_button menu_button_icon pinChat {{#if pinned}}active{{/if}}" title="{{#if pinned}}Unpin chat{{else}}Pin chat{{/if}}" aria-label="{{#if pinned}}Unpin chat{{else}}Pin chat{{/if}}" aria-pressed="{{#if pinned}}true{{else}}false{{/if}}">
                                     <i class="fa-solid fa-thumbtack fa-fw"></i>
                                 </button>
-                                <button class="menu_button menu_button_icon renameChat" title="Rename chat" data-i18n="[title]Rename chat">
+                                <button class="menu_button menu_button_icon renameChat" title="Rename chat" aria-label="Rename chat" data-i18n="[title]Rename chat;[aria-label]Rename chat">
                                     <i class="fa-solid fa-pen-to-square fa-fw"></i>
                                 </button>
-                                <button class="menu_button menu_button_icon deleteChat" title="Delete chat" data-i18n="[title]Delete chat">
+                                <button class="menu_button menu_button_icon deleteChat" title="Delete chat" aria-label="Delete chat" data-i18n="[title]Delete chat;[aria-label]Delete chat">
                                     <i class="fa-solid fa-trash fa-fw"></i>
                                 </button>
                             </div>
@@ -466,15 +450,15 @@
                             </div>
                         </div>
                     </div>
-                </div>
+                </article>
                 {{/with}}
             {{/each}}
             {{#if more}}
-                <button class="menu_button menu_button_icon showMoreChats">
+                <button class="menu_button menu_button_icon showMoreChats" aria-controls="welcome-recent-chat-list" aria-expanded="false">
                     <small class="fa-solid fa-chevron-down fa-fw fa-1x"></small>
                 </button>
             {{/if}}
             </div>
         </div>
-    </div>
+    </section>
 </div>

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -6,7 +6,6 @@ import {
     doNewChat,
     event_types,
     eventSource,
-    firstRun,
     getCharacters,
     getCurrentChatId,
     getRequestHeaders,
@@ -25,7 +24,7 @@ import {
     this_chid,
 } from '../script.js';
 import { deleteGroupChatByName, getGroupAvatar, groups, is_group_generating, openGroupById, openGroupChat } from './group-chats.js';
-import { enableExtension, extension_settings, findExtension, installExtension } from './extensions.js';
+import { deleteExtension, enableExtension, extension_settings, findExtension, getExtensionType, installExtension } from './extensions.js';
 import { t } from './i18n.js';
 import { getPresetManager } from './preset-manager.js';
 import { isIOSWebKitPlatform } from './mobile-send-button.js';
@@ -39,8 +38,8 @@ const assistantAvatarKey = 'assistant';
 const pinnedChatsKey = 'pinnedChats';
 
 const tutorialStatusKey = 'WelcomePage_TutorialStatus';
+const tutorialIndexKey = 'WelcomePage_TutorialIndex';
 const welcomeDeckViewKey = 'WelcomePage_DeckView';
-const welcomeDeckCollapsedKey = 'WelcomePage_DeckCollapsed';
 const welcomePanelModeKey = 'WelcomePage_PanelMode';
 const DEFAULT_BUNDLED_ASSISTANT_ID = 'guide';
 const bundledAssistantNahidaAvatarKey = 'bundledAssistantNahidaAvatar';
@@ -48,9 +47,9 @@ const DEFAULT_NEUTRAL_ASSISTANT_NAME = 'Assistant';
 
 const AGENT_MESSAGE_EXTRA_KEY = 'inChatAgents';
 const AGENT_PROMPT_TRANSFORM_HISTORY_KEY = 'inChatAgentTransformHistory';
-const STARTER_PACK_PRESET_NAME_SILLYBUNNY = 'Pura\'s Director Preset (SillyBunny)';
+const STARTER_PACK_PRESET_NAME_SILLYBUNNY = 'Pura\'s Director Preset 15.0 (SillyBunny)';
 const STARTER_PACK_PRESET_TITLE = 'Pura\'s Director Preset';
-const STARTER_PACK_CREATOR_NAME = 'purachina';
+const TLD_PRESET_NAME = 'TLD Card Conversion Preset (Standalone)';
 const STARTER_PACK_SITE_URL = 'https://platberlitz.github.io/';
 const GEECHAN_PRESET_NAME = 'Geechan - Universal Roleplay (Chat Completions) (v5.2)';
 const GEECHAN_SITE_URL = 'https://rentry.org/geechan';
@@ -67,7 +66,7 @@ const STARTER_PACK_EXTENSIONS = Object.freeze({
     }),
     cssSnippets: Object.freeze({
         id: 'third-party/SillyBunny-CssSnippets',
-        repoUrl: 'https://github.com/platberlitz/SillyBunny-CssSnippets',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-CssSnippets',
     }),
     moonlitEchoes: Object.freeze({
         id: 'third-party/SillyBunny-MoonlitEchoesTheme',
@@ -81,119 +80,146 @@ const STARTER_PACK_EXTENSIONS = Object.freeze({
         id: 'third-party/SillyTavern-LALib',
         repoUrl: 'https://github.com/LenAnderson/SillyTavern-LALib',
     }),
-    tooltips: Object.freeze({
-        id: 'third-party/SillyTavern-Tooltips',
-        repoUrl: 'https://github.com/LenAnderson/SillyTavern-Tooltips',
-    }),
     adhdBunnyUi: Object.freeze({
         id: 'third-party/ADHDBunny-UI',
         repoUrl: 'https://github.com/OnlyJimmy/ADHDBunny-UI',
+    }),
+    promptingLab: Object.freeze({
+        id: 'third-party/SillyBunny-Prompting-Lab',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-Prompting-Lab',
+    }),
+    worldInfoLab: Object.freeze({
+        id: 'third-party/SillyBunny-WorldInfo-Lab',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-WorldInfo-Lab',
+    }),
+    regexAgentThemes: Object.freeze({
+        id: 'third-party/SillyBunny-Regex-Agent-Themes',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-Regex-Agent-Themes',
+    }),
+    botSearcher: Object.freeze({
+        id: 'third-party/SillyBunny-BotSearcher',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-BotSearcher',
+    }),
+    macroEnhanced: Object.freeze({
+        id: 'third-party/SillyBunny-MacroEnhanced',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-MacroEnhanced',
+    }),
+    promptTags: Object.freeze({
+        id: 'third-party/SillyBunny-PromptTags',
+        repoUrl: 'https://github.com/SillyBunnyTeam/SillyBunny-PromptTags',
     }),
 });
 
 const WELCOME_TUTORIAL_STEPS = Object.freeze([
     {
-        title: 'Start from home',
-        body: 'The Home Page is your personal starting point. You can start a Temporary Chat, open one of our built-in assistants, or access a few essential quick-settings right away.',
+        title: 'Your homepage',
+        body: 'The Home Page is your personal launchpad. You can quickly access various essential functions of SillyBunny here. For full access to this program\'s functionality, please use the top bar for further navigation and configuration.',
         hint: 'If you just want to directly chat with your chosen model, clicking Temporary Chat will get you started.',
-        chips: ['Temporary Chat', 'Open Assistant', 'Import Characters'],
-        actionLabel: 'Open Assistant',
-        actionType: 'open-assistant',
-        actionValue: '',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open Workspace', type: 'open-tab', value: 'left:presets' }),
+            Object.freeze({ label: 'Open Customize', type: 'open-tab', value: 'right:settings' }),
+            Object.freeze({ label: 'Open Characters', type: 'open-characters-menu' }),
+        ]),
     },
     {
         title: 'Connect a model',
-        body: 'Clicking the API button will bring you to a screen to connect a provider, and choose an LLM of your choice. You will need to connect a model before you can begin chatting.',
+        body: 'You will need to connect a large language model (LLM) to actually utilize the functionalities of this program. Open the API sub-tab found in Workspace to get started.',
         hint: 'Not sure what provider to use? OpenRouter is a good place to start. SillyBunny needs at least one working connection before you can chat.',
-        chips: ['API', 'Providers', 'Models', 'Connection'],
-        actionLabel: 'Open API',
-        actionType: 'open-tab',
-        actionValue: 'left:api',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open API', type: 'open-tab', value: 'left:api' }),
+            Object.freeze({ label: 'Open Sampling', type: 'open-tab', value: 'left:sampling' }),
+        ]),
     },
     {
         title: 'Choose a preset',
-        body: 'First, select a preset of your choice: this helps dictate model responses. Chat and Text Completions formatting lives with the presets tab, and World Info helps the model remember lore and setting details.',
-        hint: 'You only really need to start with a preset! We recommend using our bundled Geechan or Director preset. Access the other workspace sections once you feel more comfortable.',
-        chips: ['Presets', 'Formatting', 'World Info', 'Context'],
-        actionLabel: 'Open Presets',
-        actionType: 'open-tab',
-        actionValue: 'left:presets',
+        body: 'Next, you can optionally enable a preset of your choice. This influences your model\'s responses and give it appropriate instructions for its task. We recommend starting with a Chat Completions preset if you\'re unsure.',
+        hint: 'Presets are entirely optional, but can be beneficial for response quality. Our bundled Geechan or Director presets are a great starting preset option if you\'re unsure.',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open Presets', type: 'open-tab', value: 'left:presets' }),
+            Object.freeze({ label: 'Open World Info', type: 'open-tab', value: 'left:world-info' }),
+        ]),
     },
     {
-        title: 'Personalize your workspace',
-        body: 'The Customize menu in the top bar handles your theming and customization needs. You can optionally enable extra extensions, then manage personas from Characters.',
-        hint: 'Customization and extensions are optional, but recommended. While we ship a starter pack, nothing turns itself on without your permission.',
-        chips: ['Settings', 'Extensions', 'Background'],
-        actionLabel: 'Open Extensions',
-        actionType: 'open-tab',
-        actionValue: 'right:extensions',
+        title: 'Load a character',
+        body: 'Now that you\'ve gotten the pre-requisites out of the way, you\'re close to being able to chat! Open the Characters menu and select a character to get started on your RP/storywriting journey.',
+        hint: 'You will need to source your own character cards from online (or create your own!) if you want more than just the bundled characters. SillyBunny supports all cards following the V2/V3 format.',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open Characters', type: 'open-characters-menu' }),
+            Object.freeze({ label: 'Open Personas', type: 'open-tab', value: 'characters:persona' }),
+            Object.freeze({ label: 'Open World Info', type: 'open-tab', value: 'left:world-info' }),
+        ]),
     },
     {
-        title: 'Ask our assistants when stuck',
-        body: 'Our built-in assistants can help explain LLM basics and SillyBunny concepts and terminology without assuming you already know the jargon.',
-        hint: 'Make sure you have a model connected first! You can really ask our assistants anything and they will help explain more abstract concepts.',
-        chips: ['LLM basics', 'SillyBunny tips', 'SillyTavern terms'],
-        actionLabel: 'Prefill a beginner question',
-        actionType: 'assistant-prompt',
-        actionValue: 'Explain the difference between providers, models, presets, personas, and world info in simple terms.',
+        title: 'Customize your workspace',
+        body: 'Congrats, you\'re done! If you wish to delve into all the functionality and customization that SillyBunny can offer, please explore our UI from the top bar. A good starting point is SillyBunny\'s vast extension ecosystem. For more information: check out the UI Handbook tab!',
+        hint: 'The world of AI creative writing is vast and seemingly neverending. We recommend asking our built-in assistants for more help if you\'re confused!',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open UI Handbook', type: 'open-deck-view', value: 'basics' }),
+            Object.freeze({ label: 'Open Extensions', type: 'open-tab', value: 'right:extensions' }),
+            Object.freeze({ label: 'Open Assistant', type: 'open-assistant', assistantId: 'guide' }),
+            Object.freeze({ label: 'Open Assistant Nahida', type: 'open-assistant', assistantId: 'nahida' }),
+        ]),
     },
 ]);
 
 const WELCOME_GUIDE_CARDS = Object.freeze([
     {
         title: 'Workspace Menu',
-        body: 'Open the Workspace button in the top bar when you want to change how the AI behaves: connecting APIs, swapping presets, tuning sampling or formatting, and loading lore and agent helpers.',
-        chips: ['Presets', 'API', 'Sampling', 'World Info', 'Agents'],
+        body: 'Open the Workspace button in the top bar when you want to change how the LLM behaves behind the scenes. You can connect APIs, swap presets, tune samplers or formatting, and load in-chat agents to complement your chat.',
         icon: 'fa-compass-drafting',
-        actionLabel: 'Open the Workspace menu',
-        actionType: 'open-tab',
-        actionValue: 'left:presets',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open the Workspace menu', type: 'open-tab', value: 'left:presets' }),
+            Object.freeze({ label: 'Open API', type: 'open-tab', value: 'left:api' }),
+            Object.freeze({ label: 'Open Sampling', type: 'open-tab', value: 'left:sampling' }),
+            Object.freeze({ label: 'Open Agents', type: 'open-tab', value: 'left:agents' }),
+        ]),
     },
     {
         title: 'Customize Menu',
-        body: 'Open the Customize button in the top bar when you want to change your workspace setup: app settings, extensions, backgrounds, and the visual feel of SillyBunny.',
-        chips: ['Settings', 'Extensions', 'Background'],
+        body: 'Open the Customize button in the top bar when you want to change any setting related to SillyBunny itself. This includes app settings, extensions, backgrounds, and visual settings.',
         icon: 'fa-screwdriver-wrench',
-        actionLabel: 'Open the Customize menu',
-        actionType: 'open-tab',
-        actionValue: 'right:settings',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open the Customize menu', type: 'open-tab', value: 'right:settings' }),
+            Object.freeze({ label: 'Open Extensions', type: 'open-tab', value: 'right:extensions' }),
+            Object.freeze({ label: 'Open Backgrounds', type: 'open-tab', value: 'right:background' }),
+        ]),
     },
     {
         title: 'Characters Menu',
         body: 'Open the Characters button in the top bar when you want to access characters, edit personas, or create character cards. We have a few characters bundled for you to give you an idea of how to create them!',
-        chips: ['Character Cards', 'Persona', 'Create Character', 'Open Character'],
         icon: 'fa-solid fa-id-card',
-        actionLabel: 'Open the Characters menu',
-        actionType: 'open-characters-menu',
-        actionValue: '',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open the Characters menu', type: 'open-characters-menu' }),
+            Object.freeze({ label: 'Open Personas', type: 'open-tab', value: 'characters:persona' }),
+            Object.freeze({ label: 'Import Characters', type: 'open-import-characters' }),
+        ]),
     },
     {
         title: 'Global Search',
         body: 'Open the search icon in the top bar to do a global search across all settings pages to quickly find the setting you are looking for!',
-        chips: ['Global Search', 'Fuzzy Search', 'Settings', 'Top Bar'],
         icon: 'fa-search',
-        actionLabel: 'Open the Search bar',
-        actionType: 'open-global-search',
-        actionValue: '',
-        isSearchTrigger: true,
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open the Search bar', type: 'open-global-search', isSearchTrigger: true }),
+        ]),
     },
     {
         title: 'Quick-access Buttons',
         body: 'We have a few quick access buttons for your convenience in the home screen. Temporary Chat opens a quick burner chat. Open Assistant brings up one of our built-in assistants. Import Characters lets you bring in a character of your choosing.',
-        chips: ['Temporary Chat', 'Open Assistant', 'Import Characters'],
         icon: 'fa-hand-pointer',
-        actionLabel: 'Import a character',
-        actionType: 'open-import-characters',
-        actionValue: '',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Temporary Chat', type: 'open-temporary-chat' }),
+            Object.freeze({ label: 'Open Assistant', type: 'open-assistant', assistantId: 'guide' }),
+            Object.freeze({ label: 'Import Characters', type: 'open-import-characters' }),
+        ]),
     },
     {
-        title: 'Confused?',
-        body: 'If you are ever confused, check through our launchpad documentation or ask one of our assistants a question. It is not necessary to memorize the whole interface to start using it!',
-        chips: ['Open Launchpad', 'Bunny guide', 'Docs', 'Start small'],
-        icon: 'fa-life-ring',
-        actionLabel: 'Open Launchpad',
-        actionType: 'replay-tutorial',
-        actionValue: '',
+        title: 'Chat Modes',
+        body: 'With a selected character card, you can swap between either roleplay or conversation modes. Use roleplay if you want a traditional chatting experience with your character. Use conversation if you wish to simulate an instant-messaging live-chat environment with your character.',
+        icon: 'fa-comments',
+        actions: Object.freeze([
+            Object.freeze({ label: 'Open Roleplay', type: 'open-roleplay' }),
+            Object.freeze({ label: 'Open Conversation', type: 'open-conversation' }),
+        ]),
     },
 ]);
 
@@ -217,7 +243,6 @@ const WELCOME_BUNDLED_ASSISTANTS = Object.freeze([
         personality: 'Patient, beginner-friendly, calm, and practical.',
         scenario: 'You are the built-in Bunny Guide for SillyBunny. Help the user understand the interface, APIs, presets, prompt settings, personas, and world info in plain, approachable language.',
         firstMessage: 'Hi. I\'m the Bunny Guide. If anything in SillyBunny feels confusing, ask in plain English and I\'ll walk through it with you step by step.',
-        chips: Object.freeze(['LLM basics', 'SillyBunny help', 'Plain English', 'purachina']),
         questions: Object.freeze([
             'What is an LLM, in plain English?',
             'What is a character card?',
@@ -248,7 +273,6 @@ const WELCOME_BUNDLED_ASSISTANTS = Object.freeze([
         personality: 'Patient, observant, encouraging, thoughtful, and concise.',
         scenario: 'You are Assistant Nahida, a bundled helper for SillyBunny. Guide the user through prompts, token budgeting, presets, reasoning settings, context size, and general workflow questions with calm clarity.',
         firstMessage: 'Hello. I\'m Assistant Nahida, a bundled helper made by Geechan. If you want, we can sort out prompts, presets, context size, or any confusing settings together.',
-        chips: Object.freeze(['LLM basics', 'SillyBunny help', 'Philosophical', 'Geechan']),
         questions: Object.freeze([
             'Can you help me make sense of my current system prompt?',
             'What should I tune first: model, preset, or prompt settings?',
@@ -264,26 +288,26 @@ const WELCOME_BUNDLED_ASSISTANTS = Object.freeze([
 const WELCOME_DECK_VIEWS = Object.freeze([
     {
         id: 'tour',
-        title: 'First Steps',
-        summary: 'A guided five-step tour for brand-new users.',
+        title: 'Starting Tutorial',
+        summary: 'New to SillyBunny? Start here!',
         icon: 'fa-route',
     },
     {
         id: 'basics',
-        title: 'Core Buttons',
+        title: 'UI Handbook',
         summary: 'A plain-English guide on our graphical shell.',
         icon: 'fa-compass-drafting',
     },
     {
         id: 'guide',
-        title: 'Bunny Guide + Assistant Nahida',
+        title: 'Bundled Assistants',
         summary: 'Two bundled helpers for plain-English setup help.',
         icon: 'fa-user-graduate',
     },
     {
         id: 'starter',
         title: 'Bundled Extras',
-        summary: 'Optional bundled extras, presets, and creator picks.',
+        summary: 'A repository of our pre-bundled and recommended extensions/presets.',
         icon: 'fa-gift',
     },
 ]);
@@ -328,7 +352,7 @@ function saveRecentChatsSettings(settings) {
 
 
 /**
- * @typedef {Pick<RecentChat, 'group' | 'avatar' | 'file_name'>} PinnedChat
+ * @typedef {Pick<RecentChat, 'group' | 'avatar' | 'file_name' | 'is_conversation' | 'conversation_branch_id'>} PinnedChat
  */
 
 /**
@@ -369,6 +393,10 @@ class PinnedChatsManager {
      * @returns {string} Key for pinned chat storage
      */
     static getKey(recentChat) {
+        if (recentChat.is_conversation && recentChat.conversation_branch_id) {
+            const ownerKey = recentChat.group ? `group_${recentChat.group}` : `char_${recentChat.avatar || ''}`;
+            return `conversation_${ownerKey}_branch_${recentChat.conversation_branch_id}`;
+        }
         return `${recentChat.group ? 'group_' + recentChat.group : ''}${recentChat.avatar ? 'char_' + recentChat.avatar : ''}_${recentChat.file_name}`;
     }
 
@@ -416,10 +444,54 @@ class PinnedChatsManager {
                 group: recentChat.group,
                 avatar: recentChat.avatar,
                 file_name: recentChat.file_name,
+                is_conversation: recentChat.is_conversation,
+                conversation_branch_id: recentChat.conversation_branch_id,
             };
         } else {
             delete pinState[pinKey];
         }
+        this.#saveState(pinState);
+    }
+
+    /**
+     * Removes a deleted chat from pinned storage.
+     * @param {{ avatar?: string, group?: string, fileName: string }} chat Chat identity
+     */
+    static removeDeleted({ avatar = '', group = '', fileName }) {
+        const pinState = { ...this.getState() };
+        const normalizedFileName = String(fileName).replace(/\.jsonl$/i, '');
+        let changed = false;
+
+        for (const [key, pinnedChat] of Object.entries(pinState)) {
+            if (pinnedChat.is_conversation) {
+                continue;
+            }
+            const pinnedFileName = String(pinnedChat.file_name || '').replace(/\.jsonl$/i, '');
+            const matchesOwner = group
+                ? String(pinnedChat.group || '') === String(group)
+                : String(pinnedChat.avatar || '') === String(avatar);
+            if (pinnedFileName === normalizedFileName && matchesOwner) {
+                delete pinState[key];
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            this.#saveState(pinState);
+        }
+    }
+
+    /**
+     * Removes one exact chat from pinned storage.
+     * @param {RecentChat} recentChat Recent chat data
+     */
+    static remove(recentChat) {
+        const pinKey = this.getKey(recentChat);
+        const pinState = { ...this.getState() };
+        if (!(pinKey in pinState)) {
+            return;
+        }
+        delete pinState[pinKey];
         this.#saveState(pinState);
     }
 
@@ -437,11 +509,14 @@ class PinnedChatsManager {
         const updatedChat = { ...recentChat, file_name: newFileName };
         const newKey = this.getKey(updatedChat);
         pinState[newKey] = {
+            ...pinState[oldKey],
             group: recentChat.group,
             avatar: recentChat.avatar,
             file_name: newFileName,
         };
-        delete pinState[oldKey];
+        if (oldKey !== newKey) {
+            delete pinState[oldKey];
+        }
         this.#saveState(pinState);
     }
 
@@ -451,7 +526,7 @@ class PinnedChatsManager {
      */
     static getAll() {
         const pinState = this.getState();
-        return Object.values(pinState);
+        return Object.values(pinState).filter(pinnedChat => !pinnedChat.is_conversation);
     }
 }
 
@@ -624,16 +699,6 @@ function getInitialDeckView() {
     return 'tour';
 }
 
-function isWelcomeDeckCollapsed() {
-    const stored = getWelcomeUiPreference(welcomeDeckCollapsedKey);
-    if (stored === null) {
-        // Check if this is first run - if so, default to expanded (false)
-        // Otherwise default to collapsed (true)
-        return !firstRun;
-    }
-    return stored === 'true';
-}
-
 function isWelcomePanelMode(mode) {
     return Object.values(WELCOME_PANEL_MODES).includes(mode);
 }
@@ -644,14 +709,16 @@ function getWelcomePanelMode() {
 }
 
 function getWelcomeUiPreference(key) {
+    const accountValue = accountStorage.getItem(key);
+    if (accountValue !== null) {
+        return accountValue;
+    }
+
     try {
         const localValue = globalThis.localStorage?.getItem(key) ?? null;
 
         if (localValue !== null) {
-            if (accountStorage.getItem(key) !== localValue) {
-                accountStorage.setItem(key, localValue);
-            }
-
+            accountStorage.setItem(key, localValue);
             return localValue;
         }
     } catch {
@@ -682,9 +749,7 @@ function buildDeckTabs(activeView) {
 function buildGuideCards() {
     return WELCOME_GUIDE_CARDS.map(card => ({
         ...card,
-        chips: [...card.chips],
-        chipColumnCount: Math.max(2, Math.min(card.chips.length || 1, 4)),
-        isSearchTrigger: card.isSearchTrigger || false,
+        actions: card.actions.map(action => ({ ...action })),
     }));
 }
 
@@ -699,19 +764,17 @@ function buildBundledAssistantCards() {
         actionLabel: assistant.actionLabel,
         actionIcon: assistant.actionIcon,
         cardIcon: assistant.cardIcon,
-        chips: [...assistant.chips],
-        chipColumnCount: Math.max(2, Math.min(assistant.chips.length || 1, 4)),
         questions: [...assistant.questions],
         hasQuestions: assistant.questions.length > 0,
     }));
 }
 
-function buildTutorialSteps() {
+function buildTutorialSteps(activeIndex = 0) {
     return WELCOME_TUTORIAL_STEPS.map((step, index) => ({
         ...step,
-        chips: [...step.chips],
+        actions: step.actions.map(action => ({ ...action })),
         stepNumber: index + 1,
-        active: index === 0,
+        active: index === activeIndex,
     }));
 }
 
@@ -719,24 +782,26 @@ function getStarterPackExtensionConfig(extensionName) {
     return Object.values(STARTER_PACK_EXTENSIONS).find(extension => extension.id === extensionName) ?? null;
 }
 
-function buildExtensionStarterPackItem({ title, body, icon, chips, extensionName }) {
+function buildExtensionStarterPackItem({ title, body, icon, extensionName }) {
     const extension = findExtension(extensionName);
     const extensionConfig = getStarterPackExtensionConfig(extensionName);
-    const chipColumnCount = Math.max(2, Math.min(chips.length || 1, 4));
 
     if (!extension && extensionConfig) {
+        const isCurrentUserAdmin = isAdmin();
         return {
             title,
             body,
             icon,
-            chips: [...chips],
-            chipColumnCount,
             statusLabel: 'Git install',
             statusTone: 'warm',
             actionIcon: 'fa-download',
-            actionLabel: isAdmin() ? 'Install for all users' : 'Install for me',
-            actionType: 'install-starter-extension',
+            actionLabel: isCurrentUserAdmin ? 'Install for all users' : 'Install for this user',
+            actionType: isCurrentUserAdmin ? 'install-starter-extension-global' : 'install-starter-extension-user',
             actionValue: extensionName,
+            secondaryActionLabel: isCurrentUserAdmin ? 'Install for this user' : '',
+            secondaryActionIcon: 'fa-user',
+            secondaryActionType: 'install-starter-extension-user',
+            secondaryActionValue: extensionName,
         };
     }
 
@@ -745,8 +810,6 @@ function buildExtensionStarterPackItem({ title, body, icon, chips, extensionName
             title,
             body,
             icon,
-            chips: [...chips],
-            chipColumnCount,
             statusLabel: 'Unavailable',
             statusTone: 'neutral',
             actionIcon: 'fa-arrow-up-right-from-square',
@@ -761,14 +824,16 @@ function buildExtensionStarterPackItem({ title, body, icon, chips, extensionName
             title,
             body,
             icon,
-            chips: [...chips],
-            chipColumnCount,
             statusLabel: 'Enabled',
             statusTone: 'good',
             actionIcon: 'fa-arrow-up-right-from-square',
             actionLabel: 'Manage in Extensions',
             actionType: 'open-tab',
             actionValue: 'right:extensions',
+            secondaryActionLabel: 'Remove Extension',
+            secondaryActionIcon: 'fa-trash',
+            secondaryActionType: 'remove-starter-extension',
+            secondaryActionValue: extension.name,
         };
     }
 
@@ -776,14 +841,16 @@ function buildExtensionStarterPackItem({ title, body, icon, chips, extensionName
         title,
         body,
         icon,
-        chips: [...chips],
-        chipColumnCount,
         statusLabel: 'Installed',
         statusTone: 'warm',
         actionLabel: 'Enable and reload',
         actionIcon: 'fa-wand-magic-sparkles',
         actionType: 'enable-extension',
         actionValue: extension.name,
+        secondaryActionLabel: 'Remove Extension',
+        secondaryActionIcon: 'fa-trash',
+        secondaryActionType: 'remove-starter-extension',
+        secondaryActionValue: extension.name,
     };
 }
 
@@ -794,21 +861,17 @@ function buildPresetStarterPackItem() {
     const selectedPresetName = isOpenAiStyleApi ? presetManager?.getSelectedPresetName() : '';
     const isSelected = selectedPresetName === STARTER_PACK_PRESET_NAME_SILLYBUNNY;
     const hasBundledPreset = Boolean(sillyBunnyPreset);
-    const chips = ['Chat Completions', 'Bundled', 'Agent-aware', STARTER_PACK_CREATOR_NAME];
-    const chipColumnCount = Math.max(2, Math.min(chips.length, 4));
-    const body = 'purachina\'s website contains his character cards, presets, and other projects. A SillyBunny-tuned version of his Director Preset ships included and is ready to use for Chat Completions.';
+    const body = 'Purachina\'s Director v15.0 preset is fully bundled with SillyBunny as a preset option. This preset is ideal if you want the LLM to have maximum control over the story, the characters, *and* your persona. Simply go to the Presets menu to find it. If you wish to see more of Pura\'s character cards and other projects, check out the link below!';
 
     if (!isOpenAiStyleApi) {
         return {
             title: STARTER_PACK_PRESET_TITLE,
-            body: `${body} Switch to an OpenAI-compatible chat-completions setup first, then you can apply it here.`,
+            body,
             icon: 'fa-sliders',
-            chips,
-            chipColumnCount,
             statusLabel: 'Chat Completions',
             statusTone: 'neutral',
             actionIcon: 'fa-arrow-up-right-from-square',
-            actionLabel: 'Open API',
+            actionLabel: 'API',
             actionType: 'open-tab',
             actionValue: 'left:api',
         };
@@ -817,13 +880,9 @@ function buildPresetStarterPackItem() {
     if (hasBundledPreset) {
         return {
             title: STARTER_PACK_PRESET_TITLE,
-            body: isSelected
-                ? `${body} It is selected right now.`
-                : `${body} It is bundled and ready to apply without importing files by hand.`,
+            body,
             icon: 'fa-sliders',
-            chips,
-            chipColumnCount,
-            statusLabel: isSelected ? 'Selected' : 'Bundled',
+            statusLabel: isSelected ? 'Selected' : 'Preset pack',
             statusTone: isSelected ? 'good' : 'warm',
             actionIcon: 'fa-wand-magic-sparkles',
             actionLabel: 'Apply preset',
@@ -838,10 +897,8 @@ function buildPresetStarterPackItem() {
 
     return {
         title: STARTER_PACK_PRESET_TITLE,
-        body: `${body} Open the preset panel if you need to check what is available.`,
+        body,
         icon: 'fa-sliders',
-        chips,
-        chipColumnCount,
         statusLabel: 'Open Presets',
         statusTone: 'warm',
         actionIcon: 'fa-arrow-up-right-from-square',
@@ -851,49 +908,16 @@ function buildPresetStarterPackItem() {
     };
 }
 
-function buildLinkStarterPackItem({
-    title,
-    body,
-    icon,
-    chips,
-    actionLabel,
-    actionValue,
-    secondaryActionLabel = '',
-    secondaryActionValue = '',
-    statusLabel = 'Bundled',
-    statusTone = 'warm',
-}) {
-    return {
-        title,
-        body,
-        icon,
-        chips: [...chips],
-        chipColumnCount: Math.max(2, Math.min(chips.length || 1, 4)),
-        statusLabel,
-        statusTone,
-        actionLabel,
-        actionIcon: 'fa-arrow-up-right-from-square',
-        actionType: 'open-link',
-        actionValue,
-        secondaryActionLabel,
-        secondaryActionIcon: 'fa-arrow-up-right-from-square',
-        secondaryActionType: 'open-link',
-        secondaryActionValue,
-    };
-}
-
 function buildGeechanStarterPackItem() {
     const presetManager = getPresetManager('openai');
     const isOpenAiStyleApi = main_api === 'openai';
     const isSelected = isOpenAiStyleApi && presetManager?.getSelectedPresetName() === GEECHAN_PRESET_NAME;
-    const body = 'Geechan\'s Rentry highlights his well-written character cards and guides alongside his prompts and presets. SillyBunny includes his Universal Roleplay v5.2 preset across Chat Completions, plus the matching Text Completions variant for context, system prompt, and instruct pieces. He also made our bundled Assistant Nahida card and Prose Polisher agent.';
+    const body = 'Geechan\'s Universal Roleplay v5.2 and Universal Chatroom presets are also fully bundled with SillyBunny as a preset option. The Universal Roleplay preset is ideal if you want a traditional roleplay and storywriting experience with an LLM, while your persona and general story direction remain completely in your own hands. If you wish to see more of Geechan\'s character cards, presets, and guides, check out the link below!';
 
     return {
-        title: 'Geechan',
-        body: isSelected ? `${body} This preset is selected right now.` : body,
+        title: 'Geechan\'s Universal Roleplay',
+        body,
         icon: 'fa-leaf',
-        chips: ['Chat Completions', 'Text Completions', 'Prose Polisher', 'Assistant Nahida'],
-        chipColumnCount: 4,
         statusLabel: isSelected ? 'Selected' : 'Preset pack',
         statusTone: isSelected ? 'good' : 'warm',
         actionLabel: 'Apply preset',
@@ -908,18 +932,30 @@ function buildGeechanStarterPackItem() {
 }
 
 function buildTldStarterPackItem() {
-    return buildLinkStarterPackItem({
-        title: 'TheLonelyDevil',
-        body: 'SillyBunny bundles the TLD Card Conversion Preset for character card conversions and generations, and the Memory Sharding Quick Reply set for compressing chat history into structured memory shards. We also recommend his Discord Pals program to run LLM characters inside Discord!',
+    const presetManager = getPresetManager('openai');
+    const isOpenAiStyleApi = main_api === 'openai';
+    const isSelected = isOpenAiStyleApi && presetManager?.getSelectedPresetName() === TLD_PRESET_NAME;
+    const body = 'TheLonelyDevil\'s card converter preset is ideal if you want to convert a character card into a robust, well-tested AliChat + PList format for roleplay and storywriting. Very useful if you find a card that\'s of poorer quality and want a formatting polish run applied. If you wish to see more of TheLonelyDevil\'s character cards and Discord Pals project, check out the links below!';
+
+    return {
+        title: 'TheLonelyDevil\'s Card Converter',
+        body,
         icon: 'fa-shoe-prints',
-        chips: ['Card converter', 'Memory shards', 'Discord Pals', 'BotBooru'],
-        statusLabel: 'Card Converter',
-        statusTone: 'warm',
-        actionLabel: 'Visit site',
-        actionValue: TLD_SITE_URL,
-        secondaryActionLabel: 'Discord Pals',
-        secondaryActionValue: TLD_DISCORD_PALS_URL,
-    });
+        statusLabel: !isOpenAiStyleApi ? 'Chat Completions' : (isSelected ? 'Selected' : 'Preset pack'),
+        statusTone: isSelected ? 'good' : 'warm',
+        actionLabel: isOpenAiStyleApi ? 'Apply preset' : 'API',
+        actionIcon: isOpenAiStyleApi ? 'fa-wand-magic-sparkles' : 'fa-arrow-up-right-from-square',
+        actionType: isOpenAiStyleApi ? 'apply-preset' : 'open-tab',
+        actionValue: isOpenAiStyleApi ? TLD_PRESET_NAME : 'left:api',
+        secondaryActionLabel: 'Visit site',
+        secondaryActionIcon: 'fa-arrow-up-right-from-square',
+        secondaryActionType: 'open-link',
+        secondaryActionValue: TLD_SITE_URL,
+        tertiaryActionLabel: 'Discord Pals',
+        tertiaryActionIcon: 'fa-arrow-up-right-from-square',
+        tertiaryActionType: 'open-link',
+        tertiaryActionValue: TLD_DISCORD_PALS_URL,
+    };
 }
 
 function buildStarterPackItems() {
@@ -929,61 +965,85 @@ function buildStarterPackItems() {
             buildGeechanStarterPackItem(),
             buildTldStarterPackItem(),
         ],
-        optional: [
-            buildExtensionStarterPackItem({
-                title: 'Summary Sharder',
-                body: 'A recommended way to add persistent memory to your chats. Summary Sharder keeps a rolling summary of your conversation so the AI remembers key events, characters, and context across long sessions.',
-                icon: 'fa-brain',
-                chips: ['Extension', 'Memory', 'Recommended'],
-                extensionName: STARTER_PACK_EXTENSIONS.summarySharder.id,
-            }),
+        optionalOfficial: [
             buildExtensionStarterPackItem({
                 title: 'Dialogue Colors',
-                body: `${STARTER_PACK_CREATOR_NAME}'s dialogue coloring add-on helps visually busy or emotionally dense chats stay readable, with optional regex setup if you want finer control.`,
+                body: 'A highly customizable extension that color-codes each character based on current chat context and certain parameters. Uses an LLM generation to write persistent <font color> tags into chat text, or can use a local DOM-only engine to color rendered dialogue without changing saved messages.',
                 icon: 'fa-palette',
-                chips: ['Extension', 'Readable chats', 'Opt-in'],
                 extensionName: STARTER_PACK_EXTENSIONS.dialogueColors.id,
             }),
             buildExtensionStarterPackItem({
                 title: 'CSS Snippets',
-                body: 'Manage custom CSS snippets from User Settings. Link snippets to specific themes or chats for per-character styling.',
+                body: 'Simply adds a UI to manage custom CSS snippets. Snippets can be globally activated, linked to a specific theme, or linked to a specific chat (character / group).',
                 icon: 'fa-palette',
-                chips: ['Extension', 'Styling', 'Opt-in'],
                 extensionName: STARTER_PACK_EXTENSIONS.cssSnippets.id,
             }),
             buildExtensionStarterPackItem({
                 title: 'Moonlit Echoes Theme',
-                body: 'A SillyBunny-specific fork of Moonlit Echoes that keeps its theme CSS, mobile layout fixes, and Moonlit chat styles isolated from SillyBunny core.',
+                body: 'A popular CSS theme originally designed for SillyTavern with a clean and modern design, adapted for use in SillyBunny.',
                 icon: 'fa-moon',
-                chips: ['Extension', 'Theme', 'SillyBunny fork'],
                 extensionName: STARTER_PACK_EXTENSIONS.moonlitEchoes.id,
             }),
             buildExtensionStarterPackItem({
+                title: 'Prompting Lab',
+                body: 'A troubleshooting extension used to diagnose the contents of your system prompt before it\'s sent to an LLM. Shows the persona, preset, connection profile, message contents, and more.',
+                icon: 'fa-flask',
+                extensionName: STARTER_PACK_EXTENSIONS.promptingLab.id,
+            }),
+            buildExtensionStarterPackItem({
+                title: 'World Info Lab',
+                body: 'A troubleshooting extension used to diagnose your lorebooks and world information before it\'s sent to an LLM. Useful if you need to find problematic entries.',
+                icon: 'fa-book-atlas',
+                extensionName: STARTER_PACK_EXTENSIONS.worldInfoLab.id,
+            }),
+            buildExtensionStarterPackItem({
+                title: 'Regex Agent Themes',
+                body: 'Adds several themes for the Agents and companions panels found in our In-Chat Agents feature.',
+                icon: 'fa-paintbrush',
+                extensionName: STARTER_PACK_EXTENSIONS.regexAgentThemes.id,
+            }),
+            buildExtensionStarterPackItem({
+                title: 'Bot Searcher',
+                body: 'Adds a character-card browser to SillyBunny. It can search supported card sites, show the details each site provides, and import any selected card. Note: this requires a server plugin to use.',
+                icon: 'fa-magnifying-glass',
+                extensionName: STARTER_PACK_EXTENSIONS.botSearcher.id,
+            }),
+            buildExtensionStarterPackItem({
+                title: 'Macro Enhanced',
+                body: 'Adds a wide variety of new, heavily customizable macros to SillyBunny\'s STScript engine. View all macros with /help macros.',
+                icon: 'fa-code',
+                extensionName: STARTER_PACK_EXTENSIONS.macroEnhanced.id,
+            }),
+            buildExtensionStarterPackItem({
+                title: 'Prompt Tags',
+                body: 'Adds automatic XML tags to SillyBunny\'s prompt sections. This can be useful if you want to implement XML prompting without modifying any existing presets, personas, lorebooks, or character cards.',
+                icon: 'fa-tags',
+                extensionName: STARTER_PACK_EXTENSIONS.promptTags.id,
+            }),
+        ],
+        optionalUnofficial: [
+            buildExtensionStarterPackItem({
+                title: 'Summary Sharder',
+                body: 'An extension that captures chat history before it falls out of context. It summarizes message ranges into structured "Memory Shards" with 16 labeled sections, manages message visibility, and routes output to system messages or lorebook entries - so nothing important is forgotten. In effect: this helps manage long-term context for LLMs.',
+                icon: 'fa-brain',
+                extensionName: STARTER_PACK_EXTENSIONS.summarySharder.id,
+            }),
+            buildExtensionStarterPackItem({
                 title: 'Group Utilities',
-                body: 'A SillyBunny-focused group-chat bundle with presence tracking, group greetings, shared group context utilities, and quick SendAs controls in one optional install.',
+                body: 'A compilation of utilities used to enhance group chats and their capabilities.',
                 icon: 'fa-users',
-                chips: ['Extension', 'Groups', 'Presence', 'SendAs'],
                 extensionName: STARTER_PACK_EXTENSIONS.groupUtilities.id,
             }),
             buildExtensionStarterPackItem({
                 title: 'LALib',
-                body: 'LenAnderson\'s shared helper library powers several other extensions, so having it in the Starter Pack makes later installs smoother and reduces dependency hunting.',
+                body: 'A library of STScript commands - a common dependency for many popular SillyTavern extensions.',
                 icon: 'fa-toolbox',
-                chips: ['Extension', 'Recommended', 'Utility'],
                 extensionName: STARTER_PACK_EXTENSIONS.laLib.id,
             }),
             buildExtensionStarterPackItem({
-                title: 'Tooltips',
-                body: 'Adds richer hover help across supported UI pieces so confusing controls are easier to understand without leaving the screen or digging through docs first.',
-                icon: 'fa-circle-info',
-                chips: ['Extension', 'Recommended', 'Help'],
-                extensionName: STARTER_PACK_EXTENSIONS.tooltips.id,
-            }),
-            buildExtensionStarterPackItem({
                 title: 'ADHDBunny UI',
-                body: 'A desktop-first SillyBunny UI overhaul designed to keep chat central while making common tools easier to reach and reducing workspace distractions.',
+                body: 'An optional CSS theme for SillyBunny which further simplifies the graphical shell and user interface. Developed by Jimmy.',
                 icon: 'fa-rabbit',
-                chips: ['Extension', 'Workspace', 'Desktop-first', 'Opt-in'],
                 extensionName: STARTER_PACK_EXTENSIONS.adhdBunnyUi.id,
             }),
         ],
@@ -992,8 +1052,10 @@ function buildStarterPackItems() {
 
 function buildWelcomeTemplateData(chats) {
     const activeDeckView = getInitialDeckView();
-    const deckCollapsed = isWelcomeDeckCollapsed();
     const welcomePanelMode = getWelcomePanelMode();
+    const tutorialStatus = getWelcomeUiPreference(tutorialStatusKey) || '';
+    const storedTutorialIndex = Number.parseInt(getWelcomeUiPreference(tutorialIndexKey) || '0', 10) || 0;
+    const tutorialIndex = clamp(storedTutorialIndex, 0, WELCOME_TUTORIAL_STEPS.length - 1);
 
     return {
         chats,
@@ -1001,7 +1063,6 @@ function buildWelcomeTemplateData(chats) {
         version: displayVersion,
         more: chats.length > getRecentChatsSettings().collapsedDisplayed,
         activeDeckView,
-        deckCollapsed,
         welcomePanelMode,
         welcomePanelFull: welcomePanelMode === WELCOME_PANEL_MODES.full,
         welcomePanelCompact: welcomePanelMode === WELCOME_PANEL_MODES.compact,
@@ -1012,9 +1073,9 @@ function buildWelcomeTemplateData(chats) {
         deckBasicsActive: activeDeckView === 'basics',
         deckGuideActive: activeDeckView === 'guide',
         deckStarterActive: activeDeckView === 'starter',
-        tutorialExpanded: true,
-        tutorialIndex: 0,
-        tutorialSteps: buildTutorialSteps(),
+        tutorialExpanded: tutorialStatus !== 'completed',
+        tutorialIndex,
+        tutorialSteps: buildTutorialSteps(tutorialIndex),
         guideCards: buildGuideCards(),
         bundledAssistants: buildBundledAssistantCards(),
         starterPackItems: buildStarterPackItems(),
@@ -1037,8 +1098,6 @@ async function highlightLaunchpadItem(extensionId) {
     }
 
     setWelcomeDeckView(welcomePanel, 'starter');
-    setWelcomeDeckCollapsed(welcomePanel, false);
-
     const selector = `.welcomeStarterPackCard[data-launchpad-extension="${CSS.escape(extensionId)}"]`;
     const card = welcomePanel.querySelector(selector);
     if (!(card instanceof HTMLElement)) {
@@ -1111,8 +1170,22 @@ function getRecentChatItemType(item) {
  * @param {object} [options] Options
  * @param {boolean} [options.expanded] Whether all chats in the active filter should be shown
  */
-function updateRecentChatFilterView(root, { expanded = false } = {}) {
+function getExpandedRecentChatFilters(root) {
+    return new Set((root.dataset.expandedRecentChatFilters || '').split(',').filter(Boolean));
+}
+
+function updateRecentChatFilterView(root, { expanded } = {}) {
     const filter = root.dataset.recentChatFilter || 'all';
+    const expandedFilters = getExpandedRecentChatFilters(root);
+    if (typeof expanded === 'boolean') {
+        if (expanded) {
+            expandedFilters.add(filter);
+        } else {
+            expandedFilters.delete(filter);
+        }
+        root.dataset.expandedRecentChatFilters = [...expandedFilters].join(',');
+    }
+    const filterExpanded = expandedFilters.has(filter);
     const chatItems = Array.from(root.querySelectorAll('.recentChat'));
     const { collapsedDisplayed } = getRecentChatsSettings();
     let matchingCount = 0;
@@ -1120,7 +1193,7 @@ function updateRecentChatFilterView(root, { expanded = false } = {}) {
     chatItems.forEach((chatItem) => {
         const chatType = getRecentChatItemType(chatItem);
         const matchesFilter = filter === 'all' || chatType === filter;
-        const hiddenByLimit = matchesFilter && !expanded && matchingCount >= collapsedDisplayed;
+        const hiddenByLimit = matchesFilter && !filterExpanded && matchingCount >= collapsedDisplayed;
 
         if (matchesFilter) {
             matchingCount++;
@@ -1136,10 +1209,39 @@ function updateRecentChatFilterView(root, { expanded = false } = {}) {
 
     root.querySelectorAll('button.showMoreChats').forEach((button) => {
         const hasMoreChats = matchingCount > collapsedDisplayed;
+        const expandedAndVisible = filterExpanded && hasMoreChats;
         button.classList.toggle('displayNone', !hasMoreChats);
-        button.classList.toggle('rotated', expanded && hasMoreChats);
-        button.setAttribute('aria-expanded', String(expanded && hasMoreChats));
+        button.classList.toggle('rotated', expandedAndVisible);
+        button.setAttribute('aria-expanded', String(expandedAndVisible));
+        button.setAttribute('title', expandedAndVisible ? t`Show less recent chats` : t`Show more recent chats`);
     });
+}
+
+function setRecentChatFilter(root, filter) {
+    root.dataset.recentChatFilter = filter;
+    root.querySelectorAll('[data-recent-chat-filter]').forEach((button) => {
+        const active = button.getAttribute('data-recent-chat-filter') === filter;
+        button.classList.toggle('active', active);
+        button.setAttribute('aria-pressed', String(active));
+    });
+    updateRecentChatFilterView(root);
+}
+
+function handleLinearNavigation(event, buttons, activeButton, activate) {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key) || buttons.length === 0) {
+        return;
+    }
+
+    event.preventDefault();
+    const currentIndex = Math.max(0, buttons.indexOf(activeButton));
+    const nextIndex = event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+            ? buttons.length - 1
+            : (currentIndex + (event.key === 'ArrowRight' ? 1 : -1) + buttons.length) % buttons.length;
+    const nextButton = buttons[nextIndex];
+    nextButton.focus();
+    activate(nextButton);
 }
 
 function openShellTab(route) {
@@ -1149,29 +1251,41 @@ function openShellTab(route) {
     const [shellKey, tabId] = String(normalizedRoute || '').split(':');
 
     if (!shellKey || !tabId) {
-        return;
+        return false;
     }
 
     if (globalThis.SillyBunnyShell?.openTab) {
         globalThis.SillyBunnyShell.openTab(shellKey, tabId);
-        return;
+        return true;
     }
 
-    const fallbackSelector = {
-        'left:presets': '#ai-config-button > .drawer-toggle',
-        'left:api': '#sys-settings-button > .drawer-toggle',
-        'characters:world-info': '#WI-SP-button > .drawer-toggle',
-        'right:settings': '#user-settings-button > .drawer-toggle',
-        'right:extensions': '#extensions-settings-button > .drawer-toggle',
-        'characters:persona': '#persona-management-button > .drawer-toggle',
-        'right:background': '#backgrounds-button > .drawer-toggle',
+    const fallbackRoute = {
+        'left:presets': { selector: '#ai-config-button > .drawer-toggle', shellRoot: '#left-nav-panel' },
+        'left:sampling': { selector: '#ai-config-button > .drawer-toggle', shellRoot: '#left-nav-panel', tabId: 'sampling' },
+        'left:api': { selector: '#sys-settings-button > .drawer-toggle', shellRoot: '#left-nav-panel' },
+        'left:agents': { selector: '#ai-config-button > .drawer-toggle', shellRoot: '#left-nav-panel', tabId: 'agents' },
+        'characters:world-info': { selector: '#WI-SP-button > .drawer-toggle' },
+        'right:settings': { selector: '#user-settings-button > .drawer-toggle', shellRoot: '#user-settings-block' },
+        'right:extensions': { selector: '#extensions-settings-button > .drawer-toggle', shellRoot: '#user-settings-block' },
+        'characters:persona': { selector: '#persona-management-button > .drawer-toggle' },
+        'right:background': { selector: '#backgrounds-button > .drawer-toggle', shellRoot: '#user-settings-block' },
     }[normalizedRoute];
 
-    if (!fallbackSelector) {
-        return;
+    if (!fallbackRoute) {
+        return false;
     }
 
-    document.querySelector(fallbackSelector)?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const fallback = document.querySelector(fallbackRoute.selector);
+    const shellRoot = fallbackRoute.shellRoot ? document.querySelector(fallbackRoute.shellRoot) : null;
+    if (!(shellRoot instanceof HTMLElement) || !shellRoot.classList.contains('openDrawer')) {
+        fallback?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    }
+    if (fallback && fallbackRoute.tabId) {
+        window.requestAnimationFrame(() => {
+            document.querySelector(`.sb-shell-tab[data-sb-tab="${fallbackRoute.tabId}"]`)?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+    }
+    return Boolean(fallback);
 }
 
 function focusSendTextarea(sendTextArea, { skipIOS = false } = {}) {
@@ -1265,48 +1379,21 @@ function setWelcomeDeckView(root, view, { persist = true } = {}) {
     root.dataset.activeDeckView = safeView;
 
     root.querySelectorAll('.welcomeDeckTab').forEach((button) => {
-        button.classList.toggle('is-active', button.getAttribute('data-deck-target') === safeView);
+        const active = button.getAttribute('data-deck-target') === safeView;
+        button.classList.toggle('is-active', active);
+        button.setAttribute('aria-selected', String(active));
+        button.setAttribute('tabindex', active ? '0' : '-1');
     });
 
     root.querySelectorAll('.welcomeDeckPanel').forEach((panel) => {
-        panel.classList.toggle('is-active', panel.getAttribute('data-deck-panel') === safeView);
+        const active = panel.getAttribute('data-deck-panel') === safeView;
+        panel.classList.toggle('is-active', active);
+        panel.toggleAttribute('hidden', !active);
+        panel.setAttribute('aria-hidden', String(!active));
     });
 
     if (persist) {
         setWelcomeUiPreference(welcomeDeckViewKey, safeView);
-    }
-}
-
-function setWelcomeDeckCollapsed(root, collapsed, { persist = true } = {}) {
-    if (!(root instanceof HTMLElement)) {
-        return;
-    }
-
-    const deck = root.querySelector('.welcomeDeck');
-
-    if (!(deck instanceof HTMLElement)) {
-        return;
-    }
-
-    root.dataset.deckCollapsed = String(collapsed);
-    deck.dataset.collapsed = String(collapsed);
-    deck.classList.toggle('is-collapsed', collapsed);
-
-    const toggleButton = deck.querySelector('.welcomeDeckToggle');
-
-    if (toggleButton instanceof HTMLButtonElement) {
-        toggleButton.setAttribute('aria-expanded', String(!collapsed));
-        toggleButton.setAttribute('title', collapsed ? 'Open Launchpad' : 'Close Launchpad');
-    }
-
-    // Update active state on Open Launchpad button in hero section
-    const openLaunchpadButton = root.querySelector('.openLaunchpad');
-    if (openLaunchpadButton instanceof HTMLElement) {
-        openLaunchpadButton.classList.toggle('is-active', !collapsed);
-    }
-
-    if (persist) {
-        setWelcomeUiPreference(welcomeDeckCollapsedKey, collapsed ? 'true' : 'false');
     }
 }
 
@@ -1354,29 +1441,59 @@ async function applyOpenAiPreset(name) {
     return true;
 }
 
-async function installStarterPackExtension(extensionName) {
+async function installStarterPackExtension(extensionName, global) {
     const extensionConfig = getStarterPackExtensionConfig(extensionName);
     if (!extensionConfig) {
         return false;
     }
 
-    await installExtension(extensionConfig.repoUrl, isAdmin());
+    try {
+        const installed = await installExtension(extensionConfig.repoUrl, global && isAdmin());
+        if (!installed) {
+            return false;
+        }
 
-    const installedExtension = findExtension(extensionName);
-    if (!installedExtension) {
-        await refreshWelcomeScreen();
+        const installedExtension = findExtension(extensionName);
+        if (!installedExtension) {
+            return false;
+        }
+
+        if (!installedExtension.enabled) {
+            await enableExtension(installedExtension.name, false);
+        }
+
+        location.reload();
+        return true;
+    } catch (error) {
+        console.error(`Failed to install starter pack extension "${extensionName}".`, error);
         return false;
     }
-
-    if (!installedExtension.enabled) {
-        await enableExtension(installedExtension.name, false);
-    }
-
-    location.reload();
-    return true;
 }
 
-function setTutorialUiState(panel, index, expanded) {
+async function removeStarterPackExtension(extensionName) {
+    const extension = findExtension(extensionName);
+    if (!extension) {
+        toastr.warning(t`Extension is no longer installed.`);
+        return;
+    }
+
+    if (getExtensionType(extension.name) === 'global' && !isAdmin()) {
+        toastr.error(t`You don't have permission to delete global extensions.`);
+        return;
+    }
+
+    const confirmed = await callGenericPopup(
+        t`Are you sure you want to remove ${extension.name}?`,
+        POPUP_TYPE.CONFIRM,
+    );
+    if (!confirmed) {
+        return;
+    }
+
+    await deleteExtension(extension.name);
+}
+
+function setTutorialUiState(panel, index, expanded, { persist = true } = {}) {
     if (!(panel instanceof HTMLElement)) {
         return;
     }
@@ -1391,13 +1508,26 @@ function setTutorialUiState(panel, index, expanded) {
     panel.dataset.tutorialIndex = String(safeIndex);
     panel.dataset.tutorialExpanded = String(expanded);
     panel.classList.toggle('tutorialCollapsed', !expanded);
+    if (persist) {
+        setWelcomeUiPreference(tutorialIndexKey, String(safeIndex));
+    }
 
     steps.forEach((step, stepIndex) => {
-        step.classList.toggle('is-active', stepIndex === safeIndex);
+        const active = stepIndex === safeIndex;
+        step.classList.toggle('is-active', active);
+        step.toggleAttribute('hidden', !active);
+        step.setAttribute('aria-hidden', String(!active));
     });
 
     progressButtons.forEach((button, buttonIndex) => {
-        button.classList.toggle('is-active', buttonIndex === safeIndex);
+        const active = buttonIndex === safeIndex;
+        button.classList.toggle('is-active', active);
+        button.setAttribute('aria-pressed', String(active));
+        if (active) {
+            button.setAttribute('aria-current', 'step');
+        } else {
+            button.removeAttribute('aria-current');
+        }
     });
 
     if (previousButton instanceof HTMLButtonElement) {
@@ -1409,12 +1539,31 @@ function setTutorialUiState(panel, index, expanded) {
     }
 }
 
+async function openRoleplayWorkspaceFromWelcome() {
+    const conversationModule = await import('./sillybunny-conversation.js');
+    const avatar = conversationModule.getRoleplayAvatarForWelcome?.();
+    const characterId = avatar ? characters.findIndex(character => character?.avatar === avatar) : -1;
+    if (characterId === -1) {
+        toastr.warning('Pick or import a character before opening Roleplay Mode.');
+        return false;
+    }
+
+    if (!await selectCharacterById(characterId, { switchMenu: false })) {
+        return false;
+    }
+
+    conversationModule.disableConversationModeForCurrentCharacter?.({ focusRoleplay: false });
+    document.getElementById('send_textarea')?.focus?.({ preventScroll: false });
+    return true;
+}
+
 function dismissTutorial(panel, status) {
     if (status) {
         setWelcomeUiPreference(tutorialStatusKey, status);
     }
 
-    setTutorialUiState(panel, 0, false);
+    const currentIndex = Number.parseInt(panel.dataset.tutorialIndex || '0', 10) || 0;
+    setTutorialUiState(panel, currentIndex, false);
 }
 
 async function handleWelcomeAction(button, sendTextArea) {
@@ -1428,11 +1577,22 @@ async function handleWelcomeAction(button, sendTextArea) {
         case 'open-tab':
             openShellTab(value);
             break;
+        case 'open-deck-view':
+            if (welcomePanel instanceof HTMLElement) {
+                setWelcomeDeckView(welcomePanel, value);
+            }
+            break;
         case 'enable-extension':
             await enableExtension(value);
             break;
-        case 'install-starter-extension':
-            await installStarterPackExtension(value);
+        case 'remove-starter-extension':
+            await removeStarterPackExtension(value);
+            break;
+        case 'install-starter-extension-global':
+            await installStarterPackExtension(value, true);
+            break;
+        case 'install-starter-extension-user':
+            await installStarterPackExtension(value, false);
             break;
         case 'apply-preset':
             if (await applyOpenAiPreset(value)) {
@@ -1448,6 +1608,14 @@ async function handleWelcomeAction(button, sendTextArea) {
             focusSendTextarea(sendTextArea);
             await openBundledAssistantCard(assistantId);
             focusSendTextarea(sendTextArea, { skipIOS: true });
+            break;
+        case 'open-temporary-chat':
+            focusSendTextarea(sendTextArea);
+            await newAssistantChat({ temporary: true });
+            focusSendTextarea(sendTextArea, { skipIOS: true });
+            break;
+        case 'open-roleplay':
+            await openRoleplayWorkspaceFromWelcome();
             break;
         case 'open-conversation': {
             const conversationModule = await import('./sillybunny-conversation.js');
@@ -1472,28 +1640,12 @@ async function handleWelcomeAction(button, sendTextArea) {
             document.querySelector('.open_characters_library')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
             break;
         case 'replay-tutorial':
+            setWelcomeUiPreference(tutorialStatusKey, '');
             if (welcomePanel instanceof HTMLElement) {
                 setWelcomeDeckView(welcomePanel, 'tour');
-                setWelcomeDeckCollapsed(welcomePanel, false);
             }
             if (tutorialPanel instanceof HTMLElement) {
                 setTutorialUiState(tutorialPanel, 0, true);
-            }
-            break;
-        case 'open-launchpad':
-            if (welcomePanel instanceof HTMLElement) {
-                const isCurrentlyCollapsed = isWelcomeDeckCollapsed();
-                if (isCurrentlyCollapsed) {
-                    setWelcomeDeckView(welcomePanel, welcomePanel.dataset.activeDeckView || getInitialDeckView());
-                    setWelcomeDeckCollapsed(welcomePanel, false);
-                } else {
-                    setWelcomeDeckCollapsed(welcomePanel, true);
-                }
-            }
-            break;
-        case 'close-guide':
-            if (welcomePanel instanceof HTMLElement) {
-                setWelcomeDeckCollapsed(welcomePanel, true);
             }
             break;
         case 'open-link':
@@ -1547,28 +1699,10 @@ async function sendWelcomePanel(chats, expand = false) {
             return;
         }
         const templateData = buildWelcomeTemplateData(chats);
-        const template = await renderTemplateAsync('/scripts/templates/welcomePanelOnboarding.html?v=20260505a', templateData, true, true, true);
+        const template = await renderTemplateAsync('/scripts/templates/welcomePanelOnboarding.html?v=20260805p', templateData, true, true, true);
         const fragment = document.createRange().createContextualFragment(template);
         const nextPanel = fragment.querySelector('.welcomePanel');
         fragment.querySelectorAll('.welcomePanel').forEach((root) => {
-            const recentHiddenClass = 'recentHidden';
-            const recentHiddenKey = 'WelcomePage_RecentChatsHidden';
-            const deck = root.querySelector('.welcomeDeck');
-            if (getWelcomeUiPreference(recentHiddenKey) === 'true') {
-                root.classList.add(recentHiddenClass);
-            }
-            root.querySelectorAll('.showRecentChats').forEach((button) => {
-                button.addEventListener('click', () => {
-                    root.classList.remove(recentHiddenClass);
-                    setWelcomeUiPreference(recentHiddenKey, 'false');
-                });
-            });
-            root.querySelectorAll('.hideRecentChats').forEach((button) => {
-                button.addEventListener('click', () => {
-                    root.classList.add(recentHiddenClass);
-                    setWelcomeUiPreference(recentHiddenKey, 'true');
-                });
-            });
             root.querySelectorAll('[data-welcome-panel-mode-target]').forEach((button) => {
                 button.addEventListener('click', () => {
                     setWelcomePanelMode(root, button.getAttribute('data-welcome-panel-mode-target') || WELCOME_PANEL_MODES.full);
@@ -1577,13 +1711,7 @@ async function sendWelcomePanel(chats, expand = false) {
             root.querySelectorAll('[data-recent-chat-filter]').forEach((button) => {
                 button.addEventListener('click', () => {
                     const filter = button.getAttribute('data-recent-chat-filter') || 'all';
-                    root.dataset.recentChatFilter = filter;
-                    root.querySelectorAll('[data-recent-chat-filter]').forEach((tab) => {
-                        const active = tab === button;
-                        tab.classList.toggle('active', active);
-                        tab.setAttribute('aria-pressed', String(active));
-                    });
-                    updateRecentChatFilterView(root);
+                    setRecentChatFilter(root, filter);
                 });
             });
             root.querySelectorAll('.recentChatsSettings').forEach((button) => {
@@ -1596,17 +1724,21 @@ async function sendWelcomePanel(chats, expand = false) {
             const tutorialPanel = root.querySelector('.welcomeTourPanel');
             setWelcomePanelMode(root, root.dataset.homePanelMode || getWelcomePanelMode(), { persist: false });
             setWelcomeDeckView(root, root.dataset.activeDeckView || getInitialDeckView(), { persist: false });
-            setWelcomeDeckCollapsed(root, deck instanceof HTMLElement ? deck.dataset.collapsed === 'true' : isWelcomeDeckCollapsed(), { persist: false });
-
             root.querySelectorAll('.welcomeDeckTab').forEach((button) => {
-                button.addEventListener('click', () => {
+                const activateDeckTab = () => {
                     const targetView = button.getAttribute('data-deck-target') || '';
                     setWelcomeDeckView(root, targetView);
 
                     if (targetView === 'tour' && tutorialPanel instanceof HTMLElement) {
+                        setWelcomeUiPreference(tutorialStatusKey, '');
                         const currentIndex = Number.parseInt(tutorialPanel.dataset.tutorialIndex || '0', 10) || 0;
                         setTutorialUiState(tutorialPanel, currentIndex, true);
                     }
+                };
+                button.addEventListener('click', activateDeckTab);
+                button.addEventListener('keydown', (event) => {
+                    const tabs = Array.from(root.querySelectorAll('.welcomeDeckTab'));
+                    handleLinearNavigation(event, tabs, button, nextButton => nextButton.click());
                 });
             });
 
@@ -1615,12 +1747,18 @@ async function sendWelcomePanel(chats, expand = false) {
                     tutorialPanel,
                     Number.parseInt(tutorialPanel.dataset.tutorialIndex || '0', 10) || 0,
                     tutorialPanel.dataset.tutorialExpanded !== 'false',
+                    { persist: false },
                 );
 
                 tutorialPanel.querySelectorAll('.welcomeTourProgressButton').forEach((button) => {
-                    button.addEventListener('click', () => {
+                    const activateTutorialStep = () => {
                         const targetIndex = Number.parseInt(button.getAttribute('data-step-target') || '0', 10) || 0;
                         setTutorialUiState(tutorialPanel, targetIndex, true);
+                    };
+                    button.addEventListener('click', activateTutorialStep);
+                    button.addEventListener('keydown', (event) => {
+                        const buttons = Array.from(tutorialPanel.querySelectorAll('.welcomeTourProgressButton'));
+                        handleLinearNavigation(event, buttons, button, nextButton => nextButton.click());
                     });
                 });
 
@@ -1645,17 +1783,53 @@ async function sendWelcomePanel(chats, expand = false) {
         fragment.querySelectorAll('.welcomeActionButton').forEach((button) => {
             button.addEventListener('click', async (event) => {
                 event.preventDefault();
-                await handleWelcomeAction(button, sendTextArea);
+                const isInstallAction = button.dataset.action === 'install-starter-extension-global'
+                    || button.dataset.action === 'install-starter-extension-user';
+                const starterCard = button.closest('.welcomeStarterPackCard');
+                const installButtons = isInstallAction && starterCard
+                    ? Array.from(starterCard.querySelectorAll('[data-action="install-starter-extension-global"], [data-action="install-starter-extension-user"]'))
+                    : [];
+                if (isInstallAction && button instanceof HTMLButtonElement) {
+                    if (installButtons.some(installButton => installButton instanceof HTMLButtonElement && installButton.disabled)) {
+                        return;
+                    }
+                    starterCard?.setAttribute('aria-busy', 'true');
+                    installButtons.forEach((installButton) => {
+                        if (installButton instanceof HTMLButtonElement) {
+                            installButton.disabled = true;
+                            installButton.classList.add('is-pending');
+                        }
+                    });
+                }
+
+                try {
+                    await handleWelcomeAction(button, sendTextArea);
+                } finally {
+                    if (isInstallAction && button instanceof HTMLButtonElement && document.contains(button)) {
+                        starterCard?.removeAttribute('aria-busy');
+                        installButtons.forEach((installButton) => {
+                            if (installButton instanceof HTMLButtonElement) {
+                                installButton.disabled = false;
+                                installButton.classList.remove('is-pending');
+                            }
+                        });
+                    }
+                }
             });
         });
-        fragment.querySelectorAll('.recentChat').forEach((item) => {
-            item.addEventListener('click', () => {
+        fragment.querySelectorAll('.recentChatOpen').forEach((button) => {
+            button.addEventListener('click', () => {
+                const item = button.closest('.recentChat');
+                if (!(item instanceof HTMLElement)) {
+                    return;
+                }
                 const avatarId = item.getAttribute('data-avatar');
                 const groupId = item.getAttribute('data-group');
                 const fileName = item.getAttribute('data-file');
                 const isConversation = item.getAttribute('data-recent-chat-type') === 'conversation';
                 if (isConversation && avatarId) {
-                    void openRecentConversationChat(avatarId, groupId);
+                    const branchId = item.getAttribute('data-conversation-branch-id');
+                    void openRecentConversationChat(avatarId, groupId, branchId);
                     return;
                 }
                 if (avatarId && fileName) {
@@ -1670,7 +1844,7 @@ async function sendWelcomePanel(chats, expand = false) {
             const showRecentChatsTitle = t`Show more recent chats`;
             const hideRecentChatsTitle = t`Show less recent chats`;
 
-            button.setAttribute('title', showRecentChatsTitle);
+            button.setAttribute('title', button.classList.contains('rotated') ? hideRecentChatsTitle : showRecentChatsTitle);
             button.addEventListener('click', () => {
                 const rotate = button.classList.contains('rotated');
                 const root = button.closest('.welcomePanel');
@@ -1709,7 +1883,16 @@ async function sendWelcomePanel(chats, expand = false) {
                 const avatarId = chatItem.getAttribute('data-avatar');
                 const groupId = chatItem.getAttribute('data-group');
                 const fileName = chatItem.getAttribute('data-file');
+                const branchId = chatItem.getAttribute('data-conversation-branch-id');
+                const branchName = chatItem.getAttribute('data-conversation-branch-name');
                 if (chatItem.getAttribute('data-recent-chat-type') === 'conversation') {
+                    if (avatarId && branchId && branchName) {
+                        const recentChat = chats.find(chat => chat.is_conversation
+                            && chat.avatar === avatarId
+                            && String(chat.group || '') === String(groupId || '')
+                            && chat.conversation_branch_id === branchId);
+                        void renameRecentConversationChat(avatarId, groupId, branchId, branchName, recentChat);
+                    }
                     return;
                 }
                 if (avatarId && fileName) {
@@ -1730,7 +1913,15 @@ async function sendWelcomePanel(chats, expand = false) {
                 const avatarId = chatItem.getAttribute('data-avatar');
                 const groupId = chatItem.getAttribute('data-group');
                 const fileName = chatItem.getAttribute('data-file');
+                const branchId = chatItem.getAttribute('data-conversation-branch-id');
                 if (chatItem.getAttribute('data-recent-chat-type') === 'conversation') {
+                    if (avatarId && branchId) {
+                        const recentChat = chats.find(chat => chat.is_conversation
+                            && chat.avatar === avatarId
+                            && String(chat.group || '') === String(groupId || '')
+                            && chat.conversation_branch_id === branchId);
+                        void deleteRecentConversationChat(avatarId, groupId, branchId, recentChat);
+                    }
                     return;
                 }
                 if (avatarId && fileName) {
@@ -1751,10 +1942,11 @@ async function sendWelcomePanel(chats, expand = false) {
                 const avatarId = chatItem.getAttribute('data-avatar');
                 const groupId = chatItem.getAttribute('data-group');
                 const fileName = chatItem.getAttribute('data-file');
-                if (chatItem.getAttribute('data-recent-chat-type') === 'conversation') {
-                    return;
-                }
-                const recentChat = chats.find(c => c.chat_name === fileName && ((c.is_group && c.group === groupId) || (!c.is_group && c.avatar === avatarId)));
+                const branchId = chatItem.getAttribute('data-conversation-branch-id');
+                const isConversation = chatItem.getAttribute('data-recent-chat-type') === 'conversation';
+                const recentChat = chats.find(c => isConversation
+                    ? c.is_conversation && c.avatar === avatarId && String(c.group || '') === String(groupId || '') && c.conversation_branch_id === branchId
+                    : c.chat_name === fileName && ((c.is_group && c.group === groupId) || (!c.is_group && c.avatar === avatarId)));
                 if (!recentChat) {
                     console.error('Recent chat not found for pinning.');
                     return;
@@ -1801,7 +1993,11 @@ async function openRecentCharacterChat(avatarId, fileName) {
     }
 
     try {
-        await selectCharacterById(characterId);
+        const selected = await selectCharacterById(characterId);
+        if (!selected) {
+            toastr.warning(t`Failed to open recent chat. See console for details.`);
+            return;
+        }
         setActiveCharacter(avatarId);
         saveSettingsDebounced();
         const currentChatId = getCurrentChatId();
@@ -1820,8 +2016,9 @@ async function openRecentCharacterChat(avatarId, fileName) {
  * Opens a character in Conversation Mode from the welcome page.
  * @param {string} avatarId Avatar file name
  * @param {string} groupId Group ID, when opening a group-scoped Conversation
+ * @param {string} branchId Conversation branch ID
  */
-async function openRecentConversationChat(avatarId, groupId = '') {
+async function openRecentConversationChat(avatarId, groupId = '', branchId = '') {
     const characterId = characters.findIndex(x => x.avatar === avatarId);
     if (characterId === -1) {
         console.error(`Character not found for avatar ID: ${avatarId}`);
@@ -1832,6 +2029,7 @@ async function openRecentConversationChat(avatarId, groupId = '') {
         setConversationWelcomeOpeningSuppressed(true);
         const conversationModule = await import('./sillybunny-conversation.js');
         const opened = conversationModule.openConversationWorkspaceForAvatar?.(avatarId, {
+            branchId,
             groupId: groupId || null,
             showToast: false,
         });
@@ -1849,6 +2047,75 @@ async function openRecentConversationChat(avatarId, groupId = '') {
 }
 
 /**
+ * Renames a Conversation Mode branch from the welcome page.
+ * @param {string} avatarId Avatar file name
+ * @param {string} groupId Group ID, when renaming a group-scoped Conversation
+ * @param {string} branchId Conversation branch ID
+ * @param {string} branchName Current branch name
+ * @param {RecentChat|undefined} recentChat Recent chat record
+ */
+async function renameRecentConversationChat(avatarId, groupId, branchId, branchName, recentChat) {
+    try {
+        const popupText = await renderTemplateAsync('chatRename');
+        const newName = await callGenericPopup(popupText, POPUP_TYPE.INPUT, branchName);
+        if (!newName || typeof newName !== 'string' || newName === branchName) {
+            return;
+        }
+
+        const conversationModule = await import('./sillybunny-conversation.js');
+        const renamed = conversationModule.renameConversationBranch?.(avatarId, branchId, newName, { groupId });
+        if (!renamed) {
+            toastr.warning(t`Failed to rename Conversation chat.`);
+            return;
+        }
+
+        if (recentChat && !groupId) {
+            PinnedChatsManager.rename(recentChat, newName.trim());
+        }
+        await refreshWelcomeScreen();
+        toastr.success(t`Chat renamed.`);
+    } catch (error) {
+        console.error('Error renaming recent Conversation chat:', error);
+        toastr.error(t`Failed to rename Conversation chat. See console for details.`);
+    }
+}
+
+/**
+ * Deletes a Conversation Mode branch from the welcome page.
+ * @param {string} avatarId Avatar file name
+ * @param {string} groupId Group ID, when deleting a group-scoped Conversation
+ * @param {string} branchId Conversation branch ID
+ * @param {RecentChat|undefined} recentChat Recent chat record
+ */
+async function deleteRecentConversationChat(avatarId, groupId, branchId, recentChat) {
+    try {
+        const confirm = await callGenericPopup(t`Delete the Chat File?`, POPUP_TYPE.CONFIRM);
+        if (!confirm) {
+            return;
+        }
+
+        const conversationModule = await import('./sillybunny-conversation.js');
+        const result = conversationModule.deleteConversationWelcomeBranch?.(avatarId, branchId, { groupId });
+        const deleted = Boolean(result?.deleted);
+        if (!deleted) {
+            toastr.warning(t`Failed to delete Conversation chat.`);
+            return;
+        }
+
+        if (recentChat) {
+            PinnedChatsManager.remove(recentChat);
+        }
+        await refreshWelcomeScreen();
+        if (!result.reset) {
+            toastr.success(t`Chat deleted.`);
+        }
+    } catch (error) {
+        console.error('Error deleting recent Conversation chat:', error);
+        toastr.error(t`Failed to delete Conversation chat. See console for details.`);
+    }
+}
+
+/**
  * Opens a recent group chat.
  * @param {string} groupId Group ID
  * @param {string} fileName Chat file name
@@ -1861,7 +2128,11 @@ async function openRecentGroupChat(groupId, fileName) {
     }
 
     try {
-        await openGroupById(groupId);
+        const selected = await openGroupById(groupId);
+        if (!selected) {
+            toastr.warning(t`Failed to open recent group chat. See console for details.`);
+            return;
+        }
         setActiveGroup(groupId);
         saveSettingsDebounced();
         const currentChatId = getCurrentChatId();
@@ -1957,7 +2228,11 @@ async function deleteRecentCharacterChat(avatarId, fileName) {
             console.log('Deletion cancelled by user');
             return;
         }
-        await deleteCharacterChatByName(String(characterId), fileName);
+        const deleted = await deleteCharacterChatByName(String(characterId), fileName);
+        if (!deleted) {
+            return;
+        }
+        PinnedChatsManager.removeDeleted({ avatar: avatarId, fileName });
         await refreshWelcomeScreen();
         toastr.success(t`Chat deleted.`);
     } catch (error) {
@@ -1983,7 +2258,11 @@ async function deleteRecentGroupChat(groupId, fileName) {
             console.log('Deletion cancelled by user');
             return;
         }
-        await deleteGroupChatByName(groupId, fileName);
+        const deleted = await deleteGroupChatByName(groupId, fileName);
+        if (!deleted) {
+            return;
+        }
+        PinnedChatsManager.removeDeleted({ group: groupId, fileName });
         await refreshWelcomeScreen();
         toastr.success(t`Group chat deleted.`);
     } catch (error) {
@@ -2007,9 +2286,23 @@ async function refreshWelcomeScreen({ flashChat = null } = {}) {
 
     const scrollTop = chatElement.scrollTop;
     const scrollHeight = chatElement.scrollHeight;
-    const expand = chatElement.querySelectorAll('button.showMoreChats.rotated').length > 0;
+    const currentPanel = chatElement.querySelector('.welcomePanel');
+    const recentChatFilter = currentPanel instanceof HTMLElement ? currentPanel.dataset.recentChatFilter || 'all' : 'all';
+    const expandedRecentChatFilters = currentPanel instanceof HTMLElement ? currentPanel.dataset.expandedRecentChatFilters || '' : '';
 
-    await openWelcomeScreen({ force: true, expand });
+    await openWelcomeScreen({ force: true });
+
+    const nextPanel = chatElement.querySelector('.welcomePanel');
+    if (nextPanel instanceof HTMLElement) {
+        nextPanel.dataset.recentChatFilter = recentChatFilter;
+        nextPanel.dataset.expandedRecentChatFilters = expandedRecentChatFilters;
+        nextPanel.querySelectorAll('[data-recent-chat-filter]').forEach((button) => {
+            const active = button.getAttribute('data-recent-chat-filter') === recentChatFilter;
+            button.classList.toggle('active', active);
+            button.setAttribute('aria-pressed', String(active));
+        });
+        updateRecentChatFilterView(nextPanel);
+    }
 
     // Restore scroll position or flash specific chat
     if (flashChat) {
@@ -2109,6 +2402,9 @@ async function openRecentChatsSettingsPopup() {
  * @property {boolean} hidden Chat will be hidden by default
  * @property {boolean} pinned Indicates if the chat is pinned
  * @property {boolean} is_agent Indicates if the chat contains Agent-authored edits or transform history
+ * @property {boolean} [is_conversation] Indicates if the chat is a Conversation Mode branch
+ * @property {string} [conversation_branch_id] Conversation Mode branch ID
+ * @property {string} [conversation_branch_name] Conversation Mode branch name
  */
 function shouldSeparateAgentRecentChats() {
     return Boolean(extension_settings?.inChatAgents?.globalSettings?.separateRecentChats);
@@ -2129,11 +2425,18 @@ function isAgentRecentChat(chatData) {
 
 async function getRecentChats() {
     const settings = getRecentChatsSettings();
+    const finalizeRecentChats = chats => chats
+        .slice(0, settings.maxDisplayed)
+        .map((recentChat, index) => ({
+            ...recentChat,
+            hidden: index >= settings.collapsedDisplayed,
+            pinned: PinnedChatsManager.isPinned(recentChat),
+        }));
     const getConversationChats = async () => {
         try {
             const conversationModule = await import('./sillybunny-conversation.js');
             const conversationChats = conversationModule.getConversationWelcomeChats?.({ max: settings.maxDisplayed }) || [];
-            return conversationChats.map((chat, index) => ({ ...chat, hidden: index >= settings.collapsedDisplayed }));
+            return conversationChats;
         } catch (error) {
             console.warn('Failed to load Conversation Mode recent chats', error);
             return [];
@@ -2148,14 +2451,14 @@ async function getRecentChats() {
 
     if (!response.ok) {
         console.warn('Failed to fetch recent character chats');
-        return getConversationChats();
+        return finalizeRecentChats(await getConversationChats());
     }
 
     /** @type {RecentChat[]} */
     const data = await response.json();
 
     if (!Array.isArray(data) || data.length === 0) {
-        return getConversationChats();
+        return finalizeRecentChats(await getConversationChats());
     }
 
     const dataWithEntities = data
@@ -2176,7 +2479,7 @@ async function getRecentChats() {
             return momentComparison;
         });
 
-    dataWithEntities.forEach(({ chat, character, group }, index) => {
+    dataWithEntities.forEach(({ chat, character, group }) => {
         const chatTimestamp = timestampToMoment(chat.last_mes);
         chat.char_name = character?.name || group?.name || '';
         chat.date_short = chatTimestamp.format('l');
@@ -2184,7 +2487,7 @@ async function getRecentChats() {
         chat.chat_name = chat.file_name.replace('.jsonl', '');
         chat.char_thumbnail = character ? getThumbnailUrl('avatar', character.avatar) : system_avatar;
         chat.is_group = !!group;
-        chat.hidden = index >= settings.collapsedDisplayed;
+        chat.hidden = false;
         chat.avatar = chat.avatar || '';
         chat.group = chat.group || '';
         chat.pinned = PinnedChatsManager.isPinned(chat);
@@ -2194,25 +2497,20 @@ async function getRecentChats() {
 
     const roleplayChats = dataWithEntities.map(t => t.chat);
     const conversationChats = await getConversationChats();
-    if (!conversationChats.length) {
-        return roleplayChats;
-    }
+    const mergedChats = [...roleplayChats, ...conversationChats].sort((first, second) => {
+        const firstPinned = PinnedChatsManager.isPinned(first);
+        const secondPinned = PinnedChatsManager.isPinned(second);
 
-    return [...roleplayChats, ...conversationChats]
-        .sort((first, second) => {
-            const firstPinned = PinnedChatsManager.isPinned(first);
-            const secondPinned = PinnedChatsManager.isPinned(second);
+        if (firstPinned && !secondPinned) {
+            return -1;
+        }
+        if (!firstPinned && secondPinned) {
+            return 1;
+        }
 
-            if (firstPinned && !secondPinned) {
-                return -1;
-            }
-            if (!firstPinned && secondPinned) {
-                return 1;
-            }
-
-            return sortMoments(timestampToMoment(first.last_mes), timestampToMoment(second.last_mes));
-        })
-        .map((chat, index) => ({ ...chat, hidden: index >= settings.collapsedDisplayed }));
+        return sortMoments(timestampToMoment(first.last_mes), timestampToMoment(second.last_mes));
+    });
+    return finalizeRecentChats(mergedChats);
 }
 
 export async function openPermanentAssistantChat({ tryCreate = true, created = false } = {}) {
@@ -2295,7 +2593,7 @@ async function createBundledAssistant(config) {
     formData.append('scenario', config.scenario);
     formData.append('first_mes', config.firstMessage);
     formData.append('creator', config.creator);
-    formData.append('tags', [...config.chips, 'assistant', 'bundled'].join(', '));
+    formData.append('tags', [...(config.chips ?? []), 'assistant', 'bundled'].join(', '));
 
     try {
         const avatarResponse = await fetch(config.portrait);
@@ -2389,10 +2687,7 @@ export function initWelcomeScreen() {
         }
     });
 
-    const events = [event_types.CHAT_CHANGED, event_types.APP_READY];
-    for (const event of events) {
-        eventSource.makeFirst(event, openWelcomeScreen);
-    }
+    eventSource.makeFirst(event_types.CHAT_CHANGED, openWelcomeScreen);
 
     eventSource.on(event_types.CHARACTER_MANAGEMENT_DROPDOWN, (target) => {
         if (target !== 'set_as_assistant') {

--- a/tests/sillybunny-conversation-core-data-regressions.test.js
+++ b/tests/sillybunny-conversation-core-data-regressions.test.js
@@ -35,6 +35,7 @@ await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/typing
 
 const {
     deleteConversationBranch,
+    deleteConversationWelcomeBranch,
     getConversationGroupThreadAnchor,
     getConversationStore,
     normalizeGroupConversationSettings,
@@ -205,5 +206,24 @@ describe('Conversation core persisted data regressions', () => {
         resetCharacterConversationBranches('char.png', { groupId: '', personaId: 'persona-a.png' });
         expect(threadStore.branches.main.memorySummary).toBe('Durable memory');
         expect(getConversationStore().characters['persona:persona-a.png:char.png'].memorySummary).toBe('Durable memory');
+    });
+
+    test('reports when deleting a welcome branch resets the sole thread', () => {
+        const threadStore = {
+            activeBranchId: 'only',
+            branches: {
+                only: { id: 'only', messages: [{ id: 'old-message' }] },
+            },
+            settings: {},
+        };
+        extensionSettings.sillybunny_conversation = createStore({
+            characters: { 'persona:persona-a.png:char.png': threadStore },
+        });
+
+        expect(deleteConversationWelcomeBranch('char.png', 'only', { personaId: 'persona-a.png' })).toEqual({
+            deleted: true,
+            reset: true,
+        });
+        expect(threadStore.branches.only.messages).toEqual([]);
     });
 });


### PR DESCRIPTION
Completely reworks the home screen preparing for release v1.7.0, bringing it up to current project standards.

**Changes:**
- Completely reorganized the Home Screen across Full Home, Compact, and List Only modes.
- Reorganised all pills to have more relevant content.
- Launchpad now remains open at all times in the Full Home menu. Launchpad still remains closed in Compact and List Only modes. Launchpad merged into one section.
- Completely reworded all tutorials and text from the ground up to be fully human-written and free of any LLM wording.
- Tutorial is now divided into a more logical flow for a new user: Home page, API, preset, character cards, UI customisation.
- Reworked Bundled Extras so they're divided into pre-installed, official, and unofficial extensions.
- Renamed a lot of sections to make more sense to the end user.
- Various padding, styling, and presentation fixes matching current design standards: spacing, radii, colors, motion, typography, and mobile targets.

**Additions:**
- Added accessible tab, keyboard navigation, focus, filtering, and recent-chat controls.
- Added documentation pillab for Roleplay and Conversation modes in the UI Handbook. Replaced the existing superfluous documentation pill .
- Added Conversation Mode recent-chat pin, rename, delete, and exact-branch opening, matching behaviour for regular chats.
- Added all missing SillyBunny extensions.
- Added extension installation, removal, permission checks, and failure handling from Home.
- Added lazy image loading, recent-chat state persistence, pin cleanup, and duplicate-render prevention.

**Removals:**
- Removed Tooltips from Bundled Extras. It is now included by default.
- Removed the static Home mascot media panel and reclaimed its space. It was pretty useless, and went against our new design philosophy.
- Removed one word pills that served no purpose and cluttered the UI.
- Removed extraneous close buttons and navigation buttons (like Open Conversation).