### PR TITLE
fix: conversation mode selected character

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1330,6 +1330,9 @@ export async function selectCharacterById(id, { switchMenu = true } = {}) {
         setCharacterId(id);
         chat_metadata = {};
         await getChat({ switchMenu });
+        window.dispatchEvent(new CustomEvent('sb:roleplay-character-selected', {
+            detail: { avatar: characters[this_chid]?.avatar || '' },
+        }));
         syncCharacterMenuActiveEntity();
         return true;
     } else {

--- a/public/scripts/sillybunny-conversation/init.js
+++ b/public/scripts/sillybunny-conversation/init.js
@@ -164,6 +164,17 @@ export function init() {
         const personaId = detail?.personaId || getConversationPersonaId();
         void selectConversationThread(avatar, { branchId, groupId, personaId, showToast: detail?.showToast !== false });
     });
+    window.addEventListener('sb:roleplay-character-selected', (event) => {
+        if (!conversationState.conversationWorkspaceOpen) {
+            return;
+        }
+
+        const detail = event instanceof CustomEvent ? event.detail : null;
+        const avatar = detail?.avatar || '';
+        if (avatar) {
+            void selectConversationThread(avatar, { showToast: false });
+        }
+    });
     window.addEventListener('sb:close-conversation-workspace', () => disableConversationModeForCurrentCharacter({ focusRoleplay: false }));
     window.addEventListener('sb:conversation-runtime-needed', ensureConversationRuntimeStarted);
     window.addEventListener('beforeunload', stopConversationAutoWorker);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -24,7 +24,7 @@ import {
 } from './topbar-extension-slot/index.js';
 import { escapeRegex } from './util/escape-regex.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
-import { flushCharacterSaveDebounced, getOneCharacter, getThumbnailUrl, parseAvatarSource, refreshCsrfToken, saveSettingsDebounced } from '../script.js';
+import { characters, flushCharacterSaveDebounced, getOneCharacter, getThumbnailUrl, parseAvatarSource, refreshCsrfToken, saveSettingsDebounced, this_chid } from '../script.js';
 
 const sbMobileShellLifecycle = createMobileShellLifecycle();
 const sbPresetApiSyncLifecycle = createPresetApiSyncLifecycle();
@@ -8549,7 +8549,10 @@ function setCharacterShellMode(mode) {
 
     if (isConversationMode) {
         window.dispatchEvent(new CustomEvent('sb:open-conversation-workspace', {
-            detail: { showToast: false },
+            detail: {
+                avatar: characters[this_chid]?.avatar || '',
+                showToast: false,
+            },
         }));
     } else {
         window.dispatchEvent(new CustomEvent('sb:close-conversation-workspace'));

--- a/tests/conversation-mode-character-selection.test.js
+++ b/tests/conversation-mode-character-selection.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const scriptSource = readFileSync(path.join(repoRoot, 'public', 'script.js'), 'utf8').replace(/\r\n/g, '\n');
+const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8').replace(/\r\n/g, '\n');
+
+describe('Conversation mode character selection', () => {
+    test('opens the selected character card in Conversation mode', () => {
+        expect(scriptSource).toContain('window.dispatchEvent(new CustomEvent(\'sb:roleplay-character-selected\'');
+        expect(scriptSource).toContain('detail: { avatar: characters[this_chid]?.avatar || \'\' }');
+        expect(tabsSource).toContain('characters, flushCharacterSaveDebounced');
+        expect(tabsSource).toContain('saveSettingsDebounced, this_chid } from \'../script.js\';');
+        expect(tabsSource).toContain('avatar: characters[this_chid]?.avatar || \'\',');
+        expect(tabsSource).toContain('showToast: false,');
+    });
+});

--- a/tests/sillybunny-conversation-persona-runtime.test.js
+++ b/tests/sillybunny-conversation-persona-runtime.test.js
@@ -157,4 +157,18 @@ describe('conversation persona runtime', () => {
             showToast: false,
         });
     });
+
+    test('follows the newly selected roleplay character while Conversation is open', () => {
+        init();
+        selectConversationThread.mockClear();
+        conversationState.conversationWorkspaceOpen = true;
+
+        windowHandlers.get('sb:roleplay-character-selected')(new globalThis.CustomEvent({
+            avatar: 'new-character.png',
+        }));
+
+        expect(selectConversationThread).toHaveBeenCalledWith('new-character.png', {
+            showToast: false,
+        });
+    });
 });


### PR DESCRIPTION
Fixes a regression that causes Conversation Mode to not apply to a newly selected character, or when a character is selected while Conversation Mode is active.

Now switching between modes yields expected behaviour.