### PR TITLE
fix: allow bulk actions for group chats

### DIFF
--- a/public/css/character-group-overlay.css
+++ b/public/css/character-group-overlay.css
@@ -1,28 +1,26 @@
-#rm_print_characters_block.group_overlay_mode_select .character_select {
+#rm_print_characters_block.group_overlay_mode_select :is(.character_select, .group_select) {
     transition: background-color var(--sb-transition-slow);
     background-color: rgba(170, 170, 170, 0.15);
 }
 
-#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select,
-#rm_print_characters_block.group_overlay_mode_select .group_select {
+#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select {
     cursor: auto;
     filter: saturate(0.3);
 }
 
-#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select:hover,
-#rm_print_characters_block.group_overlay_mode_select .group_select:hover {
+#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select:hover {
     background: none;
 }
 
-#rm_print_characters_block.group_overlay_mode_select .character_select input.bulk_select_checkbox {
+#rm_print_characters_block.group_overlay_mode_select :is(.character_select, .group_select) input.bulk_select_checkbox {
     display: none !important;
 }
 
-#rm_print_characters_block.group_overlay_mode_select .character_select.character_selected {
+#rm_print_characters_block.group_overlay_mode_select :is(.character_select, .group_select).character_selected {
     background-color: var(--SmartThemeQuoteColor);
 }
 
-#rm_print_characters_block.group_overlay_mode_select .character_select .bulk_select_checkbox {
+#rm_print_characters_block.group_overlay_mode_select :is(.character_select, .group_select) .bulk_select_checkbox {
     visibility: hidden;
     height: 0 !important;
 }

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -505,13 +505,13 @@
         margin: 0;
     }
 
-    #rm_print_characters_block.bulk_select > .character_select {
+    #rm_print_characters_block.bulk_select > :is(.character_select, .group_select) {
         display: grid;
         grid-template-columns: minmax(var(--sb-checkbox-size, 1rem), auto) var(--avatar-base-width) minmax(0, 1fr) !important;
         gap: 8px;
     }
 
-    #rm_print_characters_block.bulk_select > .character_select > .bulk_select_checkbox {
+    #rm_print_characters_block.bulk_select > :is(.character_select, .group_select) > .bulk_select_checkbox {
         grid-column: 1;
         grid-row: 1 / span 2;
         align-self: center;
@@ -519,11 +519,11 @@
         margin: 0;
     }
 
-    #rm_print_characters_block.bulk_select > .character_select > .avatar {
+    #rm_print_characters_block.bulk_select > :is(.character_select, .group_select) > .avatar {
         grid-column: 2;
     }
 
-    #rm_print_characters_block.bulk_select > .character_select > .character_select_container {
+    #rm_print_characters_block.bulk_select > :is(.character_select, .group_select) > :is(.character_select_container, .group_select_container) {
         grid-column: 3;
         min-width: 0;
     }
@@ -594,7 +594,7 @@
         min-width: 0;
     }
 
-    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > .character_select {
+    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > :is(.character_select, .group_select) {
         display: grid !important;
         grid-template-columns: 24px var(--avatar-base-width) minmax(0, 1fr) !important;
         align-items: center;
@@ -603,7 +603,7 @@
         padding: 8px;
     }
 
-    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > .character_select > .bulk_select_checkbox {
+    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > :is(.character_select, .group_select) > .bulk_select_checkbox {
         grid-column: 1 !important;
         grid-row: 1 / -1 !important;
         align-self: center !important;
@@ -612,7 +612,7 @@
         position: static !important;
     }
 
-    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > .character_select > .avatar {
+    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > :is(.character_select, .group_select) > .avatar {
         grid-column: 2 !important;
         grid-row: 1 / -1 !important;
         align-self: center !important;
@@ -620,7 +620,7 @@
         margin: 0 !important;
     }
 
-    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > .character_select > .character_select_container {
+    body #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > :is(.character_select, .group_select) > :is(.character_select_container, .group_select_container) {
         grid-column: 3 !important;
         grid-row: 1 !important;
         display: grid !important;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -7552,7 +7552,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         white-space: normal;
     }
 
-    body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > .character_select > .bulk_select_checkbox {
+    body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > :is(.character_select, .group_select) > .bulk_select_checkbox {
         position: absolute !important;
         top: 8px !important;
         left: 8px !important;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2397,9 +2397,7 @@ body.sb-shell-resizing * {
 }
 
 #right-nav-panel:not([data-menu-type="groups"]) #rm_button_group_chats,
-#right-nav-panel[data-menu-type="groups"] #rm_button_create,
-#right-nav-panel[data-menu-type="groups"] #bulkSelectAllButton,
-#right-nav-panel[data-menu-type="groups"] #bulkDeleteButton {
+#right-nav-panel[data-menu-type="groups"] #rm_button_create {
     display: none !important;
 }
 
@@ -2627,13 +2625,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     display: none !important;
 }
 
-#right-nav-panel:not([data-menu-type="groups"]) .sb-character-create-bar #rm_button_group_chats {
+#right-nav-panel[data-menu-type="groups"]:has(#bulkEditButton.bulk_edit_overlay_active) .sb-character-create-bar #rm_button_group_chats {
     display: none !important;
 }
 
-#right-nav-panel[data-menu-type="groups"] .sb-character-create-bar #bulkEditButton.disabled {
-    opacity: 0.54;
-    cursor: not-allowed;
+#right-nav-panel:not([data-menu-type="groups"]) .sb-character-create-bar #rm_button_group_chats {
+    display: none !important;
 }
 
 #right-nav-panel[data-menu-type="characters"] > #rm_PinAndTabs,

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -2397,7 +2397,8 @@ body.sb-shell-resizing * {
 }
 
 #right-nav-panel:not([data-menu-type="groups"]) #rm_button_group_chats,
-#right-nav-panel[data-menu-type="groups"] #rm_button_create {
+#right-nav-panel[data-menu-type="groups"] #rm_button_create,
+#right-nav-panel[data-menu-type="groups"]:has(#bulkEditButton.bulk_edit_overlay_active) .sb-character-create-bar #rm_button_group_chats {
     display: none !important;
 }
 
@@ -2622,10 +2623,6 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 #right-nav-panel[data-menu-type="groups"] .sb-character-create-bar #rm_button_create {
-    display: none !important;
-}
-
-#right-nav-panel[data-menu-type="groups"]:has(#bulkEditButton.bulk_edit_overlay_active) .sb-character-create-bar #rm_button_group_chats {
     display: none !important;
 }
 

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {
+    clearChat,
     characterGroupOverlay,
     characters,
     event_types,
@@ -9,16 +10,30 @@ import {
     getRequestHeaders,
     buildAvatarList,
     characterToEntity,
+    groupToEntity,
+    printMessages,
     printCharactersDebounced,
     deleteCharacter,
+    resetChatState,
 } from '../script.js';
 
 import { favsToHotswap } from './RossAscends-mods.js';
 import { loader } from './action-loader.js';
+// SillyBunny: group-list bulk actions share the upstream character overlay.
+import { groups, resetSelectedGroup, selected_group } from './group-chats.js';
 import { convertCharacterToPersona } from './personas.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
 import { createTagInput, getTagKeyForEntity, getTagsList, printTagList, tag_map, compareTagsForSort, removeTagFromMap, importTags, tag_import_setting } from './tags.js';
 import { t } from './i18n.js';
+
+function getBulkEntity(id) {
+    if (typeof id === 'number') {
+        return characters[id] ? characterToEntity(characters[id], id) : null;
+    }
+
+    const group = groups.find(item => String(item.id) === id);
+    return group ? groupToEntity(group) : null;
+}
 
 /**
  * Static object representing the actions of the
@@ -29,7 +44,7 @@ class CharacterContextMenu {
      * Tag one or more characters,
      * opens a popup.
      *
-     * @param {Array<number>} selectedCharacters
+     * @param {Array<number|string>} selectedCharacters
      */
     static tag = (selectedCharacters) => {
         characterGroupOverlay.bulkTagPopupHandler.show(selectedCharacters);
@@ -170,8 +185,8 @@ class CharacterContextMenu {
  */
 class BulkTagPopupHandler {
     /**
-     * The characters for this popup
-     * @type {number[]}
+     * The entity keys for this popup
+     * @type {Array<number|string>}
      */
     characterIds;
 
@@ -195,11 +210,20 @@ class BulkTagPopupHandler {
      */
     #getHtml = () => {
         const characterData = JSON.stringify({ characterIds: this.characterIds });
+        const isGroups = this.characterIds.some(id => typeof id === 'string');
+        const noun = isGroups ? 'groups' : 'characters';
+        const importButtons = isGroups ? '' : `
+                        <div id="bulk_tag_popup_import_all_tags" class="menu_button" title="Import all tags from selected characters" data-i18n="[title]Import all tags from selected characters">
+                            Import All
+                        </div>
+                        <div id="bulk_tag_popup_import_existing_tags" class="menu_button" title="Import existing tags from selected characters" data-i18n="[title]Import existing tags from selected characters">
+                            Import Existing
+                        </div>`;
         return `<div id="bulk_tag_shadow_popup">
             <div id="bulk_tag_popup" class="wider_dialogue_popup">
                 <div id="bulk_tag_popup_holder">
-                    <h3 class="marginBot5">Modify tags of ${this.characterIds.length} characters</h3>
-                    <small class="bulk_tags_desc m-b-1">Add or remove the mutual tags of all selected characters. Import all or existing tags for all selected characters.</small>
+                    <h3 class="marginBot5">Modify tags of ${this.characterIds.length} ${noun}</h3>
+                    <small class="bulk_tags_desc m-b-1">Add or remove the mutual tags of all selected ${noun}.${isGroups ? '' : ' Import all or existing tags for all selected characters.'}</small>
                     <div id="bulk_tags_avatars_block" class="avatars_inline avatars_inline_small tags tags_inline"></div>
                     <br>
                     <div id="bulk_tags_div" class="marginBot5" data-characters='${characterData}'>
@@ -210,20 +234,15 @@ class BulkTagPopupHandler {
                         <div id="bulkTagList" class="m-t-1 tags"></div>
                     </div>
                     <div id="dialogue_popup_controls" class="m-t-1">
-                        <div id="bulk_tag_popup_reset" class="menu_button" title="Remove all tags from the selected characters" data-i18n="[title]Remove all tags from the selected characters">
+                        <div id="bulk_tag_popup_reset" class="menu_button" title="Remove all tags from the selected ${noun}" data-i18n="[title]Remove all tags from the selected characters">
                             <i class="fa-solid fa-trash-can margin-right-10px"></i>
                             All
                         </div>
-                        <div id="bulk_tag_popup_remove_mutual" class="menu_button" title="Remove all mutual tags from the selected characters" data-i18n="[title]Remove all mutual tags from the selected characters">
+                        <div id="bulk_tag_popup_remove_mutual" class="menu_button" title="Remove all mutual tags from the selected ${noun}" data-i18n="[title]Remove all mutual tags from the selected characters">
                             <i class="fa-solid fa-trash-can margin-right-10px"></i>
                             Mutual
                         </div>
-                        <div id="bulk_tag_popup_import_all_tags" class="menu_button" title="Import all tags from selected characters" data-i18n="[title]Import all tags from selected characters">
-                            Import All
-                        </div>
-                        <div id="bulk_tag_popup_import_existing_tags" class="menu_button" title="Import existing tags from selected characters" data-i18n="[title]Import existing tags from selected characters">
-                            Import Existing
-                        </div>
+                        ${importButtons}
                         <div id="bulk_tag_popup_cancel" class="menu_button" data-i18n="Cancel">Close</div>
                     </div>
                 </div>
@@ -234,20 +253,20 @@ class BulkTagPopupHandler {
     /**
      * Append and show the tag control
      *
-     * @param {number[]} characterIds - The characters that are shown inside the popup
+     * @param {Array<number|string>} characterIds - The entities that are shown inside the popup
      */
     show(characterIds) {
         // shallow copy character ids persistently into this tooltip
         this.characterIds = characterIds.slice();
 
         if (this.characterIds.length == 0) {
-            console.log('No characters selected for bulk edit tags.');
+            console.log('No entities selected for bulk edit tags.');
             return;
         }
 
         document.body.insertAdjacentHTML('beforeend', this.#getHtml());
 
-        const entities = this.characterIds.map(id => characterToEntity(characters[id], id)).filter(entity => entity.item !== undefined);
+        const entities = this.characterIds.map(getBulkEntity).filter(Boolean);
         buildAvatarList($('#bulk_tags_avatars_block'), entities);
 
         // Print the tag list with all mutuable tags, marking them as removable. That is the initial fill
@@ -259,8 +278,8 @@ class BulkTagPopupHandler {
         document.querySelector('#bulk_tag_popup_reset').addEventListener('click', this.resetTags.bind(this));
         document.querySelector('#bulk_tag_popup_remove_mutual').addEventListener('click', this.removeMutual.bind(this));
         document.querySelector('#bulk_tag_popup_cancel').addEventListener('click', this.hide.bind(this));
-        document.querySelector('#bulk_tag_popup_import_all_tags').addEventListener('click', this.importAllTags.bind(this));
-        document.querySelector('#bulk_tag_popup_import_existing_tags').addEventListener('click', this.importExistingTags.bind(this));
+        document.querySelector('#bulk_tag_popup_import_all_tags')?.addEventListener('click', this.importAllTags.bind(this));
+        document.querySelector('#bulk_tag_popup_import_existing_tags')?.addEventListener('click', this.importExistingTags.bind(this));
     }
 
     /**
@@ -397,7 +416,7 @@ class BulkEditOverlay {
 
     /**
      * @typedef {object} LastSelected - An object noting the last selected character and its state.
-     * @property {number} [characterId] - The character id of the last selected character.
+     * @property {number|string} [characterId] - The key of the last selected entity.
      * @property {boolean} [select] - The selected state of the last selected character. <c>true</c> if it was selected, <c>false</c> if it was deselected.
      */
 
@@ -460,7 +479,7 @@ class BulkEditOverlay {
 
     /**
      *
-     * @returns {number[]}
+     * @returns {Array<number|string>}
      */
     get selectedCharacters() {
         return this.#selectedCharacters;
@@ -544,7 +563,7 @@ class BulkEditOverlay {
                 this.container.classList.remove(BulkEditOverlay.selectModeClass);
                 this.#contextMenuOpen = false;
                 this.#enableClickEventsForCharacters();
-                this.#enableClickEventsForGroups();
+                this.#enableClickEventsForDisabledElements();
                 this.clearSelectedCharacters();
                 this.disableContextMenu();
                 this.#disableBulkEditButtonHighlight();
@@ -553,7 +572,7 @@ class BulkEditOverlay {
             case BulkEditOverlayState.select:
                 this.container.classList.add(BulkEditOverlay.selectModeClass);
                 this.#disableClickEventsForCharacters();
-                this.#disableClickEventsForGroups();
+                this.#disableClickEventsForDisabledElements();
                 this.enableContextMenu();
                 this.#enableBulkEditButtonHighlight();
                 break;
@@ -658,9 +677,9 @@ class BulkEditOverlay {
         event.stopPropagation();
     };
 
-    #enableClickEventsForGroups = () => this.#getDisabledElements().forEach((element) => element.removeEventListener('click', this.#stopEventPropagation));
+    #enableClickEventsForDisabledElements = () => this.#getDisabledElements().forEach((element) => element.removeEventListener('click', this.#stopEventPropagation));
 
-    #disableClickEventsForGroups = () => this.#getDisabledElements().forEach((element) => element.addEventListener('click', this.#stopEventPropagation));
+    #disableClickEventsForDisabledElements = () => this.#getDisabledElements().forEach((element) => element.addEventListener('click', this.#stopEventPropagation));
 
     #enableClickEventsForCharacters = () => this.#getEnabledElements().forEach(element => element.removeEventListener('click', this.toggleCharacterSelected));
 
@@ -670,9 +689,14 @@ class BulkEditOverlay {
 
     #disableBulkEditButtonHighlight = () => document.getElementById('bulkEditButton').classList.remove('bulk_edit_overlay_active');
 
-    #getEnabledElements = () => [...this.container.getElementsByClassName(BulkEditOverlay.characterClass)];
+    // SillyBunny: group cards use data-grid but otherwise follow the same overlay flow.
+    #getEnabledElements = () => [...this.container.getElementsByClassName(BulkEditOverlay.characterClass), ...this.container.getElementsByClassName(BulkEditOverlay.groupClass)];
 
-    #getDisabledElements = () => [...this.container.getElementsByClassName(BulkEditOverlay.groupClass), ...this.container.getElementsByClassName(BulkEditOverlay.bogusFolderClass)];
+    #getDisabledElements = () => [...this.container.getElementsByClassName(BulkEditOverlay.bogusFolderClass)];
+
+    #getEntityKey = element => element.hasAttribute('data-chid')
+        ? Number(element.getAttribute('data-chid'))
+        : element.getAttribute('data-grid');
 
     toggleCharacterSelected = event => {
         event.stopPropagation();
@@ -703,10 +727,10 @@ class BulkEditOverlay {
      * @param {HTMLElement} currentCharacter - The html element of the currently toggled character
      */
     handleShiftClick = (currentCharacter) => {
-        const characterId = Number(currentCharacter.getAttribute('data-chid'));
+        const characterId = this.#getEntityKey(currentCharacter);
         const select = !this.selectedCharacters.includes(characterId);
 
-        if (this.lastSelected.characterId >= 0 && this.lastSelected.select !== undefined) {
+        if (this.lastSelected.characterId !== undefined && this.lastSelected.select !== undefined) {
             // Only if select state and the last select state match we execute the range select
             if (select === this.lastSelected.select) {
                 this.toggleCharactersInRange(currentCharacter, select);
@@ -722,7 +746,7 @@ class BulkEditOverlay {
      * @param {boolean} [param1.markState] - Whether the toggle of this character should be remembered as the last done toggle
      */
     toggleSingleCharacter = (character, { markState = true } = {}) => {
-        const characterId = Number(character.getAttribute('data-chid'));
+        const characterId = this.#getEntityKey(character);
 
         const select = !this.selectedCharacters.includes(characterId);
         const legacyBulkEditCheckbox = /** @type {HTMLInputElement} */ (character.querySelector('.' + BulkEditOverlay.legacySelectedClass));
@@ -752,7 +776,7 @@ class BulkEditOverlay {
      */
     updateSelectedCount = (countOverride = undefined) => {
         const count = countOverride ?? this.selectedCharacters.length;
-        $(`#${BulkEditOverlay.bulkSelectedCountId}`).text(count).attr('title', `${count} characters selected`);
+        $(`#${BulkEditOverlay.bulkSelectedCountId}`).text(count).attr('title', `${count} selected`);
     };
 
     /**
@@ -763,21 +787,21 @@ class BulkEditOverlay {
      * @param {boolean} select - <c>true</c> if the characters in the range are to be selected, <c>false</c> if deselected
      */
     toggleCharactersInRange = (currentCharacter, select) => {
-        const currentCharacterId = Number(currentCharacter.getAttribute('data-chid'));
-        const characters = Array.from(document.querySelectorAll('#' + BulkEditOverlay.containerId + ' .' + BulkEditOverlay.characterClass));
+        const currentCharacterId = this.#getEntityKey(currentCharacter);
+        const characters = this.#getEnabledElements();
 
-        const startIndex = characters.findIndex(c => Number(c.getAttribute('data-chid')) === Number(this.lastSelected.characterId));
-        const endIndex = characters.findIndex(c => Number(c.getAttribute('data-chid')) === currentCharacterId);
+        const startIndex = characters.findIndex(c => this.#getEntityKey(c) === this.lastSelected.characterId);
+        const endIndex = characters.findIndex(c => this.#getEntityKey(c) === currentCharacterId);
 
         for (let i = Math.min(startIndex, endIndex); i <= Math.max(startIndex, endIndex); i++) {
             const character = characters[i];
-            const characterId = Number(character.getAttribute('data-chid'));
+            const characterId = this.#getEntityKey(character);
             const isCharacterSelected = this.selectedCharacters.includes(characterId);
 
             // Only toggle the character if it wasn't on the state we have are toggling towards.
             // Also doing a weird type check, because typescript checker doesn't like the return of 'querySelectorAll'.
             if ((select && !isCharacterSelected || !select && isCharacterSelected) && character instanceof HTMLElement) {
-                this.toggleSingleCharacter(character, { markState: currentCharacterId == characterId });
+                this.toggleSingleCharacter(character, { markState: currentCharacterId === characterId });
             }
         }
     };
@@ -840,24 +864,68 @@ class BulkEditOverlay {
     /**
      * Gets the HTML as a string that is displayed inside the popup for the bulk delete
      *
-     * @param {Array<number>} characterIds - The characters that are shown inside the popup
+     * @param {Array<number|string>} entityIds - The entities that are shown inside the popup
+     * @param {boolean} isGroups - Whether the entities are groups
      * @returns String containing the html for the popup content
      */
-    static #getDeletePopupContentHtml = (characterIds) => {
+    static #getDeletePopupContentHtml = (entityIds, isGroups) => {
+        const noun = isGroups ? 'groups' : 'characters';
+        const deleteOptions = isGroups
+            ? '<p>This will also delete all your chats with that group. If you want to delete a single conversation, select a "View past chats" option in the lower left menu.</p>'
+            : `<div id="bulk_delete_options" class="m-b-1">
+                <label for="del_char_checkbox" class="checkbox_label justifyCenter">
+                    <input type="checkbox" id="del_char_checkbox" />
+                    <span>Also delete the chat files</span>
+                </label>
+            </div>`;
         return `
-            <h3 class="marginBot5">Delete ${characterIds.length} characters?</h3>
+            <h3 class="marginBot5">Delete ${entityIds.length} ${noun}?</h3>
             <span class="bulk_delete_note">
                 <i class="fa-solid fa-triangle-exclamation warning margin-r5"></i>
                 <b>THIS IS PERMANENT!</b>
             </span>
             <div id="bulk_delete_avatars_block" class="avatars_inline avatars_inline_small tags tags_inline m-t-1"></div>
             <br>
-            <div id="bulk_delete_options" class="m-b-1">
-                <label for="del_char_checkbox" class="checkbox_label justifyCenter">
-                    <input type="checkbox" id="del_char_checkbox" />
-                    <span>Also delete the chat files</span>
-                </label>
-            </div>`;
+            ${deleteOptions}`;
+    };
+
+    #deleteGroups = async (groupIds) => {
+        let deletedSelectedGroup = false;
+
+        try {
+            for (const id of groupIds) {
+                const group = groups.find(item => String(item.id) === id);
+                const response = await fetch('/api/groups/delete', {
+                    method: 'POST',
+                    headers: getRequestHeaders(),
+                    body: JSON.stringify({ id }),
+                });
+
+                if (!response.ok) {
+                    throw new Error(`Could not delete group ${id}`);
+                }
+
+                if (Array.isArray(group?.chats)) {
+                    for (const chatId of group.chats) {
+                        await eventSource.emit(event_types.GROUP_CHAT_DELETED, chatId);
+                    }
+                }
+
+                delete tag_map[id];
+                deletedSelectedGroup ||= String(selected_group) === id;
+            }
+        } finally {
+            if (deletedSelectedGroup) {
+                await clearChat();
+                resetSelectedGroup();
+                resetChatState();
+                await printMessages();
+                $('#rm_button_selected_ch').children('h2').text('');
+            }
+
+            await getCharacters();
+            this.browseState();
+        }
     };
 
     /**
@@ -867,8 +935,9 @@ class BulkEditOverlay {
      * @returns {Promise<number>}
      */
     handleContextMenuDelete = () => {
-        const characterIds = this.selectedCharacters;
-        const popupContent = $(BulkEditOverlay.#getDeletePopupContentHtml(characterIds));
+        const entityIds = this.selectedCharacters;
+        const isGroups = entityIds.some(id => typeof id === 'string');
+        const popupContent = $(BulkEditOverlay.#getDeletePopupContentHtml(entityIds, isGroups));
         const checkbox = popupContent.find('#del_char_checkbox');
         const promise = callGenericPopup(popupContent, POPUP_TYPE.CONFIRM)
             .then((accept) => {
@@ -879,17 +948,19 @@ class BulkEditOverlay {
                 const loaderHandle = loader.show({
                     slug: 'bulk-delete',
                     title: t`Bulk Delete`,
-                    message: t`Deleting ${characterIds.length} character(s)…`,
+                    message: isGroups ? t`Deleting ${entityIds.length} group(s)…` : t`Deleting ${entityIds.length} character(s)…`,
                     toastMode: loader.ToastMode.STATIC,
                 });
-                const avatarList = characterIds.map(id => characters[id]?.avatar).filter(a => a);
-                return CharacterContextMenu.delete(avatarList, deleteChats)
-                    .then(() => this.browseState())
+                const deleteRequest = isGroups
+                    ? this.#deleteGroups(entityIds.filter(id => typeof id === 'string'))
+                    : CharacterContextMenu.delete(entityIds.map(id => characters[id]?.avatar).filter(Boolean), deleteChats)
+                        .then(() => this.browseState());
+                return deleteRequest
                     .finally(() => loaderHandle.hide());
             });
 
         // At this moment the popup is already changed in the dom, but not yet closed/resolved. We build the avatar list here
-        const entities = characterIds.map(id => characterToEntity(characters[id], id)).filter(entity => entity.item !== undefined);
+        const entities = entityIds.map(getBulkEntity).filter(Boolean);
         buildAvatarList($('#bulk_delete_avatars_block'), entities);
 
         return promise;

--- a/public/scripts/bulk-edit.js
+++ b/public/scripts/bulk-edit.js
@@ -43,7 +43,8 @@ function onEditButtonClick() {
  */
 function onSelectAllButtonClick() {
     console.log('Bulk select all button clicked');
-    const characters = Array.from(document.querySelectorAll('#' + BulkEditOverlay.containerId + ' .' + BulkEditOverlay.characterClass));
+    // SillyBunny: the shell's groups view shares the upstream bulk edit controls.
+    const characters = Array.from(document.querySelectorAll('#' + BulkEditOverlay.containerId + ' .' + BulkEditOverlay.characterClass + ', #' + BulkEditOverlay.containerId + ' .' + BulkEditOverlay.groupClass));
     let atLeastOneSelected = false;
     for (const character of characters) {
         const checked = $(character).find('.bulk_select_checkbox:checked').length > 0;
@@ -78,7 +79,8 @@ async function onDeleteButtonClick() {
  * Enables bulk selection by adding a checkbox next to each character.
  */
 function enableBulkSelect() {
-    $('#rm_print_characters_block .character_select').each((i, el) => {
+    // SillyBunny: group cards participate in bulk selection alongside character cards.
+    $('#rm_print_characters_block .character_select, #rm_print_characters_block .group_select').each((i, el) => {
         // Prevent checkbox from adding multiple times (because of stage change callback)
         if ($(el).find('.bulk_select_checkbox').length > 0) {
             return;
@@ -89,7 +91,7 @@ function enableBulkSelect() {
         });
         $(el).prepend(checkbox);
     });
-    $('#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select, #rm_print_characters_block.group_overlay_mode_select .group_select')
+    $('#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select')
         .addClass('disabled');
 
     $('#rm_print_characters_block').addClass('bulk_select');
@@ -104,7 +106,7 @@ function enableBulkSelect() {
  */
 function disableBulkSelect() {
     $('.bulk_select_checkbox').remove();
-    $('#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select, #rm_print_characters_block.group_overlay_mode_select .group_select')
+    $('#rm_print_characters_block.group_overlay_mode_select .bogus_folder_select')
         .removeClass('disabled');
     $('#rm_print_characters_block').removeClass('bulk_select');
 }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -7925,11 +7925,16 @@ function syncCharacterListControls(view) {
         }
     }
 
+    for (const actionId of ['character_context_menu_favorite', 'character_context_menu_duplicate', 'character_context_menu_persona']) {
+        const action = document.getElementById(actionId)?.closest('li');
+        if (action instanceof HTMLElement) {
+            action.hidden = normalizedView === 'groups';
+        }
+    }
+
     if (bulkEditButton instanceof HTMLElement) {
-        bulkEditButton.classList.toggle('disabled', normalizedView === 'groups');
-        bulkEditButton.setAttribute('aria-disabled', String(normalizedView === 'groups'));
         bulkEditButton.title = normalizedView === 'groups'
-            ? 'Bulk edit for groups is not available yet'
+            ? 'Bulk actions for group chats'
             : 'Bulk edit characters\n\nClick to toggle characters\nShift + Click to select/deselect a range of characters\nRight-click for actions';
     }
 }
@@ -7979,19 +7984,6 @@ function ensureCharacterListToolbarLayout() {
 
     if (searchButton instanceof HTMLElement && searchButton.parentElement !== buttonBar) {
         buttonBar.appendChild(searchButton);
-    }
-
-    const bulkEditButton = document.getElementById('bulkEditButton');
-    if (bulkEditButton instanceof HTMLElement && bulkEditButton.dataset.sbGroupsGuardBound !== 'true') {
-        bulkEditButton.dataset.sbGroupsGuardBound = 'true';
-        bulkEditButton.addEventListener('click', (event) => {
-            const panel = getCharacterPanel();
-            if (panel instanceof HTMLElement && panel.dataset.menuType === 'groups') {
-                event.preventDefault();
-                event.stopImmediatePropagation();
-                globalThis.toastr?.info?.('Bulk edit for groups is not available yet.');
-            }
-        }, { capture: true });
     }
 }
 

--- a/tests/group-chat-bulk-actions.test.js
+++ b/tests/group-chat-bulk-actions.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readSource = (...parts) => readFileSync(path.join(repoRoot, ...parts), 'utf8').replace(/\r\n/g, '\n');
+
+describe('Group chat bulk actions', () => {
+    test('routes group cards through selection, tag, and delete actions', () => {
+        const tabsSource = readSource('public', 'scripts', 'sillybunny-tabs.js');
+        const tabsCssSource = readSource('public', 'css', 'sillybunny-tabs.css');
+        const bulkEditSource = readSource('public', 'scripts', 'bulk-edit.js');
+        const overlaySource = readSource('public', 'scripts', 'BulkEditOverlay.js');
+
+        expect(tabsSource).not.toContain('sbGroupsGuardBound');
+        expect(tabsSource).not.toContain('Bulk edit for groups is not available yet');
+        expect(tabsCssSource).not.toContain('[data-menu-type="groups"] #bulkSelectAllButton');
+        expect(tabsCssSource).not.toContain('[data-menu-type="groups"] #bulkDeleteButton');
+        expect(bulkEditSource).toContain('#rm_print_characters_block .character_select, #rm_print_characters_block .group_select');
+        expect(overlaySource).toContain('element.getAttribute(\'data-grid\')');
+        expect(overlaySource).toContain('fetch(\'/api/groups/delete\'');
+        expect(overlaySource).toContain('this.characterIds.map(getBulkEntity)');
+    });
+});

--- a/tests/group-chat-bulk-actions.test.js
+++ b/tests/group-chat-bulk-actions.test.js
@@ -10,6 +10,8 @@ describe('Group chat bulk actions', () => {
     test('routes group cards through selection, tag, and delete actions', () => {
         const tabsSource = readSource('public', 'scripts', 'sillybunny-tabs.js');
         const tabsCssSource = readSource('public', 'css', 'sillybunny-tabs.css');
+        const overlayCssSource = readSource('public', 'css', 'character-group-overlay.css');
+        const mobileCssSource = readSource('public', 'css', 'mobile-styles.css');
         const bulkEditSource = readSource('public', 'scripts', 'bulk-edit.js');
         const overlaySource = readSource('public', 'scripts', 'BulkEditOverlay.js');
 
@@ -17,6 +19,10 @@ describe('Group chat bulk actions', () => {
         expect(tabsSource).not.toContain('Bulk edit for groups is not available yet');
         expect(tabsCssSource).not.toContain('[data-menu-type="groups"] #bulkSelectAllButton');
         expect(tabsCssSource).not.toContain('[data-menu-type="groups"] #bulkDeleteButton');
+        expect(overlayCssSource).toContain(':is(.character_select, .group_select).character_selected');
+        expect(overlayCssSource).not.toContain('.bogus_folder_select,\n#rm_print_characters_block.group_overlay_mode_select .group_select');
+        expect(mobileCssSource).toContain('#rm_print_characters_block.bulk_select > :is(.character_select, .group_select)');
+        expect(tabsCssSource).toContain('#rm_print_characters_block.bulk_select:not(.group_overlay_mode_select) > :is(.character_select, .group_select) > .bulk_select_checkbox');
         expect(bulkEditSource).toContain('#rm_print_characters_block .character_select, #rm_print_characters_block .group_select');
         expect(overlaySource).toContain('element.getAttribute(\'data-grid\')');
         expect(overlaySource).toContain('fetch(\'/api/groups/delete\'');


### PR DESCRIPTION
An upstream limitation where the bulk actions button is unavailable and can't be used. It can now be used.