### PR TITLE
fix: conversation mode send/save/cancel buttons non-functional

### DIFF
--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1200,10 +1200,50 @@
     justify-content: flex-end;
 }
 
-.sb-conversation-message-edit-save,
+.sb-conversation-message-edit-control.menu_button {
+    --sb-conversation-edit-action-color: var(--color-primary, var(--sb-accent));
+    inline-size: 32px;
+    min-inline-size: 32px;
+    block-size: 32px;
+    min-block-size: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
+    border-radius: var(--sb-radius-button, 10px);
+    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 12%, var(--sb-button-bg));
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 28%, transparent);
+    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 80%, var(--SmartThemeBodyColor));
+    opacity: 0.92;
+}
+
+.sb-conversation-message-edit-save {
+    --sb-conversation-edit-action-color: var(--sb-color-success);
+}
+
 .sb-conversation-message-edit-cancel {
-    padding: 4px 12px;
-    font-size: 12px;
+    --sb-conversation-edit-action-color: var(--sb-color-warning);
+}
+
+.sb-conversation-message-edit-delete {
+    --sb-conversation-edit-action-color: var(--sb-color-danger);
+}
+
+.sb-conversation-message-edit-control.menu_button:hover,
+.sb-conversation-message-edit-control.menu_button:focus-visible {
+    border-color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 48%, transparent);
+    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 18%, var(--sb-button-bg));
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-conversation-edit-action-color) 24%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
+    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 90%, var(--SmartThemeBodyColor));
+    opacity: 1;
+}
+
+.sb-conversation-message.is-editing .sb-conversation-message-actions {
+    opacity: 0;
+    pointer-events: none;
 }
 
 .sb-conversation-mention {

--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1210,12 +1210,12 @@
     align-items: center;
     justify-content: center;
     padding: 0;
-    border: 1px solid color-mix(in srgb, var(--sb-conversation-edit-action-color) 54%, transparent);
+    border: 1px solid color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
     border-radius: var(--sb-radius-button, 10px);
-    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 28%, var(--sb-button-bg));
-    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 48%, transparent);
-    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 94%, var(--SmartThemeBodyColor));
-    opacity: 1;
+    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 12%, var(--sb-button-bg));
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 28%, transparent);
+    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 80%, var(--SmartThemeBodyColor));
+    opacity: 0.92;
 }
 
 .sb-conversation-message-edit-save {
@@ -1232,12 +1232,13 @@
 
 .sb-conversation-message-edit-control.menu_button:hover,
 .sb-conversation-message-edit-control.menu_button:focus-visible {
-    border-color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 72%, transparent);
-    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 40%, var(--sb-button-bg));
+    border-color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 48%, transparent);
+    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 18%, var(--sb-button-bg));
     box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--sb-conversation-edit-action-color) 38%, transparent),
-        inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 58%, transparent);
-    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 98%, var(--SmartThemeBodyColor));
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-conversation-edit-action-color) 24%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
+    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 90%, var(--SmartThemeBodyColor));
+    opacity: 1;
 }
 
 .sb-conversation-message.is-editing .sb-conversation-message-actions {

--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1218,15 +1218,15 @@
     opacity: 0.92;
 }
 
-.sb-conversation-message-edit-save {
+.sb-conversation-message-edit-save.menu_button {
     --sb-conversation-edit-action-color: var(--sb-color-success);
 }
 
-.sb-conversation-message-edit-cancel {
+.sb-conversation-message-edit-cancel.menu_button {
     --sb-conversation-edit-action-color: var(--sb-color-warning);
 }
 
-.sb-conversation-message-edit-delete {
+.sb-conversation-message-edit-delete.menu_button {
     --sb-conversation-edit-action-color: var(--sb-color-danger);
 }
 

--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1212,7 +1212,14 @@
     padding: 0;
     border: 1px solid color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
     border-radius: var(--sb-radius-button, 10px);
-    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 12%, var(--sb-button-bg));
+    /* Tint layers over --sb-button-bg instead of mixing into it: themes may define it as a
+       gradient, which is not a valid color-mix() operand. */
+    background:
+        linear-gradient(
+            color-mix(in srgb, var(--sb-conversation-edit-action-color) 12%, transparent),
+            color-mix(in srgb, var(--sb-conversation-edit-action-color) 12%, transparent)
+        ),
+        var(--sb-button-bg);
     box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 28%, transparent);
     color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 80%, var(--SmartThemeBodyColor));
     opacity: 0.92;
@@ -1233,7 +1240,12 @@
 .sb-conversation-message-edit-control.menu_button:hover,
 .sb-conversation-message-edit-control.menu_button:focus-visible {
     border-color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 48%, transparent);
-    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 18%, var(--sb-button-bg));
+    background:
+        linear-gradient(
+            color-mix(in srgb, var(--sb-conversation-edit-action-color) 18%, transparent),
+            color-mix(in srgb, var(--sb-conversation-edit-action-color) 18%, transparent)
+        ),
+        var(--sb-button-bg);
     box-shadow:
         inset 0 0 0 1px color-mix(in srgb, var(--sb-conversation-edit-action-color) 24%, transparent),
         inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);

--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1210,12 +1210,12 @@
     align-items: center;
     justify-content: center;
     padding: 0;
-    border: 1px solid color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
+    border: 1px solid color-mix(in srgb, var(--sb-conversation-edit-action-color) 54%, transparent);
     border-radius: var(--sb-radius-button, 10px);
-    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 12%, var(--sb-button-bg));
-    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 28%, transparent);
-    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 80%, var(--SmartThemeBodyColor));
-    opacity: 0.92;
+    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 28%, var(--sb-button-bg));
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 48%, transparent);
+    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 94%, var(--SmartThemeBodyColor));
+    opacity: 1;
 }
 
 .sb-conversation-message-edit-save {
@@ -1232,18 +1232,16 @@
 
 .sb-conversation-message-edit-control.menu_button:hover,
 .sb-conversation-message-edit-control.menu_button:focus-visible {
-    border-color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 48%, transparent);
-    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 18%, var(--sb-button-bg));
+    border-color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 72%, transparent);
+    background: color-mix(in srgb, var(--sb-conversation-edit-action-color) 40%, var(--sb-button-bg));
     box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--sb-conversation-edit-action-color) 24%, transparent),
-        inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 36%, transparent);
-    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 90%, var(--SmartThemeBodyColor));
-    opacity: 1;
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-conversation-edit-action-color) 38%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--sb-conversation-edit-action-color) 58%, transparent);
+    color: color-mix(in srgb, var(--sb-conversation-edit-action-color) 98%, var(--SmartThemeBodyColor));
 }
 
 .sb-conversation-message.is-editing .sb-conversation-message-actions {
-    opacity: 0;
-    pointer-events: none;
+    display: none !important;
 }
 
 .sb-conversation-mention {

--- a/public/scripts/sillybunny-conversation/attachments.js
+++ b/public/scripts/sillybunny-conversation/attachments.js
@@ -60,6 +60,7 @@ import {
     createConversationMessageRevisionEntries,
     createConversationQueueItem,
     createConversationQueueReplyTarget,
+    createForcedConversationQueueItem,
     getLastConversationQueueUserMessage,
     requeueConversationQueueItem,
     resolveConversationQueueReplyTarget,
@@ -767,7 +768,25 @@ export async function submitConversationInput() {
     if (!pendingFiles) {
         return;
     }
-    if (!avatar || (!text && !pendingFiles.length)) {
+    if (!avatar) {
+        return;
+    }
+
+    if (!text && !pendingFiles.length) {
+        const branchMessages = getConversationThread(avatar, { branchId, create: false, groupId, personaId });
+        if (!branchMessages.some(message => message?.role === 'user')) {
+            return;
+        }
+
+        sendQueue.push(createForcedConversationQueueItem({
+            avatar,
+            branchId,
+            groupId,
+            personaId,
+            threadKey: getConversationThreadKey(avatar, groupId, { personaId }),
+            createdAt: Date.now(),
+        }, branchMessages));
+        void processSendQueue();
         return;
     }
 

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -91,7 +91,7 @@ import {
 } from './timeline-render.js';
 import { setLastConversationPreview } from './typing.js';
 
-const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260808a';
+const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260808b';
 const CONVERSATION_STYLESHEET_ID = 'sb-conversation-css';
 
 function ensureConversationStylesheet() {

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -91,7 +91,7 @@ import {
 } from './timeline-render.js';
 import { setLastConversationPreview } from './typing.js';
 
-const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260725a';
+const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260808a';
 const CONVERSATION_STYLESHEET_ID = 'sb-conversation-css';
 
 function ensureConversationStylesheet() {

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -91,7 +91,7 @@ import {
 } from './timeline-render.js';
 import { setLastConversationPreview } from './typing.js';
 
-const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260808b';
+const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260808c';
 const CONVERSATION_STYLESHEET_ID = 'sb-conversation-css';
 
 function ensureConversationStylesheet() {

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -120,7 +120,8 @@ export async function generateConversationReply(directive, settings, { responseL
 export function editConversationMessage(messageId) {
     const avatar = getCurrentCharAvatar();
     const groupId = getConversationGroupIdForAvatar(avatar);
-    const message = getConversationThread(avatar, { groupId }).find(item => item.id === messageId);
+    const personaId = getConversationPersonaId();
+    const message = getConversationThread(avatar, { create: false, groupId, personaId }).find(item => item.id === messageId);
     if (!avatar || !message) {
         return;
     }
@@ -166,7 +167,7 @@ export function editConversationMessage(messageId) {
     saveButton.onclick = () => {
         const value = textarea.value.trim();
         if (value && value !== message.mes) {
-            updateConversationThreadMessage(avatar, messageId, value, null, { groupId });
+            updateConversationThreadMessage(avatar, messageId, value, null, { groupId, personaId });
         } else {
             scheduleTimelineRender();
         }

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -165,19 +165,19 @@ export function editConversationMessage(messageId) {
 
     const saveButton = document.createElement('button');
     saveButton.type = 'button';
-    saveButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-save mes_edit_done fa-solid fa-check';
+    saveButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-save fa-solid fa-check';
     saveButton.title = 'Save message changes';
     saveButton.setAttribute('aria-label', 'Save message changes');
 
     const cancelButton = document.createElement('button');
     cancelButton.type = 'button';
-    cancelButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-cancel mes_edit_cancel fa-solid fa-xmark';
+    cancelButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-cancel fa-solid fa-xmark';
     cancelButton.title = 'Discard message changes';
     cancelButton.setAttribute('aria-label', 'Discard message changes');
 
     const deleteButton = document.createElement('button');
     deleteButton.type = 'button';
-    deleteButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-delete mes_edit_delete fa-solid fa-trash-can';
+    deleteButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-delete fa-solid fa-trash-can';
     deleteButton.title = 'Delete message';
     deleteButton.setAttribute('aria-label', 'Delete message');
     deleteButton.dataset.sbConversationAction = 'delete-message';

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -139,10 +139,22 @@ export function editConversationMessage(messageId) {
         return;
     }
 
-    // If an editor is already open in this element, do nothing.
     if (textElement.querySelector('.sb-conversation-message-edit-textarea')) {
         return;
     }
+
+    let closedExistingEditor = false;
+    document.querySelectorAll('.sb-conversation-message-edit-textarea').forEach((editor) => {
+        const previousMessageElement = editor.closest?.('.sb-conversation-message');
+        if (!previousMessageElement || previousMessageElement === messageElement) {
+            return;
+        }
+
+        previousMessageElement.classList.remove('is-editing');
+        previousMessageElement.querySelector('.sb-conversation-message-actions')?.classList.remove('open');
+        delete previousMessageElement.dataset.sbConversationMessageFingerprint;
+        closedExistingEditor = true;
+    });
 
     const textarea = document.createElement('textarea');
     textarea.className = 'sb-conversation-message-edit-textarea';
@@ -153,31 +165,47 @@ export function editConversationMessage(messageId) {
 
     const saveButton = document.createElement('button');
     saveButton.type = 'button';
-    saveButton.className = 'menu_button sb-conversation-message-edit-save';
-    saveButton.textContent = 'Save';
+    saveButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-save mes_edit_done fa-solid fa-check';
+    saveButton.title = 'Save message changes';
+    saveButton.setAttribute('aria-label', 'Save message changes');
 
     const cancelButton = document.createElement('button');
     cancelButton.type = 'button';
-    cancelButton.className = 'menu_button sb-conversation-message-edit-cancel';
-    cancelButton.textContent = 'Cancel';
+    cancelButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-cancel mes_edit_cancel fa-solid fa-xmark';
+    cancelButton.title = 'Discard message changes';
+    cancelButton.setAttribute('aria-label', 'Discard message changes');
 
-    buttonContainer.append(saveButton, cancelButton);
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'menu_button sb-conversation-message-edit-control sb-conversation-message-edit-delete mes_edit_delete fa-solid fa-trash-can';
+    deleteButton.title = 'Delete message';
+    deleteButton.setAttribute('aria-label', 'Delete message');
+    deleteButton.dataset.sbConversationAction = 'delete-message';
+    deleteButton.dataset.messageId = message.id;
+
+    buttonContainer.append(saveButton, cancelButton, deleteButton);
 
     textElement.textContent = '';
     textElement.append(textarea, buttonContainer);
+    messageElement.classList.add('is-editing');
+    messageElement.querySelector('.sb-conversation-message-actions')?.classList.remove('open');
+    if (closedExistingEditor) {
+        scheduleTimelineRender();
+    }
 
     const closeEditor = () => {
+        messageElement.classList.remove('is-editing');
+        messageElement.querySelector('.sb-conversation-message-actions')?.classList.remove('open');
         delete messageElement.dataset.sbConversationMessageFingerprint;
         scheduleTimelineRender();
     };
 
     saveButton.onclick = () => {
-        const value = textarea.value.trim();
-        if (value && value !== message.mes) {
+        const value = textarea.value;
+        if (value !== message.mes) {
             updateConversationThreadMessage(avatar, message.id, value, null, { groupId, personaId });
-        } else {
-            closeEditor();
         }
+        closeEditor();
     };
 
     cancelButton.onclick = closeEditor;

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -121,12 +121,15 @@ export function editConversationMessage(messageId) {
     const avatar = getCurrentCharAvatar();
     const groupId = getConversationGroupIdForAvatar(avatar);
     const personaId = getConversationPersonaId();
-    const message = getConversationThread(avatar, { create: false, groupId, personaId }).find(item => item.id === messageId);
+    const normalizedMessageId = String(messageId || '');
+    const message = getConversationThread(avatar, { create: false, groupId, personaId })
+        .find(item => String(item.id || '') === normalizedMessageId);
     if (!avatar || !message) {
         return;
     }
 
-    const messageElement = document.querySelector(`.sb-conversation-message[data-message-id="${messageId}"]`);
+    const messageElement = Array.from(document.querySelectorAll('.sb-conversation-message'))
+        .find(element => element.dataset.messageId === normalizedMessageId);
     if (!messageElement) {
         return;
     }

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -144,7 +144,10 @@ export function editConversationMessage(messageId) {
         return;
     }
 
-    activeConversationEditor?.close();
+    if (activeConversationEditor && !activeConversationEditor.requestClose()) {
+        return;
+    }
+
     const originalTextElement = textElement.cloneNode(true);
 
     const textarea = document.createElement('textarea');
@@ -192,12 +195,26 @@ export function editConversationMessage(messageId) {
         }
     };
 
-    activeConversationEditor = { messageElement, close: closeEditor };
+    // Switching editors drops whatever is in the textarea, so confirm first when it differs
+    // from the stored message. Falls through when no confirm() exists (non-browser hosts).
+    const requestClose = () => {
+        if (textarea.value !== message.mes
+            && typeof globalThis.confirm === 'function'
+            && !globalThis.confirm('Discard unsaved changes to the message being edited?')) {
+            return false;
+        }
+
+        closeEditor();
+        return true;
+    };
+
+    activeConversationEditor = { messageElement, requestClose };
 
     saveButton.onclick = () => {
         const value = textarea.value;
         closeEditor();
-        if (value !== message.mes) {
+        // A blanked textarea is not an edit: the delete control is the only way to drop a message.
+        if (value.trim() && value !== message.mes) {
             updateConversationThreadMessage(avatar, message.id, value, null, { groupId, personaId });
         }
     };

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -165,20 +165,22 @@ export function editConversationMessage(messageId) {
 
     textElement.textContent = '';
     textElement.append(textarea, buttonContainer);
-    textarea.focus({ preventScroll: true });
+
+    const closeEditor = () => {
+        delete messageElement.dataset.sbConversationMessageFingerprint;
+        scheduleTimelineRender();
+    };
 
     saveButton.onclick = () => {
         const value = textarea.value.trim();
         if (value && value !== message.mes) {
-            updateConversationThreadMessage(avatar, messageId, value, null, { groupId, personaId });
+            updateConversationThreadMessage(avatar, message.id, value, null, { groupId, personaId });
         } else {
-            scheduleTimelineRender();
+            closeEditor();
         }
     };
 
-    cancelButton.onclick = () => {
-        scheduleTimelineRender();
-    };
+    cancelButton.onclick = closeEditor;
 
     textarea.onkeydown = (event) => {
         if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
@@ -189,6 +191,8 @@ export function editConversationMessage(messageId) {
             cancelButton.click();
         }
     };
+
+    textarea.focus({ preventScroll: true });
 }
 
 export function applyScheduleUpdateCommand(avatar, rawArgs, { personaId = getConversationPersonaId() } = {}) {

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -23,7 +23,6 @@ import { getSpeakerPrefixMatch } from './partners-utils.js';
 import { getConnectionProfiles } from './personas.js';
 import { buildConversationPromptMessages, buildConversationSystemPrompt } from './prompt.js';
 import { formatPromptText } from './shared-helpers.js';
-import { scheduleTimelineRender } from './render-scheduler.js';
 import { clamp, getConversationReplyMaxTokens, getConversationRuntimeStatusKey, parseDurationToMs } from './schedule.js';
 import { runtimeStatusOverrides } from './state.js';
 import {
@@ -36,6 +35,8 @@ import {
     updateConversationThreadMessage,
 } from './thread-store.js';
 import { splitChatroomMessages, waitForReplyDelay, withTypingParticipant } from './typing.js';
+
+let activeConversationEditor = null;
 
 export {
     extractCharacterReplyCommandParts,
@@ -139,22 +140,12 @@ export function editConversationMessage(messageId) {
         return;
     }
 
-    if (textElement.querySelector('.sb-conversation-message-edit-textarea')) {
+    if (activeConversationEditor?.messageElement === messageElement) {
         return;
     }
 
-    let closedExistingEditor = false;
-    document.querySelectorAll('.sb-conversation-message-edit-textarea').forEach((editor) => {
-        const previousMessageElement = editor.closest?.('.sb-conversation-message');
-        if (!previousMessageElement || previousMessageElement === messageElement) {
-            return;
-        }
-
-        previousMessageElement.classList.remove('is-editing');
-        previousMessageElement.querySelector('.sb-conversation-message-actions')?.classList.remove('open');
-        delete previousMessageElement.dataset.sbConversationMessageFingerprint;
-        closedExistingEditor = true;
-    });
+    activeConversationEditor?.close();
+    const originalTextElement = textElement.cloneNode(true);
 
     const textarea = document.createElement('textarea');
     textarea.className = 'sb-conversation-message-edit-textarea';
@@ -189,23 +180,26 @@ export function editConversationMessage(messageId) {
     textElement.append(textarea, buttonContainer);
     messageElement.classList.add('is-editing');
     messageElement.querySelector('.sb-conversation-message-actions')?.classList.remove('open');
-    if (closedExistingEditor) {
-        scheduleTimelineRender();
-    }
 
     const closeEditor = () => {
+        if (textElement.isConnected) {
+            textElement.replaceWith(originalTextElement);
+        }
         messageElement.classList.remove('is-editing');
         messageElement.querySelector('.sb-conversation-message-actions')?.classList.remove('open');
-        delete messageElement.dataset.sbConversationMessageFingerprint;
-        scheduleTimelineRender();
+        if (activeConversationEditor?.messageElement === messageElement) {
+            activeConversationEditor = null;
+        }
     };
+
+    activeConversationEditor = { messageElement, close: closeEditor };
 
     saveButton.onclick = () => {
         const value = textarea.value;
+        closeEditor();
         if (value !== message.mes) {
             updateConversationThreadMessage(avatar, message.id, value, null, { groupId, personaId });
         }
-        closeEditor();
     };
 
     cancelButton.onclick = closeEditor;

--- a/tests/sillybunny-conversation-core-generation-regressions.test.js
+++ b/tests/sillybunny-conversation-core-generation-regressions.test.js
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 const appendConversationMessage = jest.fn();
 const addConversationReminder = jest.fn();
 const generateConversationImage = jest.fn();
-const scheduleTimelineRender = jest.fn();
 const updateConversationThreadMessage = jest.fn();
 const runtimeStatusOverrides = new Map();
 const threadMessages = [{ id: 'user-1', role: 'user', name: 'User', mes: 'hello', extra: {} }];
@@ -44,7 +43,6 @@ await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/prompt
 await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/shared-helpers.js', () => ({
     formatPromptText: value => String(value || ''),
 }));
-await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/render-scheduler.js', () => ({ scheduleTimelineRender }));
 await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/schedule.js', () => ({
     clamp: (value, min, max) => Math.min(max, Math.max(min, value)),
     getConversationReplyMaxTokens: () => 100,
@@ -83,7 +81,6 @@ describe('Conversation core generated reply regressions', () => {
         appendConversationMessage.mockReset().mockImplementation(async (text, options) => ({ id: `message-${appendConversationMessage.mock.calls.length}`, mes: text, ...options }));
         addConversationReminder.mockClear();
         generateConversationImage.mockClear();
-        scheduleTimelineRender.mockClear();
         updateConversationThreadMessage.mockClear();
         runtimeStatusOverrides.clear();
         delete globalThis.document;
@@ -154,9 +151,13 @@ describe('Conversation core generated reply regressions', () => {
     });
 
     test('saves only changed content and closes the editor in all cases', () => {
+        const originalTextElement = {};
         const textElement = {
             append: jest.fn(),
+            cloneNode: jest.fn(() => originalTextElement),
+            isConnected: true,
             querySelector: jest.fn(() => null),
+            replaceWith: jest.fn(),
             textContent: 'hello',
         };
         const actionBar = { classList: { remove: jest.fn() } };
@@ -194,14 +195,11 @@ describe('Conversation core generated reply regressions', () => {
         const [textarea, buttonContainer] = createdElements;
         const [saveButton, cancelButton] = buttonContainer.children;
         cancelButton.onclick();
-        expect(messageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
-        expect(scheduleTimelineRender).toHaveBeenCalledTimes(1);
+        expect(textElement.replaceWith).toHaveBeenCalledWith(originalTextElement);
+        expect(messageElement.classList.remove).toHaveBeenCalledWith('is-editing');
 
-        messageElement.dataset.sbConversationMessageFingerprint = 'fingerprint';
         saveButton.onclick();
         expect(updateConversationThreadMessage).not.toHaveBeenCalled();
-        expect(messageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
-        expect(scheduleTimelineRender).toHaveBeenCalledTimes(2);
 
         textarea.value = 'updated';
         saveButton.onclick();
@@ -209,19 +207,27 @@ describe('Conversation core generated reply regressions', () => {
             groupId: '',
             personaId: 'persona-a.png',
         });
-        expect(scheduleTimelineRender).toHaveBeenCalledTimes(3);
     });
 
     test('cancels an existing editor before opening another', () => {
-        const originalText = { querySelector: jest.fn(() => null) };
+        const restoredText = {};
+        const originalText = {
+            append: jest.fn(),
+            cloneNode: jest.fn(() => restoredText),
+            isConnected: true,
+            querySelector: jest.fn(() => null),
+            replaceWith: jest.fn(),
+            textContent: 'first',
+        };
         const originalActions = { classList: { remove: jest.fn() } };
         const previousMessageElement = {
-            classList: { remove: jest.fn() },
-            dataset: { sbConversationMessageFingerprint: 'previous-fingerprint' },
+            classList: { add: jest.fn(), remove: jest.fn() },
+            dataset: { messageId: '42', sbConversationMessageFingerprint: 'previous-fingerprint' },
             querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? originalActions : originalText),
         };
         const nextText = {
             append: jest.fn(),
+            cloneNode: jest.fn(() => ({})),
             querySelector: jest.fn(() => null),
             textContent: 'hello',
         };
@@ -231,7 +237,6 @@ describe('Conversation core generated reply regressions', () => {
             dataset: { messageId: '43' },
             querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? nextActions : nextText),
         };
-        const activeEditor = { closest: jest.fn(() => previousMessageElement) };
         globalThis.document = {
             createElement: jest.fn(() => ({
                 append: jest.fn(),
@@ -241,15 +246,19 @@ describe('Conversation core generated reply regressions', () => {
                 setAttribute: jest.fn(),
                 value: '',
             })),
-            querySelectorAll: jest.fn(selector => selector === '.sb-conversation-message-edit-textarea' ? [activeEditor] : [nextMessageElement]),
+            querySelectorAll: jest.fn(() => [previousMessageElement]),
         };
-        threadMessages.splice(0, threadMessages.length, { id: 43, role: 'user', name: 'User', mes: 'hello', extra: {} });
+        threadMessages.splice(0, threadMessages.length,
+            { id: 42, role: 'user', name: 'User', mes: 'first', extra: {} },
+            { id: 43, role: 'user', name: 'User', mes: 'hello', extra: {} },
+        );
 
+        editConversationMessage('42');
+        globalThis.document.querySelectorAll.mockReturnValue([nextMessageElement]);
         editConversationMessage('43');
 
         expect(previousMessageElement.classList.remove).toHaveBeenCalledWith('is-editing');
-        expect(previousMessageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
+        expect(originalText.replaceWith).toHaveBeenCalledWith(restoredText);
         expect(originalActions.classList.remove).toHaveBeenCalledWith('open');
-        expect(scheduleTimelineRender).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/sillybunny-conversation-core-generation-regressions.test.js
+++ b/tests/sillybunny-conversation-core-generation-regressions.test.js
@@ -1,8 +1,11 @@
+/* global globalThis */
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 const appendConversationMessage = jest.fn();
 const addConversationReminder = jest.fn();
 const generateConversationImage = jest.fn();
+const scheduleTimelineRender = jest.fn();
+const updateConversationThreadMessage = jest.fn();
 const runtimeStatusOverrides = new Map();
 const threadMessages = [{ id: 'user-1', role: 'user', name: 'User', mes: 'hello', extra: {} }];
 
@@ -41,7 +44,7 @@ await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/prompt
 await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/shared-helpers.js', () => ({
     formatPromptText: value => String(value || ''),
 }));
-await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/render-scheduler.js', () => ({ scheduleTimelineRender: jest.fn() }));
+await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/render-scheduler.js', () => ({ scheduleTimelineRender }));
 await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/schedule.js', () => ({
     clamp: (value, min, max) => Math.min(max, Math.max(min, value)),
     getConversationReplyMaxTokens: () => 100,
@@ -56,7 +59,7 @@ await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/thread
     getImageCooldownRemainingSeconds: () => 0,
     hasConversationMessageContent: message => Boolean(message?.id && message?.mes),
     markImageGenerated: jest.fn(),
-    updateConversationThreadMessage: jest.fn(),
+    updateConversationThreadMessage,
 }));
 await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/typing.js', () => ({
     splitChatroomMessages: value => String(value || '').split(/\n\s*\n+/).map(part => part.trim()).filter(Boolean),
@@ -65,6 +68,7 @@ await jest.unstable_mockModule('../public/scripts/sillybunny-conversation/typing
 }));
 
 const {
+    editConversationMessage,
     postCharacterReply,
 } = await import('../public/scripts/sillybunny-conversation/generation.js');
 
@@ -79,7 +83,10 @@ describe('Conversation core generated reply regressions', () => {
         appendConversationMessage.mockReset().mockImplementation(async (text, options) => ({ id: `message-${appendConversationMessage.mock.calls.length}`, mes: text, ...options }));
         addConversationReminder.mockClear();
         generateConversationImage.mockClear();
+        scheduleTimelineRender.mockClear();
+        updateConversationThreadMessage.mockClear();
         runtimeStatusOverrides.clear();
+        delete globalThis.document;
     });
 
     test('keeps native selfie command metadata when image generation is disabled', async () => {
@@ -142,6 +149,52 @@ describe('Conversation core generated reply regressions', () => {
         });
         expect(addConversationReminder).toHaveBeenCalledWith('char.png', '', '15m', 'check in', {
             branchId: 'branch-a',
+            personaId: 'persona-a.png',
+        });
+    });
+
+    test('closes unchanged editors and preserves legacy message identity when saving', () => {
+        const textElement = {
+            append: jest.fn(),
+            querySelector: jest.fn(() => null),
+            textContent: 'hello',
+        };
+        const messageElement = {
+            dataset: {
+                messageId: '42',
+                sbConversationMessageFingerprint: 'fingerprint',
+            },
+            querySelector: jest.fn(() => textElement),
+        };
+        const createdElements = [];
+        globalThis.document = {
+            createElement: jest.fn(() => {
+                const element = {
+                    append: jest.fn(),
+                    children: [],
+                    focus: jest.fn(),
+                    value: '',
+                };
+                element.append.mockImplementation((...children) => element.children.push(...children));
+                createdElements.push(element);
+                return element;
+            }),
+            querySelectorAll: jest.fn(() => [messageElement]),
+        };
+        threadMessages.splice(0, threadMessages.length, { id: 42, role: 'user', name: 'User', mes: 'hello', extra: {} });
+
+        editConversationMessage('42');
+
+        const [textarea, buttonContainer] = createdElements;
+        const [saveButton, cancelButton] = buttonContainer.children;
+        cancelButton.onclick();
+        expect(messageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
+        expect(scheduleTimelineRender).toHaveBeenCalledTimes(1);
+
+        textarea.value = 'updated';
+        saveButton.onclick();
+        expect(updateConversationThreadMessage).toHaveBeenCalledWith('char.png', 42, 'updated', null, {
+            groupId: '',
             personaId: 'persona-a.png',
         });
     });

--- a/tests/sillybunny-conversation-core-generation-regressions.test.js
+++ b/tests/sillybunny-conversation-core-generation-regressions.test.js
@@ -159,12 +159,14 @@ describe('Conversation core generated reply regressions', () => {
             querySelector: jest.fn(() => null),
             textContent: 'hello',
         };
+        const actionBar = { classList: { remove: jest.fn() } };
         const messageElement = {
+            classList: { add: jest.fn(), remove: jest.fn() },
             dataset: {
                 messageId: '42',
                 sbConversationMessageFingerprint: 'fingerprint',
             },
-            querySelector: jest.fn(() => textElement),
+            querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? actionBar : textElement),
         };
         const createdElements = [];
         globalThis.document = {
@@ -172,7 +174,11 @@ describe('Conversation core generated reply regressions', () => {
                 const element = {
                     append: jest.fn(),
                     children: [],
+                    classList: { add: jest.fn(), remove: jest.fn() },
+                    closest: jest.fn(() => null),
+                    dataset: {},
                     focus: jest.fn(),
+                    setAttribute: jest.fn(),
                     value: '',
                 };
                 element.append.mockImplementation((...children) => element.children.push(...children));
@@ -197,5 +203,47 @@ describe('Conversation core generated reply regressions', () => {
             groupId: '',
             personaId: 'persona-a.png',
         });
+        expect(scheduleTimelineRender).toHaveBeenCalledTimes(2);
+    });
+
+    test('cancels an existing editor before opening another', () => {
+        const originalText = { querySelector: jest.fn(() => null) };
+        const originalActions = { classList: { remove: jest.fn() } };
+        const previousMessageElement = {
+            classList: { remove: jest.fn() },
+            dataset: { sbConversationMessageFingerprint: 'previous-fingerprint' },
+            querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? originalActions : originalText),
+        };
+        const nextText = {
+            append: jest.fn(),
+            querySelector: jest.fn(() => null),
+            textContent: 'hello',
+        };
+        const nextActions = { classList: { remove: jest.fn() } };
+        const nextMessageElement = {
+            classList: { add: jest.fn() },
+            dataset: { messageId: '43' },
+            querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? nextActions : nextText),
+        };
+        const activeEditor = { closest: jest.fn(() => previousMessageElement) };
+        globalThis.document = {
+            createElement: jest.fn(() => ({
+                append: jest.fn(),
+                classList: { add: jest.fn(), remove: jest.fn() },
+                dataset: {},
+                focus: jest.fn(),
+                setAttribute: jest.fn(),
+                value: '',
+            })),
+            querySelectorAll: jest.fn(selector => selector === '.sb-conversation-message-edit-textarea' ? [activeEditor] : [nextMessageElement]),
+        };
+        threadMessages.splice(0, threadMessages.length, { id: 43, role: 'user', name: 'User', mes: 'hello', extra: {} });
+
+        editConversationMessage('43');
+
+        expect(previousMessageElement.classList.remove).toHaveBeenCalledWith('is-editing');
+        expect(previousMessageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
+        expect(originalActions.classList.remove).toHaveBeenCalledWith('open');
+        expect(scheduleTimelineRender).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/sillybunny-conversation-core-generation-regressions.test.js
+++ b/tests/sillybunny-conversation-core-generation-regressions.test.js
@@ -84,6 +84,7 @@ describe('Conversation core generated reply regressions', () => {
         updateConversationThreadMessage.mockClear();
         runtimeStatusOverrides.clear();
         delete globalThis.document;
+        delete globalThis.confirm;
     });
 
     test('keeps native selfie command metadata when image generation is disabled', async () => {
@@ -233,7 +234,7 @@ describe('Conversation core generated reply regressions', () => {
         };
         const nextActions = { classList: { remove: jest.fn() } };
         const nextMessageElement = {
-            classList: { add: jest.fn() },
+            classList: { add: jest.fn(), remove: jest.fn() },
             dataset: { messageId: '43' },
             querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? nextActions : nextText),
         };
@@ -260,5 +261,113 @@ describe('Conversation core generated reply regressions', () => {
         expect(previousMessageElement.classList.remove).toHaveBeenCalledWith('is-editing');
         expect(originalText.replaceWith).toHaveBeenCalledWith(restoredText);
         expect(originalActions.classList.remove).toHaveBeenCalledWith('open');
+    });
+
+    test('does not persist a blanked message so deletion stays explicit', () => {
+        const textElement = {
+            append: jest.fn(),
+            cloneNode: jest.fn(() => ({})),
+            isConnected: true,
+            querySelector: jest.fn(() => null),
+            replaceWith: jest.fn(),
+            textContent: 'hello',
+        };
+        const actionBar = { classList: { remove: jest.fn() } };
+        const messageElement = {
+            classList: { add: jest.fn(), remove: jest.fn() },
+            dataset: { messageId: '42' },
+            querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions' ? actionBar : textElement),
+        };
+        const createdElements = [];
+        globalThis.document = {
+            createElement: jest.fn(() => {
+                const element = {
+                    append: jest.fn(),
+                    children: [],
+                    classList: { add: jest.fn(), remove: jest.fn() },
+                    dataset: {},
+                    focus: jest.fn(),
+                    setAttribute: jest.fn(),
+                    value: '',
+                };
+                element.append.mockImplementation((...children) => element.children.push(...children));
+                createdElements.push(element);
+                return element;
+            }),
+            querySelectorAll: jest.fn(() => [messageElement]),
+        };
+        threadMessages.splice(0, threadMessages.length, { id: 42, role: 'user', name: 'User', mes: 'hello', extra: {} });
+
+        editConversationMessage('42');
+
+        const [textarea, buttonContainer] = createdElements;
+        const [saveButton] = buttonContainer.children;
+        textarea.value = '   ';
+        saveButton.onclick();
+
+        expect(updateConversationThreadMessage).not.toHaveBeenCalled();
+        expect(messageElement.classList.remove).toHaveBeenCalledWith('is-editing');
+    });
+
+    test('keeps the open editor when discarding unsaved changes is declined', () => {
+        const originalText = {
+            append: jest.fn(),
+            cloneNode: jest.fn(() => ({})),
+            isConnected: true,
+            querySelector: jest.fn(() => null),
+            replaceWith: jest.fn(),
+            textContent: 'first',
+        };
+        const previousMessageElement = {
+            classList: { add: jest.fn(), remove: jest.fn() },
+            dataset: { messageId: '42' },
+            querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions'
+                ? { classList: { remove: jest.fn() } }
+                : originalText),
+        };
+        const nextText = {
+            append: jest.fn(),
+            cloneNode: jest.fn(() => ({})),
+            querySelector: jest.fn(() => null),
+            textContent: 'hello',
+        };
+        const nextMessageElement = {
+            classList: { add: jest.fn() },
+            dataset: { messageId: '43' },
+            querySelector: jest.fn(selector => selector === '.sb-conversation-message-actions'
+                ? { classList: { remove: jest.fn() } }
+                : nextText),
+        };
+        const createdElements = [];
+        globalThis.document = {
+            createElement: jest.fn(() => {
+                const element = {
+                    append: jest.fn(),
+                    classList: { add: jest.fn(), remove: jest.fn() },
+                    dataset: {},
+                    focus: jest.fn(),
+                    setAttribute: jest.fn(),
+                    value: '',
+                };
+                createdElements.push(element);
+                return element;
+            }),
+            querySelectorAll: jest.fn(() => [previousMessageElement]),
+        };
+        globalThis.confirm = jest.fn(() => false);
+        threadMessages.splice(0, threadMessages.length,
+            { id: 42, role: 'user', name: 'User', mes: 'first', extra: {} },
+            { id: 43, role: 'user', name: 'User', mes: 'hello', extra: {} },
+        );
+
+        editConversationMessage('42');
+        const [textarea] = createdElements;
+        textarea.value = 'edited but unsaved';
+        globalThis.document.querySelectorAll.mockReturnValue([nextMessageElement]);
+        editConversationMessage('43');
+
+        expect(globalThis.confirm).toHaveBeenCalled();
+        expect(originalText.replaceWith).not.toHaveBeenCalled();
+        expect(nextMessageElement.classList.add).not.toHaveBeenCalled();
     });
 });

--- a/tests/sillybunny-conversation-core-generation-regressions.test.js
+++ b/tests/sillybunny-conversation-core-generation-regressions.test.js
@@ -153,7 +153,7 @@ describe('Conversation core generated reply regressions', () => {
         });
     });
 
-    test('closes unchanged editors and preserves legacy message identity when saving', () => {
+    test('saves only changed content and closes the editor in all cases', () => {
         const textElement = {
             append: jest.fn(),
             querySelector: jest.fn(() => null),
@@ -197,13 +197,19 @@ describe('Conversation core generated reply regressions', () => {
         expect(messageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
         expect(scheduleTimelineRender).toHaveBeenCalledTimes(1);
 
+        messageElement.dataset.sbConversationMessageFingerprint = 'fingerprint';
+        saveButton.onclick();
+        expect(updateConversationThreadMessage).not.toHaveBeenCalled();
+        expect(messageElement.dataset.sbConversationMessageFingerprint).toBeUndefined();
+        expect(scheduleTimelineRender).toHaveBeenCalledTimes(2);
+
         textarea.value = 'updated';
         saveButton.onclick();
         expect(updateConversationThreadMessage).toHaveBeenCalledWith('char.png', 42, 'updated', null, {
             groupId: '',
             personaId: 'persona-a.png',
         });
-        expect(scheduleTimelineRender).toHaveBeenCalledTimes(2);
+        expect(scheduleTimelineRender).toHaveBeenCalledTimes(3);
     });
 
     test('cancels an existing editor before opening another', () => {

--- a/tests/sillybunny-conversation-mobile-controls.test.js
+++ b/tests/sillybunny-conversation-mobile-controls.test.js
@@ -18,6 +18,14 @@ function getDeclarations(media, selector) {
         .map(declaration => [declaration.property, declaration.value]));
 }
 
+function getRuleDeclarations(selector) {
+    const rule = ast.stylesheet.rules.find(candidate => candidate.type === 'rule' && candidate.selectors.includes(selector));
+    expect(rule).toBeDefined();
+    return Object.fromEntries(rule.declarations
+        .filter(declaration => declaration.type === 'declaration')
+        .map(declaration => [declaration.property, declaration.value]));
+}
+
 describe('Conversation mobile controls', () => {
     test('44px touch targets apply to coarse pointers and the 1000px project mobile breakpoint', () => {
         const media = findMediaRule(query => query.includes('pointer: coarse') && query.includes('max-width: 1000px'));
@@ -44,5 +52,17 @@ describe('Conversation mobile controls', () => {
             .flatMap(rule => rule.selectors);
         expect(phoneSelectors).not.toContain('.sb-conversation-selfie-action');
         expect(phoneSelectors).not.toContain('.sb-conversation-reply-cancel');
+    });
+
+    test('edit controls override the base button color with semantic states', () => {
+        expect(getRuleDeclarations('.sb-conversation-message-edit-save.menu_button')).toMatchObject({
+            '--sb-conversation-edit-action-color': 'var(--sb-color-success)',
+        });
+        expect(getRuleDeclarations('.sb-conversation-message-edit-cancel.menu_button')).toMatchObject({
+            '--sb-conversation-edit-action-color': 'var(--sb-color-warning)',
+        });
+        expect(getRuleDeclarations('.sb-conversation-message-edit-delete.menu_button')).toMatchObject({
+            '--sb-conversation-edit-action-color': 'var(--sb-color-danger)',
+        });
     });
 });

--- a/tests/sillybunny-conversation-mobile-controls.test.js
+++ b/tests/sillybunny-conversation-mobile-controls.test.js
@@ -65,4 +65,19 @@ describe('Conversation mobile controls', () => {
             '--sb-conversation-edit-action-color': 'var(--sb-color-danger)',
         });
     });
+
+    test('edit controls layer their tint over the themeable button background', () => {
+        // Themes may define --sb-button-bg as a gradient, which color-mix() rejects outright,
+        // so it has to stay its own background layer rather than become a mix operand.
+        const selectors = [
+            '.sb-conversation-message-edit-control.menu_button',
+            '.sb-conversation-message-edit-control.menu_button:hover',
+        ];
+
+        for (const selector of selectors) {
+            const background = getRuleDeclarations(selector).background;
+            expect(background).toContain('var(--sb-button-bg)');
+            expect(background.trim().endsWith('var(--sb-button-bg)')).toBe(true);
+        }
+    });
 });


### PR DESCRIPTION
Attempts to address an issue where clicking the send button in Conversation Mode after deleting a prior message yields no results, and an issue where editing the message prevents the save and cancel buttons from working.