### PR TITLE
fix: prevent Bun LinkAPI timeout crashes

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1,5 +1,7 @@
 /* eslint-disable dot-notation */
 import process from 'node:process';
+import https from 'node:https';
+import { text } from 'node:stream/consumers';
 import nodeUtil from 'node:util';
 import express from 'express';
 import fetch from 'node-fetch';
@@ -61,6 +63,7 @@ import {
     addOpenRouterSignatures,
 } from '../../prompt-converters.js';
 import { applyReasoningEffortNormalization } from '../../reasoning-effort.js';
+import { isBunRuntime } from '../../runtime.js';
 
 import { readSecret, SECRET_KEYS } from '../secrets.js';
 import {
@@ -320,6 +323,26 @@ function setJsonObjectFormat(bodyParams, messages, jsonSchema) {
     messages.push(message);
 }
 
+function fetchBunLinkApiStream(url, options) {
+    return new Promise((resolve, reject) => {
+        const { body, ...requestOptions } = options;
+        const upstreamRequest = https.request(url, requestOptions, upstreamResponse => {
+            upstreamRequest.setTimeout(0);
+            const status = upstreamResponse.statusCode ?? 500;
+            resolve({
+                ok: status >= 200 && status < 300,
+                status,
+                statusText: upstreamResponse.statusMessage ?? '',
+                body: upstreamResponse,
+                text: () => text(upstreamResponse),
+            });
+        });
+
+        upstreamRequest.once('error', reject);
+        upstreamRequest.end(body);
+    });
+}
+
 /**
  * Sends a request to Claude API.
  * @param {express.Request} request Express request
@@ -510,7 +533,8 @@ async function sendClaudeRequest(request, response) {
 
         logVerboseGenerationRequest('Claude', request, requestBody);
 
-        const generateResponse = await fetch(apiUrl + '/messages', {
+        const requestUrl = apiUrl + '/messages';
+        const requestOptions = {
             method: 'POST',
             signal: controller.signal,
             body: JSON.stringify(requestBody),
@@ -520,7 +544,11 @@ async function sendClaudeRequest(request, response) {
                 'x-api-key': apiKey,
                 ...additionalHeaders,
             },
-        });
+        };
+        // SillyBunny: node-fetch's stream pipeline leaks Bun timeout rejections; direct HTTPS preserves global agents.
+        const generateResponse = isBunRuntime() && request.body.stream && request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.LINKAPI
+            ? await fetchBunLinkApiStream(requestUrl, requestOptions)
+            : await fetch(requestUrl, requestOptions);
 
         if (request.body.stream) {
             // Pipe remote SSE stream to Express response

--- a/src/util.js
+++ b/src/util.js
@@ -835,6 +835,9 @@ export async function forwardFetchResponse(from, to, request = null, onDisconnec
                 }
                 return;
             }
+
+            console.warn('Streaming request failed:', error?.message ?? error);
+            to.end();
         });
     } else {
         to.end();

--- a/tests/claude-sonnet5.test.js
+++ b/tests/claude-sonnet5.test.js
@@ -1,8 +1,12 @@
 import { beforeAll, afterAll, describe, expect, jest, test } from '@jest/globals';
 import express from 'express';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
+import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
 import { setConfigFilePath } from '../src/util.js';
@@ -52,11 +56,13 @@ describe('Claude 5 backend request handling', () => {
         tempDirs.push(configRoot);
         setConfigFilePath(configPath);
 
+        const { SECRET_KEYS, SecretManager } = await import('../src/endpoints/secrets.js');
         const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
 
         const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-claude-sonnet5-'));
         tempDirs.push(userRoot);
         userDirectories = { root: userRoot, backups: userRoot };
+        new SecretManager(userDirectories).writeSecret(SECRET_KEYS.LINKAPI, 'linkapi-test-key');
 
         const app = express();
         app.use(express.json());
@@ -219,5 +225,42 @@ describe('Claude 5 backend request handling', () => {
         const lastMessage = body.messages[body.messages.length - 1];
         // noPrefillModel: last assistant role must have been converted to user
         expect(lastMessage.role).not.toBe('assistant');
+    });
+
+    test('Bun LinkAPI streams bypass the leaking node-fetch pipeline', async () => {
+        Object.defineProperty(process.versions, 'bun', { configurable: true, value: 'test' });
+        nodeFetchMock.mockReset();
+        nodeFetchMock.mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'));
+        const upstreamResponse = Object.assign(new PassThrough(), {
+            statusCode: 200,
+            statusMessage: 'OK',
+        });
+        const upstreamRequest = Object.assign(new EventEmitter(), {
+            setTimeout: jest.fn(),
+            end: jest.fn(() => upstreamResponse.end('data: [DONE]\n\n')),
+        });
+        const requestSpy = jest.spyOn(https, 'request').mockImplementation((_url, _options, callback) => {
+            process.nextTick(() => callback(upstreamResponse));
+            return upstreamRequest;
+        });
+
+        try {
+            const res = await makeRequest({
+                chat_completion_source: CHAT_COMPLETION_SOURCES.LINKAPI,
+                linkapi_endpoint: 'us',
+                model: 'claude-fable-5',
+                stream: true,
+            });
+
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('data: [DONE]\n\n');
+            expect(requestSpy).toHaveBeenCalledWith('https://api.linkapi.ai/v1/messages', expect.any(Object), expect.any(Function));
+            expect(nodeFetchMock).not.toHaveBeenCalled();
+        } finally {
+            requestSpy.mockRestore();
+            nodeFetchMock.mockReset();
+            nodeFetchMock.mockImplementation((url, options) => actualNodeFetch(url, options));
+            delete process.versions.bun;
+        }
     });
 });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -181,6 +181,20 @@ describe('forwardFetchResponse', () => {
         expect(response.writableEnded).toBe(true);
     });
 
+    test('should finish the client response when upstream streaming fails', async () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const upstreamBody = new PassThrough();
+        const response = createMockExpressResponse();
+        response.socket = {};
+        const bodyPromise = collectResponseBody(response);
+
+        await forwardFetchResponse(new Response(upstreamBody), response);
+        upstreamBody.emit('error', new Error('The operation timed out.'));
+
+        await expect(bodyPromise).resolves.toBe('');
+        expect(response.writableEnded).toBe(true);
+    });
+
     test('should log JSON error bodies and return the original body for non-2xx streaming responses', async () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
         const body = JSON.stringify({ error: { message: 'Forbidden by upstream policy' }, detail: 'policy_denied' });


### PR DESCRIPTION
Prevents LinkAPI streaming requests from crashing SillyBunny under Bun by bypassing the node-fetch stream implementation, using native HTTPS for that specific path, and closing client responses when upstream streams fail. It happened specifically because Fable 5 was sometimes unavailable, and instead of simply erroring out it timed out and crashed.