### PR TITLE
feat: add Chats Archive as a core extension

### DIFF
--- a/public/scripts/extensions/sillybunny-chats-archive/index.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/index.js
@@ -1,0 +1,136 @@
+import { closeArchive, openArchive } from './src/ui.js';
+
+const PANEL_SELECTOR = '#right-nav-panel';
+const BUTTON_ID = 'sbca_drawer_button';
+const OBSERVER_DEBOUNCE_MS = 150;
+
+let active = false;
+let observer = null;
+let observerTarget = null;
+let pending = null;
+let readyHandler = null;
+let closing = null;
+let lifecycleGeneration = 0;
+
+function onOpen(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const ctx = globalThis.SillyTavern.getContext();
+    void openArchive(ctx, event.currentTarget).catch(error => {
+        console.error('[Chat Archive] failed to open:', error);
+        globalThis.toastr?.error(ctx.translate?.('Could not open Chat Archive.') ?? 'Could not open Chat Archive.');
+    });
+}
+
+function ensureButton() {
+    const container = document.getElementById('rm_buttons_container');
+    if (!container) {
+        return;
+    }
+    let button = document.getElementById(BUTTON_ID);
+    if (!button) {
+        const ctx = globalThis.SillyTavern.getContext();
+        const label = ctx.translate?.('Chat Archive') ?? 'Chat Archive';
+        button = document.createElement('button');
+        button.id = BUTTON_ID;
+        button.className = 'menu_button sbca-drawer-button';
+        button.type = 'button';
+        button.title = label;
+        button.setAttribute('aria-label', label);
+        button.setAttribute('aria-haspopup', 'dialog');
+        const icon = document.createElement('i');
+        icon.className = 'fa-solid fa-box-archive';
+        icon.setAttribute('aria-hidden', 'true');
+        button.append(icon);
+        button.addEventListener('click', onOpen);
+    }
+    if (button.parentElement !== container) {
+        container.append(button);
+    }
+}
+
+function ensureEntryPoints() {
+    ensureButton();
+}
+
+function install() {
+    ensureEntryPoints();
+    const target = document.querySelector(PANEL_SELECTOR) ?? document.body;
+    if (!observer) {
+        // The fork re-renders the character shell in places; re-assert cheaply.
+        observer = new MutationObserver(() => {
+            if (pending !== null) {
+                return;
+            }
+            pending = setTimeout(() => {
+                pending = null;
+                install();
+            }, OBSERVER_DEBOUNCE_MS);
+        });
+    }
+    if (observerTarget !== target) {
+        observer.disconnect();
+        observer.observe(target, { childList: true, subtree: true });
+        if (target !== document.body && target.parentElement) {
+            observer.observe(target.parentElement, { childList: true });
+        }
+        observerTarget = target;
+    }
+}
+
+async function init() {
+    const generation = ++lifecycleGeneration;
+    if (closing) {
+        await closing;
+    }
+    if (generation !== lifecycleGeneration || active) {
+        return;
+    }
+    active = true;
+    const ctx = globalThis.SillyTavern.getContext();
+    readyHandler = () => install();
+    ctx.eventSource.on(ctx.eventTypes.APP_READY, readyHandler);
+    install();
+}
+
+async function deactivate() {
+    lifecycleGeneration++;
+    if (!active) {
+        return closing;
+    }
+    active = false;
+    const ctx = globalThis.SillyTavern.getContext();
+    if (readyHandler) {
+        ctx.eventSource.removeListener(ctx.eventTypes.APP_READY, readyHandler);
+        readyHandler = null;
+    }
+    if (pending !== null) {
+        clearTimeout(pending);
+        pending = null;
+    }
+    observer?.disconnect();
+    observer = null;
+    observerTarget = null;
+    document.getElementById(BUTTON_ID)?.remove();
+    const operation = closeArchive();
+    closing = operation;
+    try {
+        await operation;
+    } finally {
+        if (closing === operation) {
+            closing = null;
+        }
+    }
+}
+
+export function activate() {
+    return init();
+}
+
+export function enable() {
+    return init();
+}
+
+export function disable() {
+    return deactivate();
+}

--- a/public/scripts/extensions/sillybunny-chats-archive/index.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/index.js
@@ -41,7 +41,10 @@ function ensureButton() {
         const icon = document.createElement('i');
         icon.className = 'fa-solid fa-box-archive';
         icon.setAttribute('aria-hidden', 'true');
-        button.append(icon);
+        const text = document.createElement('span');
+        text.className = 'sbca-drawer-button-label';
+        text.textContent = label;
+        button.append(icon, text);
         button.addEventListener('click', onOpen);
     }
     if (button.parentElement !== container) {

--- a/public/scripts/extensions/sillybunny-chats-archive/manifest.json
+++ b/public/scripts/extensions/sillybunny-chats-archive/manifest.json
@@ -1,0 +1,20 @@
+{
+    "display_name": "Chat Archive",
+    "author": "platberlitz",
+    "version": "0.4.0",
+    "description": "Browse, search, inspect, organize, and export linked chats, root files, and explicitly discovered orphaned chats. Chat files remain read-only; organization is stored in a user-file sidecar.",
+    "requires": [],
+    "optional": [],
+    "dependencies": [],
+    "js": "index.js",
+    "css": "style.css",
+    "license": "AGPL-3.0",
+    "homePage": "https://github.com/platberlitz/SillyBunny-Chats-Archive",
+    "loading_order": 140,
+    "auto_update": false,
+    "hooks": {
+        "activate": "activate",
+        "enable": "enable",
+        "disable": "disable"
+    }
+}

--- a/public/scripts/extensions/sillybunny-chats-archive/src/api.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/api.js
@@ -36,6 +36,9 @@ async function postArray(ctx, url, body, signal) {
 
 export const ORGANIZATION_FILE_NAME = '_sbca_organization.json';
 const ORGANIZATION_UPLOAD_TIMEOUT_MS = 15_000;
+const ARCHIVE_RELEASE_TIMEOUT_MS = 15_000;
+export const ARCHIVE_PAGE_SIZE = 250;
+const ARCHIVE_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
 
 function utf8ToBase64(text) {
     const bytes = new TextEncoder().encode(text);
@@ -46,27 +49,110 @@ function utf8ToBase64(text) {
     return btoa(binary);
 }
 
-async function fetchChatFiles(ctx, avatar, signal, simple = true) {
-    const url = '/api/characters/chats';
-    const data = await post(ctx, url, { avatar_url: avatar, simple }, signal);
-    if (data?.error === true) {
-        return [];
+export const searchScope = (ctx, query, scope, signal) => postArray(ctx, '/api/chats/search', { query, ...scope }, signal);
+export const exportChat = (ctx, body, signal) => post(ctx, '/api/chats/export', body, signal);
+
+function abortReason(signal) {
+    return signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+}
+
+export function createTimedSignal(signal, timeoutMs) {
+    const controller = new AbortController();
+    const onAbort = () => controller.abort(abortReason(signal));
+    const timer = setTimeout(() => {
+        controller.abort(new DOMException('The operation timed out.', 'TimeoutError'));
+    }, timeoutMs);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) {
+        onAbort();
     }
-    if (!Array.isArray(data)) {
-        throw new Error(`${url} returned an invalid response`);
+    return {
+        signal: controller.signal,
+        cleanup() {
+            clearTimeout(timer);
+            signal?.removeEventListener('abort', onAbort);
+        },
+    };
+}
+
+function parseArchivePage(data, expectedToken) {
+    if (!data || typeof data !== 'object' || Array.isArray(data) || !Array.isArray(data.rows)) {
+        throw new Error('/api/chats/archive/inventory returned an invalid response');
+    }
+    if (data.cursor !== null && (typeof data.cursor !== 'string' || !ARCHIVE_TOKEN_PATTERN.test(data.cursor))) {
+        throw new Error('/api/chats/archive/inventory returned an invalid cursor');
+    }
+    if (data.read_token !== null
+        && data.read_token !== undefined
+        && (typeof data.read_token !== 'string' || !ARCHIVE_TOKEN_PATTERN.test(data.read_token))) {
+        throw new Error('/api/chats/archive/inventory returned an invalid read token');
+    }
+    if (expectedToken && data.read_token !== expectedToken) {
+        throw new Error('/api/chats/archive/inventory changed read tokens mid-scan');
+    }
+    if (!Number.isSafeInteger(data.errors) || data.errors < 0) {
+        throw new Error('/api/chats/archive/inventory returned an invalid error count');
     }
     return data;
 }
 
-// The host may balance up to twice max across group and solo chats; 100 still bounds startup while covering the first list page.
-export const fetchRecent = (ctx, signal) => postArray(ctx, '/api/chats/recent', { max: 100 }, signal);
-export const fetchRootFiles = (ctx, signal) => fetchChatFiles(ctx, '', signal);
-// Full per-file stats (previews, counts, sizes); reads each of the character's files, so call it for one character at a time.
-export const fetchCharacterChatDetails = (ctx, avatar, signal) => fetchChatFiles(ctx, avatar, signal, false);
-export const searchScope = (ctx, query, scope, signal) => postArray(ctx, '/api/chats/search', { query, ...scope }, signal);
-export const exportChat = (ctx, body, signal) => post(ctx, '/api/chats/export', body, signal);
-export const fetchDataMaidReport = (ctx, signal) => post(ctx, '/api/data-maid/report', {}, signal);
-export const finalizeDataMaid = (ctx, token, signal) => post(ctx, '/api/data-maid/finalize', { token }, signal);
+export async function fetchArchiveInventory(ctx, scope, signal, onPage = null) {
+    if (!['archive', 'orphans'].includes(scope)) {
+        throw new TypeError(`Unsupported archive inventory scope: ${String(scope)}`);
+    }
+
+    const rows = [];
+    let cursor = null;
+    let readToken = null;
+    let errors = 0;
+    let pages = 0;
+    try {
+        do {
+            if (signal?.aborted) {
+                throw abortReason(signal);
+            }
+            const body = { scope, page_size: ARCHIVE_PAGE_SIZE };
+            if (cursor) {
+                body.cursor = cursor;
+            }
+            const page = parseArchivePage(
+                await post(ctx, '/api/chats/archive/inventory', body, signal),
+                readToken,
+            );
+            readToken ??= page.read_token ?? null;
+            if (signal?.aborted) {
+                throw abortReason(signal);
+            }
+            rows.push(...page.rows);
+            errors += page.errors;
+            onPage?.({ loaded: rows.length, errors });
+            cursor = page.cursor;
+            pages++;
+            if (cursor && page.rows.length === 0) {
+                throw new Error('/api/chats/archive/inventory returned an empty partial page');
+            }
+            if (pages > 100_000) {
+                throw new Error('/api/chats/archive/inventory exceeded the page limit');
+            }
+        } while (cursor);
+    } catch (error) {
+        if (readToken && error && typeof error === 'object') {
+            error.archiveReadToken = readToken;
+        }
+        if (cursor && error && typeof error === 'object') {
+            error.archiveCursor = cursor;
+        }
+        throw error;
+    }
+
+    if (scope === 'orphans' && !readToken) {
+        throw new Error('/api/chats/archive/inventory omitted the orphan read token');
+    }
+    if (scope === 'archive' && readToken) {
+        throw new Error('/api/chats/archive/inventory exposed a read token for linked chats');
+    }
+    return { rows, errors, readToken };
+}
 
 export async function fetchOrganization(ctx, signal) {
     const url = `/user/files/${ORGANIZATION_FILE_NAME}`;
@@ -85,68 +171,41 @@ export async function fetchOrganization(ctx, signal) {
     return response.json();
 }
 
-export function saveOrganization(ctx, organization, signal) {
+export async function saveOrganization(ctx, organization, signal) {
     const data = utf8ToBase64(JSON.stringify(organization));
-    const timeout = AbortSignal.timeout(ORGANIZATION_UPLOAD_TIMEOUT_MS);
-    const requestSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
-    return post(ctx, '/api/files/upload', { name: ORGANIZATION_FILE_NAME, data }, requestSignal);
-}
-
-export async function fetchCharacterFiles(ctx, avatars, signal) {
-    const rows = [];
-    const failedAvatars = new Set();
-    let failures = 0;
-    const results = new Array(avatars.length);
-    let nextIndex = 0;
-    const worker = async () => {
-        while (!signal?.aborted) {
-            const index = nextIndex++;
-            if (index >= avatars.length) {
-                return;
-            }
-            try {
-                results[index] = { status: 'fulfilled', value: await fetchChatFiles(ctx, avatars[index], signal) };
-            } catch (reason) {
-                results[index] = { status: 'rejected', reason };
-            }
-        }
-    };
-    await Promise.all(Array.from({ length: Math.min(8, avatars.length) }, worker));
-    if (signal?.aborted) {
-        throw signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+    const request = createTimedSignal(signal, ORGANIZATION_UPLOAD_TIMEOUT_MS);
+    try {
+        return await post(ctx, '/api/files/upload', { name: ORGANIZATION_FILE_NAME, data }, request.signal);
+    } finally {
+        request.cleanup();
     }
-    results.forEach((result, index) => {
-        const avatar = avatars[index];
-        if (result.status === 'fulfilled') {
-            for (const row of result.value) {
-                if (!row || typeof row !== 'object' || Array.isArray(row)) {
-                    failures++;
-                    failedAvatars.add(avatar);
-                    continue;
-                }
-                rows.push({ ...row, avatar, _source: 'inventory' });
-            }
-        } else {
-            if (result.reason?.name === 'AbortError') {
-                throw result.reason;
-            }
-            if (!failedAvatars.has(avatar)) {
-                failures++;
-                failedAvatars.add(avatar);
-            }
-        }
-    });
-    return { rows, failures, failedAvatars };
 }
 
-export async function fetchDataMaidFile(ctx, token, hash, signal) {
+export async function fetchArchiveFile(ctx, token, hash, signal) {
     const query = new URLSearchParams({ token, hash });
-    const response = await fetch(`/api/data-maid/view?${query}`, {
+    const response = await fetch(`/api/chats/archive/view?${query}`, {
         headers: ctx.getRequestHeaders(),
         signal,
     });
     if (!response.ok) {
-        throw new Error(`/api/data-maid/view failed with status ${response.status}`);
+        const error = new Error(`/api/chats/archive/view failed with status ${response.status}`);
+        error.status = response.status;
+        throw error;
     }
     return response.text();
+}
+
+export async function releaseArchiveSession(ctx, { token = null, cursor = null } = {}, signal) {
+    if (!token && !cursor) {
+        return;
+    }
+    const request = createTimedSignal(signal, ARCHIVE_RELEASE_TIMEOUT_MS);
+    try {
+        await post(ctx, '/api/chats/archive/release', {
+            ...(token ? { token } : {}),
+            ...(cursor ? { cursor } : {}),
+        }, request.signal);
+    } finally {
+        request.cleanup();
+    }
 }

--- a/public/scripts/extensions/sillybunny-chats-archive/src/api.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/api.js
@@ -75,7 +75,7 @@ export function createTimedSignal(signal, timeoutMs) {
     };
 }
 
-function parseArchivePage(data, expectedToken) {
+function parseArchivePage(data, expectedToken, expectedTotal) {
     if (!data || typeof data !== 'object' || Array.isArray(data) || !Array.isArray(data.rows)) {
         throw new Error('/api/chats/archive/inventory returned an invalid response');
     }
@@ -93,19 +93,27 @@ function parseArchivePage(data, expectedToken) {
     if (!Number.isSafeInteger(data.errors) || data.errors < 0) {
         throw new Error('/api/chats/archive/inventory returned an invalid error count');
     }
+    if (!Number.isSafeInteger(data.total) || data.total < data.rows.length) {
+        throw new Error('/api/chats/archive/inventory returned an invalid total');
+    }
+    if (expectedTotal !== null && data.total !== expectedTotal) {
+        throw new Error('/api/chats/archive/inventory changed totals mid-scan');
+    }
     return data;
 }
 
-export async function fetchArchiveInventory(ctx, scope, signal, onPage = null) {
+export async function* iterateArchiveInventoryPages(ctx, scope, signal) {
     if (!['archive', 'orphans'].includes(scope)) {
         throw new TypeError(`Unsupported archive inventory scope: ${String(scope)}`);
     }
 
-    const rows = [];
     let cursor = null;
     let readToken = null;
+    let total = null;
+    let loaded = 0;
     let errors = 0;
     let pages = 0;
+    let complete = false;
     try {
         do {
             if (signal?.aborted) {
@@ -118,23 +126,46 @@ export async function fetchArchiveInventory(ctx, scope, signal, onPage = null) {
             const page = parseArchivePage(
                 await post(ctx, '/api/chats/archive/inventory', body, signal),
                 readToken,
+                total,
             );
             readToken ??= page.read_token ?? null;
+            total ??= page.total;
+            cursor = page.cursor;
+            if (scope === 'orphans' && !readToken) {
+                throw new Error('/api/chats/archive/inventory omitted the orphan read token');
+            }
+            if (scope === 'archive' && readToken) {
+                throw new Error('/api/chats/archive/inventory exposed a read token for linked chats');
+            }
             if (signal?.aborted) {
                 throw abortReason(signal);
             }
-            rows.push(...page.rows);
+            loaded += page.rows.length;
             errors += page.errors;
-            onPage?.({ loaded: rows.length, errors });
-            cursor = page.cursor;
             pages++;
+            if (loaded > total) {
+                throw new Error('/api/chats/archive/inventory exceeded its declared total');
+            }
             if (cursor && page.rows.length === 0) {
                 throw new Error('/api/chats/archive/inventory returned an empty partial page');
             }
             if (pages > 100_000) {
                 throw new Error('/api/chats/archive/inventory exceeded the page limit');
             }
+            yield {
+                rows: page.rows,
+                loaded,
+                errors,
+                pageErrors: page.errors,
+                cursor,
+                readToken,
+                total,
+            };
         } while (cursor);
+        if (loaded !== total) {
+            throw new Error('/api/chats/archive/inventory completed before its declared total');
+        }
+        complete = true;
     } catch (error) {
         if (readToken && error && typeof error === 'object') {
             error.archiveReadToken = readToken;
@@ -143,13 +174,26 @@ export async function fetchArchiveInventory(ctx, scope, signal, onPage = null) {
             error.archiveCursor = cursor;
         }
         throw error;
+    } finally {
+        if (!complete && (readToken || cursor)) {
+            try {
+                await releaseArchiveSession(ctx, { token: readToken, cursor });
+            } catch {
+                // The server also discards an inventory when its request is aborted.
+            }
+        }
     }
+}
 
-    if (scope === 'orphans' && !readToken) {
-        throw new Error('/api/chats/archive/inventory omitted the orphan read token');
-    }
-    if (scope === 'archive' && readToken) {
-        throw new Error('/api/chats/archive/inventory exposed a read token for linked chats');
+export async function fetchArchiveInventory(ctx, scope, signal, onPage = null) {
+    const rows = [];
+    let errors = 0;
+    let readToken = null;
+    for await (const page of iterateArchiveInventoryPages(ctx, scope, signal)) {
+        rows.push(...page.rows);
+        errors = page.errors;
+        readToken = page.readToken;
+        onPage?.(page);
     }
     return { rows, errors, readToken };
 }

--- a/public/scripts/extensions/sillybunny-chats-archive/src/api.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/api.js
@@ -49,6 +49,24 @@ function utf8ToBase64(text) {
     return btoa(binary);
 }
 
+function base64ToUtf8(value) {
+    const binary = atob(value.trim());
+    const bytes = Uint8Array.from(binary, character => character.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+}
+
+function parseOrganizationResponse(text) {
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        try {
+            return JSON.parse(base64ToUtf8(text));
+        } catch {
+            throw error;
+        }
+    }
+}
+
 export const searchScope = (ctx, query, scope, signal) => postArray(ctx, '/api/chats/search', { query, ...scope }, signal);
 export const exportChat = (ctx, body, signal) => post(ctx, '/api/chats/export', body, signal);
 
@@ -212,7 +230,7 @@ export async function fetchOrganization(ctx, signal) {
     if (!response.ok) {
         throw new Error(`${url} failed with status ${response.status}`);
     }
-    return response.json();
+    return parseOrganizationResponse(await response.text());
 }
 
 export async function saveOrganization(ctx, organization, signal) {

--- a/public/scripts/extensions/sillybunny-chats-archive/src/api.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/api.js
@@ -1,0 +1,152 @@
+// The extension's entire network surface.
+
+async function post(ctx, url, body, signal) {
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: ctx.getRequestHeaders(),
+        body: JSON.stringify(body),
+        signal,
+    });
+    if (response.status === 204) {
+        return null;
+    }
+    if (!response.ok) {
+        let message;
+        try {
+            message = (await response.json())?.message;
+        } catch (error) {
+            if (error?.name === 'AbortError') {
+                throw error;
+            }
+        }
+        const error = new Error(message || `${url} failed with status ${response.status}`);
+        error.status = response.status;
+        throw error;
+    }
+    return response.json();
+}
+
+async function postArray(ctx, url, body, signal) {
+    const data = await post(ctx, url, body, signal);
+    if (!Array.isArray(data)) {
+        throw new Error(`${url} returned an invalid response`);
+    }
+    return data;
+}
+
+export const ORGANIZATION_FILE_NAME = '_sbca_organization.json';
+const ORGANIZATION_UPLOAD_TIMEOUT_MS = 15_000;
+
+function utf8ToBase64(text) {
+    const bytes = new TextEncoder().encode(text);
+    let binary = '';
+    for (let index = 0; index < bytes.length; index += 0x8000) {
+        binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000));
+    }
+    return btoa(binary);
+}
+
+async function fetchChatFiles(ctx, avatar, signal, simple = true) {
+    const url = '/api/characters/chats';
+    const data = await post(ctx, url, { avatar_url: avatar, simple }, signal);
+    if (data?.error === true) {
+        return [];
+    }
+    if (!Array.isArray(data)) {
+        throw new Error(`${url} returned an invalid response`);
+    }
+    return data;
+}
+
+// The host may balance up to twice max across group and solo chats; 100 still bounds startup while covering the first list page.
+export const fetchRecent = (ctx, signal) => postArray(ctx, '/api/chats/recent', { max: 100 }, signal);
+export const fetchRootFiles = (ctx, signal) => fetchChatFiles(ctx, '', signal);
+// Full per-file stats (previews, counts, sizes); reads each of the character's files, so call it for one character at a time.
+export const fetchCharacterChatDetails = (ctx, avatar, signal) => fetchChatFiles(ctx, avatar, signal, false);
+export const searchScope = (ctx, query, scope, signal) => postArray(ctx, '/api/chats/search', { query, ...scope }, signal);
+export const exportChat = (ctx, body, signal) => post(ctx, '/api/chats/export', body, signal);
+export const fetchDataMaidReport = (ctx, signal) => post(ctx, '/api/data-maid/report', {}, signal);
+export const finalizeDataMaid = (ctx, token, signal) => post(ctx, '/api/data-maid/finalize', { token }, signal);
+
+export async function fetchOrganization(ctx, signal) {
+    const url = `/user/files/${ORGANIZATION_FILE_NAME}`;
+    const response = await fetch(url, {
+        method: 'GET',
+        headers: ctx.getRequestHeaders(),
+        cache: 'no-store',
+        signal,
+    });
+    if (response.status === 404) {
+        return null;
+    }
+    if (!response.ok) {
+        throw new Error(`${url} failed with status ${response.status}`);
+    }
+    return response.json();
+}
+
+export function saveOrganization(ctx, organization, signal) {
+    const data = utf8ToBase64(JSON.stringify(organization));
+    const timeout = AbortSignal.timeout(ORGANIZATION_UPLOAD_TIMEOUT_MS);
+    const requestSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+    return post(ctx, '/api/files/upload', { name: ORGANIZATION_FILE_NAME, data }, requestSignal);
+}
+
+export async function fetchCharacterFiles(ctx, avatars, signal) {
+    const rows = [];
+    const failedAvatars = new Set();
+    let failures = 0;
+    const results = new Array(avatars.length);
+    let nextIndex = 0;
+    const worker = async () => {
+        while (!signal?.aborted) {
+            const index = nextIndex++;
+            if (index >= avatars.length) {
+                return;
+            }
+            try {
+                results[index] = { status: 'fulfilled', value: await fetchChatFiles(ctx, avatars[index], signal) };
+            } catch (reason) {
+                results[index] = { status: 'rejected', reason };
+            }
+        }
+    };
+    await Promise.all(Array.from({ length: Math.min(8, avatars.length) }, worker));
+    if (signal?.aborted) {
+        throw signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+    }
+    results.forEach((result, index) => {
+        const avatar = avatars[index];
+        if (result.status === 'fulfilled') {
+            for (const row of result.value) {
+                if (!row || typeof row !== 'object' || Array.isArray(row)) {
+                    failures++;
+                    failedAvatars.add(avatar);
+                    continue;
+                }
+                rows.push({ ...row, avatar, _source: 'inventory' });
+            }
+        } else {
+            if (result.reason?.name === 'AbortError') {
+                throw result.reason;
+            }
+            if (!failedAvatars.has(avatar)) {
+                failures++;
+                failedAvatars.add(avatar);
+            }
+        }
+    });
+    return { rows, failures, failedAvatars };
+}
+
+export async function fetchDataMaidFile(ctx, token, hash, signal) {
+    const query = new URLSearchParams({ token, hash });
+    const response = await fetch(`/api/data-maid/view?${query}`, {
+        headers: ctx.getRequestHeaders(),
+        signal,
+    });
+    if (!response.ok) {
+        throw new Error(`/api/data-maid/view failed with status ${response.status}`);
+    }
+    return response.text();
+}

--- a/public/scripts/extensions/sillybunny-chats-archive/src/core.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/core.js
@@ -748,8 +748,12 @@ export function filterRows(rows, options = {}, organization = null) {
     const owner = trimmed(options.owner);
     const collection = trimmed(options.collection);
     const tag = trimmed(options.tag).toLowerCase();
+    // Runtime-only flag: an active Favorites category keeps favorites listed even when their own chat type is off.
+    const favoritesSelected = options.favoritesSelected === true;
     return rows.filter(row => {
-        if (options.kinds && !options.kinds.includes(row.kind)) {
+        const metadata = chatMetadata(row, organization);
+        const isFavorite = metadata.favorite === true;
+        if (options.kinds && !options.kinds.includes(row.kind) && !(favoritesSelected && isFavorite)) {
             return false;
         }
         if (owner && !matchesOwner(row, owner)) {
@@ -759,8 +763,7 @@ export function filterRows(rows, options = {}, organization = null) {
             return false;
         }
 
-        const metadata = chatMetadata(row, organization);
-        if (typeof options.favorite === 'boolean' && (metadata.favorite === true) !== options.favorite) {
+        if (typeof options.favorite === 'boolean' && isFavorite !== options.favorite) {
             return false;
         }
         if (hasFolderFilter && (options.folder === null ? !!metadata.folder : metadata.folder !== options.folder)) {
@@ -858,7 +861,15 @@ export function groupRows(rows, mode = 'flat', organization = null) {
         }
         groups.get(key).rows.push(row);
     }
-    return [...groups.values()];
+    const result = [...groups.values()];
+    if (selectedMode !== 'folder') {
+        return result;
+    }
+    const unfiledKey = JSON.stringify(['folder', null]);
+    return [
+        ...result.filter(group => group.key !== unfiledKey),
+        ...result.filter(group => group.key === unfiledKey),
+    ];
 }
 
 /**

--- a/public/scripts/extensions/sillybunny-chats-archive/src/core.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/core.js
@@ -1,0 +1,930 @@
+// Pure data helpers: no DOM and no fetch.
+
+const SIZE_UNITS = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4 };
+const CHAT_KINDS = new Set(['solo', 'group', 'orphan']);
+const ORPHAN_TYPES = new Set(['missing-character', 'missing-group', 'unlinked-group', 'root']);
+const SORT_KEYS = new Set(['recent', 'oldest', 'size', 'smallest', 'count', 'fewest', 'name', 'name-reverse', 'owner']);
+const GROUP_KEYS = new Set(['flat', 'owner', 'type', 'folder']);
+const DENSITIES = new Set(['comfortable', 'compact', 'minimal']);
+const OWNER_FILTER_KINDS = new Set(['character', 'group']);
+const OWNER_FILTER_PREFIX = '@sbca:';
+const PREVIEW_LENGTH = 400;
+const JSONL_CHUNK_SIZE = 1000;
+
+function isRecord(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validTimestamp(value) {
+    const timestamp = Number(value);
+    return Number.isFinite(new Date(timestamp).valueOf()) ? timestamp : 0;
+}
+
+function trimmed(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function previewText(value, maxLength = Infinity) {
+    const preview = trimmed(value).replace(/\s+/g, ' ');
+    return preview.length > maxLength ? `${preview.slice(0, maxLength - 3)}...` : preview;
+}
+
+function uniqueStrings(values, allowed = null) {
+    const result = [];
+    const seen = new Set();
+    for (const value of Array.isArray(values) ? values : []) {
+        const item = trimmed(value);
+        const folded = item.toLowerCase();
+        if (item && !seen.has(folded) && (!allowed || allowed.has(item))) {
+            seen.add(folded);
+            result.push(item);
+        }
+    }
+    return result;
+}
+
+function uniqueIds(values) {
+    const result = [];
+    const seen = new Set();
+    for (const value of Array.isArray(values) ? values : []) {
+        const id = trimmed(value);
+        if (id && !seen.has(id)) {
+            seen.add(id);
+            result.push(id);
+        }
+    }
+    return result;
+}
+
+/**
+ * Parses the host's human-readable file size ("1.5MB", "512B", "1.2 KB") back to bytes.
+ * @param {string} text
+ * @returns {number}
+ */
+export function parseHumanSize(text) {
+    const match = /^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb)$/i.exec(String(text ?? '').trim());
+    if (!match) {
+        return 0;
+    }
+    const bytes = Number(match[1]) * SIZE_UNITS[match[2].toLowerCase()];
+    return Number.isFinite(bytes) ? bytes : 0;
+}
+
+/**
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function formatBytes(bytes) {
+    const value = Number(bytes);
+    if (!Number.isFinite(value) || value < 0) {
+        return '';
+    }
+    if (value < 1024) {
+        return `${value}B`;
+    }
+    const units = ['KB', 'MB', 'GB', 'TB'];
+    let size = value;
+    let unit = -1;
+    do {
+        size /= 1024;
+        unit++;
+    } while (size >= 1024 && unit < units.length - 1);
+    return `${Number(size.toFixed(size >= 10 ? 0 : 1))}${units[unit]}`;
+}
+
+/**
+ * Parses the server's `last_mes` into epoch milliseconds. It is mtimeMs (number)
+ * for empty chats but the last message's send_date (string, host-humanized
+ * format) otherwise. Pass the host's timestampToMoment to handle those.
+ * @param {number|string} value
+ * @param {(ts: number|string) => {isValid: () => boolean, valueOf: () => number}} [toMoment]
+ * @returns {number}
+ */
+export function parseLastMes(value, toMoment) {
+    if (typeof value === 'number') {
+        return validTimestamp(value);
+    }
+    if (!value) {
+        return 0;
+    }
+    try {
+        const moment = toMoment?.(value);
+        if (moment?.isValid?.()) {
+            return validTimestamp(moment.valueOf());
+        }
+    } catch {
+        // Fall through to Date.parse.
+    }
+    const parsed = Date.parse(value);
+    return validTimestamp(parsed);
+}
+
+/**
+ * Normalizes one /api/chats/recent row against the loaded character and group lists.
+ * Rows carry `avatar` (character chats), `group` (group chats), or neither (root orphans).
+ * @param {object} row Raw ChatInfo row from the server
+ * @param {Array<{avatar: string, name?: string}>|Map<string, object>} characters
+ * @param {Array<{id: string, name?: string}>|Map<string, object>} groups
+ * @param {(ts: number|string) => object} [toMoment] Host timestampToMoment for send_date strings
+ */
+export function normalizeRow(row, characters = [], groups = [], toMoment = undefined) {
+    if (!isRecord(row)) {
+        return null;
+    }
+    if ((row.avatar != null && typeof row.avatar !== 'string')
+        || (row.group != null && typeof row.group !== 'string' && typeof row.group !== 'number')
+        || (row.chatFolder != null && typeof row.chatFolder !== 'string')
+        || (row.file_name != null && typeof row.file_name !== 'string')
+        || (row.file_id != null && typeof row.file_id !== 'string' && typeof row.file_id !== 'number')) {
+        return null;
+    }
+    const avatar = row.avatar ?? null;
+    const chatFolder = row.chatFolder ?? (avatar ? avatar.replace(/\.png$/i, '') : null);
+    const groupId = row.group ?? null;
+    const character = avatar
+        ? characters instanceof Map ? characters.get(avatar) : characters.find(x => x?.avatar === avatar)
+        : null;
+    const group = groupId !== null
+        ? groups instanceof Map ? groups.get(String(groupId)) : groups.find(x => x && String(x.id) === String(groupId))
+        : null;
+
+    let kind = 'orphan';
+    let ownerName = '';
+    let orphanType = 'root';
+    if (group) {
+        kind = 'group';
+        ownerName = group.name || groupId;
+    } else if (character) {
+        kind = 'solo';
+        ownerName = character.name || avatar;
+    } else if (avatar) {
+        // Chat folder exists but no character PNG resolves to it anymore.
+        ownerName = avatar.replace(/\.png$/i, '');
+        orphanType = 'missing-character';
+    } else if (groupId !== null) {
+        ownerName = String(groupId);
+        orphanType = 'missing-group';
+    }
+
+    const fileName = typeof row.file_name === 'string' ? row.file_name : '';
+    const sizeBytes = parseHumanSize(row.file_size);
+    const sizeKnown = sizeBytes > 0 || /^\s*0(?:\.0+)?\s*(?:b|kb|mb|gb|tb)\s*$/i.test(String(row.file_size ?? ''));
+    const mtime = parseLastMes(row.last_mes, toMoment);
+    const countValue = Number(row.chat_items);
+    const count = row.chat_items === undefined || row.chat_items === null
+        ? null
+        : Number.isSafeInteger(countValue) && countValue >= 0 ? countValue : 0;
+    return {
+        kind,
+        orphanType: kind === 'orphan' ? orphanType : null,
+        source: row._source ?? 'recent',
+        ownerName,
+        avatar,
+        chatFolder,
+        groupId: group ? group.id : groupId,
+        file_id: fileName ? fileName.replace(/\.jsonl$/i, '') : String(row.file_id ?? ''),
+        file_name: fileName,
+        sizeText: row.file_size ?? '',
+        sizeBytes,
+        sizeKnown,
+        count,
+        mtime,
+        mtimeKnown: mtime !== 0,
+        snippet: previewText(row.mes, PREVIEW_LENGTH),
+    };
+}
+
+/**
+ * Maps a Data Maid orphan record into the normalized archive row shape.
+ * @param {{name?: string, hash?: string, parent?: string, size?: number, mtime?: number}} record
+ * @param {'missing-character'|'unlinked-group'} orphanType
+ */
+export function dataMaidRecordToRow(record, orphanType) {
+    if (!isRecord(record) || typeof record.name !== 'string' || typeof record.hash !== 'string') {
+        return null;
+    }
+    const fileName = String(record.name ?? '');
+    const rawSize = Number(record.size);
+    const hasSize = Number.isFinite(rawSize) && rawSize >= 0;
+    const sizeBytes = hasSize ? rawSize : 0;
+    const mtime = parseLastMes(record.mtime);
+    const chatFolder = orphanType === 'missing-character' ? String(record.parent ?? '') : null;
+    return {
+        kind: 'orphan',
+        orphanType,
+        source: 'data-maid',
+        ownerName: chatFolder ?? '',
+        avatar: null,
+        chatFolder,
+        groupId: null,
+        file_id: fileName.replace(/\.jsonl$/i, ''),
+        file_name: fileName,
+        sizeText: hasSize ? formatBytes(sizeBytes) : '',
+        sizeBytes,
+        sizeKnown: hasSize,
+        count: null,
+        mtime,
+        mtimeKnown: mtime !== 0,
+        snippet: '',
+        dataMaidHash: String(record.hash ?? ''),
+    };
+}
+
+export function physicalChatKey(row) {
+    const fileId = String(row?.file_id ?? '');
+    if (row?.kind === 'group' || row?.orphanType === 'missing-group' || row?.orphanType === 'unlinked-group') {
+        return JSON.stringify(['group', fileId]);
+    }
+    if (row?.kind === 'solo' || row?.orphanType === 'missing-character' || row?.chatFolder || row?.avatar) {
+        const folder = row.chatFolder ?? String(row.avatar ?? '').replace(/\.png$/i, '');
+        return JSON.stringify(['character', folder, fileId]);
+    }
+    return JSON.stringify(['root', fileId]);
+}
+
+export function ownerFilterKey(row) {
+    if (row?.kind === 'group' || row?.orphanType === 'missing-group') {
+        const id = row.groupId == null ? '' : String(row.groupId);
+        return id ? `${OWNER_FILTER_PREFIX}${JSON.stringify(['group', id])}` : '';
+    }
+    if (row?.kind === 'solo' || row?.orphanType === 'missing-character') {
+        const folder = row.chatFolder ?? String(row.avatar ?? '').replace(/\.png$/i, '');
+        return folder ? `${OWNER_FILTER_PREFIX}${JSON.stringify(['character', folder])}` : '';
+    }
+    return '';
+}
+
+export function parseOwnerFilter(value) {
+    const selected = trimmed(value);
+    if (!selected.startsWith(OWNER_FILTER_PREFIX)) {
+        return null;
+    }
+    try {
+        const encoded = selected.slice(OWNER_FILTER_PREFIX.length);
+        const parsed = JSON.parse(encoded);
+        if (!Array.isArray(parsed)
+            || parsed.length !== 2
+            || !OWNER_FILTER_KINDS.has(parsed[0])
+            || typeof parsed[1] !== 'string'
+            || !parsed[1]
+            || JSON.stringify(parsed) !== encoded) {
+            return null;
+        }
+        return { kind: parsed[0], id: parsed[1] };
+    } catch {
+        return null;
+    }
+}
+
+function matchesOwner(row, owner) {
+    const selected = trimmed(owner);
+    if (!selected) {
+        return true;
+    }
+    if (parseOwnerFilter(selected)) {
+        return ownerFilterKey(row) === selected;
+    }
+    return [row?.ownerName, row?.groupId, row?.chatFolder, row?.avatar]
+        .some(value => String(value ?? '') === selected);
+}
+
+function normalizeNamedItems(items, shape = (_item, id, name) => ({ id, name })) {
+    const result = [];
+    const ids = new Set();
+    const names = new Set();
+    for (const item of Array.isArray(items) ? items : []) {
+        if (!isRecord(item)) {
+            continue;
+        }
+        const id = trimmed(item.id);
+        const name = trimmed(item.name);
+        const foldedName = name.toLowerCase();
+        if (!id || !name || ids.has(id) || names.has(foldedName)) {
+            continue;
+        }
+        const normalized = shape(item, id, name);
+        if (normalized) {
+            ids.add(id);
+            names.add(foldedName);
+            result.push(normalized);
+        }
+    }
+    return result;
+}
+
+function referenceIds(organization, field) {
+    if (!organization) {
+        return null;
+    }
+    return new Set((Array.isArray(organization[field]) ? organization[field] : []).map(item => item.id));
+}
+
+export function normalizeSavedView(view, organization = null) {
+    if (!isRecord(view)) {
+        return {};
+    }
+    const result = {};
+    const query = trimmed(view.query);
+    if (query) {
+        result.query = query;
+    }
+    if (Array.isArray(view.kinds)) {
+        result.kinds = uniqueStrings(view.kinds, CHAT_KINDS);
+    }
+    const sort = trimmed(view.sort);
+    if (SORT_KEYS.has(sort)) {
+        result.sort = sort;
+    }
+    const group = trimmed(view.group);
+    if (GROUP_KEYS.has(group)) {
+        result.group = group;
+    }
+    const density = trimmed(view.density);
+    if (DENSITIES.has(density)) {
+        result.density = density;
+    }
+    const owner = trimmed(view.owner);
+    if (owner) {
+        result.owner = owner;
+    }
+    const orphan = trimmed(view.orphan);
+    if (ORPHAN_TYPES.has(orphan)) {
+        result.orphan = orphan;
+    }
+    if (typeof view.favorite === 'boolean') {
+        result.favorite = view.favorite;
+    }
+
+    const folderIds = referenceIds(organization, 'folders');
+    if (view.folder === null) {
+        result.folder = null;
+    } else {
+        const folder = trimmed(view.folder);
+        if (folder && (!folderIds || folderIds.has(folder))) {
+            result.folder = folder;
+        }
+    }
+    const collectionIds = referenceIds(organization, 'collections');
+    const collection = trimmed(view.collection);
+    if (collection && (!collectionIds || collectionIds.has(collection))) {
+        result.collection = collection;
+    }
+    const tag = trimmed(view.tag);
+    if (tag) {
+        result.tag = tag;
+    }
+
+    for (const field of ['minSize', 'maxSize']) {
+        if (typeof view[field] === 'number' && Number.isFinite(view[field]) && view[field] >= 0) {
+            result[field] = view[field];
+        }
+    }
+    for (const field of ['minMessages', 'maxMessages']) {
+        if (Number.isSafeInteger(view[field]) && view[field] >= 0) {
+            result[field] = view[field];
+        }
+    }
+    for (const field of ['minDate', 'maxDate']) {
+        if (typeof view[field] === 'number' && Number.isFinite(view[field]) && view[field] >= 0) {
+            result[field] = view[field];
+        } else {
+            const date = trimmed(view[field]);
+            if (date && Number.isFinite(Date.parse(date))) {
+                result[field] = date;
+            }
+        }
+    }
+    return result;
+}
+
+export function createDefaultOrganization() {
+    return { version: 1, lastView: {}, views: [], folders: [], collections: [], chats: {} };
+}
+
+export function normalizeOrganization(value) {
+    if (!isRecord(value)) {
+        throw new TypeError('Organization root must be an object');
+    }
+    if (value.version !== 1) {
+        throw new Error(`Unsupported organization version: ${String(value.version)}`);
+    }
+
+    const folders = normalizeNamedItems(value.folders);
+    const collections = normalizeNamedItems(value.collections);
+    const references = { folders, collections };
+    const views = normalizeNamedItems(value.views, (item, id, name) => (
+        isRecord(item.view) ? { id, name, view: normalizeSavedView(item.view, references) } : null
+    ));
+    const folderIds = referenceIds(references, 'folders');
+    const collectionIds = referenceIds(references, 'collections');
+    const chats = [];
+    const chatKeys = new Set();
+    for (const [rawKey, metadata] of isRecord(value.chats) ? Object.entries(value.chats) : []) {
+        const key = rawKey.trim();
+        if (!key || chatKeys.has(key) || !isRecord(metadata)) {
+            continue;
+        }
+        const normalized = {};
+        if (metadata.favorite === true) {
+            normalized.favorite = true;
+        }
+        const folder = trimmed(metadata.folder);
+        if (folder && folderIds.has(folder)) {
+            normalized.folder = folder;
+        }
+        const chatCollections = uniqueIds(metadata.collections).filter(id => collectionIds.has(id));
+        if (chatCollections.length > 0) {
+            normalized.collections = chatCollections;
+        }
+        const tags = uniqueStrings(metadata.tags);
+        if (tags.length > 0) {
+            normalized.tags = tags;
+        }
+        if (Object.keys(normalized).length > 0) {
+            chatKeys.add(key);
+            chats.push([key, normalized]);
+        }
+    }
+    return {
+        version: 1,
+        lastView: normalizeSavedView(value.lastView, references),
+        views,
+        folders,
+        collections,
+        chats: Object.fromEntries(chats),
+    };
+}
+
+export function parseOrganization(text) {
+    return normalizeOrganization(JSON.parse(text));
+}
+
+/**
+ * Maps one /api/chats/search result (whose `file_name` is actually extension-less)
+ * into the /api/chats/recent row shape so normalizeRow can consume it.
+ * @param {object} result Search result from the server
+ * @param {{avatar_url?: string, group_id?: string}} scope The scope the search ran against
+ */
+export function deepResultToRecentRow(result, scope) {
+    if (!isRecord(result) || typeof result.file_name !== 'string' || !result.file_name) {
+        return null;
+    }
+    return {
+        _source: 'search',
+        avatar: scope.avatar_url,
+        group: scope.group_id,
+        file_id: result.file_name,
+        file_name: `${result.file_name}.jsonl`,
+        file_size: result.file_size,
+        chat_items: result.message_count,
+        last_mes: result.last_mes,
+        mes: result.preview_message,
+    };
+}
+
+export function buildSearchScopes(characters = [], groups = [], owner = '') {
+    const scopes = characters
+        .filter(character => typeof character?.avatar === 'string' && character.avatar)
+        .filter(character => matchesOwner({
+            kind: 'solo',
+            ownerName: character.name,
+            avatar: character.avatar,
+            chatFolder: character.avatar.replace(/\.png$/i, ''),
+        }, owner))
+        .map(character => ({ avatar_url: character.avatar }));
+    for (const group of groups) {
+        if (!group || (typeof group.id !== 'string' && typeof group.id !== 'number')) {
+            continue;
+        }
+        if (!matchesOwner({ kind: 'group', ownerName: group.name, groupId: group.id }, owner)) {
+            continue;
+        }
+        scopes.push({ group_id: group.id });
+        if (typeof group.id === 'string' && group.id !== '0' && /^\d+$/.test(group.id) && String(Number(group.id)) === group.id) {
+            scopes.push({ group_id: Number(group.id) });
+        }
+    }
+    return scopes;
+}
+
+function* jsonlLines(text) {
+    const source = String(text ?? '');
+    let start = 0;
+    let lineNumber = 0;
+    while (start <= source.length) {
+        let end = source.indexOf('\n', start);
+        if (end < 0) {
+            end = source.length;
+        }
+        lineNumber++;
+        let line = source.slice(start, end);
+        if (line.endsWith('\r')) {
+            line = line.slice(0, -1);
+        }
+        if (lineNumber === 1) {
+            line = line.replace(/^\uFEFF/, '');
+        }
+        yield { line, lineNumber };
+        if (end === source.length) {
+            break;
+        }
+        start = end + 1;
+    }
+}
+
+function throwIfAborted(signal) {
+    if (signal?.aborted) {
+        throw signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+    }
+}
+
+function chunkSize(value) {
+    return Number.isSafeInteger(value) && value > 0 ? value : JSONL_CHUNK_SIZE;
+}
+
+/**
+ * Parses an exported JSONL chat without invoking the host's recovery-aware read endpoints.
+ * @param {string} text
+ * @returns {object[]}
+ */
+export function parseJsonl(text) {
+    const records = [];
+    for (const { line, lineNumber } of jsonlLines(text)) {
+        if (!line.trim()) {
+            continue;
+        }
+        try {
+            records.push(JSON.parse(line));
+        } catch (error) {
+            throw new Error(`Invalid JSONL on line ${lineNumber}`, { cause: error });
+        }
+    }
+    return records;
+}
+
+export async function parseChatJsonl(text, { signal, linesPerChunk = JSONL_CHUNK_SIZE } = {}) {
+    let header = null;
+    const messages = [];
+    let objectCount = 0;
+    let processed = 0;
+    const batchSize = chunkSize(linesPerChunk);
+    for (const { line, lineNumber } of jsonlLines(text)) {
+        if (line.trim()) {
+            let record;
+            try {
+                record = JSON.parse(line);
+            } catch (error) {
+                throw new Error(`Invalid JSONL on line ${lineNumber}`, { cause: error });
+            }
+            if (isRecord(record)) {
+                if (objectCount === 0 && !('mes' in record)) {
+                    header = record;
+                } else {
+                    messages.push(shapeMessage(record));
+                }
+                objectCount++;
+            }
+        }
+        if (++processed % batchSize === 0) {
+            throwIfAborted(signal);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            throwIfAborted(signal);
+        }
+    }
+    throwIfAborted(signal);
+    return {
+        header,
+        metadataKeys: Object.keys(header?.chat_metadata ?? {}),
+        messages,
+    };
+}
+
+/**
+ * Mirrors the host's plain-text export while also supporting Data Maid orphan files.
+ * @param {object[]} records
+ * @returns {string}
+ */
+export function recordsToText(records) {
+    return (Array.isArray(records) ? records : [])
+        .filter(record => !record?.is_system && typeof record?.mes === 'string' && record.mes)
+        .map(record => `${record.name ?? ''}: ${typeof record.extra?.display_text === 'string' && record.extra.display_text ? record.extra.display_text : record.mes}`)
+        .join('\n\n');
+}
+
+export function matchesQueryFragments(text, query) {
+    const searchable = String(text ?? '').toLowerCase();
+    const fragments = String(query ?? '').toLowerCase().split(/\s+/).filter(Boolean);
+    return fragments.length > 0 && fragments.every(fragment => searchable.includes(fragment));
+}
+
+export function findMatchingMessageIndex(messages, query) {
+    const fragments = [...new Set(String(query ?? '').toLowerCase().split(/\s+/).filter(Boolean))];
+    if (fragments.length === 0) {
+        return -1;
+    }
+    const matched = new Set();
+    let firstMatch = -1;
+    const list = Array.isArray(messages) ? messages : [];
+    for (let index = 0; index < list.length; index++) {
+        const text = typeof list[index]?.mes === 'string' ? list[index].mes.toLowerCase() : '';
+        let containsFragment = false;
+        for (const fragment of fragments) {
+            if (text.includes(fragment)) {
+                matched.add(fragment);
+                containsFragment = true;
+            }
+        }
+        if (containsFragment && firstMatch < 0) {
+            firstMatch = index;
+        }
+    }
+    return matched.size === fragments.length ? firstMatch : -1;
+}
+
+/**
+ * Uses the host search semantics: every whitespace-delimited fragment must occur
+ * somewhere in message content, but not necessarily in the same message.
+ * @param {object[]} records
+ * @param {string} query
+ * @returns {string|null} A matching preview, or null when the chat does not match.
+ */
+export function findMatchingSnippet(records, query) {
+    const index = findMatchingMessageIndex(records, query);
+    if (index < 0) {
+        return null;
+    }
+    return previewText(records[index].mes, PREVIEW_LENGTH);
+}
+
+function createJsonlSearch(query) {
+    return {
+        fragments: [...new Set(String(query ?? '').toLowerCase().split(/\s+/).filter(Boolean))],
+        matched: new Set(),
+        snippet: null,
+    };
+}
+
+function searchJsonlRecord(search, record) {
+    if (!isRecord(record) || typeof record.mes !== 'string') {
+        return;
+    }
+    const text = record.mes.toLowerCase();
+    let containsFragment = false;
+    for (const fragment of search.fragments) {
+        if (text.includes(fragment)) {
+            search.matched.add(fragment);
+            containsFragment = true;
+        }
+    }
+    if (containsFragment && search.snippet === null) {
+        search.snippet = previewText(record.mes, PREVIEW_LENGTH);
+    }
+}
+
+function finishJsonlSearch(search, invalidLines) {
+    return {
+        snippet: search.fragments.length > 0 && search.matched.size === search.fragments.length ? search.snippet : null,
+        invalidLines,
+    };
+}
+
+export function findMatchingSnippetInJsonl(text, query) {
+    const search = createJsonlSearch(query);
+    let invalidLines = 0;
+    for (const { line } of jsonlLines(text)) {
+        try {
+            if (line.trim()) {
+                searchJsonlRecord(search, JSON.parse(line));
+            }
+        } catch {
+            // Search the readable records even when one line is corrupt.
+            invalidLines++;
+        }
+    }
+    return finishJsonlSearch(search, invalidLines);
+}
+
+export async function findMatchingSnippetInJsonlAsync(text, query, { signal, linesPerChunk = JSONL_CHUNK_SIZE } = {}) {
+    const search = createJsonlSearch(query);
+    let invalidLines = 0;
+    let processed = 0;
+    const batchSize = chunkSize(linesPerChunk);
+    for (const { line } of jsonlLines(text)) {
+        try {
+            if (line.trim()) {
+                searchJsonlRecord(search, JSON.parse(line));
+            }
+        } catch {
+            invalidLines++;
+        }
+        if (++processed % batchSize === 0) {
+            throwIfAborted(signal);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            throwIfAborted(signal);
+        }
+    }
+    throwIfAborted(signal);
+    return finishJsonlSearch(search, invalidLines);
+}
+
+function organizationMaps(organization) {
+    return {
+        folders: new Map((organization?.folders ?? []).map(item => [item.id, item.name])),
+        collections: new Map((organization?.collections ?? []).map(item => [item.id, item.name])),
+    };
+}
+
+function chatMetadata(row, organization) {
+    const metadata = organization?.chats?.[physicalChatKey(row)];
+    return isRecord(metadata) ? metadata : {};
+}
+
+function numberBound(value, date = false) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+    if (date && typeof value === 'string') {
+        const parsed = Date.parse(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+
+function rowNumber(row, field) {
+    const value = row[field];
+    const knownField = field === 'sizeBytes' ? 'sizeKnown' : field === 'mtime' ? 'mtimeKnown' : null;
+    return Number.isFinite(value) && (!knownField || row[knownField] !== false) ? value : null;
+}
+
+export function filterRows(rows, options = {}, organization = null) {
+    const needle = String(options.text ?? '').trim().toLowerCase();
+    const maps = organizationMaps(organization);
+    const bounds = {
+        minDate: numberBound(options.minDate, true),
+        maxDate: numberBound(options.maxDate, true),
+        minSize: numberBound(options.minSize),
+        maxSize: numberBound(options.maxSize),
+        minMessages: numberBound(options.minMessages),
+        maxMessages: numberBound(options.maxMessages),
+    };
+    const ranges = [
+        [bounds.minDate, bounds.maxDate, 'mtime'],
+        [bounds.minSize, bounds.maxSize, 'sizeBytes'],
+        [bounds.minMessages, bounds.maxMessages, 'count'],
+    ];
+    const hasFolderFilter = Object.hasOwn(options, 'folder') && options.folder !== undefined && options.folder !== '';
+    const owner = trimmed(options.owner);
+    const collection = trimmed(options.collection);
+    const tag = trimmed(options.tag).toLowerCase();
+    return rows.filter(row => {
+        if (options.kinds && !options.kinds.includes(row.kind)) {
+            return false;
+        }
+        if (owner && !matchesOwner(row, owner)) {
+            return false;
+        }
+        if (options.orphan && row.orphanType !== options.orphan) {
+            return false;
+        }
+
+        const metadata = chatMetadata(row, organization);
+        if (typeof options.favorite === 'boolean' && (metadata.favorite === true) !== options.favorite) {
+            return false;
+        }
+        if (hasFolderFilter && (options.folder === null ? !!metadata.folder : metadata.folder !== options.folder)) {
+            return false;
+        }
+        if (collection && !metadata.collections?.includes(collection)) {
+            return false;
+        }
+        if (tag && !metadata.tags?.some(value => String(value).toLowerCase() === tag)) {
+            return false;
+        }
+
+        for (const [minimum, maximum, field] of ranges) {
+            if (minimum === null && maximum === null) {
+                continue;
+            }
+            const value = rowNumber(row, field);
+            if (value === null || (minimum !== null && value < minimum) || (maximum !== null && value > maximum)) {
+                return false;
+            }
+        }
+
+        if (!needle) {
+            return true;
+        }
+        const labels = [
+            maps.folders.get(metadata.folder),
+            ...(metadata.collections ?? []).map(id => maps.collections.get(id)),
+            ...(metadata.tags ?? []),
+        ];
+        return [row.file_id, row.ownerName, row.snippet, ...labels]
+            .some(field => String(field ?? '').toLowerCase().includes(needle));
+    });
+}
+
+function compareNumber(a, b, field, direction) {
+    const left = rowNumber(a, field);
+    const right = rowNumber(b, field);
+    if (left === null || right === null) {
+        return left === null ? right === null ? 0 : 1 : -1;
+    }
+    return (left - right) * direction;
+}
+
+function compareText(left, right) {
+    return String(left ?? '').localeCompare(String(right ?? ''));
+}
+
+const SORTERS = {
+    recent: (a, b) => compareNumber(a, b, 'mtime', -1),
+    oldest: (a, b) => compareNumber(a, b, 'mtime', 1),
+    size: (a, b) => compareNumber(a, b, 'sizeBytes', -1),
+    smallest: (a, b) => compareNumber(a, b, 'sizeBytes', 1),
+    count: (a, b) => compareNumber(a, b, 'count', -1),
+    fewest: (a, b) => compareNumber(a, b, 'count', 1),
+    name: (a, b) => compareText(a.file_id, b.file_id),
+    'name-reverse': (a, b) => compareText(b.file_id, a.file_id),
+    owner: (a, b) => compareText(a.ownerName, b.ownerName),
+};
+
+export function sortRows(rows, key = 'recent') {
+    const sorter = SORTERS[key] ?? SORTERS.recent;
+    return [...rows].sort((a, b) => (
+        sorter(a, b)
+        || compareText(a.file_id, b.file_id)
+        || compareText(physicalChatKey(a), physicalChatKey(b))
+    ));
+}
+
+export function groupRows(rows, mode = 'flat', organization = null) {
+    const selectedMode = GROUP_KEYS.has(mode) ? mode : 'flat';
+    const maps = organizationMaps(organization);
+    const groups = new Map();
+    for (const row of rows) {
+        let key = 'flat';
+        let label = '';
+        if (selectedMode === 'owner') {
+            const scope = row.kind === 'group' || row.orphanType === 'missing-group'
+                ? ['group', String(row.groupId ?? '')]
+                : row.chatFolder || row.avatar
+                    ? ['character', row.chatFolder ?? row.avatar]
+                    : ['orphan', row.orphanType ?? ''];
+            key = JSON.stringify(scope);
+            label = row.ownerName || 'Unknown owner';
+        } else if (selectedMode === 'type') {
+            key = String(row.kind ?? 'unknown');
+            label = key;
+        } else if (selectedMode === 'folder') {
+            const folder = chatMetadata(row, organization).folder ?? null;
+            key = JSON.stringify(['folder', folder]);
+            label = folder === null ? 'Unfiled' : maps.folders.get(folder) ?? folder;
+        }
+        if (!groups.has(key)) {
+            groups.set(key, { key, label, rows: [] });
+        }
+        groups.get(key).rows.push(row);
+    }
+    return [...groups.values()];
+}
+
+/**
+ * Splits raw JSONL records (as returned by /api/chats/get) into a header and
+ * display-ready messages. The header is the first record iff it has no `mes`.
+ * @param {object[]} records
+ */
+function shapeMessage(raw) {
+    const mes = typeof raw.mes === 'string' ? raw.mes : '';
+    const swipes = Array.isArray(raw.swipes) ? raw.swipes : [];
+    let selectedSwipe = Number.isSafeInteger(raw.swipe_id) ? raw.swipe_id : swipes.indexOf(mes);
+    if (selectedSwipe < 0 || selectedSwipe >= swipes.length) {
+        selectedSwipe = swipes.indexOf(mes);
+    }
+    const alternatives = swipes.filter((swipe, index) => typeof swipe === 'string' && index !== selectedSwipe);
+    return {
+        name: typeof raw.name === 'string' ? raw.name : '',
+        send_date: raw.send_date ?? '',
+        mes,
+        isUser: !!raw.is_user,
+        isSystem: !!raw.is_system,
+        swipeCount: alternatives.length,
+        alternatives,
+        extra: isRecord(raw.extra) ? raw.extra : null,
+    };
+}
+
+export function shapeChatRecords(records) {
+    const list = Array.isArray(records) ? records.filter(x => x && typeof x === 'object') : [];
+    const header = (list.length > 0 && !('mes' in list[0])) ? list[0] : null;
+    const messages = [];
+    for (let index = header ? 1 : 0; index < list.length; index++) {
+        messages.push(shapeMessage(list[index]));
+    }
+
+    return {
+        header,
+        metadataKeys: Object.keys(header?.chat_metadata ?? {}),
+        messages,
+    };
+}

--- a/public/scripts/extensions/sillybunny-chats-archive/src/core.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/core.js
@@ -120,7 +120,7 @@ export function parseLastMes(value, toMoment) {
 }
 
 /**
- * Normalizes one /api/chats/recent row against the loaded character and group lists.
+ * Normalizes one archive-compatible row against the loaded character and group lists.
  * Rows carry `avatar` (character chats), `group` (group chats), or neither (root orphans).
  * @param {object} row Raw ChatInfo row from the server
  * @param {Array<{avatar: string, name?: string}>|Map<string, object>} characters
@@ -135,6 +135,8 @@ export function normalizeRow(row, characters = [], groups = [], toMoment = undef
         || (row.group != null && typeof row.group !== 'string' && typeof row.group !== 'number')
         || (row.chatFolder != null && typeof row.chatFolder !== 'string')
         || (row.file_name != null && typeof row.file_name !== 'string')
+        || (row.orphan_type != null && !ORPHAN_TYPES.has(row.orphan_type))
+        || (row.archive_hash != null && typeof row.archive_hash !== 'string')
         || (row.file_id != null && typeof row.file_id !== 'string' && typeof row.file_id !== 'number')) {
         return null;
     }
@@ -165,6 +167,11 @@ export function normalizeRow(row, characters = [], groups = [], toMoment = undef
         ownerName = String(groupId);
         orphanType = 'missing-group';
     }
+    if (row.orphan_type) {
+        kind = 'orphan';
+        orphanType = row.orphan_type;
+        ownerName = row.orphan_type === 'missing-character' ? chatFolder ?? '' : ownerName;
+    }
 
     const fileName = typeof row.file_name === 'string' ? row.file_name : '';
     const sizeBytes = parseHumanSize(row.file_size);
@@ -191,42 +198,7 @@ export function normalizeRow(row, characters = [], groups = [], toMoment = undef
         mtime,
         mtimeKnown: mtime !== 0,
         snippet: previewText(row.mes, PREVIEW_LENGTH),
-    };
-}
-
-/**
- * Maps a Data Maid orphan record into the normalized archive row shape.
- * @param {{name?: string, hash?: string, parent?: string, size?: number, mtime?: number}} record
- * @param {'missing-character'|'unlinked-group'} orphanType
- */
-export function dataMaidRecordToRow(record, orphanType) {
-    if (!isRecord(record) || typeof record.name !== 'string' || typeof record.hash !== 'string') {
-        return null;
-    }
-    const fileName = String(record.name ?? '');
-    const rawSize = Number(record.size);
-    const hasSize = Number.isFinite(rawSize) && rawSize >= 0;
-    const sizeBytes = hasSize ? rawSize : 0;
-    const mtime = parseLastMes(record.mtime);
-    const chatFolder = orphanType === 'missing-character' ? String(record.parent ?? '') : null;
-    return {
-        kind: 'orphan',
-        orphanType,
-        source: 'data-maid',
-        ownerName: chatFolder ?? '',
-        avatar: null,
-        chatFolder,
-        groupId: null,
-        file_id: fileName.replace(/\.jsonl$/i, ''),
-        file_name: fileName,
-        sizeText: hasSize ? formatBytes(sizeBytes) : '',
-        sizeBytes,
-        sizeKnown: hasSize,
-        count: null,
-        mtime,
-        mtimeKnown: mtime !== 0,
-        snippet: '',
-        dataMaidHash: String(record.hash ?? ''),
+        archiveHash: row.archive_hash ?? null,
     };
 }
 
@@ -461,7 +433,7 @@ export function parseOrganization(text) {
 
 /**
  * Maps one /api/chats/search result (whose `file_name` is actually extension-less)
- * into the /api/chats/recent row shape so normalizeRow can consume it.
+ * into the archive row shape so normalizeRow can consume it.
  * @param {object} result Search result from the server
  * @param {{avatar_url?: string, group_id?: string}} scope The scope the search ran against
  */

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -1,7 +1,6 @@
 import {
     buildSearchScopes,
     createDefaultOrganization,
-    dataMaidRecordToRow,
     deepResultToRecentRow,
     filterRows,
     findMatchingMessageIndex,
@@ -22,14 +21,10 @@ import {
 import {
     fetchOrganization,
     exportChat,
-    fetchCharacterChatDetails,
-    fetchCharacterFiles,
-    fetchDataMaidFile,
-    fetchDataMaidReport,
-    fetchRecent,
-    fetchRootFiles,
-    finalizeDataMaid,
+    fetchArchiveFile,
+    fetchArchiveInventory,
     ORGANIZATION_FILE_NAME,
+    releaseArchiveSession,
     saveOrganization,
     searchScope,
 } from './api.js';
@@ -76,7 +71,6 @@ const SORT_PILLS = [
 const LIST_PAGE_SIZE = 100;
 const MESSAGE_PAGE_SIZE = 100;
 const NAVIGATION_TIMEOUT_MS = 15_000;
-const DATA_MAID_FINALIZE_TIMEOUT_MS = 15_000;
 const LAST_VIEW_SAVE_DELAY_MS = 500;
 const SEARCH_DEBOUNCE_MS = 150;
 const MAX_ORGANIZATION_IMPORT_BYTES = 5 * 1024 * 1024;
@@ -85,7 +79,6 @@ const UNFILED_VALUE = '__sbca_unfiled__';
 
 let popup = null;
 let renderId = 0;
-let dataMaidQueue = Promise.resolve();
 let hostNavigationPending = null;
 
 function el(tag, className, text) {
@@ -353,10 +346,8 @@ export async function openArchive(ctx, opener = null) {
         searchAbort: null,
         scanAbort: null,
         orphanScanComplete: false,
-        rootScanFailed: false,
-        recentScanFailed: false,
         inventoryFailures: 0,
-        dataMaidToken: null,
+        archiveReadToken: null,
         navigationPending: false,
         navigationAbort: null,
         navigationControl: null,
@@ -371,10 +362,6 @@ export async function openArchive(ctx, opener = null) {
         matchingRows: [],
         charactersByAvatar: new Map((ctx.characters ?? []).filter(character => character?.avatar).map(character => [character.avatar, character])),
         groupsById: new Map((ctx.groups ?? []).filter(group => group?.id !== undefined && group?.id !== null).map(group => [String(group.id), group])),
-        missingGroupFiles: new Set(),
-        enrichedOwners: new Set(),
-        enrichmentAbort: null,
-        enrichmentOwner: '',
         organization: null,
         organizationLoadState: 'loading',
         organizationLoadAbort: null,
@@ -421,11 +408,10 @@ export async function openArchive(ctx, opener = null) {
         state.searchAbort?.abort();
         state.navigationAbort?.abort();
         state.scanAbort?.abort();
-        state.enrichmentAbort?.abort();
         state.organizationLoadAbort?.abort();
         state.cleanup?.();
         await flushOrganization(ctx, state, ui);
-        const releasing = releaseDataMaid(ctx, state);
+        const releasing = releaseArchiveReadSession(ctx, state);
         if (popup === instance) {
             popup = null;
         }
@@ -885,7 +871,6 @@ function buildRoot(ctx, state) {
             }
             if (control === ui.owner) {
                 exitDeepSearch(ctx, state, ui);
-                void enrichSelectedOwner(ctx, state, ui);
             }
             applyViewOptions();
             noteViewEdit();
@@ -1245,7 +1230,6 @@ function applySavedView(ctx, state, ui, value, selectedViewId = null, persist = 
     updateBrowseStatus(ctx, state, ui);
     updateDeepButton(state, ui);
     updateSelectionControls(ctx, state, ui);
-    void enrichSelectedOwner(ctx, state, ui);
     if (persist) {
         state.viewTouched = true;
         if (state.organizationWritable) {
@@ -1458,74 +1442,6 @@ function refreshOwnerOptions(ctx, state, ui) {
         choices.push(fallbackOwnerChoice(ctx, current));
     }
     renderOwnerOptions(ctx, ui, choices, current);
-}
-
-// SillyBunny's simple inventory omits message previews; enrich the selected
-// character only, so browsing stays cheap for everyone else.
-async function enrichSelectedOwner(ctx, state, ui) {
-    const owner = ui.owner.value;
-    const identity = parseOwnerFilter(owner);
-    if (!identity || identity.kind !== 'character') {
-        state.enrichmentAbort?.abort();
-        state.enrichmentAbort = null;
-        state.enrichmentOwner = '';
-        return;
-    }
-    const avatar = `${identity.id}.png`;
-    if (state.enrichedOwners.has(avatar)
-        || (state.enrichmentOwner === avatar && state.enrichmentAbort)) {
-        return;
-    }
-    const needsDetails = state.rows.some(row => (
-        row.source === 'inventory' && ownerFilterKey(row) === owner
-    ));
-    if (!needsDetails) {
-        return;
-    }
-    state.enrichmentAbort?.abort();
-    const controller = new AbortController();
-    state.enrichmentAbort = controller;
-    state.enrichmentOwner = avatar;
-    let details;
-    try {
-        details = await fetchCharacterChatDetails(ctx, avatar, controller.signal);
-    } catch (error) {
-        if (error?.name !== 'AbortError') {
-            console.warn('[Chat Archive] failed to load chat previews for the selected character:', error);
-        }
-        return;
-    } finally {
-        if (state.enrichmentAbort === controller) {
-            state.enrichmentAbort = null;
-            state.enrichmentOwner = '';
-        }
-    }
-    if (controller.signal.aborted || state.closed || ui.owner.value !== owner) {
-        return;
-    }
-    state.enrichedOwners.add(avatar);
-    const rowsByKey = new Map(state.rows.map(row => [physicalChatKey(row), row]));
-    let merged = false;
-    for (const detail of details) {
-        const rich = normalizeRow({ ...detail, avatar }, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
-        const row = rich && rowsByKey.get(physicalChatKey(rich));
-        if (row) {
-            Object.assign(row, {
-                sizeText: rich.sizeText,
-                sizeBytes: rich.sizeBytes,
-                sizeKnown: rich.sizeKnown,
-                count: rich.count,
-                mtime: rich.mtime,
-                mtimeKnown: rich.mtimeKnown,
-                snippet: rich.snippet,
-            });
-            merged = true;
-        }
-    }
-    if (merged) {
-        renderList(ctx, state, ui);
-        updateBrowseStatus(ctx, state, ui);
-    }
 }
 
 function refreshOrganizationUI(ctx, state, ui) {
@@ -1862,10 +1778,6 @@ async function loadRows(ctx, state, ui) {
     exitDeepSearch(ctx, state, ui);
     cancelViewer(state);
     cancelNavigation(state);
-    state.enrichmentAbort?.abort();
-    state.enrichmentAbort = null;
-    state.enrichmentOwner = '';
-    state.enrichedOwners.clear();
     state.selectedBatchKeys.clear();
     updateSelectionControls(ctx, state, ui);
     state.listAbort?.abort();
@@ -1880,84 +1792,27 @@ async function loadRows(ctx, state, ui) {
     updateDeepButton(state, ui);
 
     try {
-        let rootScanFailed = false;
-        let recentScanFailed = false;
-        let characterError = null;
-        const avatars = (ctx.characters ?? []).map(character => character?.avatar).filter(Boolean);
-        const characterFilesPromise = fetchCharacterFiles(ctx, avatars, controller.signal).catch(error => {
-            characterError = error;
-            return null;
-        });
-        const [rows, rootFiles] = await Promise.all([
-            fetchRecent(ctx, controller.signal).catch(error => {
-                if (error?.name === 'AbortError') {
-                    throw error;
-                }
-                recentScanFailed = true;
-                console.warn('[Chat Archive] failed to load the recent chat index:', error);
-                return [];
-            }),
-            fetchRootFiles(ctx, controller.signal).catch(error => {
-                if (error?.name === 'AbortError') {
-                    throw error;
-                }
-                rootScanFailed = true;
-                console.warn('[Chat Archive] failed to check root chat files:', error);
-                return [];
-            }),
-        ]);
+        const inventory = await fetchArchiveInventory(ctx, 'archive', controller.signal);
         if (state.listAbort !== controller || state.closed) {
             return;
         }
-        const previousRows = state.rows;
         const nextRows = [];
         const known = new Set();
-        let inventoryFailures = 0;
-        const addRow = raw => {
+        let inventoryFailures = inventory.errors;
+        for (const raw of inventory.rows) {
             const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
             if (!row?.file_id) {
-                return false;
-            }
-            const key = physicalChatKey(row);
-            if (!known.has(key)) {
-                known.add(key);
-                if (row.kind === 'group') {
-                    state.missingGroupFiles.delete(row.file_id);
-                }
-                nextRows.push(row);
-            }
-            return true;
-        };
-        const preserveRow = row => {
-            const key = physicalChatKey(row);
-            if (!known.has(key)) {
-                known.add(key);
-                nextRows.push(row);
-            }
-        };
-        for (const raw of rows) {
-            if (!addRow(raw)) {
-                recentScanFailed = true;
-            }
-        }
-        for (const rootFile of rootFiles) {
-            if (!addRow(rootFile)) {
-                rootScanFailed = true;
                 inventoryFailures++;
+                continue;
+            }
+            const key = physicalChatKey(row);
+            if (!known.has(key)) {
+                known.add(key);
+                nextRows.push(row);
             }
         }
-        if (recentScanFailed || rootScanFailed) {
-            for (const row of previousRows) {
-                if ((recentScanFailed && row.source === 'recent')
-                    || (rootScanFailed && row.orphanType === 'root')) {
-                    preserveRow(row);
-                }
-            }
-        }
-        state.rootScanFailed = rootScanFailed;
-        state.recentScanFailed = recentScanFailed;
-        state.inventoryFailures = 0;
         state.rows = nextRows;
+        state.inventoryFailures = inventoryFailures;
         state.selectedKey = null;
         state.selectedRow = null;
         state.selectedButton = null;
@@ -1965,77 +1820,13 @@ async function loadRows(ctx, state, ui) {
         state.listState = 'ready';
         refreshOwnerOptions(ctx, state, ui);
         renderList(ctx, state, ui);
-        updateSelectionControls(ctx, state, ui);
-        setStatus(ui, tr(ctx, 'Loading linked chat folders...'));
-
-        const characterFiles = await characterFilesPromise;
-        if (characterError) {
-            throw characterError;
-        }
-        if (state.listAbort !== controller || state.closed) {
-            return;
-        }
-        inventoryFailures += characterFiles.failures;
-        for (const characterFile of characterFiles.rows) {
-            if (!addRow(characterFile)) {
-                characterFiles.failedAvatars.add(characterFile.avatar);
-                inventoryFailures++;
-            }
-        }
-        for (const row of previousRows) {
-            if (characterFiles.failedAvatars.has(row.avatar)) {
-                preserveRow(row);
-            }
-        }
-        const knownGroupFiles = new Set(nextRows.filter(row => row.kind === 'group').map(row => row.file_id));
-        for (const group of ctx.groups ?? []) {
-            if (!group || (typeof group.id !== 'string' && typeof group.id !== 'number')) {
-                inventoryFailures++;
-                continue;
-            }
-            const files = new Set(Array.isArray(group.chats) ? group.chats : []);
-            if (group.chat_id !== undefined && group.chat_id !== null && group.chat_id !== '') {
-                files.add(group.chat_id);
-            }
-            for (const file of files) {
-                if (typeof file !== 'string' && typeof file !== 'number') {
-                    inventoryFailures++;
-                    continue;
-                }
-                const fileId = String(file).replace(/\.jsonl$/i, '');
-                if (!fileId) {
-                    inventoryFailures++;
-                    continue;
-                }
-                if (state.missingGroupFiles.has(fileId)) {
-                    continue;
-                }
-                if (!knownGroupFiles.has(fileId)) {
-                    knownGroupFiles.add(fileId);
-                    const row = normalizeRow({
-                        _source: 'inventory',
-                        group: group.id,
-                        file_id: fileId,
-                        file_name: `${fileId}.jsonl`,
-                    }, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
-                    if (row) {
-                        preserveRow(row);
-                    } else {
-                        inventoryFailures++;
-                    }
-                }
-            }
-        }
-        state.rootScanFailed = rootScanFailed;
-        state.recentScanFailed = recentScanFailed;
-        state.inventoryFailures = inventoryFailures;
-        refreshOwnerOptions(ctx, state, ui);
-        renderList(ctx, state, ui);
         updateBrowseStatus(ctx, state, ui);
         updateSelectionControls(ctx, state, ui);
-        void enrichSelectedOwner(ctx, state, ui);
     } catch (error) {
         controller.abort();
+        if (error?.archiveCursor) {
+            void releaseArchiveToken(ctx, error.archiveReadToken, error.archiveCursor);
+        }
         if (error?.name === 'AbortError') {
             return;
         }
@@ -2079,14 +1870,8 @@ function updateBrowseStatus(ctx, state, ui) {
     let text = filtered
         ? tr(ctx, '{matching} of {total} indexed chat files', { matching, total })
         : tr(ctx, '{total} indexed chat files', { total });
-    if (state.rootScanFailed) {
-        text += ` ${tr(ctx, 'Some root files could not be checked.')}`;
-    }
-    if (state.recentScanFailed) {
-        text += ` ${tr(ctx, 'Some indexed chats could not be loaded.')}`;
-    }
     if (state.inventoryFailures > 0) {
-        text += ` ${tr(ctx, 'Some linked chat folders could not be checked.')}`;
+        text += ` ${tr(ctx, 'Some indexed chats could not be loaded.')}`;
     }
     if (!state.orphanScanComplete) {
         text += ` ${tr(ctx, 'Use Find orphaned files to include chats with deleted owners.')}`;
@@ -2419,11 +2204,6 @@ async function openViewer(ctx, state, row, ui) {
         if (error?.name === 'AbortError') {
             return;
         }
-        if (error?.status === 404 && row.kind === 'group' && row.source === 'inventory') {
-            state.missingGroupFiles.add(row.file_id);
-            state.rows = state.rows.filter(candidate => physicalChatKey(candidate) !== physicalChatKey(row));
-            renderList(ctx, state, ui);
-        }
         console.error('[Chat Archive] failed to load chat:', error);
         if (state.viewerAbort === controller) {
             const errorMessage = el('div', 'sbca-viewer-error', tr(ctx, 'Could not read this chat. Refresh the archive or scan for orphaned files again.'));
@@ -2602,11 +2382,11 @@ function refreshOpenOrganizer(ctx, state, ui) {
 }
 
 async function loadRawChat(ctx, state, row, signal) {
-    if (row.source === 'data-maid') {
-        if (!state.dataMaidToken || !row.dataMaidHash) {
+    if (row.source === 'archive-orphan') {
+        if (!state.archiveReadToken || !row.archiveHash) {
             throw new Error('Orphan scan expired');
         }
-        return fetchDataMaidFile(ctx, state.dataMaidToken, row.dataMaidHash, signal);
+        return fetchArchiveFile(ctx, state.archiveReadToken, row.archiveHash, signal);
     }
 
     const isGroup = row.kind === 'group' || row.orphanType === 'missing-group';
@@ -2639,7 +2419,7 @@ function buildSummary(ctx, row) {
         summary.append(el('div', 'sbca-summary-line', facts.join(' | ')));
     }
     if (row.mtime) {
-        const label = row.source === 'data-maid' ? tr(ctx, 'Modified') : tr(ctx, 'Last message');
+        const label = row.source === 'archive-orphan' ? tr(ctx, 'Modified') : tr(ctx, 'Last message');
         summary.append(el('div', 'sbca-summary-line', `${label}: ${new Date(row.mtime).toLocaleString()}`));
     }
     return summary;
@@ -2856,12 +2636,6 @@ function formatSendDate(ctx, sendDate) {
     return String(sendDate);
 }
 
-function withDataMaidLock(operation) {
-    const run = dataMaidQueue.then(operation, operation);
-    dataMaidQueue = run.catch(() => {});
-    return run;
-}
-
 async function scanOrphans(ctx, state, ui) {
     if (state.scanAbort || state.listAbort) {
         return;
@@ -2878,69 +2652,29 @@ async function scanOrphans(ctx, state, ui) {
     setStatus(ui, tr(ctx, 'Scanning for missing-character and unlinked-group chats...'));
     updateDeepButton(state, ui);
 
-    let unclaimedToken = null;
     try {
-        // Data Maid replaces the prior token when a report completes, so consume the response before honoring local cancellation.
-        const data = await withDataMaidLock(() => fetchDataMaidReport(ctx));
-        unclaimedToken = data?.token && data.token !== state.dataMaidToken ? data.token : null;
-        if (!data?.token || !data?.report) {
-            throw new Error('Orphan scan returned an invalid response');
-        }
-        if (state.scanAbort !== controller || state.closed) {
+        const inventory = await fetchArchiveInventory(ctx, 'orphans', controller.signal);
+        if (controller.signal.aborted || state.scanAbort !== controller || state.closed) {
+            void releaseArchiveToken(ctx, inventory.readToken);
+            if (!state.closed && state.scanAbort === controller) {
+                setStatus(ui, tr(ctx, state.orphanScanComplete
+                    ? 'Scan stopped. Previous results are still shown.'
+                    : 'Scan stopped.'));
+            }
             return;
         }
-        const linkedGroupFiles = new Set(state.rows.filter(row => row.kind === 'group').map(row => row.file_id));
         const orphanRows = [];
-        let invalidRecords = 0;
-        for (const [records, orphanType] of [
-            [data.report.chats, 'missing-character'],
-            [data.report.groupChats, 'unlinked-group'],
-        ]) {
-            if (!Array.isArray(records)) {
+        let invalidRecords = inventory.errors;
+        for (const raw of inventory.rows) {
+            const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+            if (!row?.file_id || !row.archiveHash || row.kind !== 'orphan') {
                 invalidRecords++;
                 continue;
             }
-            for (const record of records) {
-                const row = dataMaidRecordToRow(record, orphanType);
-                if (!row?.file_id || !row.dataMaidHash) {
-                    invalidRecords++;
-                } else if (orphanType !== 'unlinked-group' || !linkedGroupFiles.has(row.file_id)) {
-                    orphanRows.push(row);
-                }
-            }
+            orphanRows.push(row);
         }
-        if (controller.signal.aborted) {
-            if (state.orphanScanComplete) {
-                const previousKeys = new Set(state.orphanRows.map(physicalChatKey));
-                const retainedRows = orphanRows.filter(row => previousKeys.has(physicalChatKey(row)));
-                const retainedKeys = new Set(retainedRows.map(physicalChatKey));
-                for (const key of previousKeys) {
-                    if (!retainedKeys.has(key)) {
-                        state.selectedBatchKeys.delete(key);
-                    }
-                }
-                state.dataMaidToken = data.token;
-                unclaimedToken = null;
-                state.orphanRows = retainedRows;
-                if (state.selectedRow?.source === 'data-maid') {
-                    state.selectedRow = retainedRows.find(row => physicalChatKey(row) === state.selectedKey) ?? null;
-                    state.selectedButton = null;
-                    if (!state.selectedRow) {
-                        state.selectedKey = null;
-                        resetViewer(ctx, ui);
-                    }
-                }
-                refreshOwnerOptions(ctx, state, ui);
-                renderList(ctx, state, ui);
-                updateSelectionControls(ctx, state, ui);
-                setStatus(ui, tr(ctx, 'Scan stopped. Previous results that still exist are shown.'));
-            } else {
-                setStatus(ui, tr(ctx, 'Scan stopped.'));
-            }
-            return;
-        }
-        state.dataMaidToken = data.token;
-        unclaimedToken = null;
+        const previousToken = state.archiveReadToken;
+        state.archiveReadToken = inventory.readToken;
         state.orphanRows = orphanRows;
         state.orphanScanComplete = true;
         state.selectedKey = null;
@@ -2958,7 +2692,11 @@ async function scanOrphans(ctx, state, ui) {
         if (invalidRecords > 0) {
             setStatus(ui, `${ui.status.textContent} ${tr(ctx, 'Some orphan records could not be read.')}`);
         }
+        void releaseArchiveToken(ctx, previousToken);
     } catch (error) {
+        if (error?.archiveReadToken || error?.archiveCursor) {
+            void releaseArchiveToken(ctx, error.archiveReadToken, error.archiveCursor);
+        }
         if (!state.closed && state.scanAbort === controller) {
             if (error?.name === 'AbortError') {
                 setStatus(ui, tr(ctx, state.orphanScanComplete
@@ -2972,9 +2710,6 @@ async function scanOrphans(ctx, state, ui) {
             }
         }
     } finally {
-        if (unclaimedToken) {
-            void finalizeDataMaidToken(ctx, unclaimedToken);
-        }
         if (state.scanAbort === controller) {
             state.scanAbort = null;
             if (!state.closed) {
@@ -2990,25 +2725,21 @@ async function scanOrphans(ctx, state, ui) {
     }
 }
 
-async function finalizeDataMaidToken(ctx, token) {
-    if (!token) {
+async function releaseArchiveToken(ctx, token, cursor = null) {
+    if (!token && !cursor) {
         return;
     }
     try {
-        await withDataMaidLock(() => finalizeDataMaid(
-            ctx,
-            token,
-            AbortSignal.timeout(DATA_MAID_FINALIZE_TIMEOUT_MS),
-        ));
+        await releaseArchiveSession(ctx, { token, cursor });
     } catch (error) {
         console.warn('[Chat Archive] orphan scan token already expired:', error);
     }
 }
 
-async function releaseDataMaid(ctx, state) {
-    const token = state.dataMaidToken;
-    state.dataMaidToken = null;
-    await finalizeDataMaidToken(ctx, token);
+async function releaseArchiveReadSession(ctx, state) {
+    const token = state.archiveReadToken;
+    state.archiveReadToken = null;
+    await releaseArchiveToken(ctx, token);
 }
 
 async function runDeepSearch(ctx, state, ui) {

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -119,12 +119,10 @@ function inputControl(ctx, label, type = 'text', className = 'sbca-filter') {
 function ownerControl(ctx) {
     const id = `sbca_owner_${++renderId}`;
     const wrap = el('div', 'sbca-owner-selector');
-    const label = el('span', 'sbca-label', tr(ctx, 'Character or group'));
-    label.id = `${id}_label`;
     const details = el('details', 'sbca-owner-details');
     const summary = el('summary', 'text_pole sbca-owner-summary');
     const summaryTextId = `${id}_value`;
-    summary.setAttribute('aria-labelledby', `${label.id} ${summaryTextId}`);
+    summary.setAttribute('aria-label', tr(ctx, 'Character or group'));
     const menu = el('div', 'sbca-owner-menu');
     const search = document.createElement('input');
     search.type = 'search';
@@ -134,14 +132,14 @@ function ownerControl(ctx) {
     search.autocomplete = 'off';
     const list = el('div', 'sbca-owner-options');
     list.setAttribute('role', 'group');
-    list.setAttribute('aria-labelledby', label.id);
+    list.setAttribute('aria-label', tr(ctx, 'Character or group'));
     const empty = el('p', 'sbca-owner-empty', tr(ctx, 'No characters or groups match.'));
     empty.hidden = true;
     const input = document.createElement('input');
     input.type = 'hidden';
     menu.append(search, list, empty);
     details.append(summary, menu);
-    wrap.append(label, details, input);
+    wrap.append(details, input);
     return { wrap, details, summary, summaryTextId, search, list, empty, input, choices: new Map() };
 }
 
@@ -195,9 +193,6 @@ function setOwnerValue(ctx, ui, value) {
     copy.id = ui.ownerField.summaryTextId;
     const name = el('span', 'sbca-owner-choice-name', choice.label);
     copy.append(name);
-    if (choice.meta) {
-        copy.append(el('span', 'sbca-owner-choice-meta', choice.meta));
-    }
     ui.ownerField.summary.replaceChildren(ownerChoiceVisual(ctx, choice), copy);
     for (const option of ui.ownerField.list.querySelectorAll('.sbca-owner-option')) {
         option.setAttribute('aria-pressed', String(option.dataset.sbcaOwner === selected));

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -61,6 +61,7 @@ const MESSAGE_PAGE_SIZE = 100;
 const NAVIGATION_TIMEOUT_MS = 15_000;
 const LAST_VIEW_SAVE_DELAY_MS = 500;
 const SEARCH_DEBOUNCE_MS = 150;
+const SEARCH_CONTENT_DEBOUNCE_MS = 600;
 const MAX_ORGANIZATION_IMPORT_BYTES = 5 * 1024 * 1024;
 const RAW_PREVIEW_CHARS = 200_000;
 const UNFILED_VALUE = '__sbca_unfiled__';
@@ -84,6 +85,17 @@ function button(className, text) {
     const node = el('button', className, text);
     node.type = 'button';
     return node;
+}
+
+function createOrganizationId() {
+    if (globalThis.crypto?.randomUUID) {
+        return globalThis.crypto.randomUUID();
+    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, character => {
+        const random = Math.random() * 16 | 0;
+        const value = character === 'x' ? random : (random & 0x3 | 0x8);
+        return value.toString(16);
+    });
 }
 
 function appendOption(select, value, text) {
@@ -114,6 +126,92 @@ function inputControl(ctx, label, type = 'text', className = 'sbca-filter') {
     input.className = 'text_pole';
     wrap.append(input);
     return { wrap, input };
+}
+
+function mentionSearchState(value, choices) {
+    const source = String(value ?? '');
+    const completeMentions = [];
+    const mentionPattern = /(?:^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s]+))/g;
+    for (const match of source.matchAll(mentionPattern)) {
+        let label = match[1] ?? match[2];
+        if (match[1] !== undefined) {
+            try {
+                label = JSON.parse(`"${match[1]}"`);
+            } catch {
+                label = match[1].replace(/\\(["\\])/g, '$1');
+            }
+        }
+        const choice = choices.find(item => item.name.localeCompare(label, undefined, { sensitivity: 'accent' }) === 0);
+        completeMentions.push(choice ?? { name: label, avatars: [], missing: true });
+    }
+    const activeMatch = source.match(/(?:^|\s)@(?:"((?:\\.|[^"\\])*)|([^\s]*))$/);
+    const active = activeMatch
+        ? {
+            fragment: (activeMatch[1] ?? activeMatch[2] ?? '').replace(/\\(["\\])/g, '$1'),
+            start: activeMatch.index + activeMatch[0].lastIndexOf('@'),
+        }
+        : null;
+    const searchableSource = active ? source.slice(0, active.start) : source;
+    const text = searchableSource.replace(mentionPattern, ' ');
+    return { text: text.trim(), mentions: completeMentions, active };
+}
+
+function mentionedRows(rows, mentions) {
+    const valid = mentions.filter(mention => !mention.missing);
+    if (valid.length === 0) {
+        return mentions.some(mention => mention.missing) ? [] : rows;
+    }
+    const avatars = new Set(valid.flatMap(mention => mention.avatars));
+    return rows.filter(row => row.kind === 'solo' && avatars.has(row.avatar));
+}
+
+function mentionChoices(ctx) {
+    const choices = new Map();
+    for (const character of ctx.characters ?? []) {
+        const name = typeof character?.name === 'string' ? character.name.trim() : '';
+        if (!name || !character.avatar) {
+            continue;
+        }
+        const key = name.toLocaleLowerCase();
+        const choice = choices.get(key) ?? { name, avatars: [] };
+        choice.avatars.push(character.avatar);
+        choices.set(key, choice);
+    }
+    return [...choices.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function fuzzyMentionChoices(choices, query, limit = 8) {
+    const needle = String(query ?? '').trim().toLocaleLowerCase();
+    if (!needle) {
+        return choices.slice(0, limit);
+    }
+    const ranked = [];
+    for (const choice of choices) {
+        const name = choice.name.toLocaleLowerCase();
+        const direct = name.indexOf(needle);
+        if (direct >= 0) {
+            ranked.push({ choice, score: direct * 10 + name.length - needle.length });
+            continue;
+        }
+        let cursor = 0;
+        let gaps = 0;
+        for (const character of needle) {
+            const match = name.indexOf(character, cursor);
+            if (match < 0) {
+                cursor = -1;
+                break;
+            }
+            gaps += match - cursor;
+            cursor = match + 1;
+        }
+        if (cursor >= 0) {
+            ranked.push({ choice, score: 100 + gaps * 10 + name.length - needle.length });
+        }
+    }
+    return ranked
+        .sort((left, right) => left.score - right.score || left.choice.name.localeCompare(right.choice.name))
+        .slice(0, limit)
+        .map(item => item.choice);
 }
 
 function ownerControl(ctx) {
@@ -194,6 +292,7 @@ function setOwnerValue(ctx, ui, value) {
     const name = el('span', 'sbca-owner-choice-name', choice.label);
     copy.append(name);
     ui.ownerField.summary.replaceChildren(ownerChoiceVisual(ctx, choice), copy);
+    ui.ownerField.summary.setAttribute('aria-label', `${tr(ctx, 'Character or group')}: ${choice.label}`);
     for (const option of ui.ownerField.list.querySelectorAll('.sbca-owner-option')) {
         option.setAttribute('aria-pressed', String(option.dataset.sbcaOwner === selected));
     }
@@ -419,59 +518,52 @@ function buildRoot(ctx, state) {
     heading.tabIndex = -1;
 
     const toolbar = el('div', 'sbca-toolbar');
-    const searchLabel = el('label', 'sbca-search');
-    searchLabel.append(el('span', 'sbca-label', tr(ctx, 'Filter indexed chats')));
+    const searchLabel = el('div', 'sbca-search');
+    const searchLabelText = el('label', 'sbca-label', tr(ctx, 'Search indexed chats'));
     const search = document.createElement('input');
+    search.id = `sbca_search_${++renderId}`;
     search.type = 'search';
     search.className = 'text_pole';
-    search.placeholder = tr(ctx, 'File, owner, or latest message');
+    search.setAttribute('role', 'combobox');
+    search.placeholder = tr(ctx, 'Type to search chats. Mention character names with @.');
     search.autocomplete = 'off';
     search.enterKeyHint = 'search';
+    searchLabelText.htmlFor = search.id;
+    const characterMentions = mentionChoices(ctx);
+    const mentionMenu = el('div', 'sbca-mention-menu');
+    mentionMenu.id = `sbca_mentions_${++renderId}`;
+    mentionMenu.setAttribute('role', 'listbox');
+    mentionMenu.setAttribute('aria-label', tr(ctx, 'Character mentions'));
+    mentionMenu.hidden = true;
+    search.setAttribute('aria-controls', mentionMenu.id);
+    search.setAttribute('aria-expanded', 'false');
+    search.setAttribute('aria-autocomplete', 'list');
     (avoidSoftwareKeyboard.matches ? heading : search).setAttribute('autofocus', '');
-    searchLabel.append(search);
-
-    const deepButton = button('sbca-control sbca-deep', tr(ctx, 'Search message content'));
-    deepButton.title = tr(ctx, 'Search every message in linked chats and orphaned files already shown in the archive.');
-    deepButton.disabled = true;
-
-    const searchMode = el('div', 'sbca-search-mode');
-    searchMode.hidden = true;
-    const searchModeText = el('span', 'sbca-search-mode-text');
-    const searchModeClear = button('sbca-control sbca-search-mode-clear', tr(ctx, 'Exit message results'));
-    searchMode.append(searchModeText, searchModeClear);
+    searchLabel.append(searchLabelText, search, mentionMenu);
 
     const browseStrip = el('div', 'sbca-browse-strip');
-    const savedViewField = selectControl(ctx, 'Saved view', [['', 'Current view']], 'sbca-sort sbca-browse-field');
-    const groupField = selectControl(ctx, 'Group', GROUP_OPTIONS, 'sbca-sort sbca-browse-field');
-    const densityField = selectControl(ctx, 'Density', DENSITY_OPTIONS, 'sbca-sort sbca-browse-field');
+    browseStrip.setAttribute('role', 'group');
+    browseStrip.setAttribute('aria-label', tr(ctx, 'Browse options'));
+    const savedViewField = selectControl(ctx, 'Saved view', [['', 'Current view']], 'sbca-view-setting sbca-saved-view');
+    const groupField = selectControl(ctx, 'Group', GROUP_OPTIONS, 'sbca-view-setting');
+    const densityField = selectControl(ctx, 'Density', DENSITY_OPTIONS, 'sbca-view-setting');
     const sort = document.createElement('input');
     sort.type = 'hidden';
     sort.value = 'recent';
     markOrganizationControl(savedViewField.select);
+    savedViewField.wrap.hidden = true;
     browseStrip.append(savedViewField.wrap, groupField.wrap, densityField.wrap);
-    const browseOptions = el('details', 'sbca-browse-options');
-    const browseSummary = el('summary', undefined, tr(ctx, 'Browse options'));
-    browseOptions.open = !mobileQuery.matches;
-    browseOptions.append(browseSummary, browseStrip);
 
-    const organizationState = el('div', 'sbca-organization-state');
-    const organizationStatus = el('span', 'sbca-organization-status', tr(ctx, 'Loading organization...'));
-    organizationStatus.setAttribute('role', 'status');
-    organizationStatus.setAttribute('aria-live', 'polite');
-    const organizationRetry = button('sbca-control sbca-organization-retry', tr(ctx, 'Retry'));
-    organizationRetry.hidden = true;
-    organizationState.append(organizationStatus, organizationRetry);
-
-    const options = el('details', 'sbca-options');
-    options.append(el('summary', undefined, tr(ctx, 'Filters')));
     const optionsPanel = el('div', 'sbca-options-panel');
+    optionsPanel.id = `sbca_filters_${++renderId}`;
     const filterTools = el('div', 'sbca-filter-tools');
-    const clearFilters = button('sbca-control sbca-clear-filters', tr(ctx, 'Clear filters'));
-
+    const filterToggle = button('sbca-control sbca-filter-toggle', tr(ctx, 'Filters'));
+    filterToggle.setAttribute('aria-controls', optionsPanel.id);
+    filterToggle.setAttribute('aria-expanded', String(!mobileQuery.matches));
     const kinds = el('fieldset', 'sbca-kinds');
     kinds.append(el('legend', undefined, tr(ctx, 'Chat types')));
     for (const [kind, label] of KINDS) {
-        const wrap = el('label', 'checkbox_label');
+        const wrap = el('label', 'sbca-kind-pill');
         const box = document.createElement('input');
         box.type = 'checkbox';
         box.checked = true;
@@ -479,6 +571,13 @@ function buildRoot(ctx, state) {
         wrap.append(box, document.createTextNode(tr(ctx, label)));
         kinds.append(wrap);
     }
+    const favoriteWrap = el('label', 'sbca-kind-pill sbca-favorite-filter');
+    const favorite = document.createElement('input');
+    favorite.type = 'checkbox';
+    favorite.checked = true;
+    const favoriteLabel = el('span', undefined, tr(ctx, 'Favorites'));
+    favoriteWrap.append(favorite, favoriteLabel);
+    kinds.append(favoriteWrap);
 
     const ownerField = ownerControl(ctx);
     const orphanField = selectControl(ctx, 'Orphan reason', [
@@ -488,11 +587,7 @@ function buildRoot(ctx, state) {
         ['unlinked-group', 'Unlinked group'],
         ['root', 'Root file'],
     ]);
-    const favoriteField = selectControl(ctx, 'Favorite', [
-        ['', 'Any'],
-        ['true', 'Favorite'],
-        ['false', 'Not favorite'],
-    ]);
+    orphanField.wrap.classList.add('sbca-orphan-filter', 'sbca-view-setting');
     const folderField = selectControl(ctx, 'Folder', [
         ['', 'Any folder'],
         [UNFILED_VALUE, 'Unfiled'],
@@ -504,6 +599,8 @@ function buildRoot(ctx, state) {
     tagField.input.setAttribute('list', tagOptions.id);
     const minDateField = inputControl(ctx, 'From date', 'date');
     const maxDateField = inputControl(ctx, 'To date', 'date');
+    minDateField.wrap.classList.add('sbca-date-filter');
+    maxDateField.wrap.classList.add('sbca-date-filter');
     // Keep legacy saved-view constraints applicable without keeping their low-value controls in the toolbar.
     const minSize = document.createElement('input');
     const maxSize = document.createElement('input');
@@ -512,7 +609,7 @@ function buildRoot(ctx, state) {
     for (const input of [minSize, maxSize, minMessages, maxMessages]) {
         input.type = 'hidden';
     }
-    for (const control of [favoriteField.select, folderField.select, collectionField.select, tagField.input]) {
+    for (const control of [folderField.select, collectionField.select, tagField.input]) {
         markOrganizationControl(control);
     }
 
@@ -520,9 +617,11 @@ function buildRoot(ctx, state) {
     const scanButton = button('sbca-control', tr(ctx, 'Find orphaned files'));
     scanButton.title = tr(ctx, 'Scan for chats belonging to deleted characters or unlinked groups. This can take a while.');
     const archiveActions = el('div', 'sbca-archive-actions');
-    archiveActions.append(clearFilters, refreshButton, scanButton);
-    const organizationTools = el('details', 'sbca-organization-tools');
-    organizationTools.append(el('summary', undefined, tr(ctx, 'Manage organization')));
+    archiveActions.append(refreshButton, browseStrip);
+    const orphanActions = el('div', 'sbca-orphan-actions');
+    orphanActions.append(orphanField.wrap, scanButton);
+    const organizationToggle = button('sbca-control sbca-organization-toggle', tr(ctx, 'Manage organization'));
+    organizationToggle.setAttribute('aria-expanded', 'false');
     const management = el('div', 'sbca-management');
     const managers = {
         folders: buildNamedManager(ctx, 'folders', 'Folders', 'Folder name'),
@@ -532,24 +631,25 @@ function buildRoot(ctx, state) {
     management.append(managers.folders.root, managers.collections.root, managers.views.root);
     const backup = buildBackupControls(ctx);
     const organizationPanel = el('div', 'sbca-organization-tools-panel');
+    organizationPanel.id = `sbca_organization_${++renderId}`;
+    organizationPanel.hidden = true;
+    organizationToggle.setAttribute('aria-controls', organizationPanel.id);
     organizationPanel.append(management, backup.root);
-    organizationTools.append(organizationPanel);
     optionsPanel.append(
         kinds,
-        orphanField.wrap,
-        favoriteField.wrap,
         tagOptions,
         minDateField.wrap,
         maxDateField.wrap,
     );
-    options.append(optionsPanel);
-    filterTools.append(options, organizationTools, archiveActions);
+    const secondaryActions = el('div', 'sbca-archive-secondary-actions');
+    secondaryActions.append(orphanActions, organizationToggle);
+    filterTools.append(archiveActions, filterToggle, optionsPanel, secondaryActions, organizationPanel);
 
     const status = el('div', 'sbca-status');
     status.setAttribute('role', 'status');
     status.setAttribute('aria-live', 'polite');
     status.setAttribute('aria-atomic', 'true');
-    toolbar.append(searchLabel, deepButton, searchMode, browseOptions, organizationState, filterTools, status);
+    toolbar.append(searchLabel, filterTools, status);
 
     const body = el('div', 'sbca-body');
     const listPanel = el('section', 'sbca-list-panel');
@@ -603,15 +703,19 @@ function buildRoot(ctx, state) {
         root,
         heading,
         search,
+        characterMentions,
+        mentionMenu,
         kinds,
         savedView: savedViewField.select,
+        savedViewWrap: savedViewField.wrap,
         group: groupField.select,
         density: densityField.select,
         sort,
         owner: ownerField.input,
         ownerField,
         orphan: orphanField.select,
-        favorite: favoriteField.select,
+        favorite,
+        favoriteLabel,
         folder: folderField.select,
         collection: collectionField.select,
         tag: tagField.input,
@@ -622,18 +726,13 @@ function buildRoot(ctx, state) {
         maxSize,
         minMessages,
         maxMessages,
-        deepButton,
-        searchMode,
-        searchModeText,
-        searchModeClear,
-        browseOptions,
-        options,
-        clearFilters,
+        optionsPanel,
+        filterToggle,
+        organizationToggle,
+        organizationPanel,
         refreshButton,
         scanButton,
         status,
-        organizationStatus,
-        organizationRetry,
         managers,
         backup,
         list,
@@ -711,7 +810,7 @@ function buildRoot(ctx, state) {
     backup.exportButton.addEventListener('click', () => exportOrganization(ctx, state));
     backup.importButton.addEventListener('click', () => backup.fileInput.click());
     backup.fileInput.addEventListener('change', () => void importOrganization(ctx, state, ui));
-    organizationRetry.addEventListener('click', () => {
+    backup.retryButton.addEventListener('click', () => {
         if (state.organizationLoadState === 'error') {
             void loadOrganization(ctx, state, ui);
         } else {
@@ -720,40 +819,141 @@ function buildRoot(ctx, state) {
     });
 
     let queryTimer = null;
+    let tagTimer = null;
+    let mentionActiveIndex = -1;
+    let restoreFilterFocusOnDesktop = false;
+    filterToggle.addEventListener('focus', () => {
+        restoreFilterFocusOnDesktop = true;
+    });
+    filterToggle.addEventListener('blur', event => {
+        if (event.relatedTarget) {
+            restoreFilterFocusOnDesktop = false;
+        }
+    });
     const handleBreakpoint = event => {
         const active = document.activeElement;
         const focusInBrowse = browseStrip.contains(active);
-        browseOptions.open = !event.matches;
+        const focusInFilters = optionsPanel.contains(active);
+        const organizationExpanded = organizationToggle.getAttribute('aria-expanded') === 'true';
+        const showDesktopFilters = !event.matches && !organizationExpanded;
+        optionsPanel.hidden = !showDesktopFilters;
+        filterToggle.setAttribute('aria-expanded', String(showDesktopFilters));
         if (state.closed) {
             return;
         }
         if (!event.matches) {
-            if (active === browseSummary) {
-                groupField.select.focus({ preventScroll: true });
+            if (restoreFilterFocusOnDesktop && showDesktopFilters) {
+                optionsPanel.querySelector('input, select, button')?.focus({ preventScroll: true });
+                restoreFilterFocusOnDesktop = false;
             }
             return;
         }
-        if (root.dataset.sbcaView === 'detail' && (active === document.body || toolbar.contains(active) || listPanel.contains(active))) {
+        if (root.dataset.sbcaView === 'list' && focusInFilters) {
+            restoreFilterFocusOnDesktop = true;
+            filterToggle.focus({ preventScroll: true });
+        } else if (root.dataset.sbcaView === 'detail' && (active === document.body || toolbar.contains(active) || listPanel.contains(active))) {
             viewerTitle.focus({ preventScroll: true });
         } else if (root.dataset.sbcaView === 'list' && focusInBrowse) {
-            browseSummary.focus({ preventScroll: true });
+            groupField.select.focus({ preventScroll: true });
         } else if (root.dataset.sbcaView === 'list' && (active === document.body || viewer.contains(active))) {
             search.focus({ preventScroll: true });
         }
     };
     mobileQuery.addEventListener('change', handleBreakpoint);
+    optionsPanel.hidden = mobileQuery.matches;
+    filterToggle.addEventListener('click', () => {
+        const expanded = filterToggle.getAttribute('aria-expanded') !== 'true';
+        filterToggle.setAttribute('aria-expanded', String(expanded));
+        optionsPanel.hidden = !expanded;
+        if (expanded) {
+            organizationToggle.setAttribute('aria-expanded', 'false');
+            organizationPanel.hidden = true;
+        }
+    });
+    organizationToggle.addEventListener('click', () => {
+        const expanded = organizationToggle.getAttribute('aria-expanded') !== 'true';
+        organizationToggle.setAttribute('aria-expanded', String(expanded));
+        organizationPanel.hidden = !expanded;
+        if (expanded) {
+            filterToggle.setAttribute('aria-expanded', 'false');
+            optionsPanel.hidden = true;
+        } else if (!mobileQuery.matches) {
+            filterToggle.setAttribute('aria-expanded', 'true');
+            optionsPanel.hidden = false;
+        }
+    });
     state.cleanup = () => {
         clearTimeout(queryTimer);
+        clearTimeout(tagTimer);
         mobileQuery.removeEventListener('change', handleBreakpoint);
         document.removeEventListener('pointerdown', closeOwnerOnOutside);
     };
+
+    const closeMentionMenu = () => {
+        mentionMenu.hidden = true;
+        mentionActiveIndex = -1;
+        search.removeAttribute('aria-activedescendant');
+        search.setAttribute('aria-expanded', 'false');
+    };
+    const chooseMention = choice => {
+        const active = mentionSearchState(search.value, characterMentions).active;
+        if (!active) {
+            return;
+        }
+        const token = /[\s"\\]/.test(choice.name) ? `@${JSON.stringify(choice.name)}` : `@${choice.name}`;
+        search.value = `${search.value.slice(0, active.start)}${token} `;
+        closeMentionMenu();
+        search.focus({ preventScroll: true });
+        search.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+    const renderMentionMenu = () => {
+        const active = mentionSearchState(search.value, characterMentions).active;
+        mentionMenu.replaceChildren();
+        if (!active) {
+            closeMentionMenu();
+            return;
+        }
+        const matches = fuzzyMentionChoices(characterMentions, active.fragment);
+        for (const choice of matches) {
+            const option = button('sbca-mention-option', choice.name);
+            option.id = `sbca_mention_${++renderId}`;
+            option.setAttribute('role', 'option');
+            option.setAttribute('aria-selected', 'false');
+            option.tabIndex = -1;
+            option.addEventListener('click', () => chooseMention(choice));
+            mentionMenu.append(option);
+        }
+        mentionActiveIndex = -1;
+        search.removeAttribute('aria-activedescendant');
+        mentionMenu.hidden = matches.length === 0;
+        search.setAttribute('aria-expanded', String(matches.length > 0));
+    };
+    const moveMentionSelection = direction => {
+        const options = [...mentionMenu.querySelectorAll('.sbca-mention-option')];
+        if (options.length === 0) {
+            return;
+        }
+        mentionActiveIndex = mentionActiveIndex < 0
+            ? (direction > 0 ? 0 : options.length - 1)
+            : (mentionActiveIndex + direction + options.length) % options.length;
+        options.forEach((option, index) => option.setAttribute('aria-selected', String(index === mentionActiveIndex)));
+        const active = options[mentionActiveIndex];
+        search.setAttribute('aria-activedescendant', active.id);
+        active.scrollIntoView({ block: 'nearest' });
+    };
+    searchLabel.addEventListener('focusout', () => {
+        setTimeout(() => {
+            if (!searchLabel.contains(document.activeElement)) {
+                closeMentionMenu();
+            }
+        });
+    });
 
     const applyQuery = () => {
         exitDeepSearch(ctx, state, ui);
         state.visibleLimit = LIST_PAGE_SIZE;
         renderList(ctx, state, ui);
         updateBrowseStatus(ctx, state, ui);
-        updateDeepButton(state, ui);
         updateSelectionControls(ctx, state, ui);
     };
     const applyViewOptions = () => {
@@ -785,7 +985,7 @@ function buildRoot(ctx, state) {
         }
         clearTimeout(queryTimer);
         queryTimer = null;
-        applyQuery();
+        void runDeepSearch(ctx, state, ui);
     };
     const syncSortPills = () => {
         for (const pill of ui.sortPills.querySelectorAll('.sbca-sortpill')) {
@@ -801,24 +1001,50 @@ function buildRoot(ctx, state) {
         });
     }
     search.addEventListener('input', () => {
-        exitDeepSearch(ctx, state, ui);
+        renderMentionMenu();
         noteViewEdit();
-        updateSearchMode(ctx, state, ui);
-        updateDeepButton(state, ui);
         clearTimeout(queryTimer);
-        queryTimer = setTimeout(() => {
-            queryTimer = null;
-            applyQuery();
-        }, SEARCH_DEBOUNCE_MS);
+        queryTimer = null;
+        applyQuery();
+        if (mentionSearchState(search.value, characterMentions).text && state.listState === 'ready' && !state.scanAbort) {
+            queryTimer = setTimeout(() => {
+                queryTimer = null;
+                const query = mentionSearchState(search.value, characterMentions).text;
+                if (!query || state.listState !== 'ready' || state.scanAbort || state.searchAbort
+                    || (state.deepRows !== null && state.deepQuery === query)) {
+                    return;
+                }
+                void runDeepSearch(ctx, state, ui);
+            }, SEARCH_CONTENT_DEBOUNCE_MS);
+        }
     });
     search.addEventListener('keydown', event => {
+        if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && !mentionMenu.hidden) {
+            event.preventDefault();
+            moveMentionSelection(event.key === 'ArrowDown' ? 1 : -1);
+            return;
+        }
+        if (event.key === 'Escape' && !mentionMenu.hidden) {
+            event.preventDefault();
+            closeMentionMenu();
+            return;
+        }
+        if (event.key === 'Enter' && !mentionMenu.hidden && mentionActiveIndex >= 0) {
+            event.preventDefault();
+            const option = mentionMenu.querySelectorAll('.sbca-mention-option')[mentionActiveIndex];
+            option?.click();
+            return;
+        }
         if (event.key !== 'Enter' || event.isComposing) {
             return;
         }
         event.preventDefault();
         flushQuery();
     });
-    kinds.addEventListener('change', () => {
+    kinds.addEventListener('change', event => {
+        if (event.target === ui.favorite) {
+            ui.favorite.indeterminate = false;
+        }
         applyViewOptions();
         noteViewEdit();
     });
@@ -828,7 +1054,6 @@ function buildRoot(ctx, state) {
         ui.sort,
         ui.owner,
         ui.orphan,
-        ui.favorite,
         ui.folder,
         ui.collection,
         ui.minDate,
@@ -845,13 +1070,17 @@ function buildRoot(ctx, state) {
             }
             applyViewOptions();
             noteViewEdit();
+            if (control === ui.owner && mentionSearchState(ui.search.value, ui.characterMentions).text
+                && state.listState === 'ready' && !state.scanAbort) {
+                void runDeepSearch(ctx, state, ui);
+            }
         });
     }
     ui.tag.addEventListener('input', () => {
         noteViewEdit();
-        clearTimeout(queryTimer);
-        queryTimer = setTimeout(() => {
-            queryTimer = null;
+        clearTimeout(tagTimer);
+        tagTimer = setTimeout(() => {
+            tagTimer = null;
             applyViewOptions();
         }, SEARCH_DEBOUNCE_MS);
     });
@@ -881,28 +1110,6 @@ function buildRoot(ctx, state) {
         } else {
             void scanOrphans(ctx, state, ui);
         }
-    });
-    deepButton.addEventListener('click', () => {
-        if (state.searchAbort) {
-            state.searchAbort.abort();
-        } else {
-            flushQuery();
-            void runDeepSearch(ctx, state, ui);
-        }
-    });
-    searchModeClear.addEventListener('click', () => {
-        applyQuery();
-        search.focus({ preventScroll: true });
-    });
-    clearFilters.addEventListener('click', () => {
-        clearTimeout(queryTimer);
-        queryTimer = null;
-        applySavedView(ctx, state, ui, {
-            sort: ui.sort.value,
-            group: ui.group.value,
-            density: ui.density.value,
-        });
-        search.focus({ preventScroll: true });
     });
     selectionToggle.addEventListener('click', () => {
         state.selectionMode = !state.selectionMode;
@@ -1078,6 +1285,8 @@ function buildBackupControls(ctx) {
     root.append(el('h5', 'sbca-manager-heading', tr(ctx, 'Organization backup')));
     const exportButton = button('sbca-control', tr(ctx, 'Export organization'));
     const importButton = button('sbca-control', tr(ctx, 'Import organization'));
+    const retryButton = button('sbca-control', tr(ctx, 'Retry'));
+    retryButton.hidden = true;
     markOrganizationControl(exportButton);
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
@@ -1085,12 +1294,8 @@ function buildBackupControls(ctx) {
     fileInput.hidden = true;
     const status = el('div', 'sbca-import-status');
     status.setAttribute('role', 'alert');
-    const warning = el('p', 'sbca-organization-warning', tr(ctx,
-        'Do not delete {name} through host Data Maid; it stores Chat Archive organization.',
-        { name: ORGANIZATION_FILE_NAME },
-    ));
-    root.append(exportButton, importButton, fileInput, status, warning);
-    return { root, exportButton, importButton, fileInput, status };
+    root.append(exportButton, importButton, retryButton, fileInput, status);
+    return { root, exportButton, importButton, retryButton, fileInput, status };
 }
 
 function commaValues(value) {
@@ -1125,7 +1330,7 @@ function inputDate(input, endOfDay = false) {
 function currentSavedView(state, ui) {
     const view = {
         query: ui.search.value,
-        kinds: [...ui.kinds.querySelectorAll('input:checked')].map(box => box.dataset.sbcaKind),
+        kinds: [...ui.kinds.querySelectorAll('input[data-sbca-kind]:checked')].map(box => box.dataset.sbcaKind),
         sort: ui.sort.value,
         group: ui.group.value,
         density: ui.density.value,
@@ -1139,8 +1344,8 @@ function currentSavedView(state, ui) {
         minMessages: inputNumber(ui.minMessages, 1, true),
         maxMessages: inputNumber(ui.maxMessages, 1, true),
     };
-    if (ui.favorite.value) {
-        view.favorite = ui.favorite.value === 'true';
+    if (!ui.favorite.checked) {
+        view.favorite = false;
     }
     if (ui.folder.value) {
         view.folder = ui.folder.value === UNFILED_VALUE ? null : ui.folder.value;
@@ -1189,7 +1394,9 @@ function applySavedView(ctx, state, ui, value, selectedViewId = null, persist = 
         refreshOwnerOptions(ctx, state, ui);
     }
     ui.orphan.value = view.orphan ?? '';
-    ui.favorite.value = typeof view.favorite === 'boolean' ? String(view.favorite) : '';
+    ui.favorite.checked = view.favorite !== false;
+    ui.favorite.indeterminate = false;
+    ui.favoriteLabel.textContent = tr(ctx, 'Favorites');
     ui.folder.value = view.folder === null ? UNFILED_VALUE : view.folder ?? '';
     ui.collection.value = view.collection ?? '';
     ui.tag.value = view.tag ?? '';
@@ -1205,8 +1412,10 @@ function applySavedView(ctx, state, ui, value, selectedViewId = null, persist = 
     state.visibleLimit = LIST_PAGE_SIZE;
     renderList(ctx, state, ui);
     updateBrowseStatus(ctx, state, ui);
-    updateDeepButton(state, ui);
     updateSelectionControls(ctx, state, ui);
+    if (mentionSearchState(ui.search.value, ui.characterMentions).text && state.listState === 'ready' && !state.scanAbort) {
+        void runDeepSearch(ctx, state, ui);
+    }
     if (persist) {
         state.viewTouched = true;
         if (state.organizationWritable) {
@@ -1223,20 +1432,14 @@ function setOrganizationControlsEnabled(ui, enabled) {
 }
 
 function updateOrganizationStatus(ctx, state, ui) {
-    let text = 'Saved';
-    if (state.organizationLoadState === 'loading') {
-        text = 'Loading organization...';
-    } else if (state.organizationSaveRunning) {
-        text = 'Saving...';
-    } else if (state.organizationLoadError) {
-        text = 'Unsaved - organization could not be loaded. Retry or import a backup.';
-    } else if (state.organizationSaveError) {
-        text = 'Unsaved - save failed. Retry to keep these changes.';
-    } else if (state.organizationRevision > state.organizationSavedRevision) {
-        text = 'Unsaved';
+    ui.backup.retryButton.hidden = !state.organizationLoadError && !state.organizationSaveError;
+    if (state.organizationSaveError) {
+        ui.backup.status.textContent = tr(ctx, 'Organization changes could not be saved. Retry to keep these changes.');
+        ui.backup.status.dataset.sbcaOrganizationError = 'save';
+    } else if (ui.backup.status.dataset.sbcaOrganizationError === 'save') {
+        ui.backup.status.textContent = '';
+        delete ui.backup.status.dataset.sbcaOrganizationError;
     }
-    ui.organizationStatus.textContent = tr(ctx, text);
-    ui.organizationRetry.hidden = !state.organizationLoadError && !state.organizationSaveError;
     setOrganizationControlsEnabled(ui, state.organizationWritable);
     updateSelectionControls(ctx, state, ui);
 }
@@ -1249,6 +1452,7 @@ async function loadOrganization(ctx, state, ui) {
     state.organizationLoadError = null;
     state.organizationWritable = false;
     ui.backup.status.textContent = '';
+    delete ui.backup.status.dataset.sbcaOrganizationError;
     updateOrganizationStatus(ctx, state, ui);
     try {
         const value = await fetchOrganization(ctx, controller.signal);
@@ -1266,8 +1470,25 @@ async function loadOrganization(ctx, state, ui) {
             if (state.viewTouched) {
                 state.organization = { ...state.organization, lastView: currentSavedView(state, ui) };
                 markOrganizationDirty(ctx, state, ui, true);
+                renderList(ctx, state, ui);
+                if (!state.searchAbort) {
+                    if (state.deepRows === null) {
+                        updateBrowseStatus(ctx, state, ui);
+                    } else {
+                        setStatus(ui, tr(ctx, '{matching} of {total} matching chats', {
+                            matching: state.matchingRows.length,
+                            total: state.deepRows.length,
+                        }));
+                    }
+                }
+                updateSelectionControls(ctx, state, ui);
             } else {
                 applySavedView(ctx, state, ui, state.organization.lastView, null, false);
+            }
+            if (mentionSearchState(ui.search.value, ui.characterMentions).text
+                && state.listState === 'ready'
+                && !state.scanAbort) {
+                void runDeepSearch(ctx, state, ui);
             }
             refreshOpenOrganizer(ctx, state, ui);
             updateOrganizationStatus(ctx, state, ui);
@@ -1282,6 +1503,7 @@ async function loadOrganization(ctx, state, ui) {
             state.organizationLoadError = error;
             state.organizationWritable = false;
             ui.backup.status.textContent = tr(ctx, 'Organization could not be loaded. Retry or import a backup.');
+            ui.backup.status.dataset.sbcaOrganizationError = 'load';
             updateOrganizationStatus(ctx, state, ui);
             refreshOpenOrganizer(ctx, state, ui);
         });
@@ -1428,6 +1650,7 @@ function refreshOrganizationUI(ctx, state, ui) {
     }
     const folders = organization.folders.map(item => [item.id, item.name]);
     const collections = organization.collections.map(item => [item.id, item.name]);
+    ui.savedViewWrap.hidden = organization.views.length === 0;
     replaceSelectOptions(ui.savedView, [
         ['', tr(ctx, 'Current view')],
         ...organization.views.map(view => [view.id, view.name]),
@@ -1480,7 +1703,7 @@ function wireNamedManager(ctx, state, ui, type, manager) {
             manager.status.textContent = tr(ctx, 'That name is already in use.');
             return;
         }
-        const item = { id: crypto.randomUUID(), name };
+        const item = { id: createOrganizationId(), name };
         if (type === 'views') {
             item.view = currentSavedView(state, ui);
         }
@@ -1642,6 +1865,7 @@ async function importOrganization(ctx, state, ui) {
         refreshOrganizationUI(ctx, state, ui);
         applySavedView(ctx, state, ui, organization.lastView, null, false);
         ui.backup.status.textContent = tr(ctx, 'Imported organization. Saving replacement...');
+        delete ui.backup.status.dataset.sbcaOrganizationError;
         refreshOpenOrganizer(ctx, state, ui);
         markOrganizationDirty(ctx, state, ui);
     });
@@ -1685,29 +1909,6 @@ function mutateSelectedChats(ctx, state, ui, mutation) {
     commitChatMetadataChange(ctx, state, ui);
 }
 
-function updateDeepButton(state, ui) {
-    if (!state.searchAbort) {
-        ui.deepButton.disabled = state.listState !== 'ready' || !ui.search.value.trim() || !!state.scanAbort;
-    }
-}
-
-function updateSearchMode(ctx, state, ui) {
-    const searching = !!state.searchAbort;
-    const active = searching || state.deepRows !== null;
-    ui.searchMode.hidden = !active;
-    if (!active) {
-        return;
-    }
-    const query = state.deepQuery || ui.search.value.trim();
-    ui.searchModeText.textContent = searching
-        ? tr(ctx, 'Searching all message content for "{query}"...', { query })
-        : tr(ctx, 'Message content results for "{query}": {count} chats', {
-            query,
-            count: state.deepRows.length,
-        });
-    ui.searchModeClear.hidden = searching;
-}
-
 function clearViewerMatch(ui) {
     for (const match of ui.viewerContent.querySelectorAll('.sbca-msg-match')) {
         match.classList.remove('sbca-msg-match');
@@ -1732,7 +1933,6 @@ function cancelSearch(ctx, state, ui) {
         setStatus(ui, '');
     }
     ui.status.removeAttribute('aria-busy');
-    ui.deepButton.textContent = tr(ctx, 'Search message content');
 }
 
 function cancelViewer(state) {
@@ -1778,7 +1978,6 @@ async function loadRows(ctx, state, ui) {
     resetViewer(ctx, ui);
     renderList(ctx, state, ui);
     setStatus(ui, tr(ctx, 'Loading chats...'));
-    updateDeepButton(state, ui);
 
     try {
         for await (const page of iterateArchiveInventoryPages(ctx, 'archive', controller.signal)) {
@@ -1814,6 +2013,9 @@ async function loadRows(ctx, state, ui) {
         renderList(ctx, state, ui);
         updateBrowseStatus(ctx, state, ui);
         updateSelectionControls(ctx, state, ui);
+        if (mentionSearchState(ui.search.value, ui.characterMentions).text) {
+            void runDeepSearch(ctx, state, ui);
+        }
     } catch (error) {
         if (error?.name === 'AbortError') {
             if (state.listAbort === controller && !state.closed) {
@@ -1822,6 +2024,9 @@ async function loadRows(ctx, state, ui) {
                 renderList(ctx, state, ui);
                 updateSelectionControls(ctx, state, ui);
                 setStatus(ui, `${tr(ctx, 'Scan stopped.')} ${tr(ctx, '{total} indexed chat files', { total: state.rows.length })}`);
+                if (mentionSearchState(ui.search.value, ui.characterMentions).text) {
+                    void runDeepSearch(ctx, state, ui);
+                }
             }
             return;
         }
@@ -1835,6 +2040,9 @@ async function loadRows(ctx, state, ui) {
             setStatus(ui, tr(ctx, state.listState === 'ready'
                 ? 'Could not refresh chats. Showing the previous results.'
                 : 'Could not load chats. Try again.'));
+            if (state.listState === 'ready' && mentionSearchState(ui.search.value, ui.characterMentions).text) {
+                void runDeepSearch(ctx, state, ui);
+            }
         }
     } finally {
         if (state.listAbort === controller) {
@@ -1843,15 +2051,15 @@ async function loadRows(ctx, state, ui) {
             ui.refreshButton.disabled = false;
             ui.refreshButton.textContent = tr(ctx, 'Refresh');
             ui.scanButton.disabled = false;
-            updateDeepButton(state, ui);
         }
     }
 }
 
 function visibleRows(state, ui) {
-    const source = state.deepRows ?? allRows(state);
-    const text = state.deepRows === null ? ui.search.value : '';
-    const options = { ...currentSavedView(state, ui), text };
+    const search = mentionSearchState(ui.search.value, ui.characterMentions);
+    const source = mentionedRows(state.deepRows ?? allRows(state), search.mentions);
+    const text = state.deepRows === null ? search.text : '';
+    const options = { ...currentSavedView(state, ui), text, favoritesSelected: ui.favorite.checked };
     delete options.query;
     delete options.sort;
     delete options.group;
@@ -1872,14 +2080,10 @@ function updateBrowseStatus(ctx, state, ui) {
     if (state.inventoryFailures > 0) {
         text += ` ${tr(ctx, 'Some indexed chats could not be loaded.')}`;
     }
-    if (!state.orphanScanComplete) {
-        text += ` ${tr(ctx, 'Use Find orphaned files to include chats with deleted owners.')}`;
-    }
     setStatus(ui, text);
 }
 
 function renderList(ctx, state, ui) {
-    updateSearchMode(ctx, state, ui);
     ui.list.replaceChildren();
     state.selectedButton = null;
     if (state.listState === 'loading') {
@@ -2233,18 +2437,11 @@ function buildChatOrganizer(ctx, state, row, ui) {
     const key = physicalChatKey(row);
     const tagInputKey = organizationFocusKey('organizer', key, 'tag-input');
     const metadata = state.organization?.chats?.[key] ?? {};
-    const favorite = button('sbca-control sbca-favorite-toggle', tr(ctx, metadata.favorite ? 'Unfavorite' : 'Favorite'));
-    favorite.setAttribute('aria-pressed', String(metadata.favorite === true));
-    markOrganizationControl(favorite, organizationFocusKey('organizer', key, 'favorite'));
-    favorite.addEventListener('click', () => mutateChatMetadata(ctx, state, ui, row, value => {
-        if (value.favorite) {
-            delete value.favorite;
-        } else {
-            value.favorite = true;
-        }
-    }));
 
     const folderField = selectControl(ctx, 'Folder', [['', 'Unfiled']]);
+    const folderLabel = folderField.wrap.querySelector('.sbca-label');
+    folderLabel.classList.add('sbca-organizer-section-title');
+    folderLabel.id = `sbca_organizer_folder_${++renderId}`;
     for (const folder of state.organization?.folders ?? []) {
         appendOption(folderField.select, folder.id, folder.name);
     }
@@ -2258,33 +2455,48 @@ function buildChatOrganizer(ctx, state, row, ui) {
         }
     }));
 
-    const collections = el('fieldset', 'sbca-organizer-collections');
-    collections.append(el('legend', undefined, tr(ctx, 'Collections')));
+    const collectionsField = selectControl(ctx, 'Collections', [['', 'Collections']]);
+    const collectionsLabel = collectionsField.wrap.querySelector('.sbca-label');
+    collectionsLabel.classList.add('sbca-organizer-section-title');
+    collectionsLabel.id = `sbca_organizer_collections_${++renderId}`;
+    const collections = el('div', 'sbca-organizer-collections');
+    collections.setAttribute('role', 'group');
+    collections.setAttribute('aria-labelledby', collectionsLabel.id);
     const selectedCollections = new Set(metadata.collections ?? []);
-    if ((state.organization?.collections.length ?? 0) === 0) {
-        collections.append(el('p', 'sbca-placeholder', tr(ctx, 'No collections yet.')));
-    }
     for (const collection of state.organization?.collections ?? []) {
-        const label = el('label', 'checkbox_label');
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.checked = selectedCollections.has(collection.id);
-        markOrganizationControl(checkbox, organizationFocusKey('organizer', key, 'collection', collection.id));
-        checkbox.addEventListener('change', () => mutateChatMetadata(ctx, state, ui, row, value => {
-            const ids = new Set(value.collections ?? []);
-            if (checkbox.checked) {
-                ids.add(collection.id);
-            } else {
-                ids.delete(collection.id);
-            }
-            value.collections = [...ids];
-        }));
-        label.append(checkbox, document.createTextNode(collection.name));
-        collections.append(label);
+        appendOption(collectionsField.select, collection.id, collection.name);
     }
+    collectionsField.select.value = '';
+    markOrganizationControl(collectionsField.select, organizationFocusKey('organizer', key, 'collection'));
+    collectionsField.select.addEventListener('change', () => mutateChatMetadata(ctx, state, ui, row, value => {
+        value.collections = [...new Set([...(value.collections ?? []), collectionsField.select.value])].filter(Boolean);
+    }));
+    collections.append(collectionsField.wrap);
+    const collectionList = el('div', 'sbca-tag-list sbca-collection-list');
+    for (const collection of state.organization?.collections ?? []) {
+        if (!selectedCollections.has(collection.id)) {
+            continue;
+        }
+        const item = el('span', 'sbca-tag-item sbca-collection-item');
+        const remove = button('sbca-control sbca-tag-remove', tr(ctx, 'Remove'));
+        remove.setAttribute('aria-label', tr(ctx, 'Remove collection {name}', { name: collection.name }));
+        remove.title = collection.name;
+        markOrganizationControl(remove, organizationFocusKey('organizer', key, 'collection', collection.id));
+        remove.addEventListener('click', () => mutateChatMetadata(ctx, state, ui, row, value => {
+            value.collections = (value.collections ?? []).filter(id => id !== collection.id);
+        }));
+        item.append(el('span', 'sbca-tag-text', collection.name), remove);
+        collectionList.append(item);
+    }
+    collections.append(collectionList);
 
     const tags = el('div', 'sbca-organizer-tags');
-    tags.append(el('span', 'sbca-label', tr(ctx, 'Tags')));
+    const tagsLabel = el('span', 'sbca-label', tr(ctx, 'Tags'));
+    tagsLabel.classList.add('sbca-organizer-section-title');
+    tagsLabel.id = `sbca_organizer_tags_${++renderId}`;
+    tags.setAttribute('role', 'group');
+    tags.setAttribute('aria-labelledby', tagsLabel.id);
+    tags.append(tagsLabel);
     const tagList = el('div', 'sbca-tag-list');
     for (const tag of metadata.tags ?? []) {
         const item = el('span', 'sbca-tag-item');
@@ -2294,7 +2506,7 @@ function buildChatOrganizer(ctx, state, row, ui) {
         remove.addEventListener('click', () => mutateChatMetadata(ctx, state, ui, row, value => {
             value.tags = (value.tags ?? []).filter(name => name.toLocaleLowerCase() !== tag.toLocaleLowerCase());
         }));
-        item.append(el('span', undefined, tag), remove);
+        item.append(el('span', 'sbca-tag-text', tag), remove);
         tagList.append(item);
     }
     const tagCreate = el('div', 'sbca-tag-create');
@@ -2319,7 +2531,11 @@ function buildChatOrganizer(ctx, state, row, ui) {
     });
     tagCreate.append(tagField.wrap, tagAdd);
     tags.append(tagList, tagCreate);
-    organizer.append(favorite, folderField.wrap, collections, tags);
+    const folder = el('div', 'sbca-organizer-folder');
+    folder.setAttribute('role', 'group');
+    folder.setAttribute('aria-labelledby', folderLabel.id);
+    folder.append(folderField.wrap);
+    organizer.append(folder, collections, tags);
     for (const control of organizer.querySelectorAll('[data-sbca-organization-control]')) {
         control.disabled = !state.organizationWritable;
     }
@@ -2382,6 +2598,10 @@ function refreshOpenOrganizer(ctx, state, ui) {
     const current = ui.viewerContent.querySelector('.sbca-organizer');
     if (current) {
         current.replaceWith(buildChatOrganizer(ctx, state, state.selectedRow, ui));
+    }
+    const favoriteAction = ui.viewerContent.querySelector('.sbca-favorite-action');
+    if (favoriteAction) {
+        syncViewerFavoriteAction(state, state.selectedRow, favoriteAction);
     }
 }
 
@@ -2458,7 +2678,7 @@ function renderViewer(ctx, state, row, raw, shaped, ui) {
         latest?.focus({ preventScroll: true });
         latest?.scrollIntoView({ block: 'start' });
     } : null;
-    const actions = buildViewerActions(ctx, state, row, raw, true, showLatest);
+    const actions = buildViewerActions(ctx, state, row, raw, true, showLatest, ui);
     const details = el('div', 'sbca-viewer-details');
     details.append(buildSummary(ctx, row));
     const metadata = shaped.header?.chat_metadata;
@@ -2484,7 +2704,7 @@ function renderViewer(ctx, state, row, raw, shaped, ui) {
     match?.scrollIntoView({ block: 'center' });
 }
 
-function buildViewerActions(ctx, state, row, raw, allowText, showLatest = null) {
+function buildViewerActions(ctx, state, row, raw, allowText, showLatest, ui) {
     const actions = el('div', 'sbca-viewer-actions');
     if (showLatest) {
         const latestButton = actionButton(ctx, 'Latest messages', 'fa-angles-down');
@@ -2508,7 +2728,33 @@ function buildViewerActions(ctx, state, row, raw, allowText, showLatest = null) 
         jumpButton.addEventListener('click', () => void jumpToChat(ctx, state, row, jumpButton));
         actions.append(jumpButton);
     }
+    actions.append(buildViewerFavoriteAction(ctx, state, row, ui));
     return actions;
+}
+
+function buildViewerFavoriteAction(ctx, state, row, ui) {
+    const key = physicalChatKey(row);
+    const control = actionButton(ctx, 'Favorite', 'fa-heart');
+    control.classList.add('sbca-favorite-action');
+    markOrganizationControl(control, organizationFocusKey('viewer-action', key, 'favorite'));
+    syncViewerFavoriteAction(state, row, control);
+    control.addEventListener('click', () => {
+        const pressed = state.organization?.chats?.[key]?.favorite === true;
+        mutateChatMetadata(ctx, state, ui, row, value => {
+            if (pressed) {
+                delete value.favorite;
+            } else {
+                value.favorite = true;
+            }
+        });
+    });
+    return control;
+}
+
+function syncViewerFavoriteAction(state, row, control) {
+    const key = physicalChatKey(row);
+    control.setAttribute('aria-pressed', String(state.organization?.chats?.[key]?.favorite === true));
+    control.disabled = !state.organizationWritable;
 }
 
 function renderMalformedViewer(ctx, state, row, raw, ui) {
@@ -2525,7 +2771,7 @@ function renderMalformedViewer(ctx, state, row, raw, ui) {
         rawView,
     );
     ui.viewerContent.replaceChildren(
-        buildViewerActions(ctx, state, row, raw, false),
+        buildViewerActions(ctx, state, row, raw, false, null, ui),
         buildChatOrganizer(ctx, state, row, ui),
         details,
     );
@@ -2657,7 +2903,6 @@ async function scanOrphans(ctx, state, ui) {
     ui.scanButton.removeAttribute('aria-disabled');
     ui.scanButton.textContent = tr(ctx, 'Stop scan');
     setStatus(ui, tr(ctx, 'Scanning for missing-character and unlinked-group chats...'));
-    updateDeepButton(state, ui);
 
     const previousRows = state.orphanRows;
     const previousToken = state.archiveReadToken;
@@ -2744,8 +2989,10 @@ async function scanOrphans(ctx, state, ui) {
                 ui.scanButton.textContent = tr(ctx, state.orphanScanComplete
                     ? 'Rescan orphaned files'
                     : 'Find orphaned files');
+                if (mentionSearchState(ui.search.value, ui.characterMentions).text) {
+                    void runDeepSearch(ctx, state, ui);
+                }
             }
-            updateDeepButton(state, ui);
         }
     }
 }
@@ -2771,30 +3018,33 @@ async function releaseArchiveReadSession(ctx, state) {
 }
 
 async function runDeepSearch(ctx, state, ui) {
-    const query = ui.search.value.trim();
+    const search = mentionSearchState(ui.search.value, ui.characterMentions);
+    const query = search.text;
     if (!query) {
-        globalThis.toastr?.warning(tr(ctx, 'Enter a filter before searching message content.'));
         return;
     }
 
+    cancelSearch(ctx, state, ui);
     const controller = new AbortController();
     state.searchAbort = controller;
     state.deepRows = null;
     state.deepQuery = query;
     clearViewerMatch(ui);
     const { signal } = controller;
-    ui.deepButton.disabled = false;
-    ui.deepButton.textContent = tr(ctx, 'Stop search');
     ui.status.setAttribute('aria-busy', 'true');
     renderList(ctx, state, ui);
 
-    const scopes = buildSearchScopes(ctx.characters, ctx.groups, ui.owner.value);
+    const mentionedAvatars = new Set(search.mentions.filter(mention => !mention.missing).flatMap(mention => mention.avatars));
+    const hasMentions = search.mentions.length > 0;
+    const scopes = buildSearchScopes(ctx.characters, ctx.groups, ui.owner.value)
+        .filter(scope => !hasMentions || (scope.avatar_url && mentionedAvatars.has(scope.avatar_url)));
     const localFiles = filterRows(
-        allRows(state).filter(row => row.kind === 'orphan'),
+        mentionedRows(allRows(state), search.mentions).filter(row => row.kind === 'orphan'),
         { owner: ui.owner.value },
     );
     const total = scopes.length + localFiles.length;
-    const found = new Map();
+    const found = new Map(filterRows(mentionedRows(allRows(state), search.mentions), { text: query }, state.organization)
+        .map(row => [physicalChatKey(row), row]));
     let completed = 0;
     let errors = 0;
 
@@ -2817,22 +3067,7 @@ async function runDeepSearch(ctx, state, ui) {
                     if (found.has(physicalChatKey(row))) {
                         continue;
                     }
-                    try {
-                        const raw = await loadRawChat(ctx, state, row, signal);
-                        const { snippet, invalidLines } = await findMatchingSnippetInJsonlAsync(raw, query, { signal });
-                        if (invalidLines > 0) {
-                            errors++;
-                        }
-                        if (snippet !== null) {
-                            found.set(physicalChatKey(row), { ...row, snippet, matchSnippet: true });
-                        }
-                    } catch (error) {
-                        if (error?.name === 'AbortError') {
-                            throw error;
-                        }
-                        errors++;
-                        console.warn('[Chat Archive] search result verification failed:', error);
-                    }
+                    found.set(physicalChatKey(row), { ...row, matchSnippet: true });
                 }
                 if (malformed) {
                     errors++;
@@ -2896,9 +3131,6 @@ async function runDeepSearch(ctx, state, ui) {
         if (state.searchAbort === controller) {
             state.searchAbort = null;
             ui.status.removeAttribute('aria-busy');
-            ui.deepButton.textContent = tr(ctx, 'Search message content');
-            updateDeepButton(state, ui);
-            updateSearchMode(ctx, state, ui);
         }
     }
 }

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -1,0 +1,3387 @@
+import {
+    buildSearchScopes,
+    createDefaultOrganization,
+    dataMaidRecordToRow,
+    deepResultToRecentRow,
+    filterRows,
+    findMatchingMessageIndex,
+    findMatchingSnippetInJsonlAsync,
+    groupRows,
+    normalizeRow,
+    normalizeOrganization,
+    normalizeSavedView,
+    ownerFilterKey,
+    parseChatJsonl,
+    parseOrganization,
+    parseJsonl,
+    parseOwnerFilter,
+    physicalChatKey,
+    recordsToText,
+    sortRows,
+} from './core.js';
+import {
+    fetchOrganization,
+    exportChat,
+    fetchCharacterChatDetails,
+    fetchCharacterFiles,
+    fetchDataMaidFile,
+    fetchDataMaidReport,
+    fetchRecent,
+    fetchRootFiles,
+    finalizeDataMaid,
+    ORGANIZATION_FILE_NAME,
+    saveOrganization,
+    searchScope,
+} from './api.js';
+
+const KINDS = [
+    ['solo', 'Characters'],
+    ['group', 'Groups'],
+    ['orphan', 'Orphaned'],
+];
+
+const SORT_OPTIONS = [
+    ['recent', 'Recent'],
+    ['oldest', 'Oldest'],
+    ['size', 'Largest'],
+    ['smallest', 'Smallest'],
+    ['count', 'Most messages'],
+    ['fewest', 'Fewest messages'],
+    ['name', 'Name A-Z'],
+    ['name-reverse', 'Name Z-A'],
+    ['owner', 'Owner'],
+];
+
+const GROUP_OPTIONS = [
+    ['flat', 'Flat'],
+    ['owner', 'Owner'],
+    ['type', 'Type'],
+    ['folder', 'Folder'],
+];
+
+const DENSITY_OPTIONS = [
+    ['comfortable', 'Comfortable'],
+    ['compact', 'Compact'],
+    ['minimal', 'Minimal'],
+];
+
+const SORT_PILLS = [
+    ['recent', 'Recent'],
+    ['oldest', 'Oldest'],
+    ['name', 'A-Z'],
+    ['size', 'Largest'],
+    ['count', 'Most messages'],
+];
+
+const LIST_PAGE_SIZE = 100;
+const MESSAGE_PAGE_SIZE = 100;
+const NAVIGATION_TIMEOUT_MS = 15_000;
+const DATA_MAID_FINALIZE_TIMEOUT_MS = 15_000;
+const LAST_VIEW_SAVE_DELAY_MS = 500;
+const SEARCH_DEBOUNCE_MS = 150;
+const MAX_ORGANIZATION_IMPORT_BYTES = 5 * 1024 * 1024;
+const RAW_PREVIEW_CHARS = 200_000;
+const UNFILED_VALUE = '__sbca_unfiled__';
+
+let popup = null;
+let renderId = 0;
+let dataMaidQueue = Promise.resolve();
+let hostNavigationPending = null;
+
+function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) {
+        node.className = className;
+    }
+    if (text !== undefined) {
+        node.textContent = text;
+    }
+    return node;
+}
+
+function button(className, text) {
+    const node = el('button', className, text);
+    node.type = 'button';
+    return node;
+}
+
+function appendOption(select, value, text) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    select.append(option);
+    return option;
+}
+
+function selectControl(ctx, label, options, className = 'sbca-filter') {
+    const wrap = el('label', className);
+    wrap.append(el('span', 'sbca-label', tr(ctx, label)));
+    const select = document.createElement('select');
+    select.className = 'text_pole';
+    for (const [value, text] of options) {
+        appendOption(select, value, tr(ctx, text));
+    }
+    wrap.append(select);
+    return { wrap, select };
+}
+
+function inputControl(ctx, label, type = 'text', className = 'sbca-filter') {
+    const wrap = el('label', className);
+    wrap.append(el('span', 'sbca-label', tr(ctx, label)));
+    const input = document.createElement('input');
+    input.type = type;
+    input.className = 'text_pole';
+    wrap.append(input);
+    return { wrap, input };
+}
+
+function ownerControl(ctx) {
+    const id = `sbca_owner_${++renderId}`;
+    const wrap = el('div', 'sbca-owner-selector');
+    const label = el('span', 'sbca-label', tr(ctx, 'Character or group'));
+    label.id = `${id}_label`;
+    const details = el('details', 'sbca-owner-details');
+    const summary = el('summary', 'text_pole sbca-owner-summary');
+    const summaryTextId = `${id}_value`;
+    summary.setAttribute('aria-labelledby', `${label.id} ${summaryTextId}`);
+    const menu = el('div', 'sbca-owner-menu');
+    const search = document.createElement('input');
+    search.type = 'search';
+    search.className = 'text_pole sbca-owner-search';
+    search.placeholder = tr(ctx, 'Search characters and groups');
+    search.setAttribute('aria-label', tr(ctx, 'Search characters and groups'));
+    search.autocomplete = 'off';
+    const list = el('div', 'sbca-owner-options');
+    list.setAttribute('role', 'group');
+    list.setAttribute('aria-labelledby', label.id);
+    const empty = el('p', 'sbca-owner-empty', tr(ctx, 'No characters or groups match.'));
+    empty.hidden = true;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    menu.append(search, list, empty);
+    details.append(summary, menu);
+    wrap.append(label, details, input);
+    return { wrap, details, summary, summaryTextId, search, list, empty, input, choices: new Map() };
+}
+
+function ownerChoiceVisual(ctx, choice) {
+    if (choice.avatar) {
+        const image = document.createElement('img');
+        image.className = 'sbca-owner-mini-avatar';
+        image.src = ctx.getThumbnailUrl('avatar', choice.avatar);
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        return image;
+    }
+    const iconName = choice.kind === 'group'
+        ? 'fa-users'
+        : choice.kind === 'character'
+            ? 'fa-user-slash'
+            : 'fa-layer-group';
+    const icon = el('i', `sbca-owner-mini-icon fa-solid ${iconName}`);
+    icon.setAttribute('aria-hidden', 'true');
+    return icon;
+}
+
+function fallbackOwnerChoice(ctx, value) {
+    const parsed = parseOwnerFilter(value);
+    if (parsed) {
+        return {
+            value,
+            label: parsed.id,
+            meta: tr(ctx, parsed.kind === 'character' ? 'Character unavailable' : 'Group unavailable'),
+            kind: parsed.kind,
+            id: parsed.id,
+            avatar: null,
+        };
+    }
+    return {
+        value,
+        label: value || tr(ctx, 'All characters and groups'),
+        meta: value ? tr(ctx, 'Saved filter') : '',
+        kind: '',
+        id: '',
+        avatar: null,
+    };
+}
+
+function setOwnerValue(ctx, ui, value) {
+    const selected = value ?? '';
+    ui.owner.value = selected;
+    const choice = ui.ownerField.choices.get(selected) ?? fallbackOwnerChoice(ctx, selected);
+    const copy = el('span', 'sbca-owner-choice-copy');
+    copy.id = ui.ownerField.summaryTextId;
+    const name = el('span', 'sbca-owner-choice-name', choice.label);
+    copy.append(name);
+    if (choice.meta) {
+        copy.append(el('span', 'sbca-owner-choice-meta', choice.meta));
+    }
+    ui.ownerField.summary.replaceChildren(ownerChoiceVisual(ctx, choice), copy);
+    for (const option of ui.ownerField.list.querySelectorAll('.sbca-owner-option')) {
+        option.setAttribute('aria-pressed', String(option.dataset.sbcaOwner === selected));
+    }
+}
+
+function renderOwnerOptions(ctx, ui, choices, selected) {
+    ui.ownerField.choices = new Map(choices.map(choice => [choice.value, choice]));
+    ui.ownerField.list.replaceChildren();
+    for (const choice of choices) {
+        const option = button('sbca-owner-option');
+        option.dataset.sbcaOwner = choice.value;
+        option.dataset.sbcaSearch = `${choice.label} ${choice.meta} ${choice.id}`.toLocaleLowerCase();
+        option.setAttribute('aria-label', choice.meta ? `${choice.label}, ${choice.meta}` : choice.label);
+        option.append(ownerChoiceVisual(ctx, choice));
+        const copy = el('span', 'sbca-owner-choice-copy');
+        copy.append(el('span', 'sbca-owner-choice-name', choice.label));
+        if (choice.meta) {
+            copy.append(el('span', 'sbca-owner-choice-meta', choice.meta));
+        }
+        option.append(copy);
+        const select = () => {
+            const changed = ui.owner.value !== choice.value;
+            setOwnerValue(ctx, ui, choice.value);
+            ui.ownerField.details.open = false;
+            ui.ownerField.summary.focus({ preventScroll: true });
+            if (changed) {
+                ui.owner.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+        };
+        // Mouse/pen commit on pointerdown: platforms that do not focus buttons
+        // on press can lose the click when the focusout auto-close hides the
+        // option first. Touch waits for click so scroll gestures that start on
+        // an option are not mistaken for selection.
+        option.addEventListener('pointerdown', event => {
+            if (event.button !== 0 || event.pointerType === 'touch') {
+                return;
+            }
+            select();
+        });
+        option.addEventListener('click', select);
+        ui.ownerField.list.append(option);
+    }
+    setOwnerValue(ctx, ui, selected);
+    filterOwnerOptions(ui);
+}
+
+function filterOwnerOptions(ui) {
+    const query = ui.ownerField.search.value.trim().toLocaleLowerCase();
+    let visible = 0;
+    for (const option of ui.ownerField.list.querySelectorAll('.sbca-owner-option')) {
+        option.hidden = !!query && !option.dataset.sbcaSearch.includes(query);
+        visible += option.hidden ? 0 : 1;
+    }
+    ui.ownerField.empty.hidden = visible > 0;
+}
+
+function organizationFocusKey(...parts) {
+    return JSON.stringify(parts);
+}
+
+function markOrganizationControl(node, focusKey = '', fallbackKey = '') {
+    node.dataset.sbcaOrganizationControl = '';
+    if (focusKey) {
+        node.dataset.sbcaFocusKey = focusKey;
+    }
+    if (fallbackKey) {
+        node.dataset.sbcaFocusFallback = fallbackKey;
+    }
+    return node;
+}
+
+function preserveArchiveFocus(ui, update) {
+    const active = document.activeElement;
+    const snapshot = active && ui.root.contains(active) ? {
+        key: active.dataset.sbcaFocusKey,
+        fallback: active.dataset.sbcaFocusFallback,
+        list: ui.list.contains(active),
+        viewer: ui.viewerContent.contains(active),
+    } : null;
+    update();
+    if (!snapshot || active.isConnected) {
+        return;
+    }
+    const controls = [...ui.root.querySelectorAll('[data-sbca-focus-key]')];
+    const target = controls.find(control => control.dataset.sbcaFocusKey === snapshot.key)
+        ?? controls.find(control => control.dataset.sbcaFocusKey === snapshot.fallback)
+        ?? (snapshot.viewer ? ui.viewerTitle : snapshot.list ? ui.listHeading : null);
+    target?.focus({ preventScroll: true });
+}
+
+function actionButton(ctx, label, icon) {
+    const node = button('sbca-control sbca-action');
+    const glyph = el('i', `fa-solid ${icon}`);
+    glyph.setAttribute('aria-hidden', 'true');
+    node.append(glyph, el('span', 'sbca-button-copy', tr(ctx, label)));
+    return node;
+}
+
+function tr(ctx, text, replacements = {}) {
+    let translated = ctx.translate?.(text) ?? text;
+    for (const [key, value] of Object.entries(replacements)) {
+        translated = translated.replaceAll(`{${key}}`, () => String(value));
+    }
+    return translated;
+}
+
+function setStatus(ui, text) {
+    ui.status.textContent = text;
+}
+
+function allRows(state) {
+    return [...state.rows, ...state.orphanRows];
+}
+
+export async function closeArchive() {
+    await popup?.completeCancelled();
+}
+
+export async function openArchive(ctx, opener = null) {
+    if (popup) {
+        popup.dlg?.focus();
+        return;
+    }
+
+    const state = {
+        rows: [],
+        orphanRows: [],
+        deepRows: null,
+        deepQuery: '',
+        listState: 'loading',
+        listAbort: null,
+        viewerAbort: null,
+        searchAbort: null,
+        scanAbort: null,
+        orphanScanComplete: false,
+        rootScanFailed: false,
+        recentScanFailed: false,
+        inventoryFailures: 0,
+        dataMaidToken: null,
+        navigationPending: false,
+        navigationAbort: null,
+        navigationControl: null,
+        restoreFocus: true,
+        selectedKey: null,
+        selectedRow: null,
+        selectedButton: null,
+        selectedBatchKeys: new Set(),
+        selectionMode: false,
+        collapsedGroups: new Set(),
+        visibleLimit: LIST_PAGE_SIZE,
+        matchingRows: [],
+        charactersByAvatar: new Map((ctx.characters ?? []).filter(character => character?.avatar).map(character => [character.avatar, character])),
+        groupsById: new Map((ctx.groups ?? []).filter(group => group?.id !== undefined && group?.id !== null).map(group => [String(group.id), group])),
+        missingGroupFiles: new Set(),
+        enrichedOwners: new Set(),
+        enrichmentAbort: null,
+        enrichmentOwner: '',
+        organization: null,
+        organizationLoadState: 'loading',
+        organizationLoadAbort: null,
+        organizationLoadError: null,
+        organizationWritable: false,
+        organizationRevision: 0,
+        organizationRequestedRevision: 0,
+        organizationSavedRevision: 0,
+        organizationSaveError: null,
+        organizationSaveRunning: false,
+        organizationSavePromise: Promise.resolve(),
+        lastViewSaveTimer: null,
+        viewTouched: false,
+        selectedViewId: null,
+        closed: false,
+    };
+    const ui = buildRoot(ctx, state);
+    const instance = new ctx.Popup(ui.root, ctx.POPUP_TYPE.TEXT, '', {
+        wide: true,
+        large: true,
+        allowVerticalScrolling: false,
+        okButton: tr(ctx, 'Close'),
+    });
+    popup = instance;
+    state.popup = instance;
+    instance.dlg?.classList.add('sbca-dialog');
+    instance.dlg?.setAttribute('aria-labelledby', 'sbca_heading');
+    instance.okButton?.addEventListener('keydown', event => {
+        if (event.key === ' ') {
+            event.preventDefault();
+            instance.okButton.click();
+        }
+    });
+
+    try {
+        const shown = instance.show();
+        void loadRows(ctx, state, ui);
+        void loadOrganization(ctx, state, ui);
+        await shown;
+    } finally {
+        state.closed = true;
+        state.listAbort?.abort();
+        state.viewerAbort?.abort();
+        state.searchAbort?.abort();
+        state.navigationAbort?.abort();
+        state.scanAbort?.abort();
+        state.enrichmentAbort?.abort();
+        state.organizationLoadAbort?.abort();
+        state.cleanup?.();
+        await flushOrganization(ctx, state, ui);
+        const releasing = releaseDataMaid(ctx, state);
+        if (popup === instance) {
+            popup = null;
+        }
+        if (state.restoreFocus) {
+            const returnTarget = opener?.isConnected ? opener : document.getElementById('sbca_drawer_button');
+            returnTarget?.focus({ preventScroll: true });
+        }
+        void releasing;
+    }
+}
+
+function buildRoot(ctx, state) {
+    const root = el('div', 'sbca-root');
+    root.dataset.sbcaView = 'list';
+    root.dataset.sbcaDensity = 'comfortable';
+    const mobileQuery = globalThis.matchMedia('(max-width: 1000px)');
+    const avoidSoftwareKeyboard = globalThis.matchMedia('(max-width: 1000px), (any-pointer: coarse)');
+
+    const heading = el('h3', 'sbca-heading', tr(ctx, 'Chat Archive'));
+    heading.id = 'sbca_heading';
+    heading.tabIndex = -1;
+
+    const toolbar = el('div', 'sbca-toolbar');
+    const searchLabel = el('label', 'sbca-search');
+    searchLabel.append(el('span', 'sbca-label', tr(ctx, 'Filter indexed chats')));
+    const search = document.createElement('input');
+    search.type = 'search';
+    search.className = 'text_pole';
+    search.placeholder = tr(ctx, 'File, owner, or latest message');
+    search.autocomplete = 'off';
+    search.enterKeyHint = 'search';
+    (avoidSoftwareKeyboard.matches ? heading : search).setAttribute('autofocus', '');
+    searchLabel.append(search);
+
+    const deepButton = button('sbca-control sbca-deep', tr(ctx, 'Search message content'));
+    deepButton.title = tr(ctx, 'Search every message in linked chats and orphaned files already shown in the archive.');
+    deepButton.disabled = true;
+
+    const searchMode = el('div', 'sbca-search-mode');
+    searchMode.hidden = true;
+    const searchModeText = el('span', 'sbca-search-mode-text');
+    const searchModeClear = button('sbca-control sbca-search-mode-clear', tr(ctx, 'Exit message results'));
+    searchMode.append(searchModeText, searchModeClear);
+
+    const browseStrip = el('div', 'sbca-browse-strip');
+    const savedViewField = selectControl(ctx, 'Saved view', [['', 'Current view']], 'sbca-sort sbca-browse-field');
+    const groupField = selectControl(ctx, 'Group', GROUP_OPTIONS, 'sbca-sort sbca-browse-field');
+    const densityField = selectControl(ctx, 'Density', DENSITY_OPTIONS, 'sbca-sort sbca-browse-field');
+    const sortField = selectControl(ctx, 'Sort', SORT_OPTIONS, 'sbca-sort sbca-browse-field');
+    markOrganizationControl(savedViewField.select);
+    browseStrip.append(savedViewField.wrap, groupField.wrap, densityField.wrap, sortField.wrap);
+    const browseOptions = el('details', 'sbca-browse-options');
+    const browseSummary = el('summary', undefined, tr(ctx, 'Browse options'));
+    browseOptions.open = !mobileQuery.matches;
+    browseOptions.append(browseSummary, browseStrip);
+
+    const organizationState = el('div', 'sbca-organization-state');
+    const organizationStatus = el('span', 'sbca-organization-status', tr(ctx, 'Loading organization...'));
+    organizationStatus.setAttribute('role', 'status');
+    organizationStatus.setAttribute('aria-live', 'polite');
+    const organizationRetry = button('sbca-control sbca-organization-retry', tr(ctx, 'Retry'));
+    organizationRetry.hidden = true;
+    organizationState.append(organizationStatus, organizationRetry);
+
+    const options = el('details', 'sbca-options');
+    options.append(el('summary', undefined, tr(ctx, 'Filters and organization')));
+    const optionsPanel = el('div', 'sbca-options-panel');
+    const filterTools = el('div', 'sbca-filter-tools');
+    const clearFilters = button('sbca-control sbca-clear-filters', tr(ctx, 'Clear filters'));
+
+    const kinds = el('fieldset', 'sbca-kinds');
+    kinds.append(el('legend', undefined, tr(ctx, 'Chat types')));
+    for (const [kind, label] of KINDS) {
+        const wrap = el('label', 'checkbox_label');
+        const box = document.createElement('input');
+        box.type = 'checkbox';
+        box.checked = true;
+        box.dataset.sbcaKind = kind;
+        wrap.append(box, document.createTextNode(tr(ctx, label)));
+        kinds.append(wrap);
+    }
+
+    const ownerField = ownerControl(ctx);
+    const orphanField = selectControl(ctx, 'Orphan reason', [
+        ['', 'Any reason'],
+        ['missing-character', 'Missing character'],
+        ['missing-group', 'Missing group'],
+        ['unlinked-group', 'Unlinked group'],
+        ['root', 'Root file'],
+    ]);
+    const favoriteField = selectControl(ctx, 'Favorite', [
+        ['', 'Any'],
+        ['true', 'Favorite'],
+        ['false', 'Not favorite'],
+    ]);
+    const folderField = selectControl(ctx, 'Folder', [
+        ['', 'Any folder'],
+        [UNFILED_VALUE, 'Unfiled'],
+    ]);
+    const collectionField = selectControl(ctx, 'Collection', [['', 'Any collection']]);
+    const tagField = inputControl(ctx, 'Tag');
+    const tagOptions = document.createElement('datalist');
+    tagOptions.id = `sbca_tag_options_${++renderId}`;
+    tagField.input.setAttribute('list', tagOptions.id);
+    const minDateField = inputControl(ctx, 'From date', 'date');
+    const maxDateField = inputControl(ctx, 'To date', 'date');
+    const minSizeField = inputControl(ctx, 'Minimum size (MB)', 'number');
+    const maxSizeField = inputControl(ctx, 'Maximum size (MB)', 'number');
+    const minMessagesField = inputControl(ctx, 'Minimum messages', 'number');
+    const maxMessagesField = inputControl(ctx, 'Maximum messages', 'number');
+    for (const input of [minSizeField.input, maxSizeField.input]) {
+        input.min = '0';
+        input.step = 'any';
+    }
+    for (const input of [minMessagesField.input, maxMessagesField.input]) {
+        input.min = '0';
+        input.step = '1';
+    }
+    for (const control of [favoriteField.select, folderField.select, collectionField.select, tagField.input]) {
+        markOrganizationControl(control);
+    }
+
+    const refreshButton = button('sbca-control', tr(ctx, 'Refresh'));
+    const scanButton = button('sbca-control', tr(ctx, 'Find orphaned files'));
+    scanButton.title = tr(ctx, 'Scan for chats belonging to deleted characters or unlinked groups. This can take a while.');
+    const management = el('div', 'sbca-management');
+    const managers = {
+        folders: buildNamedManager(ctx, 'folders', 'Folders', 'Folder name'),
+        collections: buildNamedManager(ctx, 'collections', 'Collections', 'Collection name'),
+        views: buildNamedManager(ctx, 'views', 'Saved views', 'View name'),
+    };
+    management.append(managers.folders.root, managers.collections.root, managers.views.root);
+    const backup = buildBackupControls(ctx);
+    optionsPanel.append(
+        kinds,
+        orphanField.wrap,
+        favoriteField.wrap,
+        folderField.wrap,
+        collectionField.wrap,
+        tagField.wrap,
+        tagOptions,
+        minDateField.wrap,
+        maxDateField.wrap,
+        minSizeField.wrap,
+        maxSizeField.wrap,
+        minMessagesField.wrap,
+        maxMessagesField.wrap,
+        refreshButton,
+        scanButton,
+        management,
+        backup.root,
+    );
+    options.append(optionsPanel);
+    filterTools.append(options, clearFilters);
+
+    const status = el('div', 'sbca-status');
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.setAttribute('aria-atomic', 'true');
+    toolbar.append(searchLabel, deepButton, searchMode, browseOptions, organizationState, filterTools, status);
+
+    const body = el('div', 'sbca-body');
+    const listPanel = el('section', 'sbca-list-panel');
+    const listTop = el('div', 'sbca-list-top');
+    const listHeading = el('h4', 'sbca-section-heading', tr(ctx, 'Chats'));
+    listHeading.id = 'sbca_list_heading';
+    listHeading.tabIndex = -1;
+    const selectionBar = el('div', 'sbca-selection-bar');
+    const selectionToggle = button('sbca-control sbca-selection-toggle', tr(ctx, 'Select chats'));
+    selectionToggle.setAttribute('aria-pressed', 'false');
+    const selectionTools = el('div', 'sbca-selection-tools');
+    selectionTools.hidden = true;
+    const selectionCount = el('span', 'sbca-selection-count', tr(ctx, '0 selected'));
+    selectionCount.setAttribute('role', 'status');
+    selectionCount.setAttribute('aria-live', 'polite');
+    const selectionClear = button('sbca-control', tr(ctx, 'Clear'));
+    const selectionAll = button('sbca-control', tr(ctx, 'Select all matching (0)'));
+    const batch = buildBatchControls(ctx);
+    selectionTools.append(selectionCount, selectionClear, selectionAll, batch.root);
+    selectionBar.append(selectionToggle, selectionTools);
+    const sortPills = el('div', 'sbca-sortpills');
+    sortPills.setAttribute('role', 'group');
+    sortPills.setAttribute('aria-label', tr(ctx, 'Quick sort'));
+    for (const [value, label] of SORT_PILLS) {
+        const pill = button('sbca-sortpill', tr(ctx, label));
+        pill.dataset.sbcaSort = value;
+        pill.setAttribute('aria-pressed', 'false');
+        sortPills.append(pill);
+    }
+    const list = el('ul', 'sbca-list');
+    list.setAttribute('aria-labelledby', listHeading.id);
+    const listTools = el('details', 'sbca-list-tools');
+    const listToolsSummary = el('summary', undefined, tr(ctx, 'List tools'));
+    const listToolsPanel = el('div', 'sbca-list-tools-panel');
+    listToolsPanel.append(ownerField.wrap, sortPills, selectionBar);
+    listTools.append(listToolsSummary, listToolsPanel);
+    listTop.append(listHeading, listTools);
+    listPanel.append(listTop, list);
+
+    const viewer = el('section', 'sbca-viewer');
+    const backButton = actionButton(ctx, 'Back to chats', 'fa-arrow-left');
+    backButton.classList.add('sbca-back');
+    const viewerTitle = el('h4', 'sbca-section-heading', tr(ctx, 'Chat details'));
+    viewerTitle.id = 'sbca_viewer_heading';
+    viewerTitle.tabIndex = -1;
+    const viewerContent = el('div', 'sbca-viewer-content');
+    viewerContent.append(el('p', 'sbca-placeholder', tr(ctx, 'Select a chat to inspect it.')));
+    viewer.setAttribute('aria-labelledby', viewerTitle.id);
+    viewer.append(backButton, viewerTitle, viewerContent);
+    body.append(listPanel, viewer);
+    root.append(heading, toolbar, body);
+
+    const ui = {
+        root,
+        heading,
+        search,
+        kinds,
+        savedView: savedViewField.select,
+        group: groupField.select,
+        density: densityField.select,
+        sort: sortField.select,
+        owner: ownerField.input,
+        ownerField,
+        orphan: orphanField.select,
+        favorite: favoriteField.select,
+        folder: folderField.select,
+        collection: collectionField.select,
+        tag: tagField.input,
+        tagOptions,
+        minDate: minDateField.input,
+        maxDate: maxDateField.input,
+        minSize: minSizeField.input,
+        maxSize: maxSizeField.input,
+        minMessages: minMessagesField.input,
+        maxMessages: maxMessagesField.input,
+        deepButton,
+        searchMode,
+        searchModeText,
+        searchModeClear,
+        browseOptions,
+        options,
+        clearFilters,
+        refreshButton,
+        scanButton,
+        status,
+        organizationStatus,
+        organizationRetry,
+        managers,
+        backup,
+        list,
+        listHeading,
+        listPanel,
+        sortPills,
+        selectionToggle,
+        selectionTools,
+        selectionCount,
+        selectionClear,
+        selectionAll,
+        batch,
+        viewer,
+        viewerTitle,
+        viewerContent,
+        backButton,
+        mobileQuery,
+    };
+
+    renderOwnerOptions(ctx, ui, [fallbackOwnerChoice(ctx, '')], '');
+    ownerField.search.addEventListener('input', () => filterOwnerOptions(ui));
+    ownerField.search.addEventListener('keydown', event => {
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            ownerField.list.querySelector('.sbca-owner-option:not([hidden])')?.focus();
+        }
+    });
+    ownerField.list.addEventListener('keydown', event => {
+        const option = event.target.closest('.sbca-owner-option');
+        if (!option || !['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+            return;
+        }
+        event.preventDefault();
+        const options = [...ownerField.list.querySelectorAll('.sbca-owner-option:not([hidden])')];
+        const index = options.indexOf(option);
+        const next = event.key === 'Home'
+            ? options[0]
+            : event.key === 'End'
+                ? options.at(-1)
+                : options[(index + (event.key === 'ArrowDown' ? 1 : -1) + options.length) % options.length];
+        next?.focus();
+    });
+    ownerField.details.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && ownerField.details.open) {
+            event.preventDefault();
+            ownerField.details.open = false;
+            ownerField.summary.focus({ preventScroll: true });
+        }
+    });
+    ownerField.details.addEventListener('toggle', () => {
+        if (ownerField.details.open) {
+            ownerField.search.value = '';
+            filterOwnerOptions(ui);
+        }
+    });
+    ownerField.details.addEventListener('focusout', () => {
+        // A macrotask, not a microtask: a tap's down/up/click sequence must
+        // finish before the close check or the option hides under the click.
+        setTimeout(() => {
+            if (!ownerField.details.contains(document.activeElement)) {
+                ownerField.details.open = false;
+            }
+        });
+    });
+    const closeOwnerOnOutside = event => {
+        if (ownerField.details.open && !ownerField.details.contains(event.target)) {
+            ownerField.details.open = false;
+        }
+    };
+    document.addEventListener('pointerdown', closeOwnerOnOutside);
+
+    for (const [type, manager] of Object.entries(managers)) {
+        wireNamedManager(ctx, state, ui, type, manager);
+    }
+    backup.exportButton.addEventListener('click', () => exportOrganization(ctx, state));
+    backup.importButton.addEventListener('click', () => backup.fileInput.click());
+    backup.fileInput.addEventListener('change', () => void importOrganization(ctx, state, ui));
+    organizationRetry.addEventListener('click', () => {
+        if (state.organizationLoadState === 'error') {
+            void loadOrganization(ctx, state, ui);
+        } else {
+            requestOrganizationSave(ctx, state, ui);
+        }
+    });
+
+    let queryTimer = null;
+    const handleBreakpoint = event => {
+        const active = document.activeElement;
+        const focusInBrowse = browseStrip.contains(active);
+        browseOptions.open = !event.matches;
+        if (state.closed) {
+            return;
+        }
+        if (!event.matches) {
+            if (active === browseSummary) {
+                groupField.select.focus({ preventScroll: true });
+            }
+            return;
+        }
+        if (root.dataset.sbcaView === 'detail' && (active === document.body || toolbar.contains(active) || listPanel.contains(active))) {
+            viewerTitle.focus({ preventScroll: true });
+        } else if (root.dataset.sbcaView === 'list' && focusInBrowse) {
+            browseSummary.focus({ preventScroll: true });
+        } else if (root.dataset.sbcaView === 'list' && (active === document.body || viewer.contains(active))) {
+            search.focus({ preventScroll: true });
+        }
+    };
+    mobileQuery.addEventListener('change', handleBreakpoint);
+    state.cleanup = () => {
+        clearTimeout(queryTimer);
+        mobileQuery.removeEventListener('change', handleBreakpoint);
+        document.removeEventListener('pointerdown', closeOwnerOnOutside);
+    };
+
+    const applyQuery = () => {
+        exitDeepSearch(ctx, state, ui);
+        state.visibleLimit = LIST_PAGE_SIZE;
+        renderList(ctx, state, ui);
+        updateBrowseStatus(ctx, state, ui);
+        updateDeepButton(state, ui);
+        updateSelectionControls(ctx, state, ui);
+    };
+    const applyViewOptions = () => {
+        ui.root.dataset.sbcaDensity = ui.density.value;
+        state.visibleLimit = LIST_PAGE_SIZE;
+        renderList(ctx, state, ui);
+        syncSortPills();
+        if (!state.searchAbort) {
+            if (state.deepRows === null) {
+                updateBrowseStatus(ctx, state, ui);
+            } else {
+                setStatus(ui, tr(ctx, '{matching} of {total} matching chats', {
+                    matching: state.matchingRows.length,
+                    total: state.deepRows.length,
+                }));
+            }
+        }
+        updateSelectionControls(ctx, state, ui);
+    };
+    const noteViewEdit = () => {
+        state.viewTouched = true;
+        state.selectedViewId = null;
+        ui.savedView.value = '';
+        rememberCurrentView(ctx, state, ui);
+    };
+    const flushQuery = () => {
+        if (queryTimer === null) {
+            return;
+        }
+        clearTimeout(queryTimer);
+        queryTimer = null;
+        applyQuery();
+    };
+    const syncSortPills = () => {
+        for (const pill of ui.sortPills.querySelectorAll('.sbca-sortpill')) {
+            const active = pill.dataset.sbcaSort === ui.sort.value;
+            pill.setAttribute('aria-pressed', String(active));
+        }
+    };
+    for (const pill of ui.sortPills.querySelectorAll('.sbca-sortpill')) {
+        pill.addEventListener('click', () => {
+            ui.sort.value = pill.dataset.sbcaSort;
+            applyViewOptions();
+            noteViewEdit();
+        });
+    }
+    search.addEventListener('input', () => {
+        exitDeepSearch(ctx, state, ui);
+        noteViewEdit();
+        updateSearchMode(ctx, state, ui);
+        updateDeepButton(state, ui);
+        clearTimeout(queryTimer);
+        queryTimer = setTimeout(() => {
+            queryTimer = null;
+            applyQuery();
+        }, SEARCH_DEBOUNCE_MS);
+    });
+    search.addEventListener('keydown', event => {
+        if (event.key !== 'Enter' || event.isComposing) {
+            return;
+        }
+        event.preventDefault();
+        flushQuery();
+    });
+    kinds.addEventListener('change', () => {
+        applyViewOptions();
+        noteViewEdit();
+    });
+    for (const control of [
+        ui.group,
+        ui.density,
+        ui.sort,
+        ui.owner,
+        ui.orphan,
+        ui.favorite,
+        ui.folder,
+        ui.collection,
+        ui.minDate,
+        ui.maxDate,
+        ui.minSize,
+        ui.maxSize,
+        ui.minMessages,
+        ui.maxMessages,
+    ]) {
+        control.addEventListener('change', () => {
+            if (control === ui.density) {
+                ui.root.dataset.sbcaDensity = ui.density.value;
+                noteViewEdit();
+                return;
+            }
+            if (control === ui.owner) {
+                exitDeepSearch(ctx, state, ui);
+                void enrichSelectedOwner(ctx, state, ui);
+            }
+            applyViewOptions();
+            noteViewEdit();
+        });
+    }
+    ui.tag.addEventListener('input', () => {
+        noteViewEdit();
+        clearTimeout(queryTimer);
+        queryTimer = setTimeout(() => {
+            queryTimer = null;
+            applyViewOptions();
+        }, SEARCH_DEBOUNCE_MS);
+    });
+    ui.savedView.addEventListener('change', () => {
+        const selected = state.organization?.views.find(view => view.id === ui.savedView.value);
+        if (selected) {
+            applySavedView(ctx, state, ui, selected.view, selected.id);
+        } else {
+            state.selectedViewId = null;
+        }
+    });
+    refreshButton.addEventListener('click', () => void loadRows(ctx, state, ui));
+    scanButton.addEventListener('click', () => {
+        if (state.scanAbort) {
+            state.scanAbort.abort();
+            scanButton.disabled = true;
+            scanButton.textContent = tr(ctx, 'Stopping...');
+            setStatus(ui, tr(ctx, 'Stopping after the current server scan...'));
+        } else {
+            void scanOrphans(ctx, state, ui);
+        }
+    });
+    deepButton.addEventListener('click', () => {
+        if (state.searchAbort) {
+            state.searchAbort.abort();
+        } else {
+            flushQuery();
+            void runDeepSearch(ctx, state, ui);
+        }
+    });
+    searchModeClear.addEventListener('click', () => {
+        applyQuery();
+        search.focus({ preventScroll: true });
+    });
+    clearFilters.addEventListener('click', () => {
+        clearTimeout(queryTimer);
+        queryTimer = null;
+        applySavedView(ctx, state, ui, {
+            sort: ui.sort.value,
+            group: ui.group.value,
+            density: ui.density.value,
+        });
+        search.focus({ preventScroll: true });
+    });
+    selectionToggle.addEventListener('click', () => {
+        state.selectionMode = !state.selectionMode;
+        if (!state.selectionMode) {
+            state.selectedBatchKeys.clear();
+        } else {
+            listTools.open = true;
+        }
+        renderList(ctx, state, ui);
+        updateSelectionControls(ctx, state, ui);
+    });
+    selectionClear.addEventListener('click', () => {
+        state.selectedBatchKeys.clear();
+        renderList(ctx, state, ui);
+        updateSelectionControls(ctx, state, ui);
+    });
+    selectionAll.addEventListener('click', () => {
+        for (const row of state.matchingRows) {
+            state.selectedBatchKeys.add(physicalChatKey(row));
+        }
+        renderList(ctx, state, ui);
+        updateSelectionControls(ctx, state, ui);
+    });
+    batch.favorite.addEventListener('click', () => mutateSelectedChats(ctx, state, ui, metadata => {
+        metadata.favorite = true;
+    }));
+    batch.unfavorite.addEventListener('click', () => mutateSelectedChats(ctx, state, ui, metadata => {
+        delete metadata.favorite;
+    }));
+    batch.folderApply.addEventListener('click', () => {
+        if (!batch.folder.value) {
+            return;
+        }
+        mutateSelectedChats(ctx, state, ui, metadata => {
+            if (batch.folder.value === UNFILED_VALUE) {
+                delete metadata.folder;
+            } else {
+                metadata.folder = batch.folder.value;
+            }
+        });
+    });
+    batch.collectionAdd.addEventListener('click', () => {
+        if (batch.collection.value) {
+            mutateSelectedChats(ctx, state, ui, metadata => {
+                metadata.collections = [...new Set([...(metadata.collections ?? []), batch.collection.value])];
+            });
+        }
+    });
+    batch.collectionRemove.addEventListener('click', () => {
+        if (batch.collection.value) {
+            mutateSelectedChats(ctx, state, ui, metadata => {
+                metadata.collections = (metadata.collections ?? []).filter(id => id !== batch.collection.value);
+            });
+        }
+    });
+    batch.tagsAdd.addEventListener('click', () => {
+        const tags = commaValues(batch.tags.value);
+        if (tags.length > 0) {
+            mutateSelectedChats(ctx, state, ui, metadata => {
+                metadata.tags = [...(metadata.tags ?? []), ...tags];
+            });
+        }
+    });
+    batch.tagsRemove.addEventListener('click', () => {
+        const tags = new Set(commaValues(batch.tags.value).map(tag => tag.toLocaleLowerCase()));
+        if (tags.size > 0) {
+            mutateSelectedChats(ctx, state, ui, metadata => {
+                metadata.tags = (metadata.tags ?? []).filter(tag => !tags.has(tag.toLocaleLowerCase()));
+            });
+        }
+    });
+    backButton.addEventListener('click', () => showList(state, ui));
+    list.addEventListener('keydown', event => {
+        if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+            return;
+        }
+        const rows = [...list.querySelectorAll('.sbca-row-button')];
+        const current = rows.indexOf(event.target.closest('.sbca-row-button'));
+        if (rows.length === 0 || current < 0) {
+            return;
+        }
+        event.preventDefault();
+        if (event.key === 'ArrowDown' && current === rows.length - 1) {
+            const more = list.querySelector('.sbca-list-more .sbca-control');
+            if (more) {
+                more.click();
+                return;
+            }
+        }
+        rows[Math.max(0, Math.min(rows.length - 1, current + (event.key === 'ArrowDown' ? 1 : -1)))].focus();
+    });
+
+    updateOrganizationStatus(ctx, state, ui);
+    updateSelectionControls(ctx, state, ui);
+    setOrganizationControlsEnabled(ui, false);
+    syncSortPills();
+    return ui;
+}
+
+function buildNamedManager(ctx, type, title, inputLabel) {
+    const root = el('section', 'sbca-named-manager');
+    root.append(el('h5', 'sbca-manager-heading', tr(ctx, title)));
+    const create = el('div', 'sbca-manager-create');
+    const field = inputControl(ctx, inputLabel);
+    const add = button('sbca-control', tr(ctx, 'Create'));
+    const createKey = organizationFocusKey('manager', type, 'create');
+    markOrganizationControl(field.input, createKey);
+    markOrganizationControl(add, organizationFocusKey('manager', type, 'add'), createKey);
+    create.append(field.wrap, add);
+    const status = el('div', 'sbca-manager-status');
+    status.setAttribute('role', 'alert');
+    const list = el('div', 'sbca-manager-list');
+    root.append(create, status, list);
+    return { root, input: field.input, add, status, list, createKey };
+}
+
+function buildBatchControls(ctx) {
+    const root = el('div', 'sbca-batch-actions');
+    const favorite = button('sbca-control', tr(ctx, 'Favorite'));
+    const unfavorite = button('sbca-control', tr(ctx, 'Unfavorite'));
+    const folderField = selectControl(ctx, 'Folder', [
+        ['', 'Choose folder'],
+        [UNFILED_VALUE, 'Clear folder'],
+    ]);
+    const folderApply = button('sbca-control', tr(ctx, 'Set folder'));
+    const collectionField = selectControl(ctx, 'Collection', [['', 'Choose collection']]);
+    const collectionAdd = button('sbca-control', tr(ctx, 'Add collection'));
+    const collectionRemove = button('sbca-control', tr(ctx, 'Remove collection'));
+    const tagsField = inputControl(ctx, 'Tags (comma-separated)');
+    const tagsAdd = button('sbca-control', tr(ctx, 'Add tags'));
+    const tagsRemove = button('sbca-control', tr(ctx, 'Remove tags'));
+    for (const control of [
+        favorite,
+        unfavorite,
+        folderField.select,
+        folderApply,
+        collectionField.select,
+        collectionAdd,
+        collectionRemove,
+        tagsField.input,
+        tagsAdd,
+        tagsRemove,
+    ]) {
+        markOrganizationControl(control);
+    }
+    root.append(
+        favorite,
+        unfavorite,
+        folderField.wrap,
+        folderApply,
+        collectionField.wrap,
+        collectionAdd,
+        collectionRemove,
+        tagsField.wrap,
+        tagsAdd,
+        tagsRemove,
+    );
+    return {
+        root,
+        favorite,
+        unfavorite,
+        folder: folderField.select,
+        folderApply,
+        collection: collectionField.select,
+        collectionAdd,
+        collectionRemove,
+        tags: tagsField.input,
+        tagsAdd,
+        tagsRemove,
+    };
+}
+
+function buildBackupControls(ctx) {
+    const root = el('section', 'sbca-organization-backup');
+    root.append(el('h5', 'sbca-manager-heading', tr(ctx, 'Organization backup')));
+    const exportButton = button('sbca-control', tr(ctx, 'Export organization'));
+    const importButton = button('sbca-control', tr(ctx, 'Import organization'));
+    markOrganizationControl(exportButton);
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = '.json,application/json';
+    fileInput.hidden = true;
+    const status = el('div', 'sbca-import-status');
+    status.setAttribute('role', 'alert');
+    const warning = el('p', 'sbca-organization-warning', tr(ctx,
+        'Do not delete {name} through host Data Maid; it stores Chat Archive organization.',
+        { name: ORGANIZATION_FILE_NAME },
+    ));
+    root.append(exportButton, importButton, fileInput, status, warning);
+    return { root, exportButton, importButton, fileInput, status };
+}
+
+function commaValues(value) {
+    return String(value ?? '').split(',').map(item => item.trim()).filter(Boolean);
+}
+
+function inputNumber(input, multiplier = 1, integer = false) {
+    if (!input.value.trim()) {
+        return undefined;
+    }
+    const value = Number(input.value) * multiplier;
+    return Number.isFinite(value) && value >= 0 && (!integer || Number.isSafeInteger(value)) ? value : undefined;
+}
+
+function inputDate(input, endOfDay = false) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input.value);
+    if (!match) {
+        return undefined;
+    }
+    const value = new Date(
+        Number(match[1]),
+        Number(match[2]) - 1,
+        Number(match[3]),
+        endOfDay ? 23 : 0,
+        endOfDay ? 59 : 0,
+        endOfDay ? 59 : 0,
+        endOfDay ? 999 : 0,
+    ).valueOf();
+    return Number.isFinite(value) ? value : undefined;
+}
+
+function currentSavedView(state, ui) {
+    const view = {
+        query: ui.search.value,
+        kinds: [...ui.kinds.querySelectorAll('input:checked')].map(box => box.dataset.sbcaKind),
+        sort: ui.sort.value,
+        group: ui.group.value,
+        density: ui.density.value,
+        owner: ui.owner.value,
+        orphan: ui.orphan.value,
+        tag: ui.tag.value,
+        minDate: inputDate(ui.minDate),
+        maxDate: inputDate(ui.maxDate, true),
+        minSize: inputNumber(ui.minSize, 1024 ** 2),
+        maxSize: inputNumber(ui.maxSize, 1024 ** 2),
+        minMessages: inputNumber(ui.minMessages, 1, true),
+        maxMessages: inputNumber(ui.maxMessages, 1, true),
+    };
+    if (ui.favorite.value) {
+        view.favorite = ui.favorite.value === 'true';
+    }
+    if (ui.folder.value) {
+        view.folder = ui.folder.value === UNFILED_VALUE ? null : ui.folder.value;
+    }
+    if (ui.collection.value) {
+        view.collection = ui.collection.value;
+    }
+    return normalizeSavedView(view, state.organization);
+}
+
+function rememberCurrentView(ctx, state, ui) {
+    if (!state.organizationWritable || !state.organization) {
+        return;
+    }
+    state.organization = { ...state.organization, lastView: currentSavedView(state, ui) };
+    markOrganizationDirty(ctx, state, ui, true);
+}
+
+function dateInputValue(value) {
+    if (value === undefined) {
+        return '';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.valueOf())) {
+        return '';
+    }
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function applySavedView(ctx, state, ui, value, selectedViewId = null, persist = true) {
+    const view = normalizeSavedView(value, state.organization);
+    exitDeepSearch(ctx, state, ui);
+    ui.search.value = view.query ?? '';
+    const kinds = new Set(view.kinds ?? KINDS.map(([kind]) => kind));
+    for (const box of ui.kinds.querySelectorAll('input')) {
+        box.checked = kinds.has(box.dataset.sbcaKind);
+    }
+    ui.sort.value = view.sort ?? 'recent';
+    ui.group.value = view.group ?? 'flat';
+    ui.density.value = view.density ?? 'comfortable';
+    const owner = view.owner ?? '';
+    setOwnerValue(ctx, ui, owner);
+    if (owner && !ui.ownerField.choices.has(owner)) {
+        refreshOwnerOptions(ctx, state, ui);
+    }
+    ui.orphan.value = view.orphan ?? '';
+    ui.favorite.value = typeof view.favorite === 'boolean' ? String(view.favorite) : '';
+    ui.folder.value = view.folder === null ? UNFILED_VALUE : view.folder ?? '';
+    ui.collection.value = view.collection ?? '';
+    ui.tag.value = view.tag ?? '';
+    ui.minDate.value = dateInputValue(view.minDate);
+    ui.maxDate.value = dateInputValue(view.maxDate);
+    ui.minSize.value = view.minSize === undefined ? '' : String(view.minSize / 1024 ** 2);
+    ui.maxSize.value = view.maxSize === undefined ? '' : String(view.maxSize / 1024 ** 2);
+    ui.minMessages.value = view.minMessages ?? '';
+    ui.maxMessages.value = view.maxMessages ?? '';
+    ui.root.dataset.sbcaDensity = ui.density.value;
+    state.selectedViewId = selectedViewId;
+    ui.savedView.value = selectedViewId ?? '';
+    state.visibleLimit = LIST_PAGE_SIZE;
+    renderList(ctx, state, ui);
+    updateBrowseStatus(ctx, state, ui);
+    updateDeepButton(state, ui);
+    updateSelectionControls(ctx, state, ui);
+    void enrichSelectedOwner(ctx, state, ui);
+    if (persist) {
+        state.viewTouched = true;
+        if (state.organizationWritable) {
+            state.organization = { ...state.organization, lastView: view };
+            markOrganizationDirty(ctx, state, ui, true);
+        }
+    }
+}
+
+function setOrganizationControlsEnabled(ui, enabled) {
+    for (const control of ui.root.querySelectorAll('[data-sbca-organization-control]')) {
+        control.disabled = !enabled;
+    }
+}
+
+function updateOrganizationStatus(ctx, state, ui) {
+    let text = 'Saved';
+    if (state.organizationLoadState === 'loading') {
+        text = 'Loading organization...';
+    } else if (state.organizationSaveRunning) {
+        text = 'Saving...';
+    } else if (state.organizationLoadError) {
+        text = 'Unsaved - organization could not be loaded. Retry or import a backup.';
+    } else if (state.organizationSaveError) {
+        text = 'Unsaved - save failed. Retry to keep these changes.';
+    } else if (state.organizationRevision > state.organizationSavedRevision) {
+        text = 'Unsaved';
+    }
+    ui.organizationStatus.textContent = tr(ctx, text);
+    ui.organizationRetry.hidden = !state.organizationLoadError && !state.organizationSaveError;
+    setOrganizationControlsEnabled(ui, state.organizationWritable);
+    updateSelectionControls(ctx, state, ui);
+}
+
+async function loadOrganization(ctx, state, ui) {
+    state.organizationLoadAbort?.abort();
+    const controller = new AbortController();
+    state.organizationLoadAbort = controller;
+    state.organizationLoadState = 'loading';
+    state.organizationLoadError = null;
+    state.organizationWritable = false;
+    ui.backup.status.textContent = '';
+    updateOrganizationStatus(ctx, state, ui);
+    try {
+        const value = await fetchOrganization(ctx, controller.signal);
+        const organization = value === null ? createDefaultOrganization() : normalizeOrganization(value);
+        if (state.organizationLoadAbort !== controller || state.closed) {
+            return;
+        }
+        preserveArchiveFocus(ui, () => {
+            state.organization = organization;
+            state.organizationLoadState = 'ready';
+            state.organizationWritable = true;
+            state.organizationLoadError = null;
+            state.organizationSaveError = null;
+            refreshOrganizationUI(ctx, state, ui);
+            if (state.viewTouched) {
+                state.organization = { ...state.organization, lastView: currentSavedView(state, ui) };
+                markOrganizationDirty(ctx, state, ui, true);
+            } else {
+                applySavedView(ctx, state, ui, state.organization.lastView, null, false);
+            }
+            refreshOpenOrganizer(ctx, state, ui);
+            updateOrganizationStatus(ctx, state, ui);
+        });
+    } catch (error) {
+        if (error?.name === 'AbortError' || state.organizationLoadAbort !== controller || state.closed) {
+            return;
+        }
+        console.error('[Chat Archive] failed to load organization:', error);
+        preserveArchiveFocus(ui, () => {
+            state.organizationLoadState = 'error';
+            state.organizationLoadError = error;
+            state.organizationWritable = false;
+            ui.backup.status.textContent = tr(ctx, 'Organization could not be loaded. Retry or import a backup.');
+            updateOrganizationStatus(ctx, state, ui);
+            refreshOpenOrganizer(ctx, state, ui);
+        });
+    } finally {
+        if (state.organizationLoadAbort === controller) {
+            state.organizationLoadAbort = null;
+        }
+    }
+}
+
+function markOrganizationDirty(ctx, state, ui, debounce = false) {
+    if (!state.organizationWritable || !state.organization) {
+        return;
+    }
+    state.organizationRevision++;
+    state.organizationSaveError = null;
+    clearTimeout(state.lastViewSaveTimer);
+    state.lastViewSaveTimer = null;
+    updateOrganizationStatus(ctx, state, ui);
+    if (debounce) {
+        state.lastViewSaveTimer = setTimeout(() => {
+            state.lastViewSaveTimer = null;
+            requestOrganizationSave(ctx, state, ui);
+        }, LAST_VIEW_SAVE_DELAY_MS);
+    } else {
+        requestOrganizationSave(ctx, state, ui);
+    }
+}
+
+function requestOrganizationSave(ctx, state, ui) {
+    if (!state.organizationWritable || !state.organization || state.organizationRevision === 0) {
+        return;
+    }
+    state.organizationRequestedRevision = state.organizationRevision;
+    if (!state.organizationSaveRunning) {
+        runOrganizationSave(ctx, state, ui);
+    }
+}
+
+function runOrganizationSave(ctx, state, ui) {
+    const revision = state.organizationRequestedRevision;
+    if (!state.organizationWritable || !state.organization || revision <= state.organizationSavedRevision) {
+        return state.organizationSavePromise;
+    }
+    state.organizationSaveRunning = true;
+    state.organizationSaveError = null;
+    const snapshot = state.organization;
+    updateOrganizationStatus(ctx, state, ui);
+    // ponytail: host upload has no compare-and-swap/etag; simultaneous tabs are last-writer-wins.
+    const operation = saveOrganization(ctx, snapshot)
+        .then(() => {
+            state.organizationSavedRevision = Math.max(state.organizationSavedRevision, revision);
+        })
+        .catch(error => {
+            state.organizationSaveError = error;
+            console.error('[Chat Archive] failed to save organization:', error);
+        })
+        .finally(() => {
+            state.organizationSaveRunning = false;
+            updateOrganizationStatus(ctx, state, ui);
+            if (state.organizationRequestedRevision > revision) {
+                runOrganizationSave(ctx, state, ui);
+            }
+        });
+    state.organizationSavePromise = operation;
+    return operation;
+}
+
+async function flushOrganization(ctx, state, ui) {
+    if (state.lastViewSaveTimer) {
+        clearTimeout(state.lastViewSaveTimer);
+        state.lastViewSaveTimer = null;
+    }
+    if (state.organizationWritable && state.organizationRevision > state.organizationSavedRevision) {
+        requestOrganizationSave(ctx, state, ui);
+    }
+    while (state.organizationSaveRunning) {
+        await state.organizationSavePromise;
+    }
+    if (state.organizationWritable && state.organizationRevision > state.organizationSavedRevision) {
+        requestOrganizationSave(ctx, state, ui);
+        await state.organizationSavePromise;
+    }
+    if (state.organizationSaveError && state.organizationRevision > state.organizationSavedRevision) {
+        globalThis.toastr?.error?.(tr(ctx, 'Organization changes could not be saved.'));
+    }
+}
+
+function replaceSelectOptions(select, options, selected = select.value) {
+    select.replaceChildren();
+    for (const [value, label] of options) {
+        appendOption(select, value, label);
+    }
+    select.value = options.some(([value]) => value === selected) ? selected : '';
+}
+
+function refreshOwnerOptions(ctx, state, ui) {
+    const current = ui.owner.value;
+    const owners = new Map();
+    for (const row of allRows(state)) {
+        const value = ownerFilterKey(row);
+        const identity = parseOwnerFilter(value);
+        if (!identity) {
+            continue;
+        }
+        const choice = {
+            value,
+            label: ownerLabel(ctx, row),
+            meta: '',
+            kind: identity.kind,
+            id: identity.id,
+            avatar: identity.kind === 'character' && row.kind === 'solo' ? row.avatar : null,
+        };
+        if (!owners.has(value) || (!owners.get(value).avatar && choice.avatar)) {
+            owners.set(value, choice);
+        }
+    }
+    const counts = new Map();
+    for (const choice of owners.values()) {
+        const name = choice.label.toLocaleLowerCase();
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    for (const choice of owners.values()) {
+        if (counts.get(choice.label.toLocaleLowerCase()) > 1) {
+            choice.meta = tr(ctx, choice.kind === 'character' ? 'Character: {name}' : 'Group: {name}', { name: choice.id });
+        }
+    }
+    const choices = [...owners.values()].sort((a, b) => (
+        a.label.localeCompare(b.label)
+        || a.kind.localeCompare(b.kind)
+        || a.id.localeCompare(b.id)
+    ));
+    choices.unshift(fallbackOwnerChoice(ctx, ''));
+    if (current && !owners.has(current)) {
+        choices.push(fallbackOwnerChoice(ctx, current));
+    }
+    renderOwnerOptions(ctx, ui, choices, current);
+}
+
+// SillyBunny's simple inventory omits message previews; enrich the selected
+// character only, so browsing stays cheap for everyone else.
+async function enrichSelectedOwner(ctx, state, ui) {
+    const owner = ui.owner.value;
+    const identity = parseOwnerFilter(owner);
+    if (!identity || identity.kind !== 'character') {
+        state.enrichmentAbort?.abort();
+        state.enrichmentAbort = null;
+        state.enrichmentOwner = '';
+        return;
+    }
+    const avatar = `${identity.id}.png`;
+    if (state.enrichedOwners.has(avatar)
+        || (state.enrichmentOwner === avatar && state.enrichmentAbort)) {
+        return;
+    }
+    const needsDetails = state.rows.some(row => (
+        row.source === 'inventory' && ownerFilterKey(row) === owner
+    ));
+    if (!needsDetails) {
+        return;
+    }
+    state.enrichmentAbort?.abort();
+    const controller = new AbortController();
+    state.enrichmentAbort = controller;
+    state.enrichmentOwner = avatar;
+    let details;
+    try {
+        details = await fetchCharacterChatDetails(ctx, avatar, controller.signal);
+    } catch (error) {
+        if (error?.name !== 'AbortError') {
+            console.warn('[Chat Archive] failed to load chat previews for the selected character:', error);
+        }
+        return;
+    } finally {
+        if (state.enrichmentAbort === controller) {
+            state.enrichmentAbort = null;
+            state.enrichmentOwner = '';
+        }
+    }
+    if (controller.signal.aborted || state.closed || ui.owner.value !== owner) {
+        return;
+    }
+    state.enrichedOwners.add(avatar);
+    const rowsByKey = new Map(state.rows.map(row => [physicalChatKey(row), row]));
+    let merged = false;
+    for (const detail of details) {
+        const rich = normalizeRow({ ...detail, avatar }, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+        const row = rich && rowsByKey.get(physicalChatKey(rich));
+        if (row) {
+            Object.assign(row, {
+                sizeText: rich.sizeText,
+                sizeBytes: rich.sizeBytes,
+                sizeKnown: rich.sizeKnown,
+                count: rich.count,
+                mtime: rich.mtime,
+                mtimeKnown: rich.mtimeKnown,
+                snippet: rich.snippet,
+            });
+            merged = true;
+        }
+    }
+    if (merged) {
+        renderList(ctx, state, ui);
+        updateBrowseStatus(ctx, state, ui);
+    }
+}
+
+function refreshOrganizationUI(ctx, state, ui) {
+    const organization = state.organization;
+    if (!organization) {
+        return;
+    }
+    const folders = organization.folders.map(item => [item.id, item.name]);
+    const collections = organization.collections.map(item => [item.id, item.name]);
+    replaceSelectOptions(ui.savedView, [
+        ['', tr(ctx, 'Current view')],
+        ...organization.views.map(view => [view.id, view.name]),
+    ], state.selectedViewId ?? '');
+    if (state.selectedViewId && !organization.views.some(view => view.id === state.selectedViewId)) {
+        state.selectedViewId = null;
+    }
+    replaceSelectOptions(ui.folder, [
+        ['', tr(ctx, 'Any folder')],
+        [UNFILED_VALUE, tr(ctx, 'Unfiled')],
+        ...folders,
+    ]);
+    replaceSelectOptions(ui.collection, [['', tr(ctx, 'Any collection')], ...collections]);
+    replaceSelectOptions(ui.batch.folder, [
+        ['', tr(ctx, 'Choose folder')],
+        [UNFILED_VALUE, tr(ctx, 'Clear folder')],
+        ...folders,
+    ]);
+    replaceSelectOptions(ui.batch.collection, [['', tr(ctx, 'Choose collection')], ...collections]);
+    refreshTagOptions(state, ui);
+    for (const [type, manager] of Object.entries(ui.managers)) {
+        renderNamedManager(ctx, state, ui, type, manager);
+    }
+    setOrganizationControlsEnabled(ui, state.organizationWritable);
+    updateSelectionControls(ctx, state, ui);
+}
+
+function refreshTagOptions(state, ui) {
+    const tags = new Set();
+    for (const metadata of Object.values(state.organization?.chats ?? {})) {
+        for (const tag of metadata.tags ?? []) {
+            tags.add(tag);
+        }
+    }
+    ui.tagOptions.replaceChildren(...[...tags].sort().map(tag => {
+        const option = document.createElement('option');
+        option.value = tag;
+        return option;
+    }));
+}
+
+function wireNamedManager(ctx, state, ui, type, manager) {
+    const create = () => {
+        const name = manager.input.value.trim();
+        if (!name) {
+            manager.status.textContent = tr(ctx, 'Enter a name.');
+            return;
+        }
+        if (hasDuplicateName(state.organization?.[type], name)) {
+            manager.status.textContent = tr(ctx, 'That name is already in use.');
+            return;
+        }
+        const item = { id: crypto.randomUUID(), name };
+        if (type === 'views') {
+            item.view = currentSavedView(state, ui);
+        }
+        state.organization = normalizeOrganization({
+            ...state.organization,
+            [type]: [...state.organization[type], item],
+        });
+        state.selectedViewId = type === 'views' ? item.id : state.selectedViewId;
+        manager.input.value = '';
+        manager.status.textContent = '';
+        commitOrganizationChange(ctx, state, ui);
+    };
+    manager.add.addEventListener('click', create);
+    manager.input.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            create();
+        }
+    });
+}
+
+function hasDuplicateName(items, name, exceptId = null) {
+    const folded = name.toLocaleLowerCase();
+    return (items ?? []).some(item => item.id !== exceptId && item.name.toLocaleLowerCase() === folded);
+}
+
+function renderNamedManager(ctx, state, ui, type, manager) {
+    manager.list.replaceChildren();
+    const items = state.organization?.[type] ?? [];
+    if (items.length === 0) {
+        manager.list.append(el('p', 'sbca-placeholder', tr(ctx, 'None yet.')));
+        return;
+    }
+    for (const item of items) {
+        const row = el('div', 'sbca-manager-row');
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'text_pole';
+        input.value = item.name;
+        input.setAttribute('aria-label', tr(ctx, 'Rename {name}', { name: item.name }));
+        const rename = button('sbca-control', tr(ctx, 'Rename'));
+        const remove = button('sbca-control', tr(ctx, 'Delete'));
+        rename.setAttribute('aria-label', tr(ctx, 'Rename {name}', { name: item.name }));
+        remove.setAttribute('aria-label', tr(ctx, 'Delete {name}', { name: item.name }));
+        markOrganizationControl(input, organizationFocusKey('manager', type, item.id, 'name'), manager.createKey);
+        markOrganizationControl(rename, organizationFocusKey('manager', type, item.id, 'rename'), manager.createKey);
+        markOrganizationControl(remove, organizationFocusKey('manager', type, item.id, 'delete'), manager.createKey);
+        rename.addEventListener('click', () => {
+            const name = input.value.trim();
+            if (!name) {
+                manager.status.textContent = tr(ctx, 'Enter a name.');
+                return;
+            }
+            if (hasDuplicateName(items, name, item.id)) {
+                manager.status.textContent = tr(ctx, 'That name is already in use.');
+                return;
+            }
+            state.organization = normalizeOrganization({
+                ...state.organization,
+                [type]: items.map(value => value.id === item.id ? { ...value, name } : value),
+            });
+            manager.status.textContent = '';
+            commitOrganizationChange(ctx, state, ui);
+        });
+        remove.addEventListener('click', () => deleteNamedItem(ctx, state, ui, type, item));
+        row.append(input, rename, remove);
+        manager.list.append(row);
+    }
+}
+
+function namedItemHasReferences(organization, type, id) {
+    const field = type === 'folders' ? 'folder' : 'collection';
+    if (organization.lastView?.[field] === id || organization.views.some(view => view.view[field] === id)) {
+        return true;
+    }
+    return Object.values(organization.chats).some(metadata => (
+        type === 'folders' ? metadata.folder === id : metadata.collections?.includes(id)
+    ));
+}
+
+function deleteNamedItem(ctx, state, ui, type, item) {
+    if (type === 'views' && !globalThis.confirm(tr(ctx, 'Delete saved view {name}?', { name: item.name }))) {
+        return;
+    }
+    if ((type === 'folders' || type === 'collections')
+        && namedItemHasReferences(state.organization, type, item.id)
+        && !globalThis.confirm(tr(ctx, 'Delete {name} and remove it from chats and saved views?', { name: item.name }))) {
+        return;
+    }
+    state.organization = normalizeOrganization({
+        ...state.organization,
+        [type]: state.organization[type].filter(value => value.id !== item.id),
+    });
+    if (type === 'views' && state.selectedViewId === item.id) {
+        state.selectedViewId = null;
+    }
+    commitOrganizationChange(ctx, state, ui);
+}
+
+function commitOrganizationChange(ctx, state, ui) {
+    preserveArchiveFocus(ui, () => {
+        refreshOrganizationUI(ctx, state, ui);
+        renderList(ctx, state, ui);
+        updateBrowseStatus(ctx, state, ui);
+        refreshOpenOrganizer(ctx, state, ui);
+        markOrganizationDirty(ctx, state, ui);
+    });
+}
+
+function commitChatMetadataChange(ctx, state, ui) {
+    preserveArchiveFocus(ui, () => {
+        refreshTagOptions(state, ui);
+        renderList(ctx, state, ui);
+        updateBrowseStatus(ctx, state, ui);
+        refreshOpenOrganizer(ctx, state, ui);
+        markOrganizationDirty(ctx, state, ui);
+    });
+}
+
+function exportOrganization(ctx, state) {
+    if (!state.organization) {
+        return;
+    }
+    const text = `${JSON.stringify(normalizeOrganization(state.organization), null, 2)}\n`;
+    downloadBlob(text, 'application/json;charset=utf-8', ORGANIZATION_FILE_NAME);
+    globalThis.toastr?.success(tr(ctx, 'Organization export started.'));
+}
+
+async function importOrganization(ctx, state, ui) {
+    const file = ui.backup.fileInput.files?.[0];
+    ui.backup.fileInput.value = '';
+    if (!file) {
+        return;
+    }
+    if (file.size > MAX_ORGANIZATION_IMPORT_BYTES) {
+        ui.backup.status.textContent = tr(ctx, 'Organization files must be 5 MiB or smaller.');
+        return;
+    }
+    let organization;
+    try {
+        organization = parseOrganization(await file.text());
+    } catch (error) {
+        console.warn('[Chat Archive] invalid organization import:', error);
+        ui.backup.status.textContent = tr(ctx, 'This organization backup is invalid or unsupported.');
+        return;
+    }
+    if (!globalThis.confirm(tr(ctx, 'Replace all current folders, collections, saved views, tags, and favorites?'))) {
+        return;
+    }
+    state.organizationLoadAbort?.abort();
+    state.organizationLoadAbort = null;
+    preserveArchiveFocus(ui, () => {
+        state.organization = organization;
+        state.organizationLoadState = 'ready';
+        state.organizationLoadError = null;
+        state.organizationSaveError = null;
+        state.organizationWritable = true;
+        state.selectedViewId = null;
+        refreshOrganizationUI(ctx, state, ui);
+        applySavedView(ctx, state, ui, organization.lastView, null, false);
+        ui.backup.status.textContent = tr(ctx, 'Imported organization. Saving replacement...');
+        refreshOpenOrganizer(ctx, state, ui);
+        markOrganizationDirty(ctx, state, ui);
+    });
+}
+
+function updateSelectionControls(ctx, state, ui) {
+    const selected = state.selectedBatchKeys.size;
+    ui.selectionToggle.setAttribute('aria-pressed', String(state.selectionMode));
+    ui.selectionToggle.textContent = tr(ctx, state.selectionMode ? 'Stop selecting' : 'Select chats');
+    ui.selectionTools.hidden = !state.selectionMode;
+    ui.selectionClear.disabled = selected === 0;
+    for (const control of ui.batch.root.querySelectorAll('[data-sbca-organization-control]')) {
+        control.disabled = !state.organizationWritable || selected === 0;
+    }
+    if (!state.selectionMode) {
+        return;
+    }
+    const matchingKeys = new Set(state.matchingRows.map(physicalChatKey));
+    const hidden = [...state.selectedBatchKeys].filter(key => !matchingKeys.has(key)).length;
+    ui.selectionCount.textContent = hidden > 0
+        ? tr(ctx, '{count} selected ({hidden} hidden by filters)', { count: selected, hidden })
+        : tr(ctx, '{count} selected', { count: selected });
+    ui.selectionAll.textContent = tr(ctx, 'Select all matching ({count})', { count: matchingKeys.size });
+}
+
+function mutateSelectedChats(ctx, state, ui, mutation) {
+    if (!state.organizationWritable || state.selectedBatchKeys.size === 0) {
+        return;
+    }
+    const chats = { ...state.organization.chats };
+    for (const key of state.selectedBatchKeys) {
+        const metadata = {
+            ...(chats[key] ?? {}),
+            collections: [...(chats[key]?.collections ?? [])],
+            tags: [...(chats[key]?.tags ?? [])],
+        };
+        mutation(metadata);
+        setChatMetadata(chats, key, metadata);
+    }
+    state.organization = { ...state.organization, chats };
+    commitChatMetadataChange(ctx, state, ui);
+}
+
+function updateDeepButton(state, ui) {
+    if (!state.searchAbort) {
+        ui.deepButton.disabled = state.listState !== 'ready' || !ui.search.value.trim() || !!state.scanAbort;
+    }
+}
+
+function updateSearchMode(ctx, state, ui) {
+    const searching = !!state.searchAbort;
+    const active = searching || state.deepRows !== null;
+    ui.searchMode.hidden = !active;
+    if (!active) {
+        return;
+    }
+    const query = state.deepQuery || ui.search.value.trim();
+    ui.searchModeText.textContent = searching
+        ? tr(ctx, 'Searching all message content for "{query}"...', { query })
+        : tr(ctx, 'Message content results for "{query}": {count} chats', {
+            query,
+            count: state.deepRows.length,
+        });
+    ui.searchModeClear.hidden = searching;
+}
+
+function clearViewerMatch(ui) {
+    for (const match of ui.viewerContent.querySelectorAll('.sbca-msg-match')) {
+        match.classList.remove('sbca-msg-match');
+    }
+    for (const label of ui.viewerContent.querySelectorAll('.sbca-match-label')) {
+        label.remove();
+    }
+}
+
+function exitDeepSearch(ctx, state, ui) {
+    cancelSearch(ctx, state, ui);
+    state.deepRows = null;
+    state.deepQuery = '';
+    clearViewerMatch(ui);
+}
+
+function cancelSearch(ctx, state, ui) {
+    const controller = state.searchAbort;
+    state.searchAbort = null;
+    controller?.abort();
+    if (controller) {
+        setStatus(ui, '');
+    }
+    ui.status.removeAttribute('aria-busy');
+    ui.deepButton.textContent = tr(ctx, 'Search message content');
+}
+
+function cancelViewer(state) {
+    state.viewerAbort?.abort();
+}
+
+function cancelNavigation(state) {
+    state.navigationAbort?.abort();
+}
+
+async function loadRows(ctx, state, ui) {
+    if (state.scanAbort) {
+        return;
+    }
+    if (ui.list.contains(document.activeElement)) {
+        ui.listHeading.focus({ preventScroll: true });
+    } else if (ui.viewerContent.contains(document.activeElement)) {
+        ui.viewerTitle.focus({ preventScroll: true });
+    }
+    exitDeepSearch(ctx, state, ui);
+    cancelViewer(state);
+    cancelNavigation(state);
+    state.enrichmentAbort?.abort();
+    state.enrichmentAbort = null;
+    state.enrichmentOwner = '';
+    state.enrichedOwners.clear();
+    state.selectedBatchKeys.clear();
+    updateSelectionControls(ctx, state, ui);
+    state.listAbort?.abort();
+    const controller = new AbortController();
+    state.listAbort = controller;
+    state.listState = 'loading';
+    ui.refreshButton.disabled = true;
+    ui.scanButton.disabled = true;
+    state.visibleLimit = LIST_PAGE_SIZE;
+    renderList(ctx, state, ui);
+    setStatus(ui, tr(ctx, 'Loading chats...'));
+    updateDeepButton(state, ui);
+
+    try {
+        let rootScanFailed = false;
+        let recentScanFailed = false;
+        let characterError = null;
+        const avatars = (ctx.characters ?? []).map(character => character?.avatar).filter(Boolean);
+        const characterFilesPromise = fetchCharacterFiles(ctx, avatars, controller.signal).catch(error => {
+            characterError = error;
+            return null;
+        });
+        const [rows, rootFiles] = await Promise.all([
+            fetchRecent(ctx, controller.signal).catch(error => {
+                if (error?.name === 'AbortError') {
+                    throw error;
+                }
+                recentScanFailed = true;
+                console.warn('[Chat Archive] failed to load the recent chat index:', error);
+                return [];
+            }),
+            fetchRootFiles(ctx, controller.signal).catch(error => {
+                if (error?.name === 'AbortError') {
+                    throw error;
+                }
+                rootScanFailed = true;
+                console.warn('[Chat Archive] failed to check root chat files:', error);
+                return [];
+            }),
+        ]);
+        if (state.listAbort !== controller || state.closed) {
+            return;
+        }
+        const previousRows = state.rows;
+        const nextRows = [];
+        const known = new Set();
+        let inventoryFailures = 0;
+        const addRow = raw => {
+            const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+            if (!row?.file_id) {
+                return false;
+            }
+            const key = physicalChatKey(row);
+            if (!known.has(key)) {
+                known.add(key);
+                if (row.kind === 'group') {
+                    state.missingGroupFiles.delete(row.file_id);
+                }
+                nextRows.push(row);
+            }
+            return true;
+        };
+        const preserveRow = row => {
+            const key = physicalChatKey(row);
+            if (!known.has(key)) {
+                known.add(key);
+                nextRows.push(row);
+            }
+        };
+        for (const raw of rows) {
+            if (!addRow(raw)) {
+                recentScanFailed = true;
+            }
+        }
+        for (const rootFile of rootFiles) {
+            if (!addRow(rootFile)) {
+                rootScanFailed = true;
+                inventoryFailures++;
+            }
+        }
+        if (recentScanFailed || rootScanFailed) {
+            for (const row of previousRows) {
+                if ((recentScanFailed && row.source === 'recent')
+                    || (rootScanFailed && row.orphanType === 'root')) {
+                    preserveRow(row);
+                }
+            }
+        }
+        state.rootScanFailed = rootScanFailed;
+        state.recentScanFailed = recentScanFailed;
+        state.inventoryFailures = 0;
+        state.rows = nextRows;
+        state.selectedKey = null;
+        state.selectedRow = null;
+        state.selectedButton = null;
+        resetViewer(ctx, ui);
+        state.listState = 'ready';
+        refreshOwnerOptions(ctx, state, ui);
+        renderList(ctx, state, ui);
+        updateSelectionControls(ctx, state, ui);
+        setStatus(ui, tr(ctx, 'Loading linked chat folders...'));
+
+        const characterFiles = await characterFilesPromise;
+        if (characterError) {
+            throw characterError;
+        }
+        if (state.listAbort !== controller || state.closed) {
+            return;
+        }
+        inventoryFailures += characterFiles.failures;
+        for (const characterFile of characterFiles.rows) {
+            if (!addRow(characterFile)) {
+                characterFiles.failedAvatars.add(characterFile.avatar);
+                inventoryFailures++;
+            }
+        }
+        for (const row of previousRows) {
+            if (characterFiles.failedAvatars.has(row.avatar)) {
+                preserveRow(row);
+            }
+        }
+        const knownGroupFiles = new Set(nextRows.filter(row => row.kind === 'group').map(row => row.file_id));
+        for (const group of ctx.groups ?? []) {
+            if (!group || (typeof group.id !== 'string' && typeof group.id !== 'number')) {
+                inventoryFailures++;
+                continue;
+            }
+            const files = new Set(Array.isArray(group.chats) ? group.chats : []);
+            if (group.chat_id !== undefined && group.chat_id !== null && group.chat_id !== '') {
+                files.add(group.chat_id);
+            }
+            for (const file of files) {
+                if (typeof file !== 'string' && typeof file !== 'number') {
+                    inventoryFailures++;
+                    continue;
+                }
+                const fileId = String(file).replace(/\.jsonl$/i, '');
+                if (!fileId) {
+                    inventoryFailures++;
+                    continue;
+                }
+                if (state.missingGroupFiles.has(fileId)) {
+                    continue;
+                }
+                if (!knownGroupFiles.has(fileId)) {
+                    knownGroupFiles.add(fileId);
+                    const row = normalizeRow({
+                        _source: 'inventory',
+                        group: group.id,
+                        file_id: fileId,
+                        file_name: `${fileId}.jsonl`,
+                    }, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+                    if (row) {
+                        preserveRow(row);
+                    } else {
+                        inventoryFailures++;
+                    }
+                }
+            }
+        }
+        state.rootScanFailed = rootScanFailed;
+        state.recentScanFailed = recentScanFailed;
+        state.inventoryFailures = inventoryFailures;
+        refreshOwnerOptions(ctx, state, ui);
+        renderList(ctx, state, ui);
+        updateBrowseStatus(ctx, state, ui);
+        updateSelectionControls(ctx, state, ui);
+        void enrichSelectedOwner(ctx, state, ui);
+    } catch (error) {
+        controller.abort();
+        if (error?.name === 'AbortError') {
+            return;
+        }
+        console.error('[Chat Archive] failed to list chats:', error);
+        if (state.listAbort === controller) {
+            state.listState = allRows(state).length > 0 ? 'ready' : 'error';
+            renderList(ctx, state, ui);
+            setStatus(ui, tr(ctx, state.listState === 'ready'
+                ? 'Could not refresh chats. Showing the previous results.'
+                : 'Could not load chats. Try again.'));
+        }
+    } finally {
+        if (state.listAbort === controller) {
+            state.listAbort = null;
+            ui.list.removeAttribute('aria-busy');
+            ui.refreshButton.disabled = false;
+            ui.scanButton.disabled = false;
+            updateDeepButton(state, ui);
+        }
+    }
+}
+
+function visibleRows(state, ui) {
+    const source = state.deepRows ?? allRows(state);
+    const text = state.deepRows === null ? ui.search.value : '';
+    const options = { ...currentSavedView(state, ui), text };
+    delete options.query;
+    delete options.sort;
+    delete options.group;
+    delete options.density;
+    return sortRows(filterRows(source, options, state.organization), ui.sort.value);
+}
+
+function updateBrowseStatus(ctx, state, ui) {
+    if (state.listState !== 'ready' || state.deepRows !== null) {
+        return;
+    }
+    const total = allRows(state).length;
+    const matching = state.matchingRows.length;
+    const filtered = matching !== total || ui.search.value.trim();
+    let text = filtered
+        ? tr(ctx, '{matching} of {total} indexed chat files', { matching, total })
+        : tr(ctx, '{total} indexed chat files', { total });
+    if (state.rootScanFailed) {
+        text += ` ${tr(ctx, 'Some root files could not be checked.')}`;
+    }
+    if (state.recentScanFailed) {
+        text += ` ${tr(ctx, 'Some indexed chats could not be loaded.')}`;
+    }
+    if (state.inventoryFailures > 0) {
+        text += ` ${tr(ctx, 'Some linked chat folders could not be checked.')}`;
+    }
+    if (!state.orphanScanComplete) {
+        text += ` ${tr(ctx, 'Use Find orphaned files to include chats with deleted owners.')}`;
+    }
+    setStatus(ui, text);
+}
+
+function renderList(ctx, state, ui) {
+    updateSearchMode(ctx, state, ui);
+    ui.list.replaceChildren();
+    state.selectedButton = null;
+    if (state.listState === 'loading') {
+        state.matchingRows = [];
+        ui.list.setAttribute('aria-busy', 'true');
+        ui.list.append(listMessage(tr(ctx, 'Loading chats...')));
+        return;
+    }
+    if (state.listState === 'error') {
+        state.matchingRows = [];
+        const item = listMessage(tr(ctx, 'The chat list could not be loaded.'));
+        const retry = button('sbca-control', tr(ctx, 'Try again'));
+        retry.addEventListener('click', () => void loadRows(ctx, state, ui));
+        item.append(retry);
+        ui.list.append(item);
+        return;
+    }
+
+    const rows = visibleRows(state, ui);
+    state.matchingRows = rows;
+    if (rows.length === 0) {
+        const message = state.deepRows !== null
+            ? tr(ctx, 'No chats contain that message content.')
+            : allRows(state).length === 0
+                ? tr(ctx, 'No chat files were found.')
+                : tr(ctx, 'No chats match these filters.');
+        ui.list.append(listMessage(message));
+        return;
+    }
+
+    const shownRows = new Set(rows.slice(0, state.visibleLimit));
+    for (const group of groupRows(rows, ui.group.value, state.organization)) {
+        const shownGroupRows = group.rows.filter(row => shownRows.has(row));
+        if (shownGroupRows.length === 0) {
+            continue;
+        }
+        const collapseKey = JSON.stringify([ui.group.value, group.key]);
+        const collapsed = state.collapsedGroups.has(collapseKey);
+        if (ui.group.value !== 'flat') {
+            const item = el('li', 'sbca-group-header');
+            const heading = button('sbca-group-button', `${groupDisplayLabel(ctx, ui.group.value, group.label)} (${group.rows.length})`);
+            heading.dataset.sbcaGroupKey = collapseKey;
+            heading.setAttribute('aria-expanded', String(!collapsed));
+            heading.addEventListener('click', () => {
+                if (state.collapsedGroups.has(collapseKey)) {
+                    state.collapsedGroups.delete(collapseKey);
+                } else {
+                    state.collapsedGroups.add(collapseKey);
+                }
+                renderList(ctx, state, ui);
+                [...ui.list.querySelectorAll('.sbca-group-button')]
+                    .find(control => control.dataset.sbcaGroupKey === collapseKey)
+                    ?.focus({ preventScroll: true });
+            });
+            item.append(heading);
+            ui.list.append(item);
+        }
+        if (!collapsed) {
+            for (const row of shownGroupRows) {
+                ui.list.append(buildRow(ctx, state, ui, row));
+            }
+        }
+    }
+    appendListMore(ctx, state, ui, rows);
+}
+
+function appendListMore(ctx, state, ui, rows) {
+    if (rows.length <= state.visibleLimit) {
+        return;
+    }
+    const remaining = rows.length - state.visibleLimit;
+    const item = el('li', 'sbca-list-more');
+    const more = button('sbca-control', tr(ctx, 'Show {count} more', { count: Math.min(LIST_PAGE_SIZE, remaining) }));
+    more.addEventListener('click', () => {
+        const firstNewRow = state.visibleLimit;
+        state.visibleLimit += LIST_PAGE_SIZE;
+        if (ui.group.value !== 'flat') {
+            const newKeys = new Set(rows.slice(firstNewRow, state.visibleLimit).map(physicalChatKey));
+            renderList(ctx, state, ui);
+            ([...ui.list.querySelectorAll('.sbca-row-button')]
+                .find(control => newKeys.has(control.dataset.sbcaKey)) ?? ui.list.querySelector('.sbca-list-more .sbca-control'))
+                ?.focus({ preventScroll: true });
+            return;
+        }
+        item.remove();
+        const fragment = document.createDocumentFragment();
+        let firstButton = null;
+        for (const row of rows.slice(firstNewRow, state.visibleLimit)) {
+            const rowItem = buildRow(ctx, state, ui, row);
+            firstButton ??= rowItem.querySelector('.sbca-row-button');
+            fragment.append(rowItem);
+        }
+        ui.list.append(fragment);
+        appendListMore(ctx, state, ui, rows);
+        (firstButton ?? ui.list.querySelector('.sbca-list-more .sbca-control'))?.focus({ preventScroll: true });
+    });
+    item.append(more);
+    ui.list.append(item);
+}
+
+function groupDisplayLabel(ctx, mode, label) {
+    if (mode === 'type') {
+        return tr(ctx, Object.fromEntries(KINDS)[label] ?? label);
+    }
+    if (mode === 'folder' && label === 'Unfiled') {
+        return tr(ctx, 'Unfiled');
+    }
+    return label || tr(ctx, 'Unknown owner');
+}
+
+function listMessage(text) {
+    const item = el('li', 'sbca-list-message');
+    item.append(el('p', 'sbca-placeholder', text));
+    return item;
+}
+
+function buildRow(ctx, state, ui, row) {
+    const item = el('li', 'sbca-row');
+    const block = button('sbca-row-button');
+    const key = physicalChatKey(row);
+    block.dataset.sbcaKind = row.kind;
+    block.dataset.sbcaKey = key;
+    if (state.selectedKey === key) {
+        block.setAttribute('aria-current', 'true');
+        state.selectedButton = block;
+    }
+
+    const head = el('span', 'sbca-row-head');
+    if (row.kind === 'solo') {
+        const img = document.createElement('img');
+        img.className = 'sbca-avatar';
+        img.src = ctx.getThumbnailUrl('avatar', row.avatar);
+        img.alt = '';
+        img.loading = 'lazy';
+        img.decoding = 'async';
+        head.append(img);
+    } else {
+        const icon = el('i', `sbca-avatar-icon fa-solid ${row.kind === 'group' ? 'fa-users' : 'fa-triangle-exclamation'}`);
+        icon.setAttribute('aria-hidden', 'true');
+        head.append(icon);
+    }
+
+    const title = el('span', 'sbca-row-title');
+    title.append(el('span', 'sbca-filename', row.file_id));
+    const owner = el('span', 'sbca-owner', ownerLabel(ctx, row));
+    if (row.kind === 'orphan') {
+        owner.append(el('span', 'sbca-badge', orphanLabel(ctx, row.orphanType)));
+    }
+    title.append(owner);
+    head.append(title);
+
+    const info = el('span', 'sbca-row-info');
+    if (row.mtime) {
+        const date = new Date(row.mtime);
+        if (!Number.isNaN(date.valueOf())) {
+            const time = el('time', undefined, date.toLocaleDateString());
+            time.dateTime = date.toISOString();
+            info.append(time);
+        }
+    }
+    if (row.sizeText) {
+        info.append(el('span', undefined, row.sizeText));
+    }
+    if (row.count !== null) {
+        info.append(el('span', undefined, messageCount(ctx, row.count)));
+    }
+    head.append(info);
+    block.append(head);
+    const metadata = state.organization?.chats?.[key];
+    if (metadata) {
+        const indicators = el('span', 'sbca-curation-indicators');
+        if (metadata.favorite) {
+            indicators.append(el('span', 'sbca-curation-favorite', tr(ctx, 'Favorite')));
+        }
+        const folder = state.organization.folders.find(item => item.id === metadata.folder);
+        if (folder) {
+            indicators.append(el('span', 'sbca-curation-folder', tr(ctx, 'Folder: {name}', { name: folder.name })));
+        }
+        for (const id of metadata.collections ?? []) {
+            const collection = state.organization.collections.find(item => item.id === id);
+            if (collection) {
+                indicators.append(el('span', 'sbca-curation-collection', tr(ctx, 'Collection: {name}', { name: collection.name })));
+            }
+        }
+        for (const tag of metadata.tags ?? []) {
+            indicators.append(el('span', 'sbca-curation-tag', tr(ctx, 'Tag: {name}', { name: tag })));
+        }
+        if (indicators.childElementCount > 0) {
+            block.append(indicators);
+        }
+    }
+    if (row.snippet) {
+        const snippet = row.snippet.length > 180 ? `${row.snippet.slice(0, 177)}...` : row.snippet;
+        block.append(el('span', 'sbca-row-preview', snippet));
+    }
+    block.addEventListener('click', () => {
+        cancelNavigation(state);
+        selectRow(state, ui, block, key);
+        state.selectedRow = row;
+        void openViewer(ctx, state, row, ui);
+    });
+    if (state.selectionMode) {
+        const selectLabel = el('label', 'sbca-row-selection');
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = state.selectedBatchKeys.has(key);
+        checkbox.setAttribute('aria-label', tr(ctx, 'Select {name} for {owner}', {
+            name: row.file_id,
+            owner: ownerLabel(ctx, row),
+        }));
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+                state.selectedBatchKeys.add(key);
+            } else {
+                state.selectedBatchKeys.delete(key);
+            }
+            updateSelectionControls(ctx, state, ui);
+        });
+        selectLabel.append(checkbox);
+        item.append(selectLabel);
+    }
+    item.append(block);
+    return item;
+}
+
+function orphanLabel(ctx, type) {
+    const labels = {
+        'missing-character': 'Missing character',
+        'missing-group': 'Missing group',
+        'unlinked-group': 'Unlinked group',
+        root: 'Root file',
+    };
+    return tr(ctx, labels[type] ?? 'Orphaned');
+}
+
+function ownerLabel(ctx, row) {
+    if (row.ownerName) {
+        return row.ownerName;
+    }
+    return row.orphanType === 'unlinked-group' ? tr(ctx, 'Unlinked group') : tr(ctx, 'Unknown owner');
+}
+
+function messageCount(ctx, count) {
+    return tr(ctx, count === 1 ? '{count} message' : '{count} messages', { count });
+}
+
+function selectRow(state, ui, block, key) {
+    ui.list.querySelectorAll('.sbca-row-button[aria-current="true"]').forEach(row => row.removeAttribute('aria-current'));
+    block.setAttribute('aria-current', 'true');
+    state.selectedKey = key;
+    state.selectedButton = block;
+}
+
+function showList(state, ui) {
+    ui.root.dataset.sbcaView = 'list';
+    const target = state.selectedButton?.isConnected ? state.selectedButton : ui.search;
+    target.focus({ preventScroll: true });
+}
+
+function showDetail(ui) {
+    ui.root.dataset.sbcaView = 'detail';
+    if (ui.mobileQuery.matches) {
+        ui.viewerTitle.focus({ preventScroll: true });
+    }
+}
+
+function resetViewer(ctx, ui) {
+    ui.root.dataset.sbcaView = 'list';
+    ui.viewerTitle.textContent = tr(ctx, 'Chat details');
+    ui.viewerContent.replaceChildren(el('p', 'sbca-placeholder', tr(ctx, 'Select a chat to inspect it.')));
+    ui.viewer.removeAttribute('aria-busy');
+}
+
+async function openViewer(ctx, state, row, ui) {
+    if (ui.viewerContent.contains(document.activeElement)) {
+        ui.viewerTitle.focus({ preventScroll: true });
+    }
+    cancelViewer(state);
+    const controller = new AbortController();
+    state.viewerAbort = controller;
+    state.selectedRow = row;
+    ui.viewerTitle.textContent = row.file_id;
+    ui.viewerContent.replaceChildren(
+        buildChatOrganizer(ctx, state, row, ui),
+        buildSummary(ctx, row),
+        el('p', 'sbca-placeholder', tr(ctx, 'Loading chat...')),
+    );
+    ui.viewer.setAttribute('aria-busy', 'true');
+    showDetail(ui);
+
+    try {
+        const raw = await loadRawChat(ctx, state, row, controller.signal);
+        if (state.viewerAbort !== controller || state.closed) {
+            return;
+        }
+        let shaped;
+        try {
+            shaped = await parseChatJsonl(raw, { signal: controller.signal });
+        } catch (error) {
+            if (error?.name === 'AbortError') {
+                throw error;
+            }
+            if (state.viewerAbort !== controller || state.closed) {
+                return;
+            }
+            console.warn('[Chat Archive] chat is readable but contains invalid JSONL:', error);
+            renderMalformedViewer(ctx, state, row, raw, ui);
+            if (!state.searchAbort && state.deepRows === null) {
+                setStatus(ui, tr(ctx, 'Opened raw file for {name}; message parsing failed.', { name: row.file_id }));
+            }
+            return;
+        }
+        if (state.viewerAbort !== controller || state.closed) {
+            return;
+        }
+        renderViewer(ctx, state, row, raw, shaped, ui);
+        if (!state.searchAbort && state.deepRows === null) {
+            setStatus(ui, tr(ctx, 'Opened {name}', { name: row.file_id }));
+        }
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            return;
+        }
+        if (error?.status === 404 && row.kind === 'group' && row.source === 'inventory') {
+            state.missingGroupFiles.add(row.file_id);
+            state.rows = state.rows.filter(candidate => physicalChatKey(candidate) !== physicalChatKey(row));
+            renderList(ctx, state, ui);
+        }
+        console.error('[Chat Archive] failed to load chat:', error);
+        if (state.viewerAbort === controller) {
+            const errorMessage = el('div', 'sbca-viewer-error', tr(ctx, 'Could not read this chat. Refresh the archive or scan for orphaned files again.'));
+            errorMessage.setAttribute('role', 'alert');
+            const retry = button('sbca-control', tr(ctx, 'Try again'));
+            retry.addEventListener('click', () => void openViewer(ctx, state, row, ui));
+            ui.viewerContent.replaceChildren(buildChatOrganizer(ctx, state, row, ui), buildSummary(ctx, row), errorMessage, retry);
+            if (!state.searchAbort && state.deepRows === null) {
+                setStatus(ui, tr(ctx, 'Could not open {name}', { name: row.file_id }));
+            }
+        }
+    } finally {
+        if (state.viewerAbort === controller) {
+            state.viewerAbort = null;
+            ui.viewer.removeAttribute('aria-busy');
+        }
+    }
+}
+
+function buildChatOrganizer(ctx, state, row, ui) {
+    const organizer = el('section', 'sbca-organizer');
+    organizer.append(el('h5', 'sbca-organizer-heading', tr(ctx, 'Organize chat')));
+    const key = physicalChatKey(row);
+    const tagInputKey = organizationFocusKey('organizer', key, 'tag-input');
+    const metadata = state.organization?.chats?.[key] ?? {};
+    const favorite = button('sbca-control sbca-favorite-toggle', tr(ctx, metadata.favorite ? 'Unfavorite' : 'Favorite'));
+    favorite.setAttribute('aria-pressed', String(metadata.favorite === true));
+    markOrganizationControl(favorite, organizationFocusKey('organizer', key, 'favorite'));
+    favorite.addEventListener('click', () => mutateChatMetadata(ctx, state, ui, row, value => {
+        if (value.favorite) {
+            delete value.favorite;
+        } else {
+            value.favorite = true;
+        }
+    }));
+
+    const folderField = selectControl(ctx, 'Folder', [['', 'Unfiled']]);
+    for (const folder of state.organization?.folders ?? []) {
+        appendOption(folderField.select, folder.id, folder.name);
+    }
+    folderField.select.value = metadata.folder ?? '';
+    markOrganizationControl(folderField.select, organizationFocusKey('organizer', key, 'folder'));
+    folderField.select.addEventListener('change', () => mutateChatMetadata(ctx, state, ui, row, value => {
+        if (folderField.select.value) {
+            value.folder = folderField.select.value;
+        } else {
+            delete value.folder;
+        }
+    }));
+
+    const collections = el('fieldset', 'sbca-organizer-collections');
+    collections.append(el('legend', undefined, tr(ctx, 'Collections')));
+    const selectedCollections = new Set(metadata.collections ?? []);
+    if ((state.organization?.collections.length ?? 0) === 0) {
+        collections.append(el('p', 'sbca-placeholder', tr(ctx, 'No collections yet.')));
+    }
+    for (const collection of state.organization?.collections ?? []) {
+        const label = el('label', 'checkbox_label');
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = selectedCollections.has(collection.id);
+        markOrganizationControl(checkbox, organizationFocusKey('organizer', key, 'collection', collection.id));
+        checkbox.addEventListener('change', () => mutateChatMetadata(ctx, state, ui, row, value => {
+            const ids = new Set(value.collections ?? []);
+            if (checkbox.checked) {
+                ids.add(collection.id);
+            } else {
+                ids.delete(collection.id);
+            }
+            value.collections = [...ids];
+        }));
+        label.append(checkbox, document.createTextNode(collection.name));
+        collections.append(label);
+    }
+
+    const tags = el('div', 'sbca-organizer-tags');
+    tags.append(el('span', 'sbca-label', tr(ctx, 'Tags')));
+    const tagList = el('div', 'sbca-tag-list');
+    for (const tag of metadata.tags ?? []) {
+        const item = el('span', 'sbca-tag-item');
+        const remove = button('sbca-control sbca-tag-remove', tr(ctx, 'Remove'));
+        remove.setAttribute('aria-label', tr(ctx, 'Remove tag {name}', { name: tag }));
+        markOrganizationControl(remove, organizationFocusKey('organizer', key, 'tag', tag), tagInputKey);
+        remove.addEventListener('click', () => mutateChatMetadata(ctx, state, ui, row, value => {
+            value.tags = (value.tags ?? []).filter(name => name.toLocaleLowerCase() !== tag.toLocaleLowerCase());
+        }));
+        item.append(el('span', undefined, tag), remove);
+        tagList.append(item);
+    }
+    const tagCreate = el('div', 'sbca-tag-create');
+    const tagField = inputControl(ctx, 'Add tags (comma-separated)');
+    const tagAdd = button('sbca-control', tr(ctx, 'Add tags'));
+    markOrganizationControl(tagField.input, tagInputKey);
+    markOrganizationControl(tagAdd, organizationFocusKey('organizer', key, 'tag-add'), tagInputKey);
+    const addTags = () => {
+        const values = commaValues(tagField.input.value);
+        if (values.length > 0) {
+            mutateChatMetadata(ctx, state, ui, row, metadataValue => {
+                metadataValue.tags = [...(metadataValue.tags ?? []), ...values];
+            });
+        }
+    };
+    tagAdd.addEventListener('click', addTags);
+    tagField.input.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            addTags();
+        }
+    });
+    tagCreate.append(tagField.wrap, tagAdd);
+    tags.append(tagList, tagCreate);
+    organizer.append(favorite, folderField.wrap, collections, tags);
+    for (const control of organizer.querySelectorAll('[data-sbca-organization-control]')) {
+        control.disabled = !state.organizationWritable;
+    }
+    return organizer;
+}
+
+function mutateChatMetadata(ctx, state, ui, row, mutation) {
+    if (!state.organizationWritable || !state.organization) {
+        return;
+    }
+    const key = physicalChatKey(row);
+    const chats = { ...state.organization.chats };
+    const metadata = {
+        ...(chats[key] ?? {}),
+        collections: [...(chats[key]?.collections ?? [])],
+        tags: [...(chats[key]?.tags ?? [])],
+    };
+    mutation(metadata);
+    setChatMetadata(chats, key, metadata);
+    state.organization = { ...state.organization, chats };
+    commitChatMetadataChange(ctx, state, ui);
+}
+
+function setChatMetadata(chats, key, value) {
+    const metadata = {};
+    if (value.favorite === true) {
+        metadata.favorite = true;
+    }
+    if (typeof value.folder === 'string' && value.folder) {
+        metadata.folder = value.folder;
+    }
+    const collections = [...new Set(value.collections ?? [])].filter(Boolean);
+    if (collections.length > 0) {
+        metadata.collections = collections;
+    }
+    const tags = [];
+    const seenTags = new Set();
+    for (const raw of value.tags ?? []) {
+        const tag = String(raw).trim();
+        const folded = tag.toLocaleLowerCase();
+        if (tag && !seenTags.has(folded)) {
+            seenTags.add(folded);
+            tags.push(tag);
+        }
+    }
+    if (tags.length > 0) {
+        metadata.tags = tags;
+    }
+    if (Object.keys(metadata).length > 0) {
+        chats[key] = metadata;
+    } else {
+        delete chats[key];
+    }
+}
+
+function refreshOpenOrganizer(ctx, state, ui) {
+    if (!state.selectedRow) {
+        return;
+    }
+    const current = ui.viewerContent.querySelector('.sbca-organizer');
+    if (current) {
+        current.replaceWith(buildChatOrganizer(ctx, state, state.selectedRow, ui));
+    }
+}
+
+async function loadRawChat(ctx, state, row, signal) {
+    if (row.source === 'data-maid') {
+        if (!state.dataMaidToken || !row.dataMaidHash) {
+            throw new Error('Orphan scan expired');
+        }
+        return fetchDataMaidFile(ctx, state.dataMaidToken, row.dataMaidHash, signal);
+    }
+
+    const isGroup = row.kind === 'group' || row.orphanType === 'missing-group';
+    // ponytail: the host maps ".png" to the chats root; use an explicit root API when one exists.
+    const avatarUrl = row.orphanType === 'root' ? '.png' : row.avatar;
+    const data = await exportChat(ctx, {
+        is_group: isGroup,
+        avatar_url: avatarUrl ?? undefined,
+        file: row.file_name || `${row.file_id}.jsonl`,
+        exportfilename: row.file_name || `${row.file_id}.jsonl`,
+        format: 'jsonl',
+    }, signal);
+    if (typeof data?.result !== 'string') {
+        throw new Error('Chat export did not return file data');
+    }
+    return data.result;
+}
+
+function buildSummary(ctx, row) {
+    const summary = el('div', 'sbca-summary');
+    summary.append(el('div', 'sbca-summary-line', ownerLabel(ctx, row)));
+    const facts = [];
+    if (row.count !== null) {
+        facts.push(messageCount(ctx, row.count));
+    }
+    if (row.sizeText) {
+        facts.push(row.sizeText);
+    }
+    if (facts.length > 0) {
+        summary.append(el('div', 'sbca-summary-line', facts.join(' | ')));
+    }
+    if (row.mtime) {
+        const label = row.source === 'data-maid' ? tr(ctx, 'Modified') : tr(ctx, 'Last message');
+        summary.append(el('div', 'sbca-summary-line', `${label}: ${new Date(row.mtime).toLocaleString()}`));
+    }
+    return summary;
+}
+
+function renderViewer(ctx, state, row, raw, shaped, ui) {
+    const matchIndex = state.deepRows === null ? -1 : findMatchingMessageIndex(shaped.messages, state.deepQuery);
+    const matchQuery = state.deepQuery;
+    const start = matchIndex < 0 ? 0 : Math.floor(matchIndex / MESSAGE_PAGE_SIZE) * MESSAGE_PAGE_SIZE;
+    const messages = el('div', 'sbca-messages');
+    messages.id = `sbca_messages_${++renderId}`;
+    const messageList = el('div', 'sbca-message-list');
+    messageList.setAttribute('role', 'list');
+    messageList.setAttribute('aria-label', tr(ctx, 'Chat messages'));
+    const showPage = pageStart => {
+        messages.replaceChildren();
+        messageList.replaceChildren();
+        if (pageStart > 0) {
+            const earlier = button('sbca-control sbca-more-messages', tr(ctx, 'Show {count} earlier messages', {
+                count: Math.min(MESSAGE_PAGE_SIZE, pageStart),
+            }));
+            earlier.addEventListener('click', () => showPage(Math.max(0, pageStart - MESSAGE_PAGE_SIZE))?.focus({ preventScroll: true }));
+            messages.append(earlier);
+        }
+        messages.append(messageList);
+        const getMatchIndex = () => state.deepRows !== null && state.deepQuery === matchQuery ? matchIndex : -1;
+        return appendMessagePage(ctx, shaped.messages, messageList, messages, pageStart, getMatchIndex, showPage);
+    };
+    const showLatest = shaped.messages.length > MESSAGE_PAGE_SIZE ? () => {
+        const latest = showPage(shaped.messages.length - MESSAGE_PAGE_SIZE);
+        latest?.focus({ preventScroll: true });
+        latest?.scrollIntoView({ block: 'start' });
+    } : null;
+    const content = [
+        buildChatOrganizer(ctx, state, row, ui),
+        buildSummary(ctx, row),
+        buildViewerActions(ctx, state, row, raw, true, showLatest),
+    ];
+    const metadata = shaped.header?.chat_metadata;
+    if (metadata && Object.keys(metadata).length > 0) {
+        content.push(jsonDetails(ctx, 'Chat metadata', metadata));
+    }
+
+    if (shaped.messages.length === 0) {
+        messages.append(messageList, el('p', 'sbca-placeholder', tr(ctx, 'This chat is empty.')));
+    } else {
+        showPage(start);
+    }
+
+    const rawView = el('pre', 'sbca-raw');
+    rawView.id = `sbca_raw_${renderId}`;
+    rawView.hidden = true;
+    const rawToggle = buildRawToggle(ctx, raw, rawView, messages);
+
+    content.push(rawToggle, messages, rawView);
+    ui.viewerContent.replaceChildren(...content);
+    const match = messages.querySelector('.sbca-msg-match');
+    match?.focus({ preventScroll: true });
+    match?.scrollIntoView({ block: 'center' });
+}
+
+function buildViewerActions(ctx, state, row, raw, allowText, showLatest = null) {
+    const actions = el('div', 'sbca-viewer-actions');
+    if (showLatest) {
+        const latestButton = actionButton(ctx, 'Latest messages', 'fa-angles-down');
+        latestButton.addEventListener('click', showLatest);
+        actions.append(latestButton);
+    }
+    const jsonlButton = actionButton(ctx, 'Download original (.jsonl)', 'fa-file-export');
+    jsonlButton.addEventListener('click', () => downloadChat(ctx, row, raw, 'jsonl', jsonlButton));
+    actions.append(jsonlButton);
+    if (allowText) {
+        const textButton = actionButton(ctx, 'Download readable text', 'fa-file-lines');
+        textButton.addEventListener('click', () => downloadChat(ctx, row, raw, 'txt', textButton));
+        actions.append(textButton);
+    }
+    if (row.kind !== 'orphan') {
+        const jumpButton = actionButton(ctx, 'Open chat', 'fa-arrow-right-to-bracket');
+        if (state.navigationPending) {
+            jumpButton.setAttribute('aria-disabled', 'true');
+            state.navigationControl = jumpButton;
+        }
+        jumpButton.addEventListener('click', () => void jumpToChat(ctx, state, row, jumpButton));
+        actions.append(jumpButton);
+    }
+    return actions;
+}
+
+function renderMalformedViewer(ctx, state, row, raw, ui) {
+    const warning = el('div', 'sbca-viewer-error', tr(ctx, 'This file contains invalid JSONL. You can still download or inspect the original file.'));
+    warning.setAttribute('role', 'alert');
+    const rawView = el('pre', 'sbca-raw');
+    rawView.id = `sbca_raw_${++renderId}`;
+    rawView.hidden = true;
+    ui.viewerContent.replaceChildren(
+        buildChatOrganizer(ctx, state, row, ui),
+        buildSummary(ctx, row),
+        buildViewerActions(ctx, state, row, raw, false),
+        warning,
+        buildRawToggle(ctx, raw, rawView),
+        rawView,
+    );
+}
+
+function buildRawToggle(ctx, raw, rawView, messages = null) {
+    const control = button('sbca-control sbca-raw-toggle', tr(ctx, 'Show raw file'));
+    control.setAttribute('aria-expanded', 'false');
+    control.setAttribute('aria-controls', rawView.id);
+    control.addEventListener('click', () => {
+        const showRaw = rawView.hidden;
+        if (showRaw && !rawView.dataset.loaded) {
+            rawView.textContent = raw.length > RAW_PREVIEW_CHARS
+                ? `${raw.slice(0, RAW_PREVIEW_CHARS)}\n\n${tr(ctx, 'Raw preview truncated. Download the original file to inspect the rest.')}`
+                : raw;
+            rawView.dataset.loaded = 'true';
+        }
+        rawView.hidden = !showRaw;
+        if (messages) {
+            messages.hidden = showRaw;
+        }
+        control.setAttribute('aria-expanded', String(showRaw));
+        control.textContent = tr(ctx, showRaw && messages ? 'Show messages' : showRaw ? 'Hide raw file' : 'Show raw file');
+    });
+    return control;
+}
+
+function appendMessagePage(ctx, messages, list, controls, start, getMatchIndex, showPage) {
+    const end = Math.min(start + MESSAGE_PAGE_SIZE, messages.length);
+    const matchIndex = getMatchIndex();
+    let firstCard = null;
+    for (let index = start; index < end; index += 1) {
+        const card = buildMessage(ctx, messages[index]);
+        if (index === matchIndex) {
+            card.classList.add('sbca-msg-match');
+            card.querySelector('.sbca-msg-head')?.append(el('span', 'sbca-match-label', tr(ctx, 'First search match')));
+        }
+        firstCard ??= card;
+        list.append(card);
+    }
+    if (end < messages.length) {
+        const more = button('sbca-control sbca-more-messages', tr(ctx, 'Show {count} more messages', {
+            count: Math.min(MESSAGE_PAGE_SIZE, messages.length - end),
+        }));
+        more.addEventListener('click', () => {
+            showPage(end)?.focus({ preventScroll: true });
+        });
+        controls.append(more);
+    }
+    return firstCard;
+}
+
+function buildMessage(ctx, message) {
+    const role = message.isSystem ? 'system' : message.isUser ? 'user' : 'assistant';
+    const roleLabels = { system: 'System', user: 'You', assistant: 'Assistant' };
+    const card = el('article', 'sbca-msg');
+    card.dataset.sbcaRole = role;
+    card.setAttribute('role', 'listitem');
+    card.tabIndex = -1;
+    const head = el('header', 'sbca-msg-head');
+    const roleLabel = tr(ctx, roleLabels[role]);
+    const displayName = message.name || roleLabel;
+    head.append(el('strong', undefined, displayName));
+    if (displayName.toLocaleLowerCase() !== roleLabel.toLocaleLowerCase()) {
+        head.append(el('span', 'sbca-role', roleLabel));
+    }
+    if (message.send_date) {
+        const time = el('time', undefined, formatSendDate(ctx, message.send_date));
+        const parsed = new Date(message.send_date);
+        if (!Number.isNaN(parsed.valueOf())) {
+            time.dateTime = parsed.toISOString();
+        }
+        head.append(time);
+    }
+    if (message.swipeCount > 0) {
+        head.append(el('span', 'sbca-chip', tr(ctx, message.swipeCount === 1
+            ? '{count} response alternative'
+            : '{count} response alternatives', { count: message.swipeCount })));
+    }
+    card.append(head, el('div', 'sbca-msg-text', message.mes));
+    if (message.alternatives.length > 0) {
+        card.append(jsonDetails(ctx, 'Response alternatives', message.alternatives));
+    }
+    if (message.extra && Object.keys(message.extra).length > 0) {
+        card.append(jsonDetails(ctx, 'Extension data', message.extra));
+    }
+    return card;
+}
+
+function jsonDetails(ctx, label, value) {
+    const details = el('details', 'sbca-json-details');
+    details.append(el('summary', undefined, tr(ctx, label)));
+    let rendered = false;
+    details.addEventListener('toggle', () => {
+        if (details.open && !rendered) {
+            details.append(el('pre', undefined, JSON.stringify(value, null, 2)));
+            rendered = true;
+        }
+    });
+    return details;
+}
+
+function formatSendDate(ctx, sendDate) {
+    if (!sendDate) {
+        return '';
+    }
+    try {
+        const moment = ctx.timestampToMoment(sendDate);
+        if (moment?.isValid?.()) {
+            return moment.format('lll');
+        }
+    } catch {
+        // Fall through to the raw value.
+    }
+    return String(sendDate);
+}
+
+function withDataMaidLock(operation) {
+    const run = dataMaidQueue.then(operation, operation);
+    dataMaidQueue = run.catch(() => {});
+    return run;
+}
+
+async function scanOrphans(ctx, state, ui) {
+    if (state.scanAbort || state.listAbort) {
+        return;
+    }
+    exitDeepSearch(ctx, state, ui);
+    cancelViewer(state);
+    cancelNavigation(state);
+    const controller = new AbortController();
+    state.scanAbort = controller;
+    ui.refreshButton.disabled = true;
+    ui.scanButton.disabled = false;
+    ui.scanButton.removeAttribute('aria-disabled');
+    ui.scanButton.textContent = tr(ctx, 'Stop scan');
+    setStatus(ui, tr(ctx, 'Scanning for missing-character and unlinked-group chats...'));
+    updateDeepButton(state, ui);
+
+    let unclaimedToken = null;
+    try {
+        // Data Maid replaces the prior token when a report completes, so consume the response before honoring local cancellation.
+        const data = await withDataMaidLock(() => fetchDataMaidReport(ctx));
+        unclaimedToken = data?.token && data.token !== state.dataMaidToken ? data.token : null;
+        if (!data?.token || !data?.report) {
+            throw new Error('Orphan scan returned an invalid response');
+        }
+        if (state.scanAbort !== controller || state.closed) {
+            return;
+        }
+        const linkedGroupFiles = new Set(state.rows.filter(row => row.kind === 'group').map(row => row.file_id));
+        const orphanRows = [];
+        let invalidRecords = 0;
+        for (const [records, orphanType] of [
+            [data.report.chats, 'missing-character'],
+            [data.report.groupChats, 'unlinked-group'],
+        ]) {
+            if (!Array.isArray(records)) {
+                invalidRecords++;
+                continue;
+            }
+            for (const record of records) {
+                const row = dataMaidRecordToRow(record, orphanType);
+                if (!row?.file_id || !row.dataMaidHash) {
+                    invalidRecords++;
+                } else if (orphanType !== 'unlinked-group' || !linkedGroupFiles.has(row.file_id)) {
+                    orphanRows.push(row);
+                }
+            }
+        }
+        if (controller.signal.aborted) {
+            if (state.orphanScanComplete) {
+                const previousKeys = new Set(state.orphanRows.map(physicalChatKey));
+                const retainedRows = orphanRows.filter(row => previousKeys.has(physicalChatKey(row)));
+                const retainedKeys = new Set(retainedRows.map(physicalChatKey));
+                for (const key of previousKeys) {
+                    if (!retainedKeys.has(key)) {
+                        state.selectedBatchKeys.delete(key);
+                    }
+                }
+                state.dataMaidToken = data.token;
+                unclaimedToken = null;
+                state.orphanRows = retainedRows;
+                if (state.selectedRow?.source === 'data-maid') {
+                    state.selectedRow = retainedRows.find(row => physicalChatKey(row) === state.selectedKey) ?? null;
+                    state.selectedButton = null;
+                    if (!state.selectedRow) {
+                        state.selectedKey = null;
+                        resetViewer(ctx, ui);
+                    }
+                }
+                refreshOwnerOptions(ctx, state, ui);
+                renderList(ctx, state, ui);
+                updateSelectionControls(ctx, state, ui);
+                setStatus(ui, tr(ctx, 'Scan stopped. Previous results that still exist are shown.'));
+            } else {
+                setStatus(ui, tr(ctx, 'Scan stopped.'));
+            }
+            return;
+        }
+        state.dataMaidToken = data.token;
+        unclaimedToken = null;
+        state.orphanRows = orphanRows;
+        state.orphanScanComplete = true;
+        state.selectedKey = null;
+        state.selectedRow = null;
+        state.selectedButton = null;
+        state.selectedBatchKeys.clear();
+        state.visibleLimit = LIST_PAGE_SIZE;
+        resetViewer(ctx, ui);
+        refreshOwnerOptions(ctx, state, ui);
+        renderList(ctx, state, ui);
+        updateSelectionControls(ctx, state, ui);
+        setStatus(ui, state.orphanRows.length > 0
+            ? tr(ctx, 'Found {count} additional orphaned chat files.', { count: state.orphanRows.length })
+            : tr(ctx, 'No additional orphaned chat files were found.'));
+        if (invalidRecords > 0) {
+            setStatus(ui, `${ui.status.textContent} ${tr(ctx, 'Some orphan records could not be read.')}`);
+        }
+    } catch (error) {
+        if (!state.closed && state.scanAbort === controller) {
+            if (error?.name === 'AbortError') {
+                setStatus(ui, tr(ctx, state.orphanScanComplete
+                    ? 'Scan stopped. Previous results are still shown.'
+                    : 'Scan stopped.'));
+            } else {
+                console.error('[Chat Archive] orphan scan failed:', error);
+                setStatus(ui, tr(ctx, state.orphanScanComplete
+                    ? 'Could not rescan orphaned files. Previous results are still shown.'
+                    : 'Could not scan for additional orphaned files. Try again.'));
+            }
+        }
+    } finally {
+        if (unclaimedToken) {
+            void finalizeDataMaidToken(ctx, unclaimedToken);
+        }
+        if (state.scanAbort === controller) {
+            state.scanAbort = null;
+            if (!state.closed) {
+                ui.refreshButton.disabled = false;
+                ui.scanButton.disabled = false;
+                ui.scanButton.removeAttribute('aria-disabled');
+                ui.scanButton.textContent = tr(ctx, state.orphanScanComplete
+                    ? 'Rescan orphaned files'
+                    : 'Find orphaned files');
+            }
+            updateDeepButton(state, ui);
+        }
+    }
+}
+
+async function finalizeDataMaidToken(ctx, token) {
+    if (!token) {
+        return;
+    }
+    try {
+        await withDataMaidLock(() => finalizeDataMaid(
+            ctx,
+            token,
+            AbortSignal.timeout(DATA_MAID_FINALIZE_TIMEOUT_MS),
+        ));
+    } catch (error) {
+        console.warn('[Chat Archive] orphan scan token already expired:', error);
+    }
+}
+
+async function releaseDataMaid(ctx, state) {
+    const token = state.dataMaidToken;
+    state.dataMaidToken = null;
+    await finalizeDataMaidToken(ctx, token);
+}
+
+async function runDeepSearch(ctx, state, ui) {
+    const query = ui.search.value.trim();
+    if (!query) {
+        globalThis.toastr?.warning(tr(ctx, 'Enter a filter before searching message content.'));
+        return;
+    }
+
+    const controller = new AbortController();
+    state.searchAbort = controller;
+    state.deepRows = null;
+    state.deepQuery = query;
+    clearViewerMatch(ui);
+    const { signal } = controller;
+    ui.deepButton.disabled = false;
+    ui.deepButton.textContent = tr(ctx, 'Stop search');
+    ui.status.setAttribute('aria-busy', 'true');
+    renderList(ctx, state, ui);
+
+    const scopes = buildSearchScopes(ctx.characters, ctx.groups, ui.owner.value);
+    const localFiles = filterRows(
+        allRows(state).filter(row => row.kind === 'orphan'),
+        { owner: ui.owner.value },
+    );
+    const total = scopes.length + localFiles.length;
+    const found = new Map();
+    let completed = 0;
+    let errors = 0;
+
+    try {
+        for (const scope of scopes) {
+            if (signal.aborted) {
+                break;
+            }
+            setStatus(ui, tr(ctx, 'Searching source {current} of {total}...', { current: completed + 1, total }));
+            try {
+                const results = await searchScope(ctx, query, scope, signal);
+                let malformed = false;
+                for (const result of results) {
+                    const recent = deepResultToRecentRow(result, scope);
+                    const row = normalizeRow(recent, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+                    if (!row?.file_id) {
+                        malformed = true;
+                        continue;
+                    }
+                    if (found.has(physicalChatKey(row))) {
+                        continue;
+                    }
+                    try {
+                        const raw = await loadRawChat(ctx, state, row, signal);
+                        const { snippet, invalidLines } = await findMatchingSnippetInJsonlAsync(raw, query, { signal });
+                        if (invalidLines > 0) {
+                            errors++;
+                        }
+                        if (snippet !== null) {
+                            found.set(physicalChatKey(row), { ...row, snippet, matchSnippet: true });
+                        }
+                    } catch (error) {
+                        if (error?.name === 'AbortError') {
+                            throw error;
+                        }
+                        errors++;
+                        console.warn('[Chat Archive] search result verification failed:', error);
+                    }
+                }
+                if (malformed) {
+                    errors++;
+                }
+            } catch (error) {
+                if (error?.name === 'AbortError') {
+                    break;
+                }
+                errors++;
+                console.warn('[Chat Archive] search scope failed:', error);
+            }
+            completed++;
+        }
+
+        for (const row of localFiles) {
+            if (signal.aborted) {
+                break;
+            }
+            if (found.has(physicalChatKey(row))) {
+                completed++;
+                continue;
+            }
+            setStatus(ui, tr(ctx, 'Searching source {current} of {total}...', { current: completed + 1, total }));
+            try {
+                const raw = await loadRawChat(ctx, state, row, signal);
+                const { snippet, invalidLines } = await findMatchingSnippetInJsonlAsync(raw, query, { signal });
+                if (invalidLines > 0) {
+                    errors++;
+                }
+                if (snippet !== null) {
+                    found.set(physicalChatKey(row), { ...row, snippet, matchSnippet: true });
+                }
+            } catch (error) {
+                if (error?.name === 'AbortError') {
+                    break;
+                }
+                errors++;
+                console.warn('[Chat Archive] local file search failed:', error);
+            }
+            completed++;
+        }
+
+        if (state.searchAbort !== controller || state.closed) {
+            return;
+        }
+        state.deepRows = [...found.values()];
+        state.visibleLimit = LIST_PAGE_SIZE;
+        renderList(ctx, state, ui);
+        if (signal.aborted) {
+            setStatus(ui, tr(ctx, 'Search stopped after {completed} of {total} sources. {count} matching chats shown.', {
+                completed,
+                total,
+                count: found.size,
+            }));
+        } else if (errors > 0) {
+            setStatus(ui, tr(ctx, '{count} matching chats. {errors} search items had errors.', { count: found.size, errors }));
+        } else {
+            setStatus(ui, tr(ctx, '{count} matching chats for "{query}".', { count: found.size, query }));
+        }
+    } finally {
+        if (state.searchAbort === controller) {
+            state.searchAbort = null;
+            ui.status.removeAttribute('aria-busy');
+            ui.deepButton.textContent = tr(ctx, 'Search message content');
+            updateDeepButton(state, ui);
+            updateSearchMode(ctx, state, ui);
+        }
+    }
+}
+
+export function navigateAndConfirm(ctx, fileId, action, { signal, timeout = NAVIGATION_TIMEOUT_MS } = {}) {
+    return new Promise((resolve, reject) => {
+        let changed = false;
+        let settled = false;
+        let abortReason = null;
+        let timer;
+        const controller = new AbortController();
+        const cleanup = () => {
+            clearTimeout(timer);
+            ctx.eventSource.removeListener(ctx.eventTypes.CHAT_CHANGED, onChanged);
+            signal?.removeEventListener('abort', onExternalAbort);
+            controller.signal.removeEventListener('abort', onAbort);
+        };
+        const finish = (failed, error) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            cleanup();
+            if (failed) {
+                reject(error);
+            } else if (changed || String(ctx.getCurrentChatId?.() ?? '') === String(fileId)) {
+                resolve();
+            } else {
+                reject(new Error('Host did not confirm the requested chat'));
+            }
+        };
+        const onChanged = chatId => {
+            if (String(chatId) === String(fileId)) {
+                changed = true;
+            }
+        };
+        const onAbort = () => {
+            abortReason = controller.signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+            finish(true, abortReason);
+        };
+        const onExternalAbort = () => controller.abort(signal.reason);
+        ctx.eventSource.on(ctx.eventTypes.CHAT_CHANGED, onChanged);
+        controller.signal.addEventListener('abort', onAbort, { once: true });
+        signal?.addEventListener('abort', onExternalAbort, { once: true });
+        if (signal?.aborted) {
+            controller.abort(signal.reason);
+            return;
+        }
+        timer = setTimeout(() => controller.abort(new DOMException('Host navigation timed out.', 'TimeoutError')), timeout);
+        Promise.resolve()
+            .then(() => abortReason ? undefined : action(controller.signal))
+            .then(() => {
+                finish(!!abortReason, abortReason);
+            }, error => {
+                finish(true, abortReason ?? error);
+            });
+    });
+}
+
+async function restorePreviousChat(ctx, host, groupChats, previous) {
+    try {
+        if (previous.groupId != null) {
+            if (await groupChats.openGroupById(previous.groupId)) {
+                if (previous.chatId) {
+                    await ctx.openGroupChat(previous.groupId, previous.chatId);
+                }
+                host.setActiveGroup(previous.groupId);
+            }
+        } else {
+            const characterIndex = Number(previous.characterIndex);
+            if (Number.isInteger(characterIndex) && characterIndex >= 0) {
+                if (await ctx.selectCharacterById(characterIndex)) {
+                    if (previous.chatId) {
+                        await ctx.openCharacterChat(previous.chatId);
+                    }
+                    host.setActiveCharacter(ctx.characters[characterIndex]?.avatar);
+                }
+            } else if (groupChats.selected_group != null || (Number.isInteger(Number(host.this_chid)) && Number(host.this_chid) >= 0)) {
+                await ctx.closeCurrentChat();
+            }
+        }
+        ctx.saveSettingsDebounced();
+    } catch (error) {
+        console.warn('[Chat Archive] could not restore the previous chat after navigation failed:', error);
+    }
+}
+
+async function jumpToChat(ctx, state, row, control) {
+    if (state.navigationPending || state.closed || hostNavigationPending) {
+        return;
+    }
+    const controller = new AbortController();
+    state.navigationPending = true;
+    hostNavigationPending = controller;
+    state.navigationAbort = controller;
+    state.navigationControl = control;
+    const copy = control.querySelector('.sbca-button-copy');
+    const original = copy.textContent;
+    control.setAttribute('aria-disabled', 'true');
+    copy.textContent = tr(ctx, 'Opening...');
+    let host;
+    let groupChats;
+    let previous;
+    let navigationStarted = false;
+    let navigationConfirmed = false;
+    let navigationFinished = false;
+    let hostActionRunning = false;
+    const releaseHostNavigation = () => {
+        if (navigationFinished && !hostActionRunning && hostNavigationPending === controller) {
+            hostNavigationPending = null;
+        }
+    };
+    const runHostAction = async action => {
+        hostActionRunning = true;
+        try {
+            return await action();
+        } finally {
+            hostActionRunning = false;
+            releaseHostNavigation();
+        }
+    };
+    try {
+        [host, groupChats] = await Promise.all([
+            import('../../../../script.js'),
+            import('../../../group-chats.js'),
+        ]);
+        controller.signal.throwIfAborted();
+        previous = {
+            groupId: groupChats.selected_group,
+            characterIndex: host.this_chid,
+            chatId: ctx.getCurrentChatId(),
+        };
+        if (row.kind === 'group') {
+            const alreadyOpen = String(groupChats.selected_group) === String(row.groupId)
+                && String(ctx.getCurrentChatId()) === String(row.file_id);
+            if (!alreadyOpen) {
+                navigationStarted = true;
+                await navigateAndConfirm(ctx, row.file_id, signal => runHostAction(async () => {
+                    const selected = await groupChats.openGroupById(row.groupId);
+                    signal.throwIfAborted();
+                    if (!selected) {
+                        throw new Error('Failed to select group');
+                    }
+                    if (String(ctx.getCurrentChatId()) !== String(row.file_id)) {
+                        await ctx.openGroupChat(row.groupId, row.file_id);
+                        signal.throwIfAborted();
+                    }
+                }), { signal: controller.signal });
+            }
+            controller.signal.throwIfAborted();
+            host.setActiveGroup(row.groupId);
+        } else {
+            const index = ctx.characters.findIndex(character => character.avatar === row.avatar);
+            if (index === -1) {
+                throw new Error(`Character not found for avatar: ${row.avatar}`);
+            }
+            const alreadyOpen = String(host.this_chid) === String(index) && String(ctx.getCurrentChatId()) === String(row.file_id);
+            if (!alreadyOpen) {
+                navigationStarted = true;
+                await navigateAndConfirm(ctx, row.file_id, signal => runHostAction(async () => {
+                    const selected = await ctx.selectCharacterById(index);
+                    signal.throwIfAborted();
+                    if (!selected) {
+                        throw new Error('Failed to select character');
+                    }
+                    if (String(ctx.getCurrentChatId()) !== String(row.file_id)) {
+                        await ctx.openCharacterChat(row.file_id);
+                        signal.throwIfAborted();
+                    }
+                }), { signal: controller.signal });
+            }
+            controller.signal.throwIfAborted();
+            host.setActiveCharacter(row.avatar);
+        }
+        if (String(ctx.getCurrentChatId()) !== String(row.file_id)) {
+            throw new Error('Host did not open the requested chat');
+        }
+        navigationConfirmed = true;
+        ctx.saveSettingsDebounced();
+        if (!state.closed && popup === state.popup) {
+            state.restoreFocus = false;
+            await state.popup.completeCancelled();
+            document.getElementById('send_textarea')?.focus();
+        }
+    } catch (error) {
+        const cancelled = error?.name === 'AbortError' || error?.name === 'TimeoutError';
+        // ponytail: host navigation cannot be canceled; do not race rollback against a timed-out call.
+        if (!cancelled && navigationStarted && !navigationConfirmed && host && groupChats && previous) {
+            await restorePreviousChat(ctx, host, groupChats, previous);
+        }
+        if (error?.name !== 'AbortError') {
+            console.error('[Chat Archive] failed to open chat:', error);
+            globalThis.toastr?.error(tr(ctx, 'Could not open this chat. The archive is still available.'));
+        }
+    } finally {
+        // ponytail: keep the lock until uncancellable timed-out host work settles.
+        navigationFinished = true;
+        releaseHostNavigation();
+        if (state.navigationAbort === controller) {
+            state.navigationPending = false;
+            state.navigationAbort = null;
+            const currentControl = state.navigationControl;
+            state.navigationControl = null;
+            for (const target of new Set([control, currentControl])) {
+                if (target?.isConnected) {
+                    target.removeAttribute('aria-disabled');
+                    target.querySelector('.sbca-button-copy').textContent = target === control ? original : tr(ctx, 'Open chat');
+                }
+            }
+        }
+    }
+}
+
+function downloadChat(ctx, row, raw, format, control) {
+    if (control.getAttribute('aria-disabled') === 'true') {
+        return;
+    }
+    const copy = control.querySelector('.sbca-button-copy');
+    const original = copy.textContent;
+    control.setAttribute('aria-disabled', 'true');
+    copy.textContent = tr(ctx, 'Preparing...');
+    try {
+        const content = format === 'txt' ? recordsToText(parseJsonl(raw)) : raw;
+        const mime = format === 'txt' ? 'text/plain;charset=utf-8' : 'application/x-ndjson;charset=utf-8';
+        downloadBlob(content, mime, `${row.file_id}.${format}`);
+        globalThis.toastr?.success(tr(ctx, 'Download started.'));
+    } catch (error) {
+        console.error('[Chat Archive] export failed:', error);
+        globalThis.toastr?.error(tr(ctx, 'Could not prepare this download.'));
+    } finally {
+        control.removeAttribute('aria-disabled');
+        copy.textContent = original;
+    }
+}
+
+function downloadBlob(content, type, filename) {
+    const url = URL.createObjectURL(new Blob([content], { type }));
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -539,7 +539,7 @@ function buildRoot(ctx, state) {
     const scanButton = button('sbca-control', tr(ctx, 'Find orphaned files'));
     scanButton.title = tr(ctx, 'Scan for chats belonging to deleted characters or unlinked groups. This can take a while.');
     const archiveActions = el('div', 'sbca-archive-actions');
-    archiveActions.append(refreshButton, scanButton);
+    archiveActions.append(clearFilters, refreshButton, scanButton);
     const management = el('div', 'sbca-management');
     const managers = {
         folders: buildNamedManager(ctx, 'folders', 'Folders', 'Folder name'),
@@ -566,7 +566,7 @@ function buildRoot(ctx, state) {
         backup.root,
     );
     options.append(optionsPanel);
-    filterTools.append(options, clearFilters, archiveActions);
+    filterTools.append(options, archiveActions);
 
     const status = el('div', 'sbca-status');
     status.setAttribute('role', 'status');
@@ -2196,11 +2196,12 @@ async function openViewer(ctx, state, row, ui) {
     state.viewerAbort = controller;
     state.selectedRow = row;
     ui.viewerTitle.textContent = row.file_id;
-    ui.viewerContent.replaceChildren(
-        buildChatOrganizer(ctx, state, row, ui),
+    const loadingDetails = el('div', 'sbca-viewer-details');
+    loadingDetails.append(
         buildSummary(ctx, row),
         el('p', 'sbca-placeholder', tr(ctx, 'Loading chat...')),
     );
+    ui.viewerContent.replaceChildren(buildChatOrganizer(ctx, state, row, ui), loadingDetails);
     ui.viewer.setAttribute('aria-busy', 'true');
     showDetail(ui);
 
@@ -2243,7 +2244,9 @@ async function openViewer(ctx, state, row, ui) {
             errorMessage.setAttribute('role', 'alert');
             const retry = button('sbca-control', tr(ctx, 'Try again'));
             retry.addEventListener('click', () => void openViewer(ctx, state, row, ui));
-            ui.viewerContent.replaceChildren(buildChatOrganizer(ctx, state, row, ui), buildSummary(ctx, row), errorMessage, retry);
+            const details = el('div', 'sbca-viewer-details');
+            details.append(buildSummary(ctx, row), errorMessage, retry);
+            ui.viewerContent.replaceChildren(buildChatOrganizer(ctx, state, row, ui), details);
             if (!state.searchAbort && state.deepRows === null) {
                 setStatus(ui, tr(ctx, 'Could not open {name}', { name: row.file_id }));
             }
@@ -2487,14 +2490,12 @@ function renderViewer(ctx, state, row, raw, shaped, ui) {
         latest?.focus({ preventScroll: true });
         latest?.scrollIntoView({ block: 'start' });
     } : null;
-    const content = [
-        buildChatOrganizer(ctx, state, row, ui),
-        buildSummary(ctx, row),
-        buildViewerActions(ctx, state, row, raw, true, showLatest),
-    ];
+    const actions = buildViewerActions(ctx, state, row, raw, true, showLatest);
+    const details = el('div', 'sbca-viewer-details');
+    details.append(buildSummary(ctx, row));
     const metadata = shaped.header?.chat_metadata;
     if (metadata && Object.keys(metadata).length > 0) {
-        content.push(jsonDetails(ctx, 'Chat metadata', metadata));
+        details.append(jsonDetails(ctx, 'Chat metadata', metadata));
     }
 
     if (shaped.messages.length === 0) {
@@ -2508,8 +2509,8 @@ function renderViewer(ctx, state, row, raw, shaped, ui) {
     rawView.hidden = true;
     const rawToggle = buildRawToggle(ctx, raw, rawView, messages);
 
-    content.push(rawToggle, messages, rawView);
-    ui.viewerContent.replaceChildren(...content);
+    details.append(rawToggle, messages, rawView);
+    ui.viewerContent.replaceChildren(actions, buildChatOrganizer(ctx, state, row, ui), details);
     const match = messages.querySelector('.sbca-msg-match');
     match?.focus({ preventScroll: true });
     match?.scrollIntoView({ block: 'center' });
@@ -2548,13 +2549,17 @@ function renderMalformedViewer(ctx, state, row, raw, ui) {
     const rawView = el('pre', 'sbca-raw');
     rawView.id = `sbca_raw_${++renderId}`;
     rawView.hidden = true;
-    ui.viewerContent.replaceChildren(
-        buildChatOrganizer(ctx, state, row, ui),
+    const details = el('div', 'sbca-viewer-details');
+    details.append(
         buildSummary(ctx, row),
-        buildViewerActions(ctx, state, row, raw, false),
         warning,
         buildRawToggle(ctx, raw, rawView),
         rawView,
+    );
+    ui.viewerContent.replaceChildren(
+        buildViewerActions(ctx, state, row, raw, false),
+        buildChatOrganizer(ctx, state, row, ui),
+        details,
     );
 }
 

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -35,18 +35,6 @@ const KINDS = [
     ['orphan', 'Orphaned'],
 ];
 
-const SORT_OPTIONS = [
-    ['recent', 'Recent'],
-    ['oldest', 'Oldest'],
-    ['size', 'Largest'],
-    ['smallest', 'Smallest'],
-    ['count', 'Most messages'],
-    ['fewest', 'Fewest messages'],
-    ['name', 'Name A-Z'],
-    ['name-reverse', 'Name Z-A'],
-    ['owner', 'Owner'],
-];
-
 const GROUP_OPTIONS = [
     ['flat', 'Flat'],
     ['owner', 'Owner'],
@@ -461,9 +449,11 @@ function buildRoot(ctx, state) {
     const savedViewField = selectControl(ctx, 'Saved view', [['', 'Current view']], 'sbca-sort sbca-browse-field');
     const groupField = selectControl(ctx, 'Group', GROUP_OPTIONS, 'sbca-sort sbca-browse-field');
     const densityField = selectControl(ctx, 'Density', DENSITY_OPTIONS, 'sbca-sort sbca-browse-field');
-    const sortField = selectControl(ctx, 'Sort', SORT_OPTIONS, 'sbca-sort sbca-browse-field');
+    const sort = document.createElement('input');
+    sort.type = 'hidden';
+    sort.value = 'recent';
     markOrganizationControl(savedViewField.select);
-    browseStrip.append(savedViewField.wrap, groupField.wrap, densityField.wrap, sortField.wrap);
+    browseStrip.append(savedViewField.wrap, groupField.wrap, densityField.wrap);
     const browseOptions = el('details', 'sbca-browse-options');
     const browseSummary = el('summary', undefined, tr(ctx, 'Browse options'));
     browseOptions.open = !mobileQuery.matches;
@@ -478,7 +468,7 @@ function buildRoot(ctx, state) {
     organizationState.append(organizationStatus, organizationRetry);
 
     const options = el('details', 'sbca-options');
-    options.append(el('summary', undefined, tr(ctx, 'Filters and organization')));
+    options.append(el('summary', undefined, tr(ctx, 'Filters')));
     const optionsPanel = el('div', 'sbca-options-panel');
     const filterTools = el('div', 'sbca-filter-tools');
     const clearFilters = button('sbca-control sbca-clear-filters', tr(ctx, 'Clear filters'));
@@ -519,17 +509,13 @@ function buildRoot(ctx, state) {
     tagField.input.setAttribute('list', tagOptions.id);
     const minDateField = inputControl(ctx, 'From date', 'date');
     const maxDateField = inputControl(ctx, 'To date', 'date');
-    const minSizeField = inputControl(ctx, 'Minimum size (MB)', 'number');
-    const maxSizeField = inputControl(ctx, 'Maximum size (MB)', 'number');
-    const minMessagesField = inputControl(ctx, 'Minimum messages', 'number');
-    const maxMessagesField = inputControl(ctx, 'Maximum messages', 'number');
-    for (const input of [minSizeField.input, maxSizeField.input]) {
-        input.min = '0';
-        input.step = 'any';
-    }
-    for (const input of [minMessagesField.input, maxMessagesField.input]) {
-        input.min = '0';
-        input.step = '1';
+    // Keep legacy saved-view constraints applicable without keeping their low-value controls in the toolbar.
+    const minSize = document.createElement('input');
+    const maxSize = document.createElement('input');
+    const minMessages = document.createElement('input');
+    const maxMessages = document.createElement('input');
+    for (const input of [minSize, maxSize, minMessages, maxMessages]) {
+        input.type = 'hidden';
     }
     for (const control of [favoriteField.select, folderField.select, collectionField.select, tagField.input]) {
         markOrganizationControl(control);
@@ -540,6 +526,8 @@ function buildRoot(ctx, state) {
     scanButton.title = tr(ctx, 'Scan for chats belonging to deleted characters or unlinked groups. This can take a while.');
     const archiveActions = el('div', 'sbca-archive-actions');
     archiveActions.append(clearFilters, refreshButton, scanButton);
+    const organizationTools = el('details', 'sbca-organization-tools');
+    organizationTools.append(el('summary', undefined, tr(ctx, 'Manage organization')));
     const management = el('div', 'sbca-management');
     const managers = {
         folders: buildNamedManager(ctx, 'folders', 'Folders', 'Folder name'),
@@ -548,25 +536,19 @@ function buildRoot(ctx, state) {
     };
     management.append(managers.folders.root, managers.collections.root, managers.views.root);
     const backup = buildBackupControls(ctx);
+    const organizationPanel = el('div', 'sbca-organization-tools-panel');
+    organizationPanel.append(management, backup.root);
+    organizationTools.append(organizationPanel);
     optionsPanel.append(
         kinds,
         orphanField.wrap,
         favoriteField.wrap,
-        folderField.wrap,
-        collectionField.wrap,
-        tagField.wrap,
         tagOptions,
         minDateField.wrap,
         maxDateField.wrap,
-        minSizeField.wrap,
-        maxSizeField.wrap,
-        minMessagesField.wrap,
-        maxMessagesField.wrap,
-        management,
-        backup.root,
     );
     options.append(optionsPanel);
-    filterTools.append(options, archiveActions);
+    filterTools.append(options, organizationTools, archiveActions);
 
     const status = el('div', 'sbca-status');
     status.setAttribute('role', 'status');
@@ -604,11 +586,8 @@ function buildRoot(ctx, state) {
     }
     const list = el('ul', 'sbca-list');
     list.setAttribute('aria-labelledby', listHeading.id);
-    const listTools = el('details', 'sbca-list-tools');
-    const listToolsSummary = el('summary', undefined, tr(ctx, 'List tools'));
-    const listToolsPanel = el('div', 'sbca-list-tools-panel');
-    listToolsPanel.append(ownerField.wrap, sortPills, selectionBar);
-    listTools.append(listToolsSummary, listToolsPanel);
+    const listTools = el('div', 'sbca-list-tools');
+    listTools.append(ownerField.wrap, sortPills, selectionBar);
     listTop.append(listHeading, listTools);
     listPanel.append(listTop, list);
 
@@ -633,7 +612,7 @@ function buildRoot(ctx, state) {
         savedView: savedViewField.select,
         group: groupField.select,
         density: densityField.select,
-        sort: sortField.select,
+        sort,
         owner: ownerField.input,
         ownerField,
         orphan: orphanField.select,
@@ -644,10 +623,10 @@ function buildRoot(ctx, state) {
         tagOptions,
         minDate: minDateField.input,
         maxDate: maxDateField.input,
-        minSize: minSizeField.input,
-        maxSize: maxSizeField.input,
-        minMessages: minMessagesField.input,
-        maxMessages: maxMessagesField.input,
+        minSize,
+        maxSize,
+        minMessages,
+        maxMessages,
         deepButton,
         searchMode,
         searchModeText,
@@ -859,10 +838,6 @@ function buildRoot(ctx, state) {
         ui.collection,
         ui.minDate,
         ui.maxDate,
-        ui.minSize,
-        ui.maxSize,
-        ui.minMessages,
-        ui.maxMessages,
     ]) {
         control.addEventListener('change', () => {
             if (control === ui.density) {
@@ -938,8 +913,6 @@ function buildRoot(ctx, state) {
         state.selectionMode = !state.selectionMode;
         if (!state.selectionMode) {
             state.selectedBatchKeys.clear();
-        } else {
-            listTools.open = true;
         }
         renderList(ctx, state, ui);
         updateSelectionControls(ctx, state, ui);

--- a/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
+++ b/public/scripts/extensions/sillybunny-chats-archive/src/ui.js
@@ -22,7 +22,7 @@ import {
     fetchOrganization,
     exportChat,
     fetchArchiveFile,
-    fetchArchiveInventory,
+    iterateArchiveInventoryPages,
     ORGANIZATION_FILE_NAME,
     releaseArchiveSession,
     saveOrganization,
@@ -348,6 +348,7 @@ export async function openArchive(ctx, opener = null) {
         orphanScanComplete: false,
         inventoryFailures: 0,
         archiveReadToken: null,
+        orphanScanReadToken: null,
         navigationPending: false,
         navigationAbort: null,
         navigationControl: null,
@@ -537,6 +538,8 @@ function buildRoot(ctx, state) {
     const refreshButton = button('sbca-control', tr(ctx, 'Refresh'));
     const scanButton = button('sbca-control', tr(ctx, 'Find orphaned files'));
     scanButton.title = tr(ctx, 'Scan for chats belonging to deleted characters or unlinked groups. This can take a while.');
+    const archiveActions = el('div', 'sbca-archive-actions');
+    archiveActions.append(refreshButton, scanButton);
     const management = el('div', 'sbca-management');
     const managers = {
         folders: buildNamedManager(ctx, 'folders', 'Folders', 'Folder name'),
@@ -559,13 +562,11 @@ function buildRoot(ctx, state) {
         maxSizeField.wrap,
         minMessagesField.wrap,
         maxMessagesField.wrap,
-        refreshButton,
-        scanButton,
         management,
         backup.root,
     );
     options.append(optionsPanel);
-    filterTools.append(options, clearFilters);
+    filterTools.append(options, clearFilters, archiveActions);
 
     const status = el('div', 'sbca-status');
     status.setAttribute('role', 'status');
@@ -892,7 +893,15 @@ function buildRoot(ctx, state) {
             state.selectedViewId = null;
         }
     });
-    refreshButton.addEventListener('click', () => void loadRows(ctx, state, ui));
+    refreshButton.addEventListener('click', () => {
+        if (state.listAbort) {
+            state.listAbort.abort();
+            refreshButton.disabled = true;
+            refreshButton.textContent = tr(ctx, 'Stopping...');
+            return;
+        }
+        void loadRows(ctx, state, ui);
+    });
     scanButton.addEventListener('click', () => {
         if (state.scanAbort) {
             state.scanAbort.abort();
@@ -1784,55 +1793,76 @@ async function loadRows(ctx, state, ui) {
     const controller = new AbortController();
     state.listAbort = controller;
     state.listState = 'loading';
-    ui.refreshButton.disabled = true;
+    ui.refreshButton.disabled = false;
+    ui.refreshButton.textContent = tr(ctx, 'Cancel');
     ui.scanButton.disabled = true;
     state.visibleLimit = LIST_PAGE_SIZE;
+    const previousRows = state.rows;
+    const previousFailures = state.inventoryFailures;
+    const nextRows = [];
+    const known = new Set();
+    let invalidRows = 0;
+    state.rows = nextRows;
+    state.inventoryFailures = 0;
+    state.selectedKey = null;
+    state.selectedRow = null;
+    state.selectedButton = null;
+    resetViewer(ctx, ui);
     renderList(ctx, state, ui);
     setStatus(ui, tr(ctx, 'Loading chats...'));
     updateDeepButton(state, ui);
 
     try {
-        const inventory = await fetchArchiveInventory(ctx, 'archive', controller.signal);
+        for await (const page of iterateArchiveInventoryPages(ctx, 'archive', controller.signal)) {
+            if (state.listAbort !== controller || state.closed || controller.signal.aborted) {
+                return;
+            }
+            for (const raw of page.rows) {
+                const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+                if (!row?.file_id) {
+                    invalidRows++;
+                    continue;
+                }
+                const key = physicalChatKey(row);
+                if (!known.has(key)) {
+                    known.add(key);
+                    nextRows.push(row);
+                }
+            }
+            state.inventoryFailures = page.errors + invalidRows;
+            refreshOwnerOptions(ctx, state, ui);
+            renderList(ctx, state, ui);
+            updateSelectionControls(ctx, state, ui);
+            setStatus(ui, `${tr(ctx, 'Loading chats...')} ${tr(ctx, '{matching} of {total} indexed chat files', {
+                matching: page.loaded,
+                total: page.total,
+            })}`);
+        }
         if (state.listAbort !== controller || state.closed) {
             return;
         }
-        const nextRows = [];
-        const known = new Set();
-        let inventoryFailures = inventory.errors;
-        for (const raw of inventory.rows) {
-            const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
-            if (!row?.file_id) {
-                inventoryFailures++;
-                continue;
-            }
-            const key = physicalChatKey(row);
-            if (!known.has(key)) {
-                known.add(key);
-                nextRows.push(row);
-            }
-        }
-        state.rows = nextRows;
-        state.inventoryFailures = inventoryFailures;
-        state.selectedKey = null;
-        state.selectedRow = null;
-        state.selectedButton = null;
-        resetViewer(ctx, ui);
         state.listState = 'ready';
         refreshOwnerOptions(ctx, state, ui);
         renderList(ctx, state, ui);
         updateBrowseStatus(ctx, state, ui);
         updateSelectionControls(ctx, state, ui);
     } catch (error) {
-        controller.abort();
-        if (error?.archiveCursor) {
-            void releaseArchiveToken(ctx, error.archiveReadToken, error.archiveCursor);
-        }
         if (error?.name === 'AbortError') {
+            if (state.listAbort === controller && !state.closed) {
+                state.listState = 'ready';
+                refreshOwnerOptions(ctx, state, ui);
+                renderList(ctx, state, ui);
+                updateSelectionControls(ctx, state, ui);
+                setStatus(ui, `${tr(ctx, 'Scan stopped.')} ${tr(ctx, '{total} indexed chat files', { total: state.rows.length })}`);
+            }
             return;
         }
         console.error('[Chat Archive] failed to list chats:', error);
         if (state.listAbort === controller) {
+            state.rows = previousRows;
+            state.inventoryFailures = previousFailures;
             state.listState = allRows(state).length > 0 ? 'ready' : 'error';
+            refreshOwnerOptions(ctx, state, ui);
             renderList(ctx, state, ui);
             setStatus(ui, tr(ctx, state.listState === 'ready'
                 ? 'Could not refresh chats. Showing the previous results.'
@@ -1843,6 +1873,7 @@ async function loadRows(ctx, state, ui) {
             state.listAbort = null;
             ui.list.removeAttribute('aria-busy');
             ui.refreshButton.disabled = false;
+            ui.refreshButton.textContent = tr(ctx, 'Refresh');
             ui.scanButton.disabled = false;
             updateDeepButton(state, ui);
         }
@@ -1884,10 +1915,12 @@ function renderList(ctx, state, ui) {
     ui.list.replaceChildren();
     state.selectedButton = null;
     if (state.listState === 'loading') {
-        state.matchingRows = [];
         ui.list.setAttribute('aria-busy', 'true');
-        ui.list.append(listMessage(tr(ctx, 'Loading chats...')));
-        return;
+        if (state.rows.length === 0) {
+            state.matchingRows = [];
+            ui.list.append(listMessage(tr(ctx, 'Loading chats...')));
+            return;
+        }
     }
     if (state.listState === 'error') {
         state.matchingRows = [];
@@ -2383,10 +2416,11 @@ function refreshOpenOrganizer(ctx, state, ui) {
 
 async function loadRawChat(ctx, state, row, signal) {
     if (row.source === 'archive-orphan') {
-        if (!state.archiveReadToken || !row.archiveHash) {
+        const readToken = state.orphanScanReadToken ?? state.archiveReadToken;
+        if (!readToken || !row.archiveHash) {
             throw new Error('Orphan scan expired');
         }
-        return fetchArchiveFile(ctx, state.archiveReadToken, row.archiveHash, signal);
+        return fetchArchiveFile(ctx, readToken, row.archiveHash, signal);
     }
 
     const isGroup = row.kind === 'group' || row.orphanType === 'missing-group';
@@ -2652,30 +2686,46 @@ async function scanOrphans(ctx, state, ui) {
     setStatus(ui, tr(ctx, 'Scanning for missing-character and unlinked-group chats...'));
     updateDeepButton(state, ui);
 
+    const previousRows = state.orphanRows;
+    const previousToken = state.archiveReadToken;
+    const nextRows = [];
+    const known = new Set();
+    let invalidRows = 0;
+    let inventoryErrors = 0;
     try {
-        const inventory = await fetchArchiveInventory(ctx, 'orphans', controller.signal);
-        if (controller.signal.aborted || state.scanAbort !== controller || state.closed) {
-            void releaseArchiveToken(ctx, inventory.readToken);
-            if (!state.closed && state.scanAbort === controller) {
-                setStatus(ui, tr(ctx, state.orphanScanComplete
-                    ? 'Scan stopped. Previous results are still shown.'
-                    : 'Scan stopped.'));
+        for await (const page of iterateArchiveInventoryPages(ctx, 'orphans', controller.signal)) {
+            if (controller.signal.aborted || state.scanAbort !== controller || state.closed) {
+                throw controller.signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
             }
+            state.orphanScanReadToken = page.readToken;
+            inventoryErrors = page.errors;
+            for (const raw of page.rows) {
+                const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
+                if (!row?.file_id || !row.archiveHash || row.kind !== 'orphan') {
+                    invalidRows++;
+                    continue;
+                }
+                const key = physicalChatKey(row);
+                if (!known.has(key)) {
+                    known.add(key);
+                    nextRows.push(row);
+                }
+            }
+            state.orphanRows = nextRows;
+            state.visibleLimit = LIST_PAGE_SIZE;
+            refreshOwnerOptions(ctx, state, ui);
+            renderList(ctx, state, ui);
+            updateSelectionControls(ctx, state, ui);
+            setStatus(ui, `${tr(ctx, 'Scanning for missing-character and unlinked-group chats...')} ${tr(ctx, '{matching} of {total} indexed chat files', {
+                matching: page.loaded,
+                total: page.total,
+            })}`);
+        }
+        if (state.scanAbort !== controller || state.closed) {
             return;
         }
-        const orphanRows = [];
-        let invalidRecords = inventory.errors;
-        for (const raw of inventory.rows) {
-            const row = normalizeRow(raw, state.charactersByAvatar, state.groupsById, ctx.timestampToMoment);
-            if (!row?.file_id || !row.archiveHash || row.kind !== 'orphan') {
-                invalidRecords++;
-                continue;
-            }
-            orphanRows.push(row);
-        }
-        const previousToken = state.archiveReadToken;
-        state.archiveReadToken = inventory.readToken;
-        state.orphanRows = orphanRows;
+        state.archiveReadToken = state.orphanScanReadToken;
+        state.orphanScanReadToken = null;
         state.orphanScanComplete = true;
         state.selectedKey = null;
         state.selectedRow = null;
@@ -2689,15 +2739,17 @@ async function scanOrphans(ctx, state, ui) {
         setStatus(ui, state.orphanRows.length > 0
             ? tr(ctx, 'Found {count} additional orphaned chat files.', { count: state.orphanRows.length })
             : tr(ctx, 'No additional orphaned chat files were found.'));
-        if (invalidRecords > 0) {
+        if (inventoryErrors + invalidRows > 0) {
             setStatus(ui, `${ui.status.textContent} ${tr(ctx, 'Some orphan records could not be read.')}`);
         }
         void releaseArchiveToken(ctx, previousToken);
     } catch (error) {
-        if (error?.archiveReadToken || error?.archiveCursor) {
-            void releaseArchiveToken(ctx, error.archiveReadToken, error.archiveCursor);
-        }
         if (!state.closed && state.scanAbort === controller) {
+            state.orphanRows = previousRows;
+            state.orphanScanReadToken = null;
+            refreshOwnerOptions(ctx, state, ui);
+            renderList(ctx, state, ui);
+            updateSelectionControls(ctx, state, ui);
             if (error?.name === 'AbortError') {
                 setStatus(ui, tr(ctx, state.orphanScanComplete
                     ? 'Scan stopped. Previous results are still shown.'
@@ -2738,8 +2790,11 @@ async function releaseArchiveToken(ctx, token, cursor = null) {
 
 async function releaseArchiveReadSession(ctx, state) {
     const token = state.archiveReadToken;
+    const pendingToken = state.orphanScanReadToken;
     state.archiveReadToken = null;
-    await releaseArchiveToken(ctx, token);
+    state.orphanScanReadToken = null;
+    await Promise.all([...new Set([token, pendingToken].filter(Boolean))]
+        .map(readToken => releaseArchiveToken(ctx, readToken)));
 }
 
 async function runDeepSearch(ctx, state, ui) {

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -364,12 +364,24 @@
     box-sizing: border-box;
     gap: var(--sbca-space-sm);
     align-items: center;
+    block-size: 46px;
     min-block-size: 46px;
+    margin: 0;
     padding: var(--sbca-space-sm) var(--sbca-space-md);
     border-radius: var(--sb-radius-button, 14px);
     color: inherit;
     cursor: pointer;
     list-style: none;
+}
+
+.sbca-owner-summary .sbca-owner-choice-copy {
+    overflow: hidden;
+}
+
+.sbca-owner-summary .sbca-owner-choice-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .sbca-owner-summary::-webkit-details-marker {
@@ -500,12 +512,16 @@
     flex-wrap: wrap;
     gap: var(--sbca-space-xs);
     align-items: center;
+    align-self: stretch;
+    min-block-size: 46px;
 }
 
 .sbca-sortpill {
     display: inline-flex;
     align-items: center;
-    min-block-size: var(--sb-control-min-height, 30px);
+    box-sizing: border-box;
+    block-size: 46px;
+    min-block-size: 46px;
     margin: 0;
     padding: var(--sbca-space-xs) var(--sbca-space-md);
     border: 1px solid var(--sbca-border);
@@ -639,7 +655,7 @@
     display: grid;
     grid-template-columns: minmax(180px, 1fr) auto;
     gap: var(--sbca-space-sm) var(--sbca-space-md);
-    align-items: end;
+    align-items: start;
     flex-basis: 100%;
     inline-size: 100%;
 }

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -1,0 +1,1127 @@
+#sbca_drawer_button:focus-visible {
+    outline: 2px solid var(--sb-focus-ring, var(--color-focus-ring, var(--SmartThemeQuoteColor, currentColor)));
+    outline-offset: 2px;
+}
+
+@media screen and (max-width: 768px) {
+    #right-nav-panel.openDrawer .sb-character-create-bar #sbca_drawer_button {
+        width: 38px !important;
+        min-width: 38px !important;
+        max-width: 38px !important;
+        height: 38px !important;
+        min-height: 38px !important;
+        max-height: 38px !important;
+        padding: 0 !important;
+    }
+}
+
+.sbca-dialog .popup-body,
+.sbca-dialog .popup-content {
+    max-block-size: none;
+    overflow: hidden !important;
+}
+
+.sbca-root {
+    --sbca-border: var(--color-border, var(--SmartThemeBorderColor, currentColor));
+    --sbca-text: var(--color-text, var(--SmartThemeBodyColor, inherit));
+    --sbca-muted: var(--sb-muted-fg, var(--color-text-secondary, var(--SmartThemeBodyColor, inherit)));
+    --sbca-surface: var(--color-surface, var(--sb-card-bg, var(--SmartThemeBlurTintColor, transparent)));
+    --sbca-accent: var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor, currentColor)));
+    --sbca-focus: var(--sb-focus-ring, var(--color-focus-ring, var(--SmartThemeQuoteColor, currentColor)));
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    block-size: 75vh;
+    block-size: 75dvh;
+    max-block-size: 100%;
+    min-block-size: 0;
+    overflow: hidden;
+    color: var(--sbca-text);
+    text-align: start;
+}
+
+/* Author display rules (e.g. .sbca-owner-option) outrank the UA [hidden]
+   rule at equal specificity, so re-assert it for every toggled element. */
+.sbca-root [hidden] {
+    display: none !important;
+}
+
+.sbca-control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-inline-size: var(--sb-control-min-height, 30px);
+    min-block-size: var(--sb-control-min-height, 30px);
+    inline-size: fit-content;
+    margin: 0;
+    padding: 6px 12px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-button, 14px);
+    background: var(--sb-button-bg, var(--sbca-surface));
+    color: inherit;
+    font: inherit;
+    font-weight: 500;
+    text-align: center;
+    white-space: normal;
+    cursor: pointer;
+}
+
+.sbca-control:not(:disabled):hover {
+    border-color: var(--sbca-accent);
+}
+
+.sbca-control:disabled,
+.sbca-control[aria-disabled="true"] {
+    filter: saturate(0.25);
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.sbca-heading,
+.sbca-section-heading {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.sbca-heading {
+    padding-inline-start: 0;
+    border: 0;
+    font-size: 1.25em;
+}
+
+.sbca-section-heading {
+    font-size: 1em;
+}
+
+.sbca-toolbar {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) auto;
+    gap: 8px;
+    align-items: end;
+}
+
+.sbca-search,
+.sbca-sort {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-inline-size: 0;
+    margin: 0;
+}
+
+.sbca-label,
+.sbca-kinds legend {
+    color: var(--sbca-muted);
+    font-size: 0.875em;
+    font-weight: 600;
+}
+
+.sbca-search input,
+.sbca-sort select {
+    inline-size: 100%;
+    min-inline-size: 0;
+}
+
+.sbca-deep {
+    min-block-size: 36px;
+    border-color: var(--sbca-accent);
+    background: color-mix(in srgb, var(--sbca-accent) 14%, var(--sbca-surface));
+    color: var(--sbca-text);
+    font-weight: 700;
+}
+
+.sbca-search-mode,
+.sbca-browse-options,
+.sbca-filter-tools,
+.sbca-status {
+    grid-column: 1 / -1;
+}
+
+.sbca-search-mode {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 7px 9px;
+    border: 1px solid var(--sbca-accent);
+    border-radius: var(--sb-radius-sm, 8px);
+    background: color-mix(in srgb, var(--sbca-accent) 10%, var(--sbca-surface));
+}
+
+.sbca-search-mode-text {
+    font-weight: 600;
+    overflow-wrap: anywhere;
+}
+
+.sbca-browse-options {
+    display: contents;
+}
+
+.sbca-browse-options > summary {
+    display: none;
+}
+
+.sbca-filter-tools {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sbca-options > summary,
+.sbca-json-details > summary {
+    inline-size: fit-content;
+    cursor: pointer;
+    color: var(--sbca-muted);
+    font-weight: 600;
+}
+
+.sbca-options-panel {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    align-items: end;
+    padding-block-start: 8px;
+}
+
+.sbca-kinds {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 10px;
+    align-items: center;
+    min-inline-size: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+.sbca-kinds legend {
+    float: inline-start;
+    margin-inline-end: 6px;
+}
+
+.sbca-kinds .checkbox_label {
+    display: inline-flex;
+    gap: 5px;
+    align-items: center;
+    margin: 0;
+    white-space: normal;
+}
+
+.sbca-status {
+    min-block-size: 1.4em;
+    color: var(--sbca-muted);
+    font-size: 0.875em;
+    overflow-wrap: anywhere;
+}
+
+.sbca-browse-strip,
+.sbca-organization-state {
+    grid-column: 1 / -1;
+}
+
+.sbca-browse-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(130px, 1fr));
+    gap: 8px;
+}
+
+.sbca-filter {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-inline-size: min(180px, 100%);
+}
+
+.sbca-organization-state,
+.sbca-list-top,
+.sbca-selection-bar,
+.sbca-selection-tools,
+.sbca-manager-create,
+.sbca-manager-row,
+.sbca-batch-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.sbca-list-top,
+.sbca-selection-bar {
+    justify-content: space-between;
+}
+
+.sbca-owner-selector {
+    inline-size: 100%;
+    min-inline-size: 0;
+}
+
+.sbca-owner-details {
+    position: relative;
+}
+
+.sbca-owner-summary {
+    display: flex;
+    box-sizing: border-box;
+    gap: 8px;
+    align-items: center;
+    min-block-size: 46px;
+    padding: 6px 10px;
+    border-radius: var(--sb-radius-button, 14px);
+    color: inherit;
+    cursor: pointer;
+    list-style: none;
+}
+
+.sbca-owner-summary::-webkit-details-marker {
+    display: none;
+}
+
+.sbca-owner-summary::after {
+    inline-size: 0.45em;
+    block-size: 0.45em;
+    margin-inline: auto 3px;
+    border-block-end: 2px solid currentColor;
+    border-inline-end: 2px solid currentColor;
+    content: '';
+    transform: rotate(45deg);
+}
+
+.sbca-owner-details[open] > .sbca-owner-summary {
+    border-color: var(--sbca-accent);
+}
+
+.sbca-owner-details[open] > .sbca-owner-summary::after {
+    transform: rotate(225deg);
+}
+
+.sbca-owner-menu {
+    position: absolute;
+    z-index: 10;
+    inset-block-start: calc(100% + 4px);
+    inset-inline: 0;
+    box-sizing: border-box;
+    inline-size: 100%;
+    padding: 8px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-sm, 8px);
+    background: var(--sbca-surface);
+}
+
+.sbca-owner-search {
+    box-sizing: border-box;
+    inline-size: 100%;
+    min-block-size: 46px;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+.sbca-owner-options {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-block-size: min(320px, 45dvh);
+    margin-block-start: 6px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.sbca-owner-option {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    inline-size: 100%;
+    min-block-size: 44px;
+    margin: 0;
+    padding: 5px 7px;
+    border: 1px solid transparent;
+    border-radius: var(--sb-radius-sm, 8px);
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
+    /* Keep filtering cheap with many characters: skip offscreen rendering. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 56px;
+}
+
+.sbca-owner-option:hover {
+    border-color: var(--sbca-border);
+}
+
+.sbca-owner-option[aria-pressed="true"] {
+    border-color: var(--sbca-accent);
+    background: color-mix(in srgb, var(--sbca-accent) 10%, var(--sbca-surface));
+    font-weight: 700;
+}
+
+.sbca-owner-mini-avatar,
+.sbca-owner-mini-icon {
+    inline-size: 30px;
+    block-size: 30px;
+    flex: 0 0 30px;
+}
+
+.sbca-owner-mini-avatar {
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.sbca-owner-mini-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--sbca-muted);
+}
+
+.sbca-owner-choice-copy {
+    display: flex;
+    min-inline-size: 0;
+    flex-direction: column;
+}
+
+.sbca-owner-choice-name,
+.sbca-owner-choice-meta {
+    overflow-wrap: anywhere;
+}
+
+.sbca-owner-choice-meta,
+.sbca-owner-empty {
+    color: var(--sbca-muted);
+    font-size: 0.8125em;
+    font-weight: 400;
+}
+
+.sbca-owner-empty {
+    margin: 6px 0 0;
+}
+
+.sbca-sortpills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+}
+
+.sbca-sortpill {
+    display: inline-flex;
+    align-items: center;
+    min-block-size: var(--sb-control-min-height, 30px);
+    margin: 0;
+    padding: 2px 10px;
+    border: 1px solid var(--sbca-border);
+    border-radius: 999px;
+    background: var(--sbca-surface);
+    color: var(--sbca-muted);
+    font: inherit;
+    font-size: 0.8125em;
+    cursor: pointer;
+}
+
+.sbca-sortpill:not(:disabled):hover {
+    border-color: var(--sbca-accent);
+}
+
+.sbca-sortpill[aria-pressed="true"] {
+    border-color: var(--sbca-accent);
+    background: var(--sb-selection-bg, var(--sbca-surface));
+    color: var(--sb-selection-fg, var(--sbca-text));
+    text-decoration-line: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+}
+
+.sbca-organization-state {
+    color: var(--sbca-muted);
+    font-size: 0.875em;
+}
+
+.sbca-management,
+.sbca-organization-backup {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px;
+    inline-size: 100%;
+}
+
+.sbca-named-manager,
+.sbca-organization-backup,
+.sbca-organizer {
+    padding: 8px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-sm, 8px);
+    background: var(--sbca-surface);
+}
+
+.sbca-manager-heading,
+.sbca-organizer-heading {
+    margin: 0 0 6px;
+    font-size: 0.9375em;
+}
+
+.sbca-manager-list,
+.sbca-tag-list,
+.sbca-curation-indicators,
+.sbca-organizer-collections {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.sbca-manager-list,
+.sbca-organizer-collections {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.sbca-manager-status,
+.sbca-import-status {
+    min-block-size: 1.3em;
+    color: var(--sbca-muted);
+    font-size: 0.875em;
+}
+
+.sbca-organization-warning {
+    margin: 6px 0 0;
+    color: var(--sb-warning-fg, var(--SmartThemeBodyColor, inherit));
+    font-size: 0.875em;
+}
+
+.sbca-body {
+    display: grid;
+    grid-template-columns: minmax(260px, 5fr) minmax(0, 6fr);
+    flex: 1 1 auto;
+    gap: 10px;
+    min-block-size: 0;
+}
+
+.sbca-list-panel {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 8px;
+    min-inline-size: 0;
+    min-block-size: 0;
+}
+
+.sbca-list-tools {
+    margin-inline-start: auto;
+}
+
+.sbca-list-tools[open] {
+    flex-basis: 100%;
+}
+
+.sbca-list-tools > summary {
+    inline-size: fit-content;
+    margin-inline-start: auto;
+    cursor: pointer;
+    color: var(--sbca-muted);
+    font-weight: 600;
+}
+
+.sbca-list-tools-panel {
+    display: grid;
+    gap: 8px;
+    padding-block-start: 8px;
+}
+
+.sbca-list,
+.sbca-viewer {
+    min-block-size: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.sbca-list {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.sbca-group-button {
+    inline-size: 100%;
+    min-block-size: 34px;
+    padding: 6px 8px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-sm, 8px);
+    background: var(--sbca-surface);
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    text-align: start;
+    cursor: pointer;
+}
+
+.sbca-group-button:hover {
+    border-color: var(--sbca-accent);
+}
+
+.sbca-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 6px;
+    align-items: start;
+}
+
+.sbca-row > .sbca-row-button:only-child {
+    grid-column: 1 / -1;
+}
+
+.sbca-row-selection {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: center;
+    padding-block-start: 8px;
+    color: var(--sbca-muted);
+    font-size: 0.75em;
+}
+
+.sbca-viewer {
+    border-inline-start: 1px solid var(--sbca-border);
+    padding-inline-start: 10px;
+}
+
+.sbca-control.sbca-back {
+    display: none;
+    margin-block-end: 8px;
+}
+
+.sbca-viewer-content {
+    padding-block: 8px;
+}
+
+.sbca-row-button {
+    display: block;
+    inline-size: 100%;
+    min-block-size: 44px;
+    padding: 8px;
+    border: 1px solid transparent;
+    border-radius: var(--sb-radius-sm, 8px);
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
+}
+
+.sbca-row-button:hover {
+    border-color: var(--sbca-border);
+    background: var(--sbca-surface);
+}
+
+.sbca-row-button[aria-current="true"] {
+    border-color: var(--sbca-accent);
+    background: var(--sbca-surface);
+}
+
+.sbca-row-head {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 8px;
+    align-items: center;
+    inline-size: 100%;
+    min-inline-size: 0;
+}
+
+.sbca-avatar {
+    inline-size: 32px;
+    block-size: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex: 0 0 auto;
+}
+
+.sbca-avatar-icon {
+    inline-size: 32px;
+    color: var(--sbca-muted);
+    text-align: center;
+    flex: 0 0 auto;
+}
+
+.sbca-row-title {
+    display: flex;
+    flex: 1 1 130px;
+    flex-direction: column;
+    min-inline-size: 0;
+}
+
+.sbca-filename,
+.sbca-owner,
+.sbca-row-preview,
+.sbca-chip,
+.sbca-summary-line {
+    overflow-wrap: anywhere;
+}
+
+.sbca-filename {
+    font-weight: 600;
+}
+
+.sbca-owner,
+.sbca-row-info,
+.sbca-row-preview,
+.sbca-summary-line,
+.sbca-msg-head time {
+    color: var(--sbca-muted);
+}
+
+.sbca-owner,
+.sbca-row-info,
+.sbca-row-preview,
+.sbca-summary-line {
+    font-size: 0.875em;
+}
+
+.sbca-badge,
+.sbca-role,
+.sbca-chip {
+    display: inline-block;
+    margin-inline-start: 6px;
+    padding: 1px 6px;
+    border: 1px solid currentColor;
+    border-radius: var(--sb-radius-sm, 8px);
+    font-size: 0.875em;
+}
+
+.sbca-badge {
+    color: var(--sb-warning-fg, var(--SmartThemeBodyColor, inherit));
+}
+
+.sbca-curation-indicators {
+    margin-block-start: 4px;
+}
+
+.sbca-curation-favorite,
+.sbca-curation-folder,
+.sbca-curation-collection,
+.sbca-curation-tag,
+.sbca-tag-item {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+    padding: 1px 6px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-sm, 8px);
+    color: var(--sbca-muted);
+    font-size: 0.8125em;
+}
+
+.sbca-curation-favorite,
+.sbca-favorite-toggle[aria-pressed="true"] {
+    border-color: var(--sbca-accent);
+    color: var(--sbca-text);
+}
+
+.sbca-row-info {
+    display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+}
+
+.sbca-row-preview {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    margin-block-start: 5px;
+    overflow: hidden;
+    white-space: pre-line;
+}
+
+.sbca-list-message,
+.sbca-list-more {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.sbca-placeholder {
+    margin: 0;
+    padding: 8px 0;
+    color: var(--sbca-muted);
+}
+
+.sbca-viewer-error {
+    margin-block: 10px;
+    color: var(--sb-warning-fg, var(--SmartThemeBodyColor, inherit));
+}
+
+.sbca-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.sbca-viewer-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-block: 10px;
+}
+
+.sbca-organizer {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    margin-block: 8px;
+}
+
+.sbca-organizer .sbca-filter {
+    inline-size: 100%;
+}
+
+.sbca-tag-remove {
+    min-inline-size: 24px;
+    min-block-size: 24px;
+    padding: 0 4px;
+}
+
+.sbca-action {
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+    min-block-size: 36px;
+}
+
+.sbca-json-details {
+    margin-block: 8px;
+}
+
+.sbca-json-details pre,
+.sbca-raw {
+    margin-block: 8px;
+    padding: 8px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-sm, 8px);
+    background: var(--sbca-surface);
+    color: inherit;
+    font-size: 0.875em;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.sbca-raw-toggle {
+    margin-block: 8px;
+}
+
+.sbca-messages,
+.sbca-message-list {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+}
+
+.sbca-msg {
+    padding: 8px 10px;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-sm, 8px);
+    background: var(--sbca-surface);
+}
+
+.sbca-msg[data-sbca-role="system"] {
+    border-style: dashed;
+}
+
+.sbca-msg-match {
+    border-color: var(--sbca-accent);
+    box-shadow: inset 0 0 0 1px var(--sbca-accent);
+}
+
+.sbca-match-label {
+    color: var(--sbca-text);
+    font-weight: 700;
+}
+
+.sbca-msg-head {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 8px;
+    align-items: baseline;
+    margin-block-end: 5px;
+    font-size: 0.875em;
+}
+
+.sbca-role {
+    margin-inline-start: 0;
+    color: var(--sbca-muted);
+}
+
+.sbca-msg-text {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.sbca-chip {
+    margin-inline-start: 0;
+    color: var(--sbca-muted);
+}
+
+.sbca-more-messages {
+    align-self: flex-start;
+}
+
+.sbca-root[data-sbca-density="compact"] .sbca-row-button {
+    min-block-size: 36px;
+    padding: 5px 6px;
+}
+
+.sbca-root[data-sbca-density="compact"] .sbca-avatar,
+.sbca-root[data-sbca-density="compact"] .sbca-avatar-icon {
+    inline-size: 24px;
+    block-size: 24px;
+}
+
+.sbca-root[data-sbca-density="compact"] .sbca-row-preview {
+    -webkit-line-clamp: 1;
+}
+
+.sbca-root[data-sbca-density="compact"] .sbca-msg {
+    padding: 5px 7px;
+}
+
+.sbca-root[data-sbca-density="minimal"] .sbca-row-button {
+    min-block-size: 30px;
+    padding: 4px 6px;
+}
+
+.sbca-root[data-sbca-density="minimal"] .sbca-avatar,
+.sbca-root[data-sbca-density="minimal"] .sbca-avatar-icon {
+    display: none;
+}
+
+.sbca-root[data-sbca-density="minimal"] .sbca-row-preview {
+    -webkit-line-clamp: 1;
+    margin-block-start: 2px;
+}
+
+.sbca-root[data-sbca-density="minimal"] .sbca-row-info,
+.sbca-root[data-sbca-density="minimal"] .sbca-owner {
+    font-size: 0.8125em;
+}
+
+.sbca-root[data-sbca-density="minimal"] .sbca-msg {
+    padding: 4px 6px;
+}
+
+.sbca-root button:focus-visible,
+.sbca-root summary:focus-visible,
+.sbca-root input:focus-visible,
+.sbca-root select:focus-visible {
+    outline: 2px solid var(--sbca-focus);
+    outline-offset: 2px;
+}
+
+.sbca-msg:focus {
+    outline: 2px solid var(--sbca-focus);
+    outline-offset: 2px;
+}
+
+@media (any-pointer: coarse) {
+    .sbca-root[data-sbca-density] .sbca-row-button,
+    .sbca-root button,
+    .sbca-root summary,
+    .sbca-kinds .checkbox_label,
+    .sbca-row-selection {
+        min-block-size: var(--sb-mobile-touch-target, 44px);
+    }
+
+    .sbca-row-selection {
+        min-inline-size: var(--sb-mobile-touch-target, 44px);
+    }
+}
+
+@media (min-width: 1001px) {
+    .sbca-toolbar:has(.sbca-options[open]) {
+        min-block-size: 0;
+        max-block-size: 60%;
+        padding: 4px;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+    }
+}
+
+@media (max-width: 1000px) {
+    .sbca-root {
+        block-size: 78vh;
+        block-size: 78dvh;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    .sbca-toolbar {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .sbca-search,
+    .sbca-deep,
+    .sbca-search-mode,
+    .sbca-browse-options,
+    .sbca-filter-tools,
+    .sbca-status {
+        grid-column: 1;
+    }
+
+    .sbca-deep {
+        inline-size: 100%;
+    }
+
+    .sbca-browse-options {
+        display: block;
+    }
+
+    .sbca-browse-options > summary {
+        display: list-item;
+        color: var(--sbca-muted);
+        font-weight: 600;
+        cursor: pointer;
+    }
+
+    .sbca-browse-options .sbca-browse-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        margin-block-start: 8px;
+    }
+
+    .sbca-filter-tools {
+        align-items: stretch;
+    }
+
+    .sbca-filter-tools > .sbca-options,
+    .sbca-clear-filters {
+        inline-size: 100%;
+    }
+
+    .sbca-root input,
+    .sbca-root select {
+        font-size: 16px;
+    }
+
+    .sbca-options-panel {
+        align-items: stretch;
+    }
+
+    .sbca-owner-menu {
+        position: static;
+        margin-block-start: 4px;
+    }
+
+    .sbca-options-panel > .sbca-control,
+    .sbca-options-panel > .sbca-filter,
+    .sbca-sort,
+    .sbca-batch-actions > .sbca-control,
+    .sbca-batch-actions > .sbca-filter {
+        inline-size: 100%;
+    }
+
+    .sbca-selection-toggle,
+    .sbca-selection-tools,
+    .sbca-batch-actions {
+        inline-size: 100%;
+    }
+
+    .sbca-body {
+        display: block;
+        flex: 0 0 auto;
+        min-block-size: auto;
+        overflow: visible;
+    }
+
+    .sbca-list-panel,
+    .sbca-viewer {
+        block-size: auto;
+        overflow: visible;
+    }
+
+    .sbca-root[data-sbca-view="list"] .sbca-viewer,
+    .sbca-root[data-sbca-view="detail"] .sbca-list-panel {
+        display: none;
+    }
+
+    .sbca-root[data-sbca-view="detail"] .sbca-toolbar {
+        display: none;
+    }
+
+    .sbca-viewer {
+        border-inline-start: 0;
+        padding-inline-start: 0;
+    }
+
+    .sbca-control.sbca-back {
+        display: inline-flex;
+    }
+
+    .sbca-viewer-actions .sbca-action {
+        inline-size: 100%;
+        justify-content: flex-start;
+    }
+}
+
+@media (min-width: 1001px) {
+    /* Desktop: the archive is a full page, not a portrait column. */
+    .sbca-dialog {
+        box-sizing: border-box;
+        width: 94vw !important;
+        max-width: 94vw !important;
+        /* The host popup sets min-height: fit-content; a min beats
+           max-height and can balloon the dialog past the viewport. */
+        min-height: 0 !important;
+        height: 92vh !important;
+        height: 92dvh !important;
+        max-height: 92vh !important;
+        max-height: 92dvh !important;
+    }
+
+    .sbca-dialog .popup-body,
+    .sbca-dialog .popup-content {
+        flex: 1 1 auto;
+        min-block-size: 0;
+    }
+
+    /* Viewport cap in case block-size: 100% collapses through the host
+       flex chain (Safari percentage-height quirks); harmless otherwise. */
+    .sbca-root {
+        block-size: 100%;
+        max-block-size: 92dvh;
+    }
+}
+
+@media (max-width: 600px) {
+    .sbca-dialog {
+        box-sizing: border-box;
+        width: 100vw !important;
+        max-width: 100vw !important;
+        /* The host popup sets min-height: fit-content; a min beats
+           max-height and can balloon the dialog past the viewport. */
+        min-height: 0 !important;
+        height: 100vh !important;
+        height: 100dvh !important;
+        max-height: 100vh !important;
+        max-height: 100dvh !important;
+        margin: 0 !important;
+        border-radius: 0;
+    }
+
+    .sbca-dialog .popup-body,
+    .sbca-dialog .popup-content {
+        flex: 1 1 auto;
+        min-block-size: 0;
+    }
+
+    .sbca-root {
+        block-size: 100%;
+        max-block-size: 100dvh;
+    }
+
+    .sbca-browse-options .sbca-browse-strip {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -417,6 +417,20 @@
     min-inline-size: min(180px, 100%);
 }
 
+/* iOS Safari sizes native date fields from their intrinsic content and ignores
+   the declared width, so the field runs past the panel and gets clipped. */
+.sbca-root input[type="date"] {
+    -webkit-appearance: none;
+    appearance: none;
+    box-sizing: border-box;
+    inline-size: 100%;
+    min-inline-size: 0;
+}
+
+.sbca-root input[type="date"]::-webkit-date-and-time-value {
+    text-align: start;
+}
+
 @media (min-width: 1001px) {
     .sbca-kinds legend {
         flex-basis: 100%;

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -204,6 +204,12 @@
     justify-content: space-between;
 }
 
+.sbca-archive-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
 .sbca-options > summary,
 .sbca-json-details > summary {
     inline-size: fit-content;
@@ -1029,8 +1035,13 @@
     }
 
     .sbca-filter-tools > .sbca-options,
-    .sbca-clear-filters {
+    .sbca-clear-filters,
+    .sbca-archive-actions {
         inline-size: 100%;
+    }
+
+    .sbca-archive-actions > .sbca-control {
+        flex: 1 1 140px;
     }
 
     .sbca-root input,

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -48,10 +48,53 @@
     }
 }
 
-.sbca-dialog .popup-body,
-.sbca-dialog .popup-content {
+.sbca-dialog {
+    --sbca-space-xs: var(--spacing-xs, 4px);
+    --sbca-space-sm: var(--spacing-sm, 8px);
+    --sbca-space-md: var(--spacing-md, 12px);
+    --sbca-space-lg: var(--spacing-lg, 16px);
+    --sbca-space-xl: var(--spacing-2xl, 24px);
+    padding: 0;
+    border-radius: var(--sb-radius-panel, 16px);
+}
+
+.sbca-dialog .popup-body {
+    box-sizing: border-box;
+    min-block-size: 0;
     max-block-size: none;
+    padding: var(--sbca-space-lg);
     overflow: hidden !important;
+}
+
+.sbca-dialog .popup-content {
+    min-block-size: 0;
+    max-block-size: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden !important;
+}
+
+.sbca-dialog .popup-controls {
+    flex: 0 0 auto;
+    align-self: stretch;
+    justify-content: flex-end;
+    margin: var(--sbca-space-md) 0 0;
+    padding: var(--sbca-space-xs) 0 0;
+    border-block-start: 1px solid var(--sbca-border, var(--SmartThemeBorderColor));
+}
+
+.sbca-dialog .popup-controls .menu_button {
+    flex: 0 1 auto;
+    min-block-size: var(--sb-mobile-touch-target, 44px);
+    padding-inline: var(--sbca-space-lg);
+}
+
+.sbca-dialog .popup-button-close {
+    top: var(--sbca-space-xs);
+    right: var(--sbca-space-xs);
+    width: var(--sb-mobile-touch-target, 44px);
+    height: var(--sb-mobile-touch-target, 44px);
+    padding: 0;
 }
 
 .sbca-root {
@@ -63,7 +106,7 @@
     --sbca-focus: var(--sb-focus-ring, var(--color-focus-ring, var(--SmartThemeQuoteColor, currentColor)));
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: var(--sbca-space-lg);
     block-size: 75vh;
     block-size: 75dvh;
     max-block-size: 100%;
@@ -83,12 +126,12 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
-    min-inline-size: var(--sb-control-min-height, 30px);
-    min-block-size: var(--sb-control-min-height, 30px);
+    gap: var(--sbca-space-sm);
+    min-inline-size: var(--sb-control-min-height, 38px);
+    min-block-size: var(--sb-control-min-height, 38px);
     inline-size: fit-content;
     margin: 0;
-    padding: 6px 12px;
+    padding: var(--sbca-space-sm) var(--sbca-space-md);
     border: 1px solid var(--sbca-border);
     border-radius: var(--sb-radius-button, 14px);
     background: var(--sb-button-bg, var(--sbca-surface));
@@ -118,19 +161,22 @@
 }
 
 .sbca-heading {
-    padding-inline-start: 0;
+    padding-inline: 0 calc(var(--sb-mobile-touch-target, 44px) + var(--sbca-space-sm));
     border: 0;
-    font-size: 1.25em;
+    font-size: calc(var(--mainFontSize) * 1.45);
+    line-height: 1.16;
+    text-wrap: balance;
 }
 
 .sbca-section-heading {
-    font-size: 1em;
+    font-size: calc(var(--mainFontSize) * 0.92);
+    line-height: 1.3;
 }
 
 .sbca-toolbar {
     display: grid;
     grid-template-columns: minmax(220px, 1fr) auto;
-    gap: 8px;
+    gap: var(--sbca-space-md);
     align-items: end;
 }
 
@@ -138,7 +184,7 @@
 .sbca-sort {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: var(--sbca-space-xs);
     min-inline-size: 0;
     margin: 0;
 }
@@ -154,10 +200,13 @@
 .sbca-sort select {
     inline-size: 100%;
     min-inline-size: 0;
+    margin: 0;
 }
 
 .sbca-deep {
-    min-block-size: 36px;
+    box-sizing: border-box;
+    block-size: var(--sb-field-min-height, 38px);
+    min-block-size: var(--sb-field-min-height, 38px);
     border-color: var(--sbca-accent);
     background: color-mix(in srgb, var(--sbca-accent) 14%, var(--sbca-surface));
     color: var(--sbca-text);
@@ -177,7 +226,7 @@
     gap: 8px;
     align-items: center;
     justify-content: space-between;
-    padding: 7px 9px;
+    padding: var(--sbca-space-sm) var(--sbca-space-md);
     border: 1px solid var(--sbca-accent);
     border-radius: var(--sb-radius-sm, 8px);
     background: color-mix(in srgb, var(--sbca-accent) 10%, var(--sbca-surface));
@@ -199,7 +248,7 @@
 .sbca-filter-tools {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px 12px;
+    gap: var(--sbca-space-sm) var(--sbca-space-md);
     align-items: center;
     justify-content: space-between;
 }
@@ -207,7 +256,8 @@
 .sbca-archive-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: var(--sbca-space-sm);
+    margin-inline-start: auto;
 }
 
 .sbca-options > summary,
@@ -221,15 +271,15 @@
 .sbca-options-panel {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px 12px;
+    gap: var(--sbca-space-sm) var(--sbca-space-md);
     align-items: end;
-    padding-block-start: 8px;
+    padding-block-start: var(--sbca-space-md);
 }
 
 .sbca-kinds {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px 10px;
+    gap: var(--sbca-space-xs) var(--sbca-space-md);
     align-items: center;
     min-inline-size: 0;
     margin: 0;
@@ -239,12 +289,12 @@
 
 .sbca-kinds legend {
     float: inline-start;
-    margin-inline-end: 6px;
+    margin-inline-end: var(--sbca-space-sm);
 }
 
 .sbca-kinds .checkbox_label {
     display: inline-flex;
-    gap: 5px;
+    gap: var(--sbca-space-xs);
     align-items: center;
     margin: 0;
     white-space: normal;
@@ -265,7 +315,7 @@
 .sbca-browse-strip {
     display: grid;
     grid-template-columns: repeat(4, minmax(130px, 1fr));
-    gap: 8px;
+    gap: var(--sbca-space-sm);
 }
 
 .sbca-filter {
@@ -284,7 +334,7 @@
 .sbca-batch-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: var(--sbca-space-sm);
     align-items: center;
 }
 
@@ -305,10 +355,10 @@
 .sbca-owner-summary {
     display: flex;
     box-sizing: border-box;
-    gap: 8px;
+    gap: var(--sbca-space-sm);
     align-items: center;
     min-block-size: 46px;
-    padding: 6px 10px;
+    padding: var(--sbca-space-sm) var(--sbca-space-md);
     border-radius: var(--sb-radius-button, 14px);
     color: inherit;
     cursor: pointer;
@@ -322,7 +372,7 @@
 .sbca-owner-summary::after {
     inline-size: 0.45em;
     block-size: 0.45em;
-    margin-inline: auto 3px;
+    margin-inline: auto var(--sbca-space-xs);
     border-block-end: 2px solid currentColor;
     border-inline-end: 2px solid currentColor;
     content: '';
@@ -339,12 +389,12 @@
 
 .sbca-owner-menu {
     position: absolute;
-    z-index: 10;
-    inset-block-start: calc(100% + 4px);
+    z-index: var(--sb-z-dropdown, 100);
+    inset-block-start: calc(100% + var(--sbca-space-xs));
     inset-inline: 0;
     box-sizing: border-box;
     inline-size: 100%;
-    padding: 8px;
+    padding: var(--sbca-space-sm);
     border: 1px solid var(--sbca-border);
     border-radius: var(--sb-radius-sm, 8px);
     background: var(--sbca-surface);
@@ -360,21 +410,21 @@
 .sbca-owner-options {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: var(--sbca-space-xs);
     max-block-size: min(320px, 45dvh);
-    margin-block-start: 6px;
+    margin-block-start: var(--sbca-space-sm);
     overflow-y: auto;
     overscroll-behavior: contain;
 }
 
 .sbca-owner-option {
     display: flex;
-    gap: 8px;
+    gap: var(--sbca-space-sm);
     align-items: center;
     inline-size: 100%;
     min-block-size: 44px;
     margin: 0;
-    padding: 5px 7px;
+    padding: var(--sbca-space-sm);
     border: 1px solid transparent;
     border-radius: var(--sb-radius-sm, 8px);
     background: transparent;
@@ -435,13 +485,13 @@
 }
 
 .sbca-owner-empty {
-    margin: 6px 0 0;
+    margin: var(--sbca-space-sm) 0 0;
 }
 
 .sbca-sortpills {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
+    gap: var(--sbca-space-xs);
     align-items: center;
 }
 
@@ -450,7 +500,7 @@
     align-items: center;
     min-block-size: var(--sb-control-min-height, 30px);
     margin: 0;
-    padding: 2px 10px;
+    padding: var(--sbca-space-xs) var(--sbca-space-md);
     border: 1px solid var(--sbca-border);
     border-radius: 999px;
     background: var(--sbca-surface);
@@ -483,22 +533,35 @@
     display: grid;
     grid-column: 1 / -1;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 10px;
+    gap: var(--sbca-space-lg);
     inline-size: 100%;
 }
 
-.sbca-named-manager,
+.sbca-management {
+    padding-block: var(--sbca-space-md);
+    border-block: 1px solid var(--sbca-border);
+}
+
+.sbca-named-manager {
+    min-inline-size: 0;
+    padding-inline-end: var(--sbca-space-lg);
+}
+
+.sbca-named-manager:not(:last-child) {
+    border-inline-end: 1px solid var(--sbca-border);
+}
+
 .sbca-organization-backup,
 .sbca-organizer {
-    padding: 8px;
+    padding: var(--sbca-space-md);
     border: 1px solid var(--sbca-border);
-    border-radius: var(--sb-radius-sm, 8px);
+    border-radius: var(--sb-radius-button, 14px);
     background: var(--sbca-surface);
 }
 
 .sbca-manager-heading,
 .sbca-organizer-heading {
-    margin: 0 0 6px;
+    margin: 0 0 var(--sbca-space-sm);
     font-size: 0.9375em;
 }
 
@@ -508,7 +571,7 @@
 .sbca-organizer-collections {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: var(--sbca-space-sm);
 }
 
 .sbca-manager-list,
@@ -525,7 +588,7 @@
 }
 
 .sbca-organization-warning {
-    margin: 6px 0 0;
+    margin: var(--sbca-space-sm) 0 0;
     color: var(--sb-warning-fg, var(--SmartThemeBodyColor, inherit));
     font-size: 0.875em;
 }
@@ -534,16 +597,24 @@
     display: grid;
     grid-template-columns: minmax(260px, 5fr) minmax(0, 6fr);
     flex: 1 1 auto;
-    gap: 10px;
+    gap: var(--sbca-space-lg);
     min-block-size: 0;
 }
 
 .sbca-list-panel {
     display: grid;
     grid-template-rows: auto minmax(0, 1fr);
-    gap: 8px;
+    gap: var(--sbca-space-md);
     min-inline-size: 0;
     min-block-size: 0;
+}
+
+.sbca-list-panel,
+.sbca-viewer {
+    padding: var(--sbca-space-md);
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-button, 14px);
+    background: color-mix(in srgb, var(--sbca-surface) 72%, transparent);
 }
 
 .sbca-list-tools {
@@ -564,8 +635,8 @@
 
 .sbca-list-tools-panel {
     display: grid;
-    gap: 8px;
-    padding-block-start: 8px;
+    gap: var(--sbca-space-sm);
+    padding-block-start: var(--sbca-space-sm);
 }
 
 .sbca-list,
@@ -578,7 +649,7 @@
 .sbca-list {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: var(--sbca-space-xs);
     margin: 0;
     padding: 0;
     list-style: none;
@@ -605,7 +676,7 @@
 .sbca-row {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
-    gap: 6px;
+    gap: var(--sbca-space-sm);
     align-items: start;
 }
 
@@ -616,32 +687,34 @@
 .sbca-row-selection {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: var(--sbca-space-xs);
     align-items: center;
-    padding-block-start: 8px;
+    padding-block-start: var(--sbca-space-sm);
     color: var(--sbca-muted);
     font-size: 0.75em;
 }
 
 .sbca-viewer {
-    border-inline-start: 1px solid var(--sbca-border);
-    padding-inline-start: 10px;
+    min-inline-size: 0;
 }
 
 .sbca-control.sbca-back {
     display: none;
-    margin-block-end: 8px;
+    margin-block-end: var(--sbca-space-sm);
 }
 
 .sbca-viewer-content {
-    padding-block: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sbca-space-md);
+    padding-block: var(--sbca-space-sm);
 }
 
 .sbca-row-button {
     display: block;
     inline-size: 100%;
     min-block-size: 44px;
-    padding: 8px;
+    padding: var(--sbca-space-sm);
     border: 1px solid transparent;
     border-radius: var(--sb-radius-sm, 8px);
     background: transparent;
@@ -664,7 +737,7 @@
 .sbca-row-head {
     display: flex;
     flex-wrap: wrap;
-    gap: 5px 8px;
+    gap: var(--sbca-space-xs) var(--sbca-space-sm);
     align-items: center;
     inline-size: 100%;
     min-inline-size: 0;
@@ -723,8 +796,8 @@
 .sbca-role,
 .sbca-chip {
     display: inline-block;
-    margin-inline-start: 6px;
-    padding: 1px 6px;
+    margin-inline-start: var(--sbca-space-sm);
+    padding: var(--sbca-space-xs) var(--sbca-space-sm);
     border: 1px solid currentColor;
     border-radius: var(--sb-radius-sm, 8px);
     font-size: 0.875em;
@@ -746,7 +819,7 @@
     display: inline-flex;
     gap: 4px;
     align-items: center;
-    padding: 1px 6px;
+    padding: var(--sbca-space-xs) var(--sbca-space-sm);
     border: 1px solid var(--sbca-border);
     border-radius: var(--sb-radius-sm, 8px);
     color: var(--sbca-muted);
@@ -763,14 +836,14 @@
     display: flex;
     flex: 0 1 auto;
     flex-wrap: wrap;
-    gap: 4px 8px;
+    gap: var(--sbca-space-xs) var(--sbca-space-sm);
 }
 
 .sbca-row-preview {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
-    margin-block-start: 5px;
+    margin-block-start: var(--sbca-space-xs);
     overflow: hidden;
     white-space: pre-line;
 }
@@ -780,39 +853,49 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 8px;
+    gap: var(--sbca-space-sm);
 }
 
 .sbca-placeholder {
     margin: 0;
-    padding: 8px 0;
+    padding: var(--sbca-space-sm) 0;
     color: var(--sbca-muted);
 }
 
 .sbca-viewer-error {
-    margin-block: 10px;
+    margin-block: var(--sbca-space-md);
     color: var(--sb-warning-fg, var(--SmartThemeBodyColor, inherit));
 }
 
 .sbca-summary {
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    gap: var(--sbca-space-xs);
+}
+
+.sbca-viewer-details {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sbca-space-md);
+    padding: var(--sbca-space-lg);
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-button, 14px);
+    background: var(--sbca-surface);
 }
 
 .sbca-viewer-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-block: 10px;
+    gap: var(--sbca-space-sm);
+    margin: 0;
 }
 
 .sbca-organizer {
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 8px;
-    margin-block: 8px;
+    gap: var(--sbca-space-sm);
+    margin: 0;
 }
 
 .sbca-organizer .sbca-filter {
@@ -827,19 +910,19 @@
 
 .sbca-action {
     display: inline-flex;
-    gap: 6px;
+    gap: var(--sbca-space-sm);
     align-items: center;
     min-block-size: 36px;
 }
 
 .sbca-json-details {
-    margin-block: 8px;
+    margin-block: var(--sbca-space-md);
 }
 
 .sbca-json-details pre,
 .sbca-raw {
-    margin-block: 8px;
-    padding: 8px;
+    margin-block: var(--sbca-space-md);
+    padding: var(--sbca-space-md);
     border: 1px solid var(--sbca-border);
     border-radius: var(--sb-radius-sm, 8px);
     background: var(--sbca-surface);
@@ -850,18 +933,18 @@
 }
 
 .sbca-raw-toggle {
-    margin-block: 8px;
+    margin-block: var(--sbca-space-md);
 }
 
 .sbca-messages,
 .sbca-message-list {
     display: flex;
     flex-direction: column;
-    gap: 7px;
+    gap: var(--sbca-space-sm);
 }
 
 .sbca-msg {
-    padding: 8px 10px;
+    padding: var(--sbca-space-md);
     border: 1px solid var(--sbca-border);
     border-radius: var(--sb-radius-sm, 8px);
     background: var(--sbca-surface);
@@ -884,9 +967,9 @@
 .sbca-msg-head {
     display: flex;
     flex-wrap: wrap;
-    gap: 5px 8px;
+    gap: var(--sbca-space-xs) var(--sbca-space-sm);
     align-items: baseline;
-    margin-block-end: 5px;
+    margin-block-end: var(--sbca-space-xs);
     font-size: 0.875em;
 }
 
@@ -977,13 +1060,17 @@
     .sbca-row-selection {
         min-inline-size: var(--sb-mobile-touch-target, 44px);
     }
+
+    .sbca-tag-remove {
+        min-inline-size: var(--sb-mobile-touch-target, 44px);
+    }
 }
 
 @media (min-width: 1001px) {
     .sbca-toolbar:has(.sbca-options[open]) {
         min-block-size: 0;
-        max-block-size: 60%;
-        padding: 4px;
+        max-block-size: min(50%, 32rem);
+        padding: var(--sbca-space-xs) var(--sbca-space-sm) var(--sbca-space-sm);
         overflow-y: auto;
         overscroll-behavior: contain;
     }
@@ -993,7 +1080,7 @@
     .sbca-root {
         block-size: 78vh;
         block-size: 78dvh;
-        overflow-x: hidden;
+        padding-inline: var(--sbca-space-xs);
         overflow-y: auto;
     }
 
@@ -1027,7 +1114,7 @@
 
     .sbca-browse-options .sbca-browse-strip {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        margin-block-start: 8px;
+        margin-block-start: var(--sbca-space-sm);
     }
 
     .sbca-filter-tools {
@@ -1055,7 +1142,7 @@
 
     .sbca-owner-menu {
         position: static;
-        margin-block-start: 4px;
+        margin-block-start: var(--sbca-space-xs);
     }
 
     .sbca-options-panel > .sbca-control,
@@ -1095,8 +1182,7 @@
     }
 
     .sbca-viewer {
-        border-inline-start: 0;
-        padding-inline-start: 0;
+        padding: var(--sbca-space-md);
     }
 
     .sbca-control.sbca-back {
@@ -1122,6 +1208,10 @@
         height: 92dvh !important;
         max-height: 92vh !important;
         max-height: 92dvh !important;
+    }
+
+    .sbca-dialog .popup-body {
+        padding: var(--sbca-space-lg);
     }
 
     .sbca-dialog .popup-body,
@@ -1154,18 +1244,60 @@
         border-radius: 0;
     }
 
+    .sbca-dialog .popup-body {
+        padding-block:
+            max(var(--sbca-space-md), env(safe-area-inset-top))
+            max(var(--sbca-space-sm), env(safe-area-inset-bottom));
+        padding-inline:
+            max(var(--sbca-space-md), env(safe-area-inset-left))
+            max(var(--sbca-space-md), env(safe-area-inset-right));
+    }
+
     .sbca-dialog .popup-body,
     .sbca-dialog .popup-content {
         flex: 1 1 auto;
         min-block-size: 0;
+        max-block-size: none !important;
+    }
+
+    .sbca-dialog .popup-controls {
+        margin-block-start: var(--sbca-space-sm);
+    }
+
+    .sbca-dialog .popup-controls .menu_button {
+        flex: 1 1 auto;
+    }
+
+    .sbca-dialog .popup-button-close {
+        top: max(var(--sbca-space-xs), env(safe-area-inset-top));
+        right: max(var(--sbca-space-xs), env(safe-area-inset-right));
     }
 
     .sbca-root {
         block-size: 100%;
         max-block-size: 100dvh;
+        padding-inline: 0;
     }
 
     .sbca-browse-options .sbca-browse-strip {
         grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media (max-width: 720px) {
+    .sbca-management {
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--sbca-space-md);
+    }
+
+    .sbca-named-manager {
+        padding: 0 0 var(--sbca-space-md);
+        border-inline-end: 0;
+        border-block-end: 1px solid var(--sbca-border);
+    }
+
+    .sbca-named-manager:last-child {
+        padding-block-end: 0;
+        border-block-end: 0;
     }
 }

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -175,18 +175,21 @@
 
 .sbca-toolbar {
     display: grid;
-    grid-template-columns: minmax(220px, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--sbca-space-md);
     align-items: end;
 }
 
-.sbca-search,
-.sbca-sort {
+.sbca-search {
     display: flex;
     flex-direction: column;
     gap: var(--sbca-space-xs);
     min-inline-size: 0;
     margin: 0;
+}
+
+.sbca-search {
+    position: relative;
 }
 
 .sbca-label,
@@ -196,72 +199,74 @@
     font-weight: 600;
 }
 
-.sbca-search input,
-.sbca-sort select {
+.sbca-search input {
     inline-size: 100%;
     min-inline-size: 0;
     margin: 0;
 }
 
-.sbca-deep {
-    box-sizing: border-box;
-    block-size: var(--sb-field-min-height, 38px);
-    min-block-size: var(--sb-field-min-height, 38px);
-    border-color: var(--sbca-accent);
-    background: color-mix(in srgb, var(--sbca-accent) 14%, var(--sbca-surface));
-    color: var(--sbca-text);
-    font-weight: 700;
+.sbca-mention-menu {
+    position: absolute;
+    z-index: var(--sb-z-dropdown, 100);
+    inset-inline: 0;
+    inset-block-start: calc(100% + var(--sbca-space-xs));
+    display: flex;
+    max-block-size: min(18rem, 45dvh);
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+    padding: var(--sbca-space-xs);
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-button, 14px);
+    background: var(--sbca-surface);
+    box-shadow: var(--sb-shadow-popup, 0 8px 24px rgb(0 0 0 / 20%));
 }
 
-.sbca-search-mode,
-.sbca-browse-options,
+.sbca-mention-option {
+    min-block-size: 40px;
+    padding: var(--sbca-space-xs) var(--sbca-space-sm);
+    border: 0;
+    border-radius: var(--sb-radius-sm, 8px);
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
+}
+
+.sbca-mention-option:hover,
+.sbca-mention-option:focus-visible,
+.sbca-mention-option[aria-selected='true'] {
+    background: var(--sb-selection-bg, var(--sbca-surface));
+    outline: 2px solid var(--sbca-focus);
+    outline-offset: -2px;
+}
+
 .sbca-filter-tools,
 .sbca-status {
     grid-column: 1 / -1;
 }
 
-.sbca-search-mode {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--sbca-space-sm) var(--sbca-space-md);
-    border: 1px solid var(--sbca-accent);
-    border-radius: var(--sb-radius-sm, 8px);
-    background: color-mix(in srgb, var(--sbca-accent) 10%, var(--sbca-surface));
-}
-
-.sbca-search-mode-text {
-    font-weight: 600;
-    overflow-wrap: anywhere;
-}
-
-.sbca-browse-options {
-    display: contents;
-}
-
-.sbca-browse-options > summary {
-    display: none;
-}
-
 .sbca-filter-tools {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: var(--sbca-space-sm) var(--sbca-space-md);
     align-items: center;
-    justify-content: space-between;
+}
+
+.sbca-filter-toggle {
+    display: none;
 }
 
 .sbca-archive-actions {
     display: flex;
+    grid-column: 1;
+    grid-row: 1;
     flex-wrap: wrap;
     gap: var(--sbca-space-sm);
-    margin-inline-start: auto;
+    align-items: center;
 }
 
-.sbca-options > summary,
-.sbca-organization-tools > summary,
 .sbca-json-details > summary {
     inline-size: fit-content;
     cursor: pointer;
@@ -270,23 +275,20 @@
 }
 
 .sbca-options-panel {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--sbca-space-sm) var(--sbca-space-md);
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: minmax(300px, 1fr) minmax(165px, 0.55fr) minmax(165px, 0.55fr);
+    gap: var(--sbca-space-md);
     align-items: end;
-    padding-block-start: var(--sbca-space-md);
-}
-
-.sbca-options[open],
-.sbca-organization-tools[open] {
-    flex-basis: 100%;
-    inline-size: 100%;
+    min-inline-size: 0;
+    padding-block-start: var(--sbca-space-sm);
+    border-block-start: 1px solid var(--sbca-border);
 }
 
 .sbca-kinds {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--sbca-space-xs) var(--sbca-space-md);
+    gap: var(--sbca-space-xs);
     align-items: center;
     min-inline-size: 0;
     margin: 0;
@@ -299,12 +301,51 @@
     margin-inline-end: var(--sbca-space-sm);
 }
 
-.sbca-kinds .checkbox_label {
+.sbca-kind-pill {
+    position: relative;
     display: inline-flex;
-    gap: var(--sbca-space-xs);
     align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    min-block-size: 44px;
     margin: 0;
-    white-space: normal;
+    padding: var(--sbca-space-xs) var(--sbca-space-md);
+    border: 1px solid var(--sbca-border);
+    border-radius: 999px;
+    background: var(--sbca-surface);
+    color: var(--sbca-muted);
+    font-size: 0.8125em;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.sbca-kind-pill input {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    margin: 0;
+    -webkit-appearance: none;
+    appearance: none;
+    clip-path: inset(50%);
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.sbca-kind-pill:hover {
+    border-color: var(--sbca-accent);
+}
+
+.sbca-kind-pill:has(input:checked) {
+    border-color: var(--sbca-accent);
+    background: var(--sb-selection-bg, var(--sbca-surface));
+    color: var(--sb-selection-fg, var(--sbca-text));
+    font-weight: 700;
+}
+
+.sbca-kind-pill:has(input:focus-visible) {
+    outline: 2px solid var(--sbca-accent);
+    outline-offset: 2px;
 }
 
 .sbca-status {
@@ -314,15 +355,59 @@
     overflow-wrap: anywhere;
 }
 
-.sbca-browse-strip,
-.sbca-organization-state {
-    grid-column: 1 / -1;
+.sbca-browse-strip {
+    display: flex;
+    gap: var(--sbca-space-xs);
+    align-items: center;
+    min-inline-size: 0;
 }
 
-.sbca-browse-strip {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(130px, 1fr));
-    gap: var(--sbca-space-sm);
+.sbca-archive-secondary-actions,
+.sbca-orphan-actions {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--sbca-space-xs);
+    align-items: center;
+}
+
+.sbca-archive-secondary-actions {
+    grid-column: 2;
+    grid-row: 1;
+    margin-inline-start: auto;
+}
+
+.sbca-orphan-actions .sbca-orphan-filter {
+    flex-direction: row;
+    align-items: center;
+    min-inline-size: 0;
+}
+
+.sbca-orphan-actions .sbca-orphan-filter select {
+    inline-size: auto;
+    min-block-size: var(--sb-control-min-height, 38px);
+    margin: 0;
+}
+
+.sbca-view-setting {
+    display: flex;
+    flex-direction: row;
+    gap: var(--sbca-space-xs);
+    align-items: center;
+    min-inline-size: 0;
+}
+
+.sbca-view-setting .sbca-label {
+    color: var(--sbca-muted);
+    font-size: 0.8125em;
+}
+
+.sbca-view-setting select {
+    inline-size: auto;
+    min-inline-size: 0;
+    min-block-size: var(--sb-control-min-height, 38px);
+    margin: 0;
+    padding-block: var(--sbca-space-xs);
+    padding-inline-start: var(--sbca-space-sm);
 }
 
 .sbca-filter {
@@ -332,7 +417,32 @@
     min-inline-size: min(180px, 100%);
 }
 
-.sbca-organization-state,
+@media (min-width: 1001px) {
+    .sbca-kinds legend {
+        flex-basis: 100%;
+        margin: 0;
+    }
+
+    .sbca-options-panel > .sbca-filter {
+        min-inline-size: 0;
+    }
+
+    .sbca-options-panel > .sbca-filter input,
+    .sbca-options-panel > .sbca-filter select {
+        box-sizing: border-box;
+        inline-size: 100%;
+        margin: 0;
+    }
+
+    .sbca-date-filter {
+        min-inline-size: 165px;
+    }
+
+    .sbca-date-filter input {
+        white-space: nowrap;
+    }
+}
+
 .sbca-list-top,
 .sbca-selection-bar,
 .sbca-selection-tools,
@@ -546,39 +656,33 @@
     text-underline-offset: 3px;
 }
 
-.sbca-organization-state {
-    color: var(--sbca-muted);
-    font-size: 0.875em;
-}
-
-.sbca-organization-tools {
-    flex: 0 1 auto;
-}
-
 .sbca-organization-tools-panel {
     display: grid;
     grid-column: 1 / -1;
-    gap: var(--sbca-space-lg);
+    gap: var(--sbca-space-md);
     inline-size: 100%;
+    max-block-size: min(42dvh, 32rem);
     padding-block-start: var(--sbca-space-md);
+    overflow-y: auto;
+    overscroll-behavior: contain;
 }
 
 .sbca-management,
 .sbca-organization-backup {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: var(--sbca-space-lg);
+    gap: var(--sbca-space-md);
     inline-size: 100%;
 }
 
 .sbca-management {
-    padding-block: var(--sbca-space-md);
+    padding-block: var(--sbca-space-sm);
     border-block: 1px solid var(--sbca-border);
 }
 
 .sbca-named-manager {
     min-inline-size: 0;
-    padding-inline-end: var(--sbca-space-lg);
+    padding-inline-end: var(--sbca-space-md);
 }
 
 .sbca-named-manager:not(:last-child) {
@@ -595,7 +699,7 @@
 
 .sbca-manager-heading,
 .sbca-organizer-heading {
-    margin: 0 0 var(--sbca-space-sm);
+    margin: 0 0 var(--sbca-space-xs);
     font-size: 0.9375em;
 }
 
@@ -605,7 +709,55 @@
 .sbca-organizer-collections {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--sbca-space-sm);
+    gap: var(--sbca-space-xs);
+}
+
+.sbca-manager-create {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--sbca-space-xs);
+    align-items: end;
+}
+
+.sbca-manager-create .sbca-filter {
+    min-inline-size: 0;
+}
+
+.sbca-manager-create .text_pole,
+.sbca-manager-row .text_pole {
+    margin: 0;
+}
+
+.sbca-manager-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: var(--sbca-space-xs);
+    align-items: center;
+}
+
+.sbca-manager-create .sbca-control,
+.sbca-manager-row .sbca-control {
+    min-block-size: var(--sb-field-min-height, 38px);
+    padding-inline: var(--sbca-space-sm);
+}
+
+.sbca-organization-backup {
+    grid-template-columns: repeat(3, max-content) minmax(0, 1fr);
+    align-items: center;
+    padding: var(--sbca-space-sm) var(--sbca-space-md);
+}
+
+.sbca-organization-backup .sbca-manager-heading {
+    grid-column: 1 / -1;
+}
+
+.sbca-organization-toggle::after {
+    content: '+';
+    font-weight: 700;
+}
+
+.sbca-organization-toggle[aria-expanded="true"]::after {
+    content: '\2212';
 }
 
 .sbca-manager-list,
@@ -618,12 +770,6 @@
 .sbca-import-status {
     min-block-size: 1.3em;
     color: var(--sbca-muted);
-    font-size: 0.875em;
-}
-
-.sbca-organization-warning {
-    margin: var(--sbca-space-sm) 0 0;
-    color: var(--sb-warning-fg, var(--SmartThemeBodyColor, inherit));
     font-size: 0.875em;
 }
 
@@ -674,7 +820,7 @@
 .sbca-list {
     display: flex;
     flex-direction: column;
-    gap: var(--sbca-space-xs);
+    gap: var(--sbca-space-sm);
     margin: 0;
     padding: 0;
     list-style: none;
@@ -740,9 +886,9 @@
     inline-size: 100%;
     min-block-size: 44px;
     padding: var(--sbca-space-sm);
-    border: 1px solid transparent;
-    border-radius: var(--sb-radius-sm, 8px);
-    background: transparent;
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-button, 14px);
+    background: color-mix(in srgb, var(--sbca-surface) 72%, transparent);
     color: inherit;
     font: inherit;
     text-align: start;
@@ -750,8 +896,14 @@
 }
 
 .sbca-row-button:hover {
-    border-color: var(--sbca-border);
+    border-color: var(--sbca-accent);
     background: var(--sbca-surface);
+}
+
+.sbca-row-button:focus-visible {
+    border-color: var(--sbca-focus);
+    outline: 2px solid var(--sbca-focus);
+    outline-offset: 2px;
 }
 
 .sbca-row-button[aria-current="true"] {
@@ -842,6 +994,8 @@
 .sbca-curation-tag,
 .sbca-tag-item {
     display: inline-flex;
+    max-inline-size: 100%;
+    min-inline-size: 0;
     gap: 4px;
     align-items: center;
     padding: var(--sbca-space-xs) var(--sbca-space-sm);
@@ -851,8 +1005,12 @@
     font-size: 0.8125em;
 }
 
-.sbca-curation-favorite,
-.sbca-favorite-toggle[aria-pressed="true"] {
+.sbca-tag-text {
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+}
+
+.sbca-curation-favorite {
     border-color: var(--sbca-accent);
     color: var(--sbca-text);
 }
@@ -915,16 +1073,94 @@
     margin: 0;
 }
 
+.sbca-favorite-action[aria-pressed='true'] {
+    border-color: var(--sbca-accent);
+    background: var(--sb-selection-bg, var(--sbca-surface));
+    color: var(--sb-selection-fg, var(--sbca-text));
+}
+
 .sbca-organizer {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: var(--sbca-space-sm);
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: start;
+    column-gap: var(--sbca-space-lg);
+    row-gap: var(--sbca-space-md);
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+}
+
+.sbca-organizer-heading {
+    grid-column: 1 / -1;
+}
+
+.sbca-organizer-folder,
+.sbca-organizer-collections,
+.sbca-organizer-tags {
+    min-inline-size: 0;
+    padding: var(--sbca-space-md);
+    border: 1px solid var(--sbca-border);
+    border-radius: var(--sb-radius-button, 14px);
+    background: var(--sbca-surface);
+}
+
+.sbca-organizer-folder .sbca-filter {
+    min-inline-size: 0;
+}
+
+.sbca-organizer-folder select {
+    box-sizing: border-box;
+    inline-size: 100%;
     margin: 0;
 }
 
-.sbca-organizer .sbca-filter {
+.sbca-organizer-collections .sbca-filter,
+.sbca-organizer-collections select {
+    min-inline-size: 0;
+}
+
+.sbca-organizer-collections select {
+    box-sizing: border-box;
     inline-size: 100%;
+    margin: 0;
+}
+
+.sbca-organizer-collections {
+    min-inline-size: 0;
+    margin: 0;
+}
+
+.sbca-organizer-section-title {
+    display: block;
+    margin-block-end: var(--sbca-space-xs);
+    color: var(--sbca-muted);
+    font-size: 0.875em;
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+
+.sbca-organizer-tags {
+    display: flex;
+    min-inline-size: 0;
+    flex-direction: column;
+    gap: var(--sbca-space-sm);
+}
+
+.sbca-organizer-tags .sbca-tag-create {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.sbca-organizer-tags .sbca-tag-create > .sbca-control {
+    inline-size: 100%;
+}
+
+.sbca-tag-create {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--sbca-space-sm);
+    align-items: end;
 }
 
 .sbca-tag-remove {
@@ -1077,7 +1313,7 @@
     .sbca-root[data-sbca-density] .sbca-row-button,
     .sbca-root button,
     .sbca-root summary,
-    .sbca-kinds .checkbox_label,
+    .sbca-kind-pill,
     .sbca-row-selection {
         min-block-size: var(--sb-mobile-touch-target, 44px);
     }
@@ -1088,6 +1324,10 @@
 
     .sbca-tag-remove {
         min-inline-size: var(--sb-mobile-touch-target, 44px);
+    }
+
+    .sbca-view-setting select {
+        min-block-size: var(--sb-mobile-touch-target, 44px);
     }
 }
 
@@ -1104,47 +1344,101 @@
     }
 
     .sbca-search,
-    .sbca-deep,
-    .sbca-search-mode,
-    .sbca-browse-options,
     .sbca-filter-tools,
     .sbca-status {
         grid-column: 1;
     }
 
-    .sbca-deep {
-        inline-size: 100%;
-    }
-
-    .sbca-browse-options {
-        display: block;
-    }
-
-    .sbca-browse-options > summary {
-        display: list-item;
-        color: var(--sbca-muted);
-        font-weight: 600;
-        cursor: pointer;
-    }
-
-    .sbca-browse-options .sbca-browse-strip {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        margin-block-start: var(--sbca-space-sm);
-    }
-
     .sbca-filter-tools {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
         align-items: stretch;
     }
 
-    .sbca-filter-tools > .sbca-options,
-    .sbca-filter-tools > .sbca-organization-tools,
-    .sbca-clear-filters,
-    .sbca-archive-actions {
+    .sbca-browse-strip,
+    .sbca-filter-toggle,
+    .sbca-options-panel,
+    .sbca-archive-actions,
+    .sbca-orphan-actions,
+    .sbca-organization-tools-panel {
+        grid-column: 1;
+        grid-row: auto;
         inline-size: 100%;
     }
 
+    .sbca-archive-secondary-actions {
+        grid-column: 1;
+        grid-row: auto;
+    }
+
+    .sbca-archive-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sbca-browse-strip {
+        flex-wrap: wrap;
+        padding-block-start: var(--sbca-space-md);
+        border-block-start: 1px solid var(--sbca-border);
+    }
+
+    .sbca-view-setting {
+        flex: 1 1 150px;
+    }
+
+    .sbca-view-setting select {
+        flex: 1 1 auto;
+    }
+
+    .sbca-filter-toggle {
+        display: inline-flex;
+        justify-content: space-between;
+    }
+
+    .sbca-filter-toggle::after,
+    .sbca-organization-toggle::after {
+        content: '+';
+        font-weight: 700;
+    }
+
+    .sbca-filter-toggle[aria-expanded="true"]::after,
+    .sbca-organization-toggle[aria-expanded="true"]::after {
+        content: '\2212';
+    }
+
     .sbca-archive-actions > .sbca-control {
-        flex: 1 1 140px;
+        inline-size: 100%;
+    }
+
+    .sbca-archive-secondary-actions {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        flex: 1 1 100%;
+        margin-inline-start: 0;
+        padding-block-start: var(--sbca-space-md);
+        border-block-start: 1px solid var(--sbca-border);
+    }
+
+    .sbca-orphan-actions {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--sbca-space-sm);
+        align-items: stretch;
+        margin-inline-start: 0;
+    }
+
+    .sbca-orphan-actions .sbca-orphan-filter,
+    .sbca-orphan-actions .sbca-control {
+        inline-size: 100%;
+    }
+
+    .sbca-orphan-actions .sbca-orphan-filter {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sbca-orphan-actions .sbca-orphan-filter select {
+        inline-size: 100%;
     }
 
     .sbca-root input,
@@ -1153,7 +1447,39 @@
     }
 
     .sbca-options-panel {
+        display: flex;
+        flex-wrap: wrap;
         align-items: stretch;
+        padding-block-start: 0;
+        border-block-start: 0;
+    }
+
+    .sbca-organization-backup {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .sbca-options-panel > .sbca-filter,
+    .sbca-options-panel > .sbca-kinds {
+        flex: 1 1 180px;
+    }
+
+    .sbca-options-panel > .sbca-kinds {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--sbca-space-sm);
+        flex-basis: 100%;
+    }
+
+    .sbca-kinds legend {
+        grid-column: 1 / -1;
+        float: none;
+        margin: 0;
+    }
+
+    .sbca-kind-pill {
+        min-inline-size: 0;
+        white-space: normal;
+        text-align: center;
     }
 
     .sbca-list-tools {
@@ -1172,7 +1498,6 @@
 
     .sbca-options-panel > .sbca-control,
     .sbca-options-panel > .sbca-filter,
-    .sbca-sort,
     .sbca-batch-actions > .sbca-control,
     .sbca-batch-actions > .sbca-filter {
         inline-size: 100%;
@@ -1217,6 +1542,21 @@
     .sbca-viewer-actions .sbca-action {
         inline-size: 100%;
         justify-content: flex-start;
+    }
+
+    .sbca-organizer,
+    .sbca-tag-create {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .sbca-organizer-collections,
+    .sbca-organizer-folder,
+    .sbca-organizer-tags {
+        grid-column: 1;
+    }
+
+    .sbca-organizer-tags {
+        padding: var(--sbca-space-md);
     }
 }
 
@@ -1304,8 +1644,19 @@
         padding-inline: 0;
     }
 
-    .sbca-browse-options .sbca-browse-strip {
-        grid-template-columns: minmax(0, 1fr);
+    .sbca-view-setting {
+        flex: 1 1 calc(50% - var(--sbca-space-xs));
+        min-inline-size: 0;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sbca-browse-strip {
+        gap: var(--sbca-space-sm);
+    }
+
+    .sbca-view-setting select {
+        inline-size: 100%;
     }
 }
 

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -3,15 +3,48 @@
     outline-offset: 2px;
 }
 
+#right-nav-panel .sb-character-create-bar #sbca_drawer_button {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto !important;
+    gap: 8px;
+    width: max-content;
+    inline-size: max-content;
+    min-width: var(--sb-mobile-touch-target, 44px);
+    min-inline-size: var(--sb-mobile-touch-target, 44px);
+    max-width: min(100%, 22rem);
+    max-inline-size: min(100%, 22rem);
+    min-height: var(--sb-mobile-touch-target, 44px);
+    padding: 0 var(--sb-shell-space-lg, 12px) !important;
+    aspect-ratio: auto;
+    white-space: normal;
+}
+
+.sbca-drawer-button-label {
+    display: block;
+    min-width: 0;
+    max-width: 18ch;
+    overflow-wrap: anywhere;
+    font-family: var(--mainFontFamily);
+    font-size: var(--sb-type-caption, 0.875rem);
+    font-weight: var(--sb-weight-title, 600);
+    line-height: var(--sb-line-compact, 1.2);
+}
+
 @media screen and (max-width: 768px) {
     #right-nav-panel.openDrawer .sb-character-create-bar #sbca_drawer_button {
-        width: 38px !important;
-        min-width: 38px !important;
-        max-width: 38px !important;
-        height: 38px !important;
-        min-height: 38px !important;
-        max-height: 38px !important;
-        padding: 0 !important;
+        width: auto !important;
+        inline-size: max-content !important;
+        min-width: var(--sb-mobile-touch-target, 44px) !important;
+        min-inline-size: var(--sb-mobile-touch-target, 44px) !important;
+        max-width: min(70vw, 22rem) !important;
+        max-inline-size: min(70vw, 22rem) !important;
+        height: auto !important;
+        min-height: var(--sb-mobile-touch-target, 44px) !important;
+        max-height: none !important;
+        padding: 4px 10px !important;
     }
 }
 

--- a/public/scripts/extensions/sillybunny-chats-archive/style.css
+++ b/public/scripts/extensions/sillybunny-chats-archive/style.css
@@ -261,6 +261,7 @@
 }
 
 .sbca-options > summary,
+.sbca-organization-tools > summary,
 .sbca-json-details > summary {
     inline-size: fit-content;
     cursor: pointer;
@@ -274,6 +275,12 @@
     gap: var(--sbca-space-sm) var(--sbca-space-md);
     align-items: end;
     padding-block-start: var(--sbca-space-md);
+}
+
+.sbca-options[open],
+.sbca-organization-tools[open] {
+    flex-basis: 100%;
+    inline-size: 100%;
 }
 
 .sbca-kinds {
@@ -314,7 +321,7 @@
 
 .sbca-browse-strip {
     display: grid;
-    grid-template-columns: repeat(4, minmax(130px, 1fr));
+    grid-template-columns: repeat(3, minmax(130px, 1fr));
     gap: var(--sbca-space-sm);
 }
 
@@ -528,10 +535,21 @@
     font-size: 0.875em;
 }
 
+.sbca-organization-tools {
+    flex: 0 1 auto;
+}
+
+.sbca-organization-tools-panel {
+    display: grid;
+    grid-column: 1 / -1;
+    gap: var(--sbca-space-lg);
+    inline-size: 100%;
+    padding-block-start: var(--sbca-space-md);
+}
+
 .sbca-management,
 .sbca-organization-backup {
     display: grid;
-    grid-column: 1 / -1;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: var(--sbca-space-lg);
     inline-size: 100%;
@@ -618,25 +636,16 @@
 }
 
 .sbca-list-tools {
-    margin-inline-start: auto;
-}
-
-.sbca-list-tools[open] {
-    flex-basis: 100%;
-}
-
-.sbca-list-tools > summary {
-    inline-size: fit-content;
-    margin-inline-start: auto;
-    cursor: pointer;
-    color: var(--sbca-muted);
-    font-weight: 600;
-}
-
-.sbca-list-tools-panel {
     display: grid;
-    gap: var(--sbca-space-sm);
-    padding-block-start: var(--sbca-space-sm);
+    grid-template-columns: minmax(180px, 1fr) auto;
+    gap: var(--sbca-space-sm) var(--sbca-space-md);
+    align-items: end;
+    flex-basis: 100%;
+    inline-size: 100%;
+}
+
+.sbca-list-tools .sbca-selection-bar {
+    grid-column: 1 / -1;
 }
 
 .sbca-list,
@@ -1066,16 +1075,6 @@
     }
 }
 
-@media (min-width: 1001px) {
-    .sbca-toolbar:has(.sbca-options[open]) {
-        min-block-size: 0;
-        max-block-size: min(50%, 32rem);
-        padding: var(--sbca-space-xs) var(--sbca-space-sm) var(--sbca-space-sm);
-        overflow-y: auto;
-        overscroll-behavior: contain;
-    }
-}
-
 @media (max-width: 1000px) {
     .sbca-root {
         block-size: 78vh;
@@ -1122,6 +1121,7 @@
     }
 
     .sbca-filter-tools > .sbca-options,
+    .sbca-filter-tools > .sbca-organization-tools,
     .sbca-clear-filters,
     .sbca-archive-actions {
         inline-size: 100%;
@@ -1138,6 +1138,15 @@
 
     .sbca-options-panel {
         align-items: stretch;
+    }
+
+    .sbca-list-tools {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .sbca-sortpills,
+    .sbca-list-tools .sbca-selection-bar {
+        grid-column: 1;
     }
 
     .sbca-owner-menu {

--- a/src/endpoints/chat-archive.js
+++ b/src/endpoints/chat-archive.js
@@ -1,0 +1,663 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+
+import express from 'express';
+import sanitize from 'sanitize-filename';
+
+import { formatBytes, isPathUnderParent, tryParse } from '../util.js';
+
+const INVENTORY_SCOPES = new Set(['archive', 'orphans']);
+const DEFAULT_PAGE_SIZE = 200;
+export const MAX_ARCHIVE_PAGE_SIZE = 500;
+const INVENTORY_TTL_MS = 5 * 60 * 1000;
+const READ_TOKEN_TTL_MS = 15 * 60 * 1000;
+const INVENTORY_CONCURRENCY = 8;
+const METADATA_READ_BUFFER_SIZE = 64 * 1024;
+const MAX_ARCHIVE_SESSIONS_PER_USER = 8;
+const TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+
+function abortError(signal) {
+    if (signal?.reason instanceof Error) {
+        return signal.reason;
+    }
+
+    const error = new Error('The operation was aborted.');
+    error.name = 'AbortError';
+    return error;
+}
+
+function throwIfAborted(signal) {
+    if (signal?.aborted) {
+        throw abortError(signal);
+    }
+}
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function forbiddenArchivePath() {
+    const error = new Error('Archive file is outside the user directory.');
+    error.code = 'ARCHIVE_PATH_FORBIDDEN';
+    return error;
+}
+
+async function openRegularArchiveFile(filePath, rootDirectory = null) {
+    let pathToOpen = filePath;
+    if (rootDirectory) {
+        const canonicalRoot = path.resolve(rootDirectory);
+        const canonicalFile = await fs.promises.realpath(filePath);
+        if (!isPathUnderParent(canonicalRoot, canonicalFile)) {
+            throw forbiddenArchivePath();
+        }
+        pathToOpen = canonicalFile;
+    }
+
+    const noFollow = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const fileHandle = await fs.promises.open(pathToOpen, fs.constants.O_RDONLY | noFollow);
+    try {
+        const stats = await fileHandle.stat();
+        if (!stats.isFile()) {
+            throw new Error('Archive inventory entry is not a regular file.');
+        }
+        return { fileHandle, pathToOpen, stats };
+    } catch (error) {
+        await fileHandle.close();
+        throw error;
+    }
+}
+
+async function readDirectory(directory) {
+    try {
+        return await fs.promises.readdir(directory, { withFileTypes: true });
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+}
+
+function isJsonlFile(dirent) {
+    return dirent.isFile() && path.extname(dirent.name).toLowerCase() === '.jsonl';
+}
+
+function compareDirentNames(left, right) {
+    if (left.name === right.name) {
+        return 0;
+    }
+    return left.name < right.name ? -1 : 1;
+}
+
+function archiveIdentity(descriptor) {
+    const record = {
+        _source: descriptor.hash ? 'archive-orphan' : 'archive-inventory',
+        file_id: path.parse(descriptor.fileName).name,
+        file_name: descriptor.fileName,
+    };
+
+    if (descriptor.avatar) {
+        record.avatar = descriptor.avatar;
+    }
+    if (descriptor.groupId !== undefined) {
+        record.group = descriptor.groupId;
+    }
+    if (descriptor.chatFolder) {
+        record.chatFolder = descriptor.chatFolder;
+    }
+    if (descriptor.orphanType) {
+        record.orphan_type = descriptor.orphanType;
+        record.archive_hash = descriptor.hash;
+    }
+
+    return record;
+}
+
+/**
+ * Reads archive list metadata while parsing only the header and final JSONL records.
+ * The intervening records are counted as lines and are never materialized or parsed.
+ * @param {string} filePath Chat JSONL path.
+ * @param {AbortSignal} [signal] Cancellation signal.
+ * @param {string|null} [rootDirectory] User root that must contain the file.
+ * @returns {Promise<object>} Archive-compatible chat metadata.
+ */
+export async function readArchiveChatMetadata(filePath, signal, rootDirectory = null) {
+    throwIfAborted(signal);
+    const { fileHandle, stats } = await openRegularArchiveFile(filePath, rootDirectory);
+
+    const metadata = {
+        file_size: formatBytes(stats.size),
+        chat_items: 0,
+        last_mes: stats.mtimeMs,
+        mes: '[The chat is empty]',
+    };
+    let firstLine = '';
+    let lastLine = '';
+    let recordCount = 0;
+    let pending = '';
+    const decoder = new StringDecoder('utf8');
+    const buffer = Buffer.allocUnsafe(METADATA_READ_BUFFER_SIZE);
+    const consumeLine = (rawLine) => {
+        let line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+        if (!line.trim()) {
+            return;
+        }
+        if (!firstLine) {
+            line = line.replace(/^\uFEFF/, '');
+            firstLine = line;
+        }
+        lastLine = line;
+        recordCount++;
+    };
+
+    try {
+        let position = 0;
+        while (position < stats.size) {
+            throwIfAborted(signal);
+            const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, position);
+            if (bytesRead === 0) {
+                break;
+            }
+            position += bytesRead;
+            pending += decoder.write(buffer.subarray(0, bytesRead));
+            let lineEnd;
+            while ((lineEnd = pending.indexOf('\n')) >= 0) {
+                consumeLine(pending.slice(0, lineEnd));
+                pending = pending.slice(lineEnd + 1);
+            }
+        }
+        pending += decoder.end();
+        if (pending) {
+            consumeLine(pending);
+        }
+    } finally {
+        await fileHandle.close();
+    }
+
+    throwIfAborted(signal);
+    const header = firstLine ? tryParse(firstLine) : null;
+    const lastRecord = lastLine ? tryParse(lastLine) : null;
+    const hasHeader = isPlainObject(header) && !Object.hasOwn(header, 'mes');
+    metadata.chat_items = Math.max(0, recordCount - (hasHeader ? 1 : 0));
+    if (isPlainObject(header?.chat_metadata)) {
+        metadata.chat_metadata = header.chat_metadata;
+    }
+    if (isPlainObject(lastRecord) && (!hasHeader || lastLine !== firstLine)) {
+        metadata.last_mes = lastRecord.send_date || stats.mtimeMs;
+        metadata.mes = typeof lastRecord.mes === 'string' && lastRecord.mes
+            ? lastRecord.mes
+            : '[The message is empty]';
+    }
+
+    return metadata;
+}
+
+async function readGroupLinks(directories, groupChatFiles, signal) {
+    const links = new Map();
+    const groupEntries = (await readDirectory(directories.groups))
+        .filter(entry => entry.isFile() && path.extname(entry.name).toLowerCase() === '.json')
+        .sort(compareDirentNames);
+
+    for (const entry of groupEntries) {
+        throwIfAborted(signal);
+        try {
+            const groupPath = path.join(directories.groups, entry.name);
+            const group = JSON.parse(await fs.promises.readFile(groupPath, 'utf8'));
+            if ((typeof group?.id !== 'string' && typeof group?.id !== 'number') || String(group.id) === '') {
+                continue;
+            }
+
+            const chatIds = new Set(Array.isArray(group.chats) ? group.chats : []);
+            if (group.chat_id !== undefined && group.chat_id !== null && group.chat_id !== '') {
+                chatIds.add(group.chat_id);
+            }
+            for (const chatId of chatIds) {
+                if (typeof chatId !== 'string' && typeof chatId !== 'number') {
+                    continue;
+                }
+                const fileName = sanitize(`${chatId}.jsonl`);
+                if (!fileName || !groupChatFiles.has(fileName) || links.has(fileName)) {
+                    continue;
+                }
+                links.set(fileName, group.id);
+            }
+        } catch (error) {
+            if (error?.name === 'AbortError') {
+                throw error;
+            }
+            console.warn(`[Chat Archive] Could not read group links from ${entry.name}:`, error);
+        }
+    }
+
+    return links;
+}
+
+async function collectArchiveDescriptors(directories, scope, signal) {
+    throwIfAborted(signal);
+    for (const key of ['root', 'characters', 'chats', 'groups', 'groupChats']) {
+        if (typeof directories[key] !== 'string') {
+            throw new TypeError(`Chat Archive requires the ${key} user directory.`);
+        }
+    }
+    const [characterEntries, chatEntries, groupChatEntries] = await Promise.all([
+        readDirectory(directories.characters),
+        readDirectory(directories.chats),
+        readDirectory(directories.groupChats),
+    ]);
+    const characterAvatars = new Map(characterEntries
+        .filter(entry => entry.isFile() && path.extname(entry.name).toLowerCase() === '.png')
+        .map(entry => [path.parse(entry.name).name, entry.name]));
+    const groupChatFiles = new Set(groupChatEntries.filter(isJsonlFile).map(entry => entry.name));
+    const groupLinks = await readGroupLinks(directories, groupChatFiles, signal);
+    const descriptors = [];
+
+    for (const entry of chatEntries.sort(compareDirentNames)) {
+        throwIfAborted(signal);
+        if (entry.isFile() && isJsonlFile(entry)) {
+            if (scope === 'archive') {
+                descriptors.push({
+                    fileName: entry.name,
+                    filePath: path.join(directories.chats, entry.name),
+                    orphanType: 'root',
+                });
+            }
+            continue;
+        }
+        if (!entry.isDirectory()) {
+            continue;
+        }
+
+        const avatar = characterAvatars.get(entry.name);
+        const isLinked = Boolean(avatar);
+        if ((scope === 'archive') !== isLinked) {
+            continue;
+        }
+        const chatFolderPath = path.join(directories.chats, entry.name);
+        const chatFiles = (await readDirectory(chatFolderPath)).filter(isJsonlFile)
+            .sort(compareDirentNames);
+        for (const chatFile of chatFiles) {
+            descriptors.push({
+                fileName: chatFile.name,
+                filePath: path.join(chatFolderPath, chatFile.name),
+                avatar,
+                chatFolder: entry.name,
+                orphanType: isLinked ? null : 'missing-character',
+            });
+        }
+    }
+
+    for (const entry of groupChatEntries.filter(isJsonlFile).sort(compareDirentNames)) {
+        throwIfAborted(signal);
+        const groupId = groupLinks.get(entry.name);
+        const isLinked = groupId !== undefined;
+        if ((scope === 'archive') !== isLinked) {
+            continue;
+        }
+        descriptors.push({
+            fileName: entry.name,
+            filePath: path.join(directories.groupChats, entry.name),
+            groupId,
+            orphanType: isLinked ? null : 'unlinked-group',
+        });
+    }
+
+    return descriptors;
+}
+
+async function mapWithConcurrency(items, signal, mapper) {
+    const results = new Array(items.length);
+    let nextIndex = 0;
+    const worker = async () => {
+        while (true) {
+            throwIfAborted(signal);
+            const index = nextIndex++;
+            if (index >= items.length) {
+                return;
+            }
+            results[index] = await mapper(items[index]);
+        }
+    };
+    await Promise.all(Array.from({ length: Math.min(INVENTORY_CONCURRENCY, items.length) }, worker));
+    return results;
+}
+
+export class ArchiveReadTokenService {
+    static TOKENS = new Map();
+
+    static cleanup(now = Date.now()) {
+        for (const [token, entry] of this.TOKENS) {
+            if (entry.expiresAt <= now) {
+                this.TOKENS.delete(token);
+            }
+        }
+    }
+
+    static create(handle, root, descriptors) {
+        this.cleanup();
+        const userTokens = [...this.TOKENS]
+            .filter(([, entry]) => entry.handle === handle)
+            .map(([token]) => token);
+        while (userTokens.length >= MAX_ARCHIVE_SESSIONS_PER_USER) {
+            this.TOKENS.delete(userTokens.shift());
+        }
+        const token = crypto.randomBytes(32).toString('hex');
+        const files = new Map();
+        for (const descriptor of descriptors) {
+            const hash = crypto.createHash('sha256').update(`${token}\0${descriptor.filePath}`).digest('hex');
+            descriptor.hash = hash;
+            files.set(hash, descriptor.filePath);
+        }
+        this.TOKENS.set(token, {
+            handle,
+            root: fs.realpathSync(root),
+            files,
+            expiresAt: Date.now() + READ_TOKEN_TTL_MS,
+        });
+        return token;
+    }
+
+    static get(token, handle) {
+        this.cleanup();
+        const entry = this.TOKENS.get(token);
+        if (!entry || entry.handle !== handle) {
+            return null;
+        }
+        entry.expiresAt = Date.now() + READ_TOKEN_TTL_MS;
+        return entry;
+    }
+
+    static canRelease(token, handle) {
+        this.cleanup();
+        const entry = this.TOKENS.get(token);
+        return !!entry && entry.handle === handle;
+    }
+
+    static release(token, handle) {
+        this.cleanup();
+        if (!this.canRelease(token, handle)) {
+            return false;
+        }
+        this.TOKENS.delete(token);
+        return true;
+    }
+}
+
+export class ArchiveInventoryService {
+    static INVENTORIES = new Map();
+
+    static cleanup(now = Date.now()) {
+        for (const [cursor, entry] of this.INVENTORIES) {
+            if (entry.expiresAt <= now) {
+                this.INVENTORIES.delete(cursor);
+                if (entry.readToken) {
+                    ArchiveReadTokenService.release(entry.readToken, entry.handle);
+                }
+            }
+        }
+    }
+
+    static async create(handle, directories, scope, signal) {
+        this.cleanup();
+        const userInventories = [...this.INVENTORIES]
+            .filter(([, entry]) => entry.handle === handle)
+            .map(([cursor]) => cursor);
+        while (userInventories.length >= MAX_ARCHIVE_SESSIONS_PER_USER) {
+            this.discard(userInventories.shift(), handle);
+        }
+        const canonicalRoot = await fs.promises.realpath(directories.root);
+        const descriptors = await collectArchiveDescriptors(directories, scope, signal);
+        throwIfAborted(signal);
+        const cursor = crypto.randomBytes(32).toString('hex');
+        const readToken = scope === 'orphans'
+            ? ArchiveReadTokenService.create(handle, canonicalRoot, descriptors)
+            : null;
+        this.INVENTORIES.set(cursor, {
+            handle,
+            scope,
+            descriptors,
+            offset: 0,
+            readToken,
+            root: canonicalRoot,
+            busy: false,
+            expiresAt: Date.now() + INVENTORY_TTL_MS,
+        });
+        return cursor;
+    }
+
+    static get(cursor, handle) {
+        this.cleanup();
+        const inventory = this.INVENTORIES.get(cursor);
+        if (!inventory || inventory.handle !== handle) {
+            return null;
+        }
+        inventory.expiresAt = Date.now() + INVENTORY_TTL_MS;
+        if (inventory.readToken) {
+            ArchiveReadTokenService.get(inventory.readToken, handle);
+        }
+        return inventory;
+    }
+
+    static discard(cursor, handle) {
+        const inventory = this.INVENTORIES.get(cursor);
+        if (!inventory || inventory.handle !== handle) {
+            return false;
+        }
+        this.INVENTORIES.delete(cursor);
+        if (inventory.readToken) {
+            ArchiveReadTokenService.release(inventory.readToken, handle);
+        }
+        return true;
+    }
+
+    static canDiscard(cursor, handle) {
+        this.cleanup();
+        const inventory = this.INVENTORIES.get(cursor);
+        return !!inventory && inventory.handle === handle;
+    }
+
+    static async page(
+        cursor,
+        handle,
+        pageSize,
+        signal,
+        inventory = this.get(cursor, handle),
+        metadataReader = readArchiveChatMetadata,
+    ) {
+        if (!inventory) {
+            return { status: 'missing' };
+        }
+        if (inventory.busy) {
+            return { status: 'busy' };
+        }
+
+        inventory.busy = true;
+        const start = inventory.offset;
+        const descriptors = inventory.descriptors.slice(start, start + pageSize);
+        let errors = 0;
+        try {
+            const rows = await mapWithConcurrency(descriptors, signal, async descriptor => {
+                try {
+                    const metadata = await metadataReader(descriptor.filePath, signal, inventory.root);
+                    return { ...archiveIdentity(descriptor), ...metadata };
+                } catch (error) {
+                    if (error?.name === 'AbortError' || signal?.aborted) {
+                        throw abortError(signal);
+                    }
+                    errors++;
+                    return archiveIdentity(descriptor);
+                }
+            });
+            throwIfAborted(signal);
+            inventory.offset = start + descriptors.length;
+            const complete = inventory.offset >= inventory.descriptors.length;
+            if (complete) {
+                this.INVENTORIES.delete(cursor);
+            }
+            return {
+                status: 'ok',
+                rows,
+                errors,
+                cursor: complete ? null : cursor,
+                readToken: inventory.readToken,
+            };
+        } finally {
+            inventory.busy = false;
+        }
+    }
+}
+
+function parsePageSize(value) {
+    if (value === undefined) {
+        return DEFAULT_PAGE_SIZE;
+    }
+    if (!Number.isSafeInteger(value) || value < 1 || value > MAX_ARCHIVE_PAGE_SIZE) {
+        return null;
+    }
+    return value;
+}
+
+function requestAbortController(request, response) {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const abortOnClosedResponse = () => {
+        if (!response.writableEnded) {
+            abort();
+        }
+    };
+    request.once('aborted', abort);
+    response.once('close', abortOnClosedResponse);
+    return {
+        signal: controller.signal,
+        cleanup: () => {
+            request.removeListener('aborted', abort);
+            response.removeListener('close', abortOnClosedResponse);
+        },
+    };
+}
+
+export const router = express.Router();
+
+router.post('/inventory', async (request, response) => {
+    if (!request.user?.directories || typeof request.user?.profile?.handle !== 'string') {
+        return response.sendStatus(403);
+    }
+
+    const pageSize = parsePageSize(request.body?.page_size);
+    const suppliedCursor = request.body?.cursor;
+    const scope = request.body?.scope;
+    if (pageSize === null
+        || (suppliedCursor !== undefined && suppliedCursor !== null && (typeof suppliedCursor !== 'string' || !TOKEN_PATTERN.test(suppliedCursor)))
+        || ((suppliedCursor === undefined || suppliedCursor === null) && !INVENTORY_SCOPES.has(scope))
+        || (scope !== undefined && !INVENTORY_SCOPES.has(scope))) {
+        return response.sendStatus(400);
+    }
+
+    const cancellation = requestAbortController(request, response);
+    const handle = request.user.profile.handle;
+    let cursor = null;
+    try {
+        cursor = suppliedCursor ?? await ArchiveInventoryService.create(
+            handle,
+            request.user.directories,
+            scope,
+            cancellation.signal,
+        );
+        const inventory = ArchiveInventoryService.get(cursor, handle);
+        if (!inventory) {
+            return response.sendStatus(403);
+        }
+        if (scope !== undefined && inventory.scope !== scope) {
+            return response.sendStatus(400);
+        }
+
+        const page = await ArchiveInventoryService.page(cursor, handle, pageSize, cancellation.signal, inventory);
+        if (page.status === 'missing') {
+            return response.sendStatus(403);
+        }
+        if (page.status === 'busy') {
+            return response.sendStatus(409);
+        }
+        return response.json({
+            rows: page.rows,
+            cursor: page.cursor,
+            read_token: page.readToken,
+            errors: page.errors,
+        });
+    } catch (error) {
+        if (error?.name === 'AbortError' || cancellation.signal.aborted) {
+            if (cursor) {
+                ArchiveInventoryService.discard(cursor, handle);
+            }
+            return;
+        }
+        console.error('[Chat Archive] Failed to build archive inventory:', error);
+        return response.sendStatus(500);
+    } finally {
+        cancellation.cleanup();
+    }
+});
+
+router.get('/view', async (request, response) => {
+    if (!request.user?.directories || typeof request.user?.profile?.handle !== 'string') {
+        return response.sendStatus(403);
+    }
+    const token = typeof request.query.token === 'string' ? request.query.token : '';
+    const hash = typeof request.query.hash === 'string' ? request.query.hash : '';
+    if (!TOKEN_PATTERN.test(token) || !TOKEN_PATTERN.test(hash)) {
+        return response.sendStatus(400);
+    }
+
+    const session = ArchiveReadTokenService.get(token, request.user.profile.handle);
+    if (!session) {
+        return response.sendStatus(403);
+    }
+    const filePath = session.files.get(hash);
+    if (!filePath) {
+        return response.sendStatus(404);
+    }
+    let archiveFile;
+    try {
+        archiveFile = await openRegularArchiveFile(filePath, session.root);
+        const contents = await archiveFile.fileHandle.readFile();
+        response.type('application/x-ndjson');
+        return response.send(contents);
+    } catch (error) {
+        if (error?.code === 'ARCHIVE_PATH_FORBIDDEN' || error?.code === 'ELOOP') {
+            return response.sendStatus(403);
+        }
+        if (error?.code === 'ENOENT') {
+            return response.sendStatus(404);
+        }
+        console.error('[Chat Archive] Failed to read archive file:', error);
+        return response.sendStatus(500);
+    } finally {
+        await archiveFile?.fileHandle.close();
+    }
+});
+
+router.post('/release', (request, response) => {
+    if (!request.user?.directories || typeof request.user?.profile?.handle !== 'string') {
+        return response.sendStatus(403);
+    }
+    const token = request.body?.token ?? null;
+    const cursor = request.body?.cursor ?? null;
+    if ((!token && !cursor)
+        || (token !== null && (typeof token !== 'string' || !TOKEN_PATTERN.test(token)))
+        || (cursor !== null && (typeof cursor !== 'string' || !TOKEN_PATTERN.test(cursor)))) {
+        return response.sendStatus(400);
+    }
+    const handle = request.user.profile.handle;
+    if ((token && !ArchiveReadTokenService.canRelease(token, handle))
+        || (cursor && !ArchiveInventoryService.canDiscard(cursor, handle))) {
+        return response.sendStatus(403);
+    }
+    if (cursor) {
+        ArchiveInventoryService.discard(cursor, handle);
+    }
+    if (token) {
+        ArchiveReadTokenService.release(token, handle);
+    }
+    return response.sendStatus(204);
+});

--- a/src/endpoints/chat-archive.js
+++ b/src/endpoints/chat-archive.js
@@ -15,8 +15,12 @@ const INVENTORY_TTL_MS = 5 * 60 * 1000;
 const READ_TOKEN_TTL_MS = 15 * 60 * 1000;
 const INVENTORY_CONCURRENCY = 8;
 const METADATA_READ_BUFFER_SIZE = 64 * 1024;
+const METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_METADATA_CACHE_ENTRIES = 2_048;
 const MAX_ARCHIVE_SESSIONS_PER_USER = 8;
 const TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+const PROC_FD_DIRECTORY = '/proc/self/fd';
+const PROCFS_UNAVAILABLE_CODES = new Set(['EACCES', 'ENOENT', 'ENOTDIR', 'ENOSYS', 'EPERM']);
 
 function abortError(signal) {
     if (signal?.reason instanceof Error) {
@@ -38,34 +42,151 @@ function isPlainObject(value) {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function forbiddenArchivePath() {
-    const error = new Error('Archive file is outside the user directory.');
+function forbiddenArchivePath(message = 'Archive file is outside the user directory.', cause) {
+    const error = new Error(message, cause ? { cause } : undefined);
     error.code = 'ARCHIVE_PATH_FORBIDDEN';
     return error;
 }
 
+function sameFileIdentity(firstStats, secondStats) {
+    return firstStats.dev === secondStats.dev
+        && firstStats.ino !== 0n
+        && firstStats.ino === secondStats.ino;
+}
+
+async function resolveProcFileDescriptor(fileDescriptor) {
+    try {
+        await fs.promises.realpath(PROC_FD_DIRECTORY);
+    } catch (error) {
+        if (PROCFS_UNAVAILABLE_CODES.has(error?.code)) {
+            return null;
+        }
+        throw error;
+    }
+
+    try {
+        return await fs.promises.realpath(path.join(PROC_FD_DIRECTORY, String(fileDescriptor)));
+    } catch (error) {
+        if (PROCFS_UNAVAILABLE_CODES.has(error?.code)) {
+            return null;
+        }
+        throw forbiddenArchivePath('Archive file descriptor could not be verified.', error);
+    }
+}
+
 async function openRegularArchiveFile(filePath, rootDirectory = null) {
-    let pathToOpen = filePath;
+    let canonicalRoot = null;
+    let expectedIdentity = null;
     if (rootDirectory) {
-        const canonicalRoot = path.resolve(rootDirectory);
-        const canonicalFile = await fs.promises.realpath(filePath);
-        if (!isPathUnderParent(canonicalRoot, canonicalFile)) {
+        canonicalRoot = await fs.promises.realpath(rootDirectory);
+    }
+    let pathToOpen = await fs.promises.realpath(filePath);
+    if (canonicalRoot) {
+        if (!isPathUnderParent(canonicalRoot, pathToOpen)) {
             throw forbiddenArchivePath();
         }
-        pathToOpen = canonicalFile;
+        const canonicalStats = await fs.promises.stat(pathToOpen, { bigint: true });
+        if (!canonicalStats.isFile()) {
+            throw new Error('Archive inventory entry is not a regular file.');
+        }
+        expectedIdentity = canonicalStats;
     }
 
     const noFollow = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
     const fileHandle = await fs.promises.open(pathToOpen, fs.constants.O_RDONLY | noFollow);
     try {
-        const stats = await fileHandle.stat();
-        if (!stats.isFile()) {
+        const [stats, openedIdentity] = await Promise.all([
+            fileHandle.stat(),
+            fileHandle.stat({ bigint: true }),
+        ]);
+        if (!stats.isFile() || !openedIdentity.isFile()) {
             throw new Error('Archive inventory entry is not a regular file.');
         }
-        return { fileHandle, pathToOpen, stats };
+
+        if (canonicalRoot) {
+            const descriptorPath = await resolveProcFileDescriptor(fileHandle.fd);
+            if (descriptorPath && !isPathUnderParent(canonicalRoot, descriptorPath)) {
+                throw forbiddenArchivePath();
+            }
+
+            let currentCanonicalFile;
+            let currentIdentity;
+            try {
+                currentCanonicalFile = await fs.promises.realpath(filePath);
+                if (!isPathUnderParent(canonicalRoot, currentCanonicalFile) || currentCanonicalFile !== pathToOpen) {
+                    throw forbiddenArchivePath('Archive file path changed while it was being opened.');
+                }
+                currentIdentity = await fs.promises.stat(currentCanonicalFile, { bigint: true });
+            } catch (error) {
+                if (error?.code === 'ARCHIVE_PATH_FORBIDDEN') {
+                    throw error;
+                }
+                throw forbiddenArchivePath('Archive file path changed while it was being opened.', error);
+            }
+
+            if (!sameFileIdentity(expectedIdentity, openedIdentity)
+                || !sameFileIdentity(openedIdentity, currentIdentity)) {
+                throw forbiddenArchivePath('Archive file identity changed while it was being opened.');
+            }
+            pathToOpen = currentCanonicalFile;
+        }
+
+        return { fileHandle, pathToOpen, stats, cacheStats: openedIdentity };
     } catch (error) {
         await fileHandle.close();
         throw error;
+    }
+}
+
+export class ArchiveMetadataCache {
+    static ENTRIES = new Map();
+
+    static cleanup(now = Date.now()) {
+        for (const [key, entry] of this.ENTRIES) {
+            if (entry.expiresAt <= now) {
+                this.ENTRIES.delete(key);
+            }
+        }
+    }
+
+    static key(canonicalPath, stats) {
+        const modifiedTime = stats.mtimeNs === undefined
+            ? `ms:${String(stats.mtimeMs)}`
+            : `ns:${String(stats.mtimeNs)}`;
+        return [
+            canonicalPath,
+            String(stats.dev),
+            String(stats.ino),
+            String(stats.size),
+            modifiedTime,
+        ].join('\0');
+    }
+
+    static get(canonicalPath, stats, now = Date.now()) {
+        const key = this.key(canonicalPath, stats);
+        const entry = this.ENTRIES.get(key);
+        if (!entry || entry.expiresAt <= now) {
+            this.ENTRIES.delete(key);
+            return null;
+        }
+        this.ENTRIES.delete(key);
+        this.ENTRIES.set(key, entry);
+        return entry.metadata;
+    }
+
+    static set(canonicalPath, stats, metadata, now = Date.now()) {
+        const key = this.key(canonicalPath, stats);
+        this.ENTRIES.delete(key);
+        if (this.ENTRIES.size >= MAX_METADATA_CACHE_ENTRIES) {
+            this.cleanup(now);
+        }
+        while (this.ENTRIES.size >= MAX_METADATA_CACHE_ENTRIES) {
+            this.ENTRIES.delete(this.ENTRIES.keys().next().value);
+        }
+        this.ENTRIES.set(key, {
+            metadata,
+            expiresAt: now + METADATA_CACHE_TTL_MS,
+        });
     }
 }
 
@@ -125,7 +246,13 @@ function archiveIdentity(descriptor) {
  */
 export async function readArchiveChatMetadata(filePath, signal, rootDirectory = null) {
     throwIfAborted(signal);
-    const { fileHandle, stats } = await openRegularArchiveFile(filePath, rootDirectory);
+    const { fileHandle, pathToOpen, stats, cacheStats } = await openRegularArchiveFile(filePath, rootDirectory);
+    const cachedMetadata = ArchiveMetadataCache.get(pathToOpen, cacheStats);
+    if (cachedMetadata) {
+        await fileHandle.close();
+        throwIfAborted(signal);
+        return cachedMetadata;
+    }
 
     const metadata = {
         file_size: formatBytes(stats.size),
@@ -191,6 +318,7 @@ export async function readArchiveChatMetadata(filePath, signal, rootDirectory = 
             : '[The message is empty]';
     }
 
+    ArchiveMetadataCache.set(pathToOpen, cacheStats, metadata);
     return metadata;
 }
 
@@ -501,6 +629,7 @@ export class ArchiveInventoryService {
                 errors,
                 cursor: complete ? null : cursor,
                 readToken: inventory.readToken,
+                total: inventory.descriptors.length,
             };
         } finally {
             inventory.busy = false;
@@ -584,6 +713,7 @@ router.post('/inventory', async (request, response) => {
             cursor: page.cursor,
             read_token: page.readToken,
             errors: page.errors,
+            total: page.total,
         });
     } catch (error) {
         if (error?.name === 'AbortError' || cancellation.signal.aborted) {

--- a/src/endpoints/chat-archive.js
+++ b/src/endpoints/chat-archive.js
@@ -15,6 +15,7 @@ const INVENTORY_TTL_MS = 5 * 60 * 1000;
 const READ_TOKEN_TTL_MS = 15 * 60 * 1000;
 const INVENTORY_CONCURRENCY = 8;
 const METADATA_READ_BUFFER_SIZE = 64 * 1024;
+const MAX_METADATA_PREVIEW_CHARS = 512;
 const METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_METADATA_CACHE_ENTRIES = 2_048;
 const MAX_ARCHIVE_SESSIONS_PER_USER = 8;
@@ -314,7 +315,7 @@ export async function readArchiveChatMetadata(filePath, signal, rootDirectory = 
     if (isPlainObject(lastRecord) && (!hasHeader || lastLine !== firstLine)) {
         metadata.last_mes = lastRecord.send_date || stats.mtimeMs;
         metadata.mes = typeof lastRecord.mes === 'string' && lastRecord.mes
-            ? lastRecord.mes
+            ? lastRecord.mes.slice(0, MAX_METADATA_PREVIEW_CHARS)
             : '[The message is empty]';
     }
 
@@ -515,6 +516,8 @@ export class ArchiveReadTokenService {
 export class ArchiveInventoryService {
     static INVENTORIES = new Map();
 
+    static CREATION_LOCKS = new Map();
+
     static cleanup(now = Date.now()) {
         for (const [cursor, entry] of this.INVENTORIES) {
             if (entry.expiresAt <= now) {
@@ -527,31 +530,45 @@ export class ArchiveInventoryService {
     }
 
     static async create(handle, directories, scope, signal) {
-        this.cleanup();
-        const userInventories = [...this.INVENTORIES]
-            .filter(([, entry]) => entry.handle === handle)
-            .map(([cursor]) => cursor);
-        while (userInventories.length >= MAX_ARCHIVE_SESSIONS_PER_USER) {
-            this.discard(userInventories.shift(), handle);
-        }
-        const canonicalRoot = await fs.promises.realpath(directories.root);
-        const descriptors = await collectArchiveDescriptors(directories, scope, signal);
-        throwIfAborted(signal);
-        const cursor = crypto.randomBytes(32).toString('hex');
-        const readToken = scope === 'orphans'
-            ? ArchiveReadTokenService.create(handle, canonicalRoot, descriptors)
-            : null;
-        this.INVENTORIES.set(cursor, {
-            handle,
-            scope,
-            descriptors,
-            offset: 0,
-            readToken,
-            root: canonicalRoot,
-            busy: false,
-            expiresAt: Date.now() + INVENTORY_TTL_MS,
+        const previous = this.CREATION_LOCKS.get(handle) ?? Promise.resolve();
+        let release;
+        const current = new Promise(resolve => {
+            release = resolve;
         });
-        return cursor;
+        this.CREATION_LOCKS.set(handle, current);
+        await previous;
+        try {
+            this.cleanup();
+            const userInventories = [...this.INVENTORIES]
+                .filter(([, entry]) => entry.handle === handle)
+                .map(([cursor]) => cursor);
+            while (userInventories.length >= MAX_ARCHIVE_SESSIONS_PER_USER) {
+                this.discard(userInventories.shift(), handle);
+            }
+            const canonicalRoot = await fs.promises.realpath(directories.root);
+            const descriptors = await collectArchiveDescriptors(directories, scope, signal);
+            throwIfAborted(signal);
+            const cursor = crypto.randomBytes(32).toString('hex');
+            const readToken = scope === 'orphans'
+                ? ArchiveReadTokenService.create(handle, canonicalRoot, descriptors)
+                : null;
+            this.INVENTORIES.set(cursor, {
+                handle,
+                scope,
+                descriptors,
+                offset: 0,
+                readToken,
+                root: canonicalRoot,
+                busy: false,
+                expiresAt: Date.now() + INVENTORY_TTL_MS,
+            });
+            return cursor;
+        } finally {
+            release();
+            if (this.CREATION_LOCKS.get(handle) === current) {
+                this.CREATION_LOCKS.delete(handle);
+            }
+        }
     }
 
     static get(cursor, handle) {

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -304,6 +304,10 @@ export class DataMaidService {
             });
             const files = await fs.promises.readdir(this.directories.files, { withFileTypes: true });
             for (const file of files) {
+                // SillyBunny: Chat Archive organization metadata is app state, not a loose upload.
+                if (file.name === '_sbca_organization.json') {
+                    continue;
+                }
                 const filePath = path.join(this.directories.files, file.name);
                 if (file.isFile() && !knownFileFullPaths.has(filePath)) {
                     result.push(filePath);

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -27,6 +27,8 @@ const CORE_EXTENSIONS = new Set([
     'vectors',
     'in-chat-agents',
     'sillybunny-debugger',
+    // SillyBunny: ship Chats Archive as a built-in core extension.
+    'sillybunny-chats-archive',
 ]);
 const BUNDLED_THIRD_PARTY_EXTENSIONS = new Set([
     'bunnypresettools',

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -27,6 +27,8 @@ import { router as assetsRouter } from './endpoints/assets.js';
 import { router as filesRouter } from './endpoints/files.js';
 import { router as charactersRouter } from './endpoints/characters.js';
 import { router as chatsRouter } from './endpoints/chats.js';
+// SillyBunny divergence: keep archive inventory and read-only orphan access isolated from upstream chat and Data Maid routes.
+import { router as chatArchiveRouter } from './endpoints/chat-archive.js';
 import { router as groupsRouter } from './endpoints/groups.js';
 import { router as worldInfoRouter } from './endpoints/worldinfo.js';
 import { router as statsRouter } from './endpoints/stats.js';
@@ -93,6 +95,7 @@ export function setupPrivateEndpoints(app) {
     app.use('/api/assets', assetsRouter);
     app.use('/api/files', filesRouter);
     app.use('/api/characters', charactersRouter);
+    app.use('/api/chats/archive', chatArchiveRouter);
     app.use('/api/chats', chatsRouter);
     app.use('/api/groups', groupsRouter);
     app.use('/api/worldinfo', worldInfoRouter);

--- a/tests/chat-archive-endpoint.test.js
+++ b/tests/chat-archive-endpoint.test.js
@@ -90,6 +90,7 @@ describe('Chat Archive endpoint', () => {
             fs.mkdirSync(directory, { recursive: true });
         }
         ArchiveInventoryService.INVENTORIES.clear();
+        ArchiveInventoryService.CREATION_LOCKS.clear();
         ArchiveMetadataCache.ENTRIES.clear();
         ArchiveReadTokenService.TOKENS.clear();
         DataMaidService.TOKENS.clear();
@@ -99,6 +100,7 @@ describe('Chat Archive endpoint', () => {
     afterEach(() => {
         jest.restoreAllMocks();
         ArchiveInventoryService.INVENTORIES.clear();
+        ArchiveInventoryService.CREATION_LOCKS.clear();
         ArchiveMetadataCache.ENTRIES.clear();
         ArchiveReadTokenService.TOKENS.clear();
         DataMaidService.TOKENS.clear();
@@ -169,6 +171,33 @@ describe('Chat Archive endpoint', () => {
             mes: 'last preview',
         });
         expect(readFileSpy).not.toHaveBeenCalled();
+    });
+
+    test('bounds cached last-message previews', async () => {
+        const filePath = path.join(directories.chats, 'large-preview.jsonl');
+        const preview = 'x'.repeat(4096);
+        fs.writeFileSync(filePath, [
+            JSON.stringify({ chat_metadata: { complete: true } }),
+            JSON.stringify({ mes: preview, send_date: '2026-02-04T04:05:06.000Z' }),
+        ].join('\n'));
+
+        const metadata = await readArchiveChatMetadata(filePath);
+
+        expect(metadata.mes).toHaveLength(512);
+    });
+
+    test('serializes concurrent inventory creation before enforcing per-user limits', async () => {
+        for (let index = 0; index < 8; index++) {
+            await ArchiveInventoryService.create('alice', directories, 'archive');
+        }
+
+        await Promise.all([
+            ArchiveInventoryService.create('alice', directories, 'archive'),
+            ArchiveInventoryService.create('alice', directories, 'archive'),
+        ]);
+
+        expect([...ArchiveInventoryService.INVENTORIES.values()]
+            .filter(entry => entry.handle === 'alice')).toHaveLength(8);
     });
 
     test('rejects an opened file handle that does not match the validated in-root path', async () => {

--- a/tests/chat-archive-endpoint.test.js
+++ b/tests/chat-archive-endpoint.test.js
@@ -12,6 +12,7 @@ setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
 
 const {
     ArchiveInventoryService,
+    ArchiveMetadataCache,
     ArchiveReadTokenService,
     MAX_ARCHIVE_PAGE_SIZE,
     readArchiveChatMetadata,
@@ -89,6 +90,7 @@ describe('Chat Archive endpoint', () => {
             fs.mkdirSync(directory, { recursive: true });
         }
         ArchiveInventoryService.INVENTORIES.clear();
+        ArchiveMetadataCache.ENTRIES.clear();
         ArchiveReadTokenService.TOKENS.clear();
         DataMaidService.TOKENS.clear();
         createArchiveFixtures();
@@ -97,6 +99,7 @@ describe('Chat Archive endpoint', () => {
     afterEach(() => {
         jest.restoreAllMocks();
         ArchiveInventoryService.INVENTORIES.clear();
+        ArchiveMetadataCache.ENTRIES.clear();
         ArchiveReadTokenService.TOKENS.clear();
         DataMaidService.TOKENS.clear();
         fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -125,6 +128,7 @@ describe('Chat Archive endpoint', () => {
 
         expect(pages).toHaveLength(2);
         expect(pages.every(page => page.rows.length <= 2)).toBe(true);
+        expect(pages.every(page => page.total === 4)).toBe(true);
         expect(rows.map(row => [row.avatar, row.group, row.orphan_type, row.file_name])).toEqual([
             ['Alice.png', undefined, undefined, 'a-first.jsonl'],
             ['Alice.png', undefined, undefined, 'a-second.jsonl'],
@@ -165,6 +169,134 @@ describe('Chat Archive endpoint', () => {
             mes: 'last preview',
         });
         expect(readFileSpy).not.toHaveBeenCalled();
+    });
+
+    test('rejects an opened file handle that does not match the validated in-root path', async () => {
+        const inRootPath = path.join(directories.chats, 'root-chat.jsonl');
+        const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-chat-archive-race-'));
+        const outsidePath = path.join(outsideRoot, 'outside.jsonl');
+        fs.writeFileSync(outsidePath, jsonl('outside replacement', 4));
+        const originalOpen = fs.promises.open.bind(fs.promises);
+        jest.spyOn(fs.promises, 'open').mockImplementation((filePath, flags, mode) => (
+            path.resolve(filePath) === path.resolve(inRootPath)
+                ? originalOpen(outsidePath, flags, mode)
+                : originalOpen(filePath, flags, mode)
+        ));
+
+        try {
+            await expect(readArchiveChatMetadata(inRootPath, undefined, directories.root)).rejects.toMatchObject({
+                code: 'ARCHIVE_PATH_FORBIDDEN',
+            });
+        } finally {
+            fs.rmSync(outsideRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('rejects an opened identity mismatch when procfs descriptor paths are unavailable', async () => {
+        const inRootPath = path.join(directories.chats, 'root-chat.jsonl');
+        const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-chat-archive-fallback-'));
+        const outsidePath = path.join(outsideRoot, 'outside.jsonl');
+        fs.writeFileSync(outsidePath, jsonl('fallback replacement', 3));
+        const originalOpen = fs.promises.open.bind(fs.promises);
+        const originalRealpath = fs.promises.realpath.bind(fs.promises);
+        jest.spyOn(fs.promises, 'open').mockImplementation((filePath, flags, mode) => (
+            path.resolve(filePath) === path.resolve(inRootPath)
+                ? originalOpen(outsidePath, flags, mode)
+                : originalOpen(filePath, flags, mode)
+        ));
+        jest.spyOn(fs.promises, 'realpath').mockImplementation(filePath => {
+            if (path.resolve(filePath) === path.resolve('/proc/self/fd')) {
+                return Promise.reject(Object.assign(new Error('procfs unavailable'), { code: 'ENOENT' }));
+            }
+            return originalRealpath(filePath);
+        });
+
+        try {
+            await expect(readArchiveChatMetadata(inRootPath, undefined, directories.root)).rejects.toMatchObject({
+                code: 'ARCHIVE_PATH_FORBIDDEN',
+            });
+        } finally {
+            fs.rmSync(outsideRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('rejects symlinks that resolve outside the canonical archive root', async () => {
+        const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-chat-archive-symlink-'));
+        const outsidePath = path.join(outsideRoot, 'outside.jsonl');
+        const linkedPath = path.join(directories.chats, 'outside-link.jsonl');
+        fs.writeFileSync(outsidePath, jsonl('outside symlink', 1));
+        fs.symlinkSync(outsidePath, linkedPath);
+
+        try {
+            await expect(readArchiveChatMetadata(linkedPath, undefined, directories.root)).rejects.toMatchObject({
+                code: 'ARCHIVE_PATH_FORBIDDEN',
+            });
+        } finally {
+            fs.rmSync(outsideRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('reuses unchanged metadata on refresh and rereads files whose metadata changed', async () => {
+        const probe = await fs.promises.open(path.join(directories.chats, 'root-chat.jsonl'), 'r');
+        const fileHandlePrototype = Object.getPrototypeOf(probe);
+        await probe.close();
+        const readSpy = jest.spyOn(fileHandlePrototype, 'read');
+
+        const firstRows = (await collectInventory('archive', MAX_ARCHIVE_PAGE_SIZE)).flatMap(page => page.rows);
+        const readsAfterFirstRefresh = readSpy.mock.calls.length;
+        const secondRows = (await collectInventory('archive', MAX_ARCHIVE_PAGE_SIZE)).flatMap(page => page.rows);
+
+        expect(readsAfterFirstRefresh).toBeGreaterThan(0);
+        expect(readSpy).toHaveBeenCalledTimes(readsAfterFirstRefresh);
+        expect(secondRows).toEqual(firstRows);
+
+        const rootChatPath = path.join(directories.chats, 'root-chat.jsonl');
+        fs.writeFileSync(rootChatPath, jsonl('root changed', 4));
+        const changedTime = new Date(Date.now() + 2_000);
+        fs.utimesSync(rootChatPath, changedTime, changedTime);
+
+        const changedRows = (await collectInventory('archive', MAX_ARCHIVE_PAGE_SIZE)).flatMap(page => page.rows);
+        const changedRoot = changedRows.find(row => row.file_name === 'root-chat.jsonl');
+        expect(readSpy.mock.calls.length).toBeGreaterThan(readsAfterFirstRefresh);
+        expect(changedRoot).toMatchObject({
+            chat_items: 4,
+            chat_metadata: { label: 'root changed' },
+            mes: 'root changed message 3',
+        });
+    });
+
+    test('rereads metadata when a path is replaced with the same size and mtime', async () => {
+        const filePath = path.join(directories.chats, 'cached-replacement.jsonl');
+        const replacementPath = path.join(directories.chats, 'cached-replacement.next.jsonl');
+        const originalContents = jsonl('original', 2);
+        const replacementContents = jsonl('replaced', 2);
+        const fixedTime = new Date('2026-03-04T05:06:07.000Z');
+        expect(Buffer.byteLength(replacementContents)).toBe(Buffer.byteLength(originalContents));
+        fs.writeFileSync(filePath, originalContents);
+        fs.utimesSync(filePath, fixedTime, fixedTime);
+
+        const originalStats = fs.statSync(filePath, { bigint: true });
+        const originalMetadata = await readArchiveChatMetadata(filePath);
+
+        fs.writeFileSync(replacementPath, replacementContents);
+        fs.utimesSync(replacementPath, fixedTime, fixedTime);
+        fs.renameSync(replacementPath, filePath);
+        const replacementStats = fs.statSync(filePath, { bigint: true });
+        expect(replacementStats.size).toBe(originalStats.size);
+        expect(replacementStats.mtimeMs).toBe(originalStats.mtimeMs);
+        expect(replacementStats.dev).toBe(originalStats.dev);
+        expect(replacementStats.ino).not.toBe(originalStats.ino);
+
+        const replacementMetadata = await readArchiveChatMetadata(filePath);
+
+        expect(originalMetadata).toMatchObject({
+            chat_metadata: { label: 'original' },
+            mes: 'original message 1',
+        });
+        expect(replacementMetadata).toMatchObject({
+            chat_metadata: { label: 'replaced' },
+            mes: 'replaced message 1',
+        });
     });
 
     test('returns deterministic bounded pages for twenty thousand descriptors', async () => {
@@ -217,6 +349,49 @@ describe('Chat Archive endpoint', () => {
         expect(rows.at(-1).file_name).toBe('chat-19999.jsonl');
         expect(rows.map(row => row.file_name)).toEqual([...rows.map(row => row.file_name)].sort());
         expect(ArchiveInventoryService.INVENTORIES.has(cursor)).toBe(false);
+    });
+
+    test('limits metadata reads to eight concurrent files', async () => {
+        const cursor = 'c'.repeat(64);
+        const descriptors = Array.from({ length: 24 }, (_, index) => ({
+            avatar: 'Concurrency.png',
+            chatFolder: 'Concurrency',
+            fileName: `${String(index).padStart(2, '0')}.jsonl`,
+            filePath: `/virtual/${index}.jsonl`,
+            orphanType: null,
+        }));
+        ArchiveInventoryService.INVENTORIES.set(cursor, {
+            handle: 'concurrency-user',
+            scope: 'archive',
+            descriptors,
+            offset: 0,
+            readToken: null,
+            root: directories.root,
+            busy: false,
+            expiresAt: Date.now() + 60_000,
+        });
+        let active = 0;
+        let maxActive = 0;
+        const metadataReader = async () => {
+            active++;
+            maxActive = Math.max(maxActive, active);
+            await new Promise(resolve => setImmediate(resolve));
+            active--;
+            return { file_size: '1 B', chat_items: 0, last_mes: 0, mes: '' };
+        };
+
+        const page = await ArchiveInventoryService.page(
+            cursor,
+            'concurrency-user',
+            MAX_ARCHIVE_PAGE_SIZE,
+            undefined,
+            undefined,
+            metadataReader,
+        );
+
+        expect(page.rows).toHaveLength(descriptors.length);
+        expect(page.total).toBe(descriptors.length);
+        expect(maxActive).toBe(8);
     });
 
     test('aborted pages do not advance their cursor offset', async () => {

--- a/tests/chat-archive-endpoint.test.js
+++ b/tests/chat-archive-endpoint.test.js
@@ -1,0 +1,404 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
+
+const {
+    ArchiveInventoryService,
+    ArchiveReadTokenService,
+    MAX_ARCHIVE_PAGE_SIZE,
+    readArchiveChatMetadata,
+    router: archiveRouter,
+} = await import('../src/endpoints/chat-archive.js');
+const { DataMaidService, router: dataMaidRouter } = await import('../src/endpoints/data-maid.js');
+
+const jsonl = (label, messages = 2) => [
+    JSON.stringify({ chat_metadata: { label }, user_name: 'User', character_name: 'Character' }),
+    ...Array.from({ length: messages }, (_, index) => JSON.stringify({
+        name: index % 2 ? 'Character' : 'User',
+        is_user: index % 2 === 0,
+        mes: `${label} message ${index}`,
+        send_date: `2026-01-${String(index + 1).padStart(2, '0')}T00:00:00.000Z`,
+    })),
+].join('\n');
+
+function createAbortingMetadataReader(controller, abortAt) {
+    let reads = 0;
+    return async () => {
+        reads++;
+        if (reads === abortAt) {
+            controller.abort();
+        }
+        return { file_size: '1 B', chat_items: 0, last_mes: 0, mes: '' };
+    };
+}
+
+describe('Chat Archive endpoint', () => {
+    let baseUrl;
+    let directories;
+    let server;
+    let tempRoot;
+
+    beforeAll(async () => {
+        const app = express();
+        app.use(express.json());
+        app.use((request, _response, next) => {
+            if (request.get('x-test-no-user') === 'true') {
+                return next();
+            }
+            request.user = {
+                profile: { handle: request.get('x-test-user') || 'alice' },
+                directories,
+            };
+            next();
+        });
+        app.use('/api/chats/archive', archiveRouter);
+        app.use('/api/data-maid', dataMaidRouter);
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-chat-archive-endpoint-'));
+        directories = {
+            root: tempRoot,
+            avatars: path.join(tempRoot, 'avatars'),
+            backups: path.join(tempRoot, 'backups'),
+            backgrounds: path.join(tempRoot, 'backgrounds'),
+            characters: path.join(tempRoot, 'characters'),
+            chats: path.join(tempRoot, 'chats'),
+            files: path.join(tempRoot, 'files'),
+            groupChats: path.join(tempRoot, 'group-chats'),
+            groups: path.join(tempRoot, 'groups'),
+            thumbnailsAvatar: path.join(tempRoot, 'thumbnails-avatar'),
+            thumbnailsBg: path.join(tempRoot, 'thumbnails-bg'),
+            thumbnailsBgMobile: path.join(tempRoot, 'thumbnails-bg-mobile'),
+            thumbnailsPersona: path.join(tempRoot, 'thumbnails-persona'),
+            userImages: path.join(tempRoot, 'user-images'),
+        };
+        for (const directory of Object.values(directories)) {
+            fs.mkdirSync(directory, { recursive: true });
+        }
+        ArchiveInventoryService.INVENTORIES.clear();
+        ArchiveReadTokenService.TOKENS.clear();
+        DataMaidService.TOKENS.clear();
+        createArchiveFixtures();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        ArchiveInventoryService.INVENTORIES.clear();
+        ArchiveReadTokenService.TOKENS.clear();
+        DataMaidService.TOKENS.clear();
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    afterAll(async () => {
+        if (server) {
+            await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        }
+    });
+
+    test('paginates complete linked character, group, and root metadata without mutating chats', async () => {
+        const chatPaths = [
+            path.join(directories.chats, 'Alice', 'a-first.jsonl'),
+            path.join(directories.chats, 'Alice', 'a-second.jsonl'),
+            path.join(directories.chats, 'root-chat.jsonl'),
+            path.join(directories.groupChats, 'group-chat.jsonl'),
+        ];
+        const before = new Map(chatPaths.map(filePath => [filePath, {
+            contents: fs.readFileSync(filePath),
+            mtimeMs: fs.statSync(filePath).mtimeMs,
+        }]));
+
+        const pages = await collectInventory('archive', 2);
+        const rows = pages.flatMap(page => page.rows);
+
+        expect(pages).toHaveLength(2);
+        expect(pages.every(page => page.rows.length <= 2)).toBe(true);
+        expect(rows.map(row => [row.avatar, row.group, row.orphan_type, row.file_name])).toEqual([
+            ['Alice.png', undefined, undefined, 'a-first.jsonl'],
+            ['Alice.png', undefined, undefined, 'a-second.jsonl'],
+            [undefined, undefined, 'root', 'root-chat.jsonl'],
+            [undefined, 'group-one', undefined, 'group-chat.jsonl'],
+        ]);
+        expect(rows.map(row => row.chat_items)).toEqual([2, 3, 1, 2]);
+        expect(rows.map(row => row.chat_metadata.label)).toEqual(['alice-first', 'alice-second', 'root', 'group-linked']);
+        expect(rows.map(row => row.mes)).toEqual([
+            'alice-first message 1',
+            'alice-second message 2',
+            'root message 0',
+            'group-linked message 1',
+        ]);
+        expect(pages.at(-1).cursor).toBeNull();
+        expect(pages.every(page => page.read_token === null)).toBe(true);
+        for (const [filePath, snapshot] of before) {
+            expect(fs.readFileSync(filePath).equals(snapshot.contents)).toBe(true);
+            expect(fs.statSync(filePath).mtimeMs).toBe(snapshot.mtimeMs);
+        }
+    });
+
+    test('reads only streamed line metadata and tolerates an unparsed middle record', async () => {
+        const filePath = path.join(directories.chats, 'streamed.jsonl');
+        fs.writeFileSync(filePath, [
+            JSON.stringify({ chat_metadata: { complete: true } }),
+            '{ this intermediary record is intentionally not parsed',
+            JSON.stringify({ mes: 'last preview', send_date: '2026-02-03T04:05:06.000Z' }),
+        ].join('\n'));
+        const readFileSpy = jest.spyOn(fs.promises, 'readFile');
+
+        const metadata = await readArchiveChatMetadata(filePath);
+
+        expect(metadata).toMatchObject({
+            chat_items: 2,
+            chat_metadata: { complete: true },
+            last_mes: '2026-02-03T04:05:06.000Z',
+            mes: 'last preview',
+        });
+        expect(readFileSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns deterministic bounded pages for twenty thousand descriptors', async () => {
+        const cursor = 'a'.repeat(64);
+        const descriptors = Array.from({ length: 20_000 }, (_, index) => ({
+            avatar: 'Scale.png',
+            chatFolder: 'Scale',
+            fileName: `chat-${String(index).padStart(5, '0')}.jsonl`,
+            filePath: `/virtual/chat-${String(index).padStart(5, '0')}.jsonl`,
+            orphanType: null,
+        }));
+        ArchiveInventoryService.INVENTORIES.set(cursor, {
+            handle: 'scale-user',
+            scope: 'archive',
+            descriptors,
+            offset: 0,
+            readToken: null,
+            busy: false,
+            expiresAt: Date.now() + 60_000,
+        });
+        const metadataReader = async filePath => ({
+            file_size: '1 KB',
+            chat_items: Number(path.basename(filePath).match(/\d+/)[0]),
+            last_mes: 1,
+            mes: '',
+        });
+        const rows = [];
+        const pageSizes = [];
+        let nextCursor = cursor;
+
+        while (nextCursor) {
+            const page = await ArchiveInventoryService.page(
+                nextCursor,
+                'scale-user',
+                MAX_ARCHIVE_PAGE_SIZE,
+                undefined,
+                undefined,
+                metadataReader,
+            );
+            expect(page.status).toBe('ok');
+            rows.push(...page.rows);
+            pageSizes.push(page.rows.length);
+            nextCursor = page.cursor;
+        }
+
+        expect(pageSizes).toHaveLength(40);
+        expect(new Set(pageSizes)).toEqual(new Set([MAX_ARCHIVE_PAGE_SIZE]));
+        expect(rows).toHaveLength(20_000);
+        expect(rows[0].file_name).toBe('chat-00000.jsonl');
+        expect(rows.at(-1).file_name).toBe('chat-19999.jsonl');
+        expect(rows.map(row => row.file_name)).toEqual([...rows.map(row => row.file_name)].sort());
+        expect(ArchiveInventoryService.INVENTORIES.has(cursor)).toBe(false);
+    });
+
+    test('aborted pages do not advance their cursor offset', async () => {
+        const cursor = 'b'.repeat(64);
+        const descriptors = Array.from({ length: 20 }, (_, index) => ({
+            avatar: 'Abort.png',
+            chatFolder: 'Abort',
+            fileName: `${String(index).padStart(2, '0')}.jsonl`,
+            filePath: `/virtual/${index}.jsonl`,
+            orphanType: null,
+        }));
+        const inventory = {
+            handle: 'abort-user',
+            scope: 'archive',
+            descriptors,
+            offset: 0,
+            readToken: null,
+            busy: false,
+            expiresAt: Date.now() + 60_000,
+        };
+        ArchiveInventoryService.INVENTORIES.set(cursor, inventory);
+        const controller = new AbortController();
+        const abortingReader = createAbortingMetadataReader(controller, 5);
+
+        await expect(ArchiveInventoryService.page(
+            cursor,
+            'abort-user',
+            10,
+            controller.signal,
+            undefined,
+            abortingReader,
+        )).rejects.toMatchObject({ name: 'AbortError' });
+        expect(inventory.offset).toBe(0);
+        expect(inventory.busy).toBe(false);
+
+        const retried = await ArchiveInventoryService.page(
+            cursor,
+            'abort-user',
+            10,
+            undefined,
+            undefined,
+            async () => ({ file_size: '1 B', chat_items: 0, last_mes: 0, mes: '' }),
+        );
+        expect(retried.rows.map(row => row.file_name)).toEqual(descriptors.slice(0, 10).map(row => row.fileName));
+        expect(inventory.offset).toBe(10);
+    });
+
+    test('validates pagination boundaries, cursor ownership, scope, and read paths', async () => {
+        expect((await fetch(`${baseUrl}/api/chats/archive/inventory`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'x-test-no-user': 'true' },
+            body: JSON.stringify({ scope: 'archive', page_size: 1 }),
+        })).status).toBe(403);
+        expect((await fetch(`${baseUrl}/api/chats/archive/view?token=${'a'.repeat(64)}&hash=${'b'.repeat(64)}`, {
+            headers: { 'x-test-no-user': 'true' },
+        })).status).toBe(403);
+        for (const pageSize of [0, MAX_ARCHIVE_PAGE_SIZE + 1, '2']) {
+            expect((await postJson('/api/chats/archive/inventory', { scope: 'archive', page_size: pageSize })).status).toBe(400);
+        }
+        expect((await postJson('/api/chats/archive/inventory', { scope: 'invalid', page_size: 1 })).status).toBe(400);
+        expect((await postJson('/api/chats/archive/inventory', { cursor: '../escape', page_size: 1 })).status).toBe(400);
+
+        const first = await postJson('/api/chats/archive/inventory', { scope: 'archive', page_size: 1 });
+        const firstPage = await first.json();
+        expect(first.status).toBe(200);
+        expect(firstPage.cursor).toMatch(/^[a-f0-9]{64}$/);
+        expect((await postJson('/api/chats/archive/inventory', {
+            cursor: firstPage.cursor,
+            scope: 'archive',
+            page_size: 1,
+        }, 'bob')).status).toBe(403);
+        expect((await postJson('/api/chats/archive/inventory', {
+            cursor: firstPage.cursor,
+            scope: 'orphans',
+            page_size: 1,
+        })).status).toBe(400);
+        expect((await postJson('/api/chats/archive/release', { cursor: firstPage.cursor }, 'bob')).status).toBe(403);
+        expect(ArchiveInventoryService.INVENTORIES.has(firstPage.cursor)).toBe(true);
+        expect((await postJson('/api/chats/archive/release', { cursor: firstPage.cursor })).status).toBe(204);
+        expect(ArchiveInventoryService.INVENTORIES.has(firstPage.cursor)).toBe(false);
+
+        const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-chat-archive-outside-'));
+        try {
+            const outsidePath = path.join(outsideRoot, 'outside.jsonl');
+            fs.writeFileSync(outsidePath, jsonl('outside', 1));
+            const descriptor = { filePath: outsidePath };
+            const token = ArchiveReadTokenService.create('alice', directories.root, [descriptor]);
+            expect((await get(`/api/chats/archive/view?token=${token}&hash=${descriptor.hash}`)).status).toBe(403);
+
+            const linkedPath = path.join(directories.chats, 'outside-link.jsonl');
+            fs.symlinkSync(outsidePath, linkedPath);
+            const linkedDescriptor = { filePath: linkedPath };
+            const linkedToken = ArchiveReadTokenService.create('alice', directories.root, [linkedDescriptor]);
+            expect((await get(`/api/chats/archive/view?token=${linkedToken}&hash=${linkedDescriptor.hash}`)).status).toBe(403);
+        } finally {
+            fs.rmSync(outsideRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('keeps archive read sessions independent from overlapping Data Maid sessions and authorization', async () => {
+        const firstArchivePages = await collectInventory('orphans', 1);
+        expect(new Set(firstArchivePages.map(page => page.read_token))).toHaveProperty('size', 1);
+        const firstArchive = firstArchivePages.at(-1);
+        const firstToken = firstArchive.read_token;
+        const firstRow = firstArchive.rows[0];
+        expect(firstToken).toMatch(/^[a-f0-9]{64}$/);
+
+        const dataMaidResponse = await postJson('/api/data-maid/report', {});
+        const dataMaid = await dataMaidResponse.json();
+        expect(dataMaidResponse.status).toBe(200);
+        expect(dataMaid.token).toMatch(/^[a-f0-9]{64}$/);
+        expect(dataMaid.token).not.toBe(firstToken);
+        expect((await postJson('/api/chats/archive/release', { token: dataMaid.token })).status).toBe(403);
+        expect(DataMaidService.TOKENS.has(dataMaid.token)).toBe(true);
+        expect((await get(`/api/chats/archive/view?token=${firstToken}&hash=${firstRow.archive_hash}`)).status).toBe(200);
+
+        const secondArchive = (await collectInventory('orphans', 500)).at(-1);
+        const secondToken = secondArchive.read_token;
+        expect(secondToken).not.toBe(firstToken);
+        expect((await get(`/api/chats/archive/view?token=${firstToken}&hash=${firstRow.archive_hash}`)).status).toBe(200);
+        expect((await postJson('/api/data-maid/delete', { token: firstToken, hashes: ['not-authorized'] })).status).toBe(403);
+        expect((await postJson('/api/data-maid/finalize', { token: secondToken })).status).toBe(403);
+        expect((await get(`/api/chats/archive/view?token=${dataMaid.token}&hash=${firstRow.archive_hash}`)).status).toBe(403);
+        expect((await get(`/api/chats/archive/view?token=${firstToken}&hash=${'f'.repeat(64)}`)).status).toBe(404);
+        expect((await get(`/api/chats/archive/view?token=${firstToken}&hash=../escape`)).status).toBe(400);
+        expect((await get(`/api/chats/archive/view?token=${firstToken}&hash=${firstRow.archive_hash}`, 'bob')).status).toBe(403);
+
+        expect((await postJson('/api/chats/archive/release', { token: firstToken })).status).toBe(204);
+        expect((await get(`/api/chats/archive/view?token=${firstToken}&hash=${firstRow.archive_hash}`)).status).toBe(403);
+        const secondRow = secondArchive.rows[0];
+        expect((await get(`/api/chats/archive/view?token=${secondToken}&hash=${secondRow.archive_hash}`)).status).toBe(200);
+        expect((await postJson('/api/data-maid/finalize', { token: dataMaid.token })).status).toBe(204);
+        expect(fs.existsSync(path.join(directories.chats, 'Deleted', 'missing-chat.jsonl'))).toBe(true);
+    });
+
+    function createArchiveFixtures() {
+        fs.writeFileSync(path.join(directories.characters, 'Alice.png'), 'card');
+        fs.mkdirSync(path.join(directories.chats, 'Alice'));
+        fs.mkdirSync(path.join(directories.chats, 'Deleted'));
+        fs.writeFileSync(path.join(directories.chats, 'Alice', 'a-first.jsonl'), jsonl('alice-first', 2));
+        fs.writeFileSync(path.join(directories.chats, 'Alice', 'a-second.jsonl'), jsonl('alice-second', 3));
+        fs.writeFileSync(path.join(directories.chats, 'Deleted', 'missing-chat.jsonl'), jsonl('missing-character', 2));
+        fs.writeFileSync(path.join(directories.chats, 'root-chat.jsonl'), jsonl('root', 1));
+        fs.writeFileSync(path.join(directories.groups, 'group-one.json'), JSON.stringify({
+            id: 'group-one',
+            name: 'Group One',
+            chat_id: 'group-chat',
+            chats: ['group-chat'],
+        }));
+        fs.writeFileSync(path.join(directories.groupChats, 'group-chat.jsonl'), jsonl('group-linked', 2));
+        fs.writeFileSync(path.join(directories.groupChats, 'unlinked-group.jsonl'), jsonl('group-unlinked', 1));
+    }
+
+    async function collectInventory(scope, pageSize) {
+        const pages = [];
+        let cursor;
+        do {
+            const response = await postJson('/api/chats/archive/inventory', {
+                scope,
+                page_size: pageSize,
+                ...(cursor ? { cursor } : {}),
+            });
+            expect(response.status).toBe(200);
+            const page = await response.json();
+            pages.push(page);
+            cursor = page.cursor;
+        } while (cursor);
+        return pages;
+    }
+
+    function postJson(url, body, user = 'alice') {
+        return fetch(`${baseUrl}${url}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-test-user': user,
+            },
+            body: JSON.stringify(body),
+        });
+    }
+
+    function get(url, user = 'alice') {
+        return fetch(`${baseUrl}${url}`, { headers: { 'x-test-user': user } });
+    }
+});

--- a/tests/sillybunny-chats-archive.e2e.js
+++ b/tests/sillybunny-chats-archive.e2e.js
@@ -24,6 +24,7 @@ const FIRST_READ_TOKEN = 'c'.repeat(64);
 const SECOND_READ_TOKEN = 'd'.repeat(64);
 const FIRST_ORPHAN_HASH = 'e'.repeat(64);
 const SECOND_ORPHAN_HASH = 'f'.repeat(64);
+const SEARCH_CONTENT_DEBOUNCE_MS = 600;
 
 test.describe.configure({ mode: 'serial' });
 test.use({
@@ -38,7 +39,7 @@ test.beforeAll(async () => {
             const url = new URL(request.url, 'http://127.0.0.1');
             if (url.pathname === '/') {
                 response.setHeader('Content-Type', 'text/html; charset=utf-8');
-                response.end(fixtureHtml(url.searchParams.has('long')));
+                response.end(fixtureHtml(url.searchParams.has('long'), url.searchParams.has('duplicate-characters')));
                 return;
             }
             const asset = url.pathname.startsWith('/extension/')
@@ -120,6 +121,85 @@ test('owns the popup frame spacing and keeps mobile controls inside the viewport
     ], null, null, 1)));
 
     await openArchive(page);
+    await expect(page.locator('.sbca-saved-view')).toBeHidden();
+    const filters = page.locator('.sbca-filter-toggle');
+    const filterPanel = page.locator('.sbca-options-panel');
+    await expect(filters).toBeVisible();
+    await expect(filters).toHaveAttribute('aria-expanded', 'false');
+    await expect(filterPanel).toBeHidden();
+    const filterTarget = await filters.evaluate(control => {
+        const rect = control.getBoundingClientRect();
+        return { height: rect.height, width: rect.width };
+    });
+    expect(filterTarget.height).toBeGreaterThanOrEqual(44);
+    expect(filterTarget.width).toBeGreaterThanOrEqual(44);
+    const viewTargets = await page.locator('.sbca-view-setting select:visible').evaluateAll(selects => selects.map(select => {
+        const rect = select.getBoundingClientRect();
+        return { height: rect.height, width: rect.width };
+    }));
+    expect(viewTargets.length).toBeGreaterThan(0);
+    for (const target of viewTargets) {
+        expect(target.height).toBeGreaterThanOrEqual(44);
+        expect(target.width).toBeGreaterThanOrEqual(44);
+    }
+    await filters.click();
+    await expect(filters).toHaveAttribute('aria-expanded', 'true');
+    await expect(filterPanel).toBeVisible();
+    const mobileControls = await page.locator('.sbca-root').evaluate(root => {
+        const browse = root.querySelector('.sbca-browse-strip');
+        const viewSettings = [...browse.querySelectorAll('.sbca-view-setting:not([hidden])')];
+        const viewRects = viewSettings.map(setting => setting.getBoundingClientRect());
+        const kinds = root.querySelector('.sbca-kinds');
+        const kindRects = [...kinds.querySelectorAll('.sbca-kind-pill')].map(pill => pill.getBoundingClientRect());
+        const refresh = root.querySelector('.sbca-archive-actions > .sbca-control');
+        const filters = root.querySelector('.sbca-filter-toggle');
+        const options = root.querySelector('.sbca-options-panel');
+        const secondary = root.querySelector('.sbca-archive-secondary-actions');
+        const orphanActions = root.querySelector('.sbca-orphan-actions');
+        const orphanFilter = orphanActions.querySelector('.sbca-orphan-filter');
+        const orphanSelect = orphanFilter.querySelector('select');
+        const orphanScan = orphanActions.querySelector('.sbca-control');
+        const organizationToggle = root.querySelector('.sbca-organization-toggle');
+        const browseStyle = getComputedStyle(browse);
+        const secondaryStyle = getComputedStyle(secondary);
+        const orphanActionsRect = orphanActions.getBoundingClientRect();
+        const orphanFilterRect = orphanFilter.getBoundingClientRect();
+        const orphanSelectRect = orphanSelect.getBoundingClientRect();
+        const orphanScanRect = orphanScan.getBoundingClientRect();
+        const organizationRect = organizationToggle.getBoundingClientRect();
+        return {
+            browseGap: viewRects[1].left - viewRects[0].right,
+            browseSeparatedFromRefresh: browse.getBoundingClientRect().top > refresh.getBoundingClientRect().bottom
+                && parseFloat(browseStyle.borderBlockStartWidth) > 0,
+            equalViewWidths: Math.abs(viewRects[0].width - viewRects[1].width) <= 1,
+            filtersSeparatedFromSecondary: secondary.getBoundingClientRect().top > Math.max(
+                filters.getBoundingClientRect().bottom,
+                options.getBoundingClientRect().bottom,
+            )
+                && parseFloat(secondaryStyle.borderBlockStartWidth) > 0,
+            kindRowCount: new Set(kindRects.map(rect => Math.round(rect.top))).size,
+            kindsFit: kinds.scrollWidth <= kinds.clientWidth,
+            kindTargetsFit: kindRects.every(rect => rect.width >= 44 && rect.height >= 44),
+            orphanControlsOrdered: orphanSelectRect.bottom <= orphanScanRect.top
+                && orphanScanRect.bottom <= organizationRect.top,
+            orphanControlsFullWidth: Math.abs(orphanFilterRect.left - orphanActionsRect.left) <= 0.5
+                && Math.abs(orphanFilterRect.right - orphanActionsRect.right) <= 0.5
+                && Math.abs(orphanScanRect.left - orphanActionsRect.left) <= 0.5
+                && Math.abs(orphanScanRect.right - orphanActionsRect.right) <= 0.5,
+            orphanControlsFit: orphanActions.scrollWidth <= orphanActions.clientWidth
+                && secondary.scrollWidth <= secondary.clientWidth,
+        };
+    });
+    expect(mobileControls.browseGap).toBeGreaterThanOrEqual(8);
+    expect(mobileControls.browseSeparatedFromRefresh).toBe(true);
+    expect(mobileControls.equalViewWidths).toBe(true);
+    expect(mobileControls.filtersSeparatedFromSecondary).toBe(true);
+    expect(mobileControls.kindRowCount).toBe(2);
+    expect(mobileControls.kindsFit).toBe(true);
+    expect(mobileControls.kindTargetsFit).toBe(true);
+    expect(mobileControls.orphanControlsOrdered).toBe(true);
+    expect(mobileControls.orphanControlsFullWidth).toBe(true);
+    expect(mobileControls.orphanControlsFit).toBe(true);
     const frame = await page.locator('.sbca-dialog').evaluate(dialog => {
         const body = dialog.querySelector('.popup-body');
         const content = dialog.querySelector('.popup-content');
@@ -175,9 +255,34 @@ test('owns the popup frame spacing and keeps mobile controls inside the viewport
 
 test('keeps a balanced master-detail workspace on desktop', async ({ page }) => {
     let releaseExport;
+    const organizationUploads = [];
     const exportGate = new Promise(resolve => { releaseExport = resolve; });
     await page.setViewportSize({ width: 1440, height: 900 });
-    await routeOrganization(page);
+    await routeOrganization(page, {
+        version: 1,
+        lastView: {},
+        views: [{
+            id: 'breakpoint-view',
+            name: 'Breakpoint saved view',
+            view: {},
+        }],
+        folders: [{ id: 'folder-one', name: 'Folder one' }],
+        collections: [
+            { id: 'collection-one', name: 'Collection one' },
+            { id: 'collection-two', name: 'Collection two' },
+            { id: 'collection-three', name: 'Collection three' },
+        ],
+        chats: {
+            '["character","Alice","desktop-chat"]': {
+                collections: ['collection-one', 'collection-two'],
+            },
+        },
+    });
+    await page.route('**/api/files/upload', async route => {
+        const body = route.request().postDataJSON();
+        organizationUploads.push(JSON.parse(Buffer.from(body.data, 'base64').toString('utf8')));
+        await fulfillJson(route, { path: body.name });
+    });
     await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
         linkedRow('desktop-chat'),
     ], null, null, 1)));
@@ -205,33 +310,66 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
         const list = dialog.querySelector('.sbca-list-panel');
         const viewer = dialog.querySelector('.sbca-viewer');
         const search = dialog.querySelector('.sbca-search input');
-        const deepSearch = dialog.querySelector('.sbca-deep');
         const ownerSummary = dialog.querySelector('.sbca-owner-summary');
         const sortPill = dialog.querySelector('.sbca-sortpill');
-        const clearFilters = dialog.querySelector('.sbca-clear-filters');
-        const refresh = dialog.querySelector('.sbca-archive-actions > :nth-child(2)');
-        const scan = dialog.querySelector('.sbca-archive-actions > :nth-child(3)');
+        const refresh = dialog.querySelector('.sbca-archive-actions > .sbca-control:first-child');
+        const orphanActions = dialog.querySelector('.sbca-orphan-actions');
+        const orphanReason = orphanActions.querySelector('select');
+        const scan = orphanActions.querySelector('.sbca-control');
+        const organizationToggle = dialog.querySelector('.sbca-organization-toggle');
+        const kindPills = [...dialog.querySelectorAll('.sbca-kind-pill')];
         const viewerContent = dialog.querySelector('.sbca-viewer-content');
         const viewerDetails = dialog.querySelector('.sbca-viewer-details');
         const organizer = dialog.querySelector('.sbca-organizer');
+        const organizerFolder = organizer.querySelector('.sbca-organizer-folder');
         const dialogRect = dialog.getBoundingClientRect();
         const rootRect = root.getBoundingClientRect();
         const listRect = list.getBoundingClientRect();
         const viewerRect = viewer.getBoundingClientRect();
         const searchRect = search.getBoundingClientRect();
-        const deepSearchRect = deepSearch.getBoundingClientRect();
+        const refreshRect = refresh.getBoundingClientRect();
+        const archiveActionsRect = refresh.parentElement.getBoundingClientRect();
+        const orphanActionsRect = orphanActions.getBoundingClientRect();
+        const orphanReasonRect = orphanReason.getBoundingClientRect();
+        const scanRect = scan.getBoundingClientRect();
         const ownerSummaryRect = ownerSummary.getBoundingClientRect();
         const sortPillRect = sortPill.getBoundingClientRect();
         const detailsRect = viewerDetails.getBoundingClientRect();
         const organizerRect = organizer.getBoundingClientRect();
+        const collections = organizer.querySelector('.sbca-organizer-collections');
+        const tags = organizer.querySelector('.sbca-organizer-tags');
+        const folderRect = organizerFolder.getBoundingClientRect();
+        const collectionsRect = collections.getBoundingClientRect();
+        const tagsRect = tags.getBoundingClientRect();
+        const folderStyle = getComputedStyle(organizerFolder);
+        const collectionsStyle = getComputedStyle(collections);
+        const tagsStyle = getComputedStyle(tags);
+        const sectionTitleStyles = [...organizer.querySelectorAll('.sbca-organizer-section-title')]
+            .map(title => getComputedStyle(title))
+            .map(style => ({ fontSize: style.fontSize, fontWeight: style.fontWeight, lineHeight: style.lineHeight }));
+        const viewerActions = [...dialog.querySelectorAll('.sbca-viewer-actions .sbca-action')];
+        const actionLabels = viewerActions.map(action => action.textContent.trim());
+        const openIndex = actionLabels.indexOf('Open chat');
+        const favoriteIndex = actionLabels.indexOf('Favorite');
         return {
-            actionOrder: [clearFilters, refresh, scan].map(control => control.textContent.trim()),
+            clearFiltersCount: dialog.querySelectorAll('.sbca-clear-filters').length,
             detailOrder: [...viewerContent.children].map(child => child.className),
             contentInset: rootRect.left - dialogRect.left,
-            controlsAligned: Math.abs(searchRect.top - deepSearchRect.top) <= 0.5
-                && Math.abs(searchRect.bottom - deepSearchRect.bottom) <= 0.5,
+            hasManualMessageSearch: [...dialog.querySelectorAll('button')]
+                .some(control => control.textContent.trim() === 'Search message content'),
+            kindPillTargets: kindPills.map(pill => {
+                const rect = pill.getBoundingClientRect();
+                return { height: rect.height, width: rect.width };
+            }),
             listToolsAligned: Math.abs(ownerSummaryRect.top - sortPillRect.top) <= 0.5
                 && Math.abs(ownerSummaryRect.height - sortPillRect.height) <= 2,
+            orphanControlsAligned: Math.abs(orphanReasonRect.bottom - scanRect.bottom) <= 0.5,
+            orphanTargets: [orphanReasonRect, scanRect].map(rect => ({ height: rect.height, width: rect.width })),
+            orphanControlsBesideOrganization: Math.abs(orphanActionsRect.top - organizationToggle.getBoundingClientRect().top) <= 0.5
+                && orphanActionsRect.right <= organizationToggle.getBoundingClientRect().left,
+            organizationIndicator: getComputedStyle(organizationToggle, '::after').content,
+            refreshAtStart: Math.abs(refreshRect.left - archiveActionsRect.left) <= 0.5,
+            searchIsFullWidth: searchRect.width > 800,
             detailsRadius: parseFloat(getComputedStyle(viewerDetails).borderRadius),
             dialogHeightRatio: dialogRect.height / innerHeight,
             dialogWidthRatio: dialogRect.width / innerWidth,
@@ -239,6 +377,18 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
             listWidth: listRect.width,
             noHorizontalOverflow: root.scrollWidth <= root.clientWidth,
             organizerBeforeInformation: organizerRect.bottom <= detailsRect.top,
+            favoriteActionFollowsOpen: favoriteIndex === openIndex + 1,
+            organizerHasPillSections: parseFloat(folderStyle.borderTopWidth) > 0
+                && parseFloat(collectionsStyle.borderTopWidth) > 0
+                && parseFloat(tagsStyle.borderTopWidth) > 0
+                && parseFloat(folderStyle.borderRadius) > 0
+                && parseFloat(collectionsStyle.borderRadius) > 0
+                && parseFloat(tagsStyle.borderRadius) > 0,
+            organizerUsesColumns: Math.abs(folderRect.top - collectionsRect.top) <= 0.5
+                && Math.abs(collectionsRect.top - tagsRect.top) <= 0.5
+                && folderRect.right <= collectionsRect.left
+                && collectionsRect.right <= tagsRect.left,
+            sectionTitleStyles,
             viewerRadius: parseFloat(getComputedStyle(viewer).borderRadius),
             viewerStartsAfterList: viewerRect.left > listRect.right,
             viewerWidth: viewerRect.width,
@@ -251,9 +401,23 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
     expect(layout.dialogHeightRatio).toBeLessThanOrEqual(0.93);
     expect(layout.contentInset).toBeGreaterThanOrEqual(16);
     expect(layout.contentInset).toBeLessThanOrEqual(18);
-    expect(layout.controlsAligned).toBe(true);
+    expect(layout.searchIsFullWidth).toBe(true);
     expect(layout.listToolsAligned).toBe(true);
-    expect(layout.actionOrder).toEqual(['Clear filters', 'Refresh', 'Find orphaned files']);
+    expect(layout.clearFiltersCount).toBe(0);
+    expect(layout.hasManualMessageSearch).toBe(false);
+    expect(layout.refreshAtStart).toBe(true);
+    expect(layout.orphanControlsBesideOrganization).toBe(true);
+    expect(layout.orphanControlsAligned).toBe(true);
+    for (const target of layout.orphanTargets) {
+        expect(target.height).toBeGreaterThanOrEqual(44);
+        expect(target.width).toBeGreaterThanOrEqual(44);
+    }
+    expect(layout.organizationIndicator).toContain('+');
+    expect(layout.kindPillTargets).toHaveLength(4);
+    for (const target of layout.kindPillTargets) {
+        expect(target.height).toBeGreaterThanOrEqual(44);
+        expect(target.width).toBeGreaterThanOrEqual(44);
+    }
     expect(layout.listRadius).toBeGreaterThan(0);
     expect(layout.viewerRadius).toBeGreaterThan(0);
     expect(layout.viewerStartsAfterList).toBe(true);
@@ -261,32 +425,181 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
     expect(layout.detailOrder).toEqual(['sbca-viewer-actions', 'sbca-organizer', 'sbca-viewer-details']);
     expect(layout.detailsRadius).toBeGreaterThan(0);
     expect(layout.organizerBeforeInformation).toBe(true);
+    expect(layout.favoriteActionFollowsOpen).toBe(true);
+    expect(layout.organizerUsesColumns).toBe(true);
+    expect(layout.organizerHasPillSections).toBe(true);
+    expect(layout.sectionTitleStyles).toHaveLength(3);
+    expect(new Set(layout.sectionTitleStyles.map(style => JSON.stringify(style))).size).toBe(1);
     expect(layout.noHorizontalOverflow).toBe(true);
+    const favoriteAction = page.locator('.sbca-favorite-action');
+    await expect(page.locator('.sbca-organizer .sbca-favorite-toggle')).toHaveCount(0);
+    await expect(favoriteAction).toHaveAttribute('aria-pressed', 'false');
+    await favoriteAction.click();
+    await expect(favoriteAction).toHaveAttribute('aria-pressed', 'true');
+    await expect(favoriteAction).toContainText('Favorite');
+    const favoriteFilter = page.locator('.sbca-favorite-filter');
+    await expect(favoriteFilter).toContainText('Favorites');
+    await favoriteFilter.click();
+    await expect(favoriteFilter.locator('input')).not.toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveCount(0);
+    await favoriteFilter.click();
+    await expect(favoriteFilter.locator('input')).toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveText('desktop-chat');
+    await favoriteAction.click();
+    await expect(favoriteAction).toHaveAttribute('aria-pressed', 'false');
+    await expect(favoriteAction).toContainText('Favorite');
+    await expect(page.locator('.sbca-organizer-folder')).toHaveAttribute('role', 'group');
+    await expect(page.locator('.sbca-organizer-folder')).toHaveAttribute('aria-labelledby', /.+/);
+    await expect(page.locator('.sbca-organizer-collections')).toHaveAttribute('role', 'group');
+    await expect(page.locator('.sbca-organizer-collections')).toHaveAttribute('aria-labelledby', /.+/);
+    await expect(page.locator('.sbca-organizer-tags')).toHaveAttribute('role', 'group');
+    await expect(page.locator('.sbca-organizer-tags')).toHaveAttribute('aria-labelledby', /.+/);
+    const folderSelect = page.locator('.sbca-organizer-folder select');
+    await expect(folderSelect).toBeEnabled();
+    await expect(folderSelect.locator('option')).toHaveText(['Unfiled', 'Folder one']);
+    await folderSelect.selectOption('folder-one');
+    await expect.poll(() => organizationUploads.at(-1)?.chats?.['["character","Alice","desktop-chat"]']?.folder)
+        .toBe('folder-one');
+    const collectionSelect = page.locator('.sbca-organizer-collections select');
+    await expect(collectionSelect).toBeEnabled();
+    await expect(collectionSelect.locator('option')).toHaveText([
+        'Collections',
+        'Collection one',
+        'Collection two',
+        'Collection three',
+    ]);
+    await expect(page.locator('.sbca-collection-item .sbca-tag-text')).toHaveText(['Collection one', 'Collection two']);
+    await expect(page.locator('.sbca-collection-item button').first()).toHaveAccessibleName('Remove collection Collection one');
+    await collectionSelect.selectOption('collection-three');
+    await expect.poll(() => organizationUploads.at(-1)?.chats?.['["character","Alice","desktop-chat"]']?.collections)
+        .toEqual(['collection-one', 'collection-two', 'collection-three']);
 });
 
-test('keeps filters concise and organization management full width when expanded', async ({ page }) => {
+test('keeps desktop filters visible and organization management full width when requested', async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
-    await routeOrganization(page);
+    await routeOrganization(page, {
+        version: 1,
+        lastView: {},
+        views: [],
+        folders: [],
+        collections: [],
+        chats: {
+            '["character","Alice","favorite-chat"]': { favorite: true },
+        },
+    });
     await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
-        linkedRow('organization-chat'),
-    ], null, null, 1)));
+        linkedRow('favorite-chat'),
+        linkedRow('ordinary-chat'),
+    ], null, null, 2)));
 
     await openArchive(page);
     await expect(page.getByText('Sort', { exact: true })).toHaveCount(0);
     await expect(page.getByText('List tools', { exact: true })).toHaveCount(0);
-    await expect(page.getByText('Filters', { exact: true })).toBeVisible();
-    await expect(page.getByText('Manage organization', { exact: true })).toBeVisible();
+    await expect(page.locator('.sbca-filter-toggle')).toBeHidden();
+    await expect(page.locator('.sbca-options-panel')).toBeVisible();
+    const filterLayout = await page.locator('.sbca-filter-tools').evaluate(filterTools => {
+        const panel = filterTools.querySelector('.sbca-options-panel');
+        const browse = filterTools.querySelector('.sbca-browse-strip');
+        const actions = filterTools.querySelector('.sbca-archive-actions');
+        const refresh = actions.querySelector('.sbca-control');
+        const orphanActions = filterTools.querySelector('.sbca-orphan-actions');
+        const orphanReason = orphanActions.querySelector('select');
+        const scan = orphanActions.querySelector('.sbca-control');
+        const controls = [...panel.children].filter(control => control.matches('.sbca-kinds, .sbca-filter'));
+        const panelRect = panel.getBoundingClientRect();
+        const browseRect = browse.getBoundingClientRect();
+        const actionsRect = actions.getBoundingClientRect();
+        const refreshRect = refresh.getBoundingClientRect();
+        const orphanActionsRect = orphanActions.getBoundingClientRect();
+        const orphanReasonRect = orphanReason.getBoundingClientRect();
+        const scanRect = scan.getBoundingClientRect();
+        return {
+            browseAndActionsShareRow: Math.abs(browseRect.top - actionsRect.top) <= 0.5
+                && browseRect.bottom <= actionsRect.bottom + 0.5,
+            controlsBelowActionRow: panelRect.top > Math.max(browseRect.bottom, actionsRect.bottom),
+            orphanControlsShareRow: Math.abs(orphanReasonRect.bottom - scanRect.bottom) <= 0.5,
+            orphanControlsInActionRow: orphanActionsRect.top >= actionsRect.top
+                && orphanActionsRect.bottom <= actionsRect.bottom,
+            refreshAtStart: Math.abs(refreshRect.left - actionsRect.left) <= 0.5,
+            controls: controls.map(control => {
+                const label = control.querySelector('.sbca-label, legend');
+                const field = control.querySelector('input[type="date"], select');
+                const rect = control.getBoundingClientRect();
+                return {
+                    fieldFits: !field || field.scrollWidth <= field.clientWidth,
+                    labelFits: label.scrollWidth <= label.clientWidth,
+                    bottom: rect.bottom,
+                    width: rect.width,
+                };
+            }),
+            columnCount: getComputedStyle(panel).gridTemplateColumns.split(' ').length,
+            panelWidth: panelRect.width,
+            panelSingleRow: controls.every(control => Math.abs(control.getBoundingClientRect().bottom - controls[0].getBoundingClientRect().bottom) <= 0.5),
+        };
+    });
+    expect(filterLayout.browseAndActionsShareRow).toBe(true);
+    expect(filterLayout.controlsBelowActionRow).toBe(true);
+    expect(filterLayout.orphanControlsShareRow).toBe(true);
+    expect(filterLayout.orphanControlsInActionRow).toBe(true);
+    expect(filterLayout.refreshAtStart).toBe(true);
+    expect(filterLayout.controls).toHaveLength(3);
+    expect(filterLayout.columnCount).toBe(3);
+    expect(filterLayout.panelSingleRow).toBe(true);
+    expect(filterLayout.panelWidth).toBeGreaterThan(800);
+    for (const control of filterLayout.controls) {
+        expect(control.width).toBeGreaterThan(100);
+        expect(control.labelFits).toBe(true);
+        expect(control.fieldFits).toBe(true);
+    }
+    const favoritePill = page.locator('.sbca-favorite-filter');
+    const favoriteFilter = favoritePill.locator('input');
+    await expect(favoriteFilter).toBeChecked();
+    const favoriteInputStyle = await favoriteFilter.evaluate(input => {
+        const style = getComputedStyle(input);
+        return {
+            appearance: style.appearance,
+            opacity: style.opacity,
+            pseudoContent: getComputedStyle(input.closest('.sbca-favorite-filter'), '::after').content,
+        };
+    });
+    expect(favoriteInputStyle.appearance).toBe('none');
+    expect(favoriteInputStyle.opacity).toBe('0');
+    expect(favoriteInputStyle.pseudoContent).toBe('none');
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-chat', 'ordinary-chat']);
+    await expect(page.locator('.sbca-status')).not.toContainText('Use Find orphaned files to include chats with deleted owners.');
+    await favoritePill.click();
+    await expect(favoriteFilter).not.toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveText(['ordinary-chat']);
+    await favoritePill.click();
+    await expect(favoriteFilter).toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-chat', 'ordinary-chat']);
+
+    const characterPill = page.locator('.sbca-kind-pill').filter({ hasText: 'Characters' });
+    await characterPill.click();
+    await expect(characterPill.locator('input')).not.toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-chat']);
+    await favoritePill.click();
+    await expect(page.locator('.sbca-filename')).toHaveCount(0);
+    await favoritePill.click();
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-chat']);
+    await characterPill.click();
+    await expect(characterPill.locator('input')).toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-chat', 'ordinary-chat']);
+    await page.getByText('Manage organization', { exact: true }).click();
+    await expect(page.locator('.sbca-options-panel')).toBeHidden();
 
     const layout = await page.locator('.sbca-toolbar').evaluate(toolbar => {
         const root = toolbar.closest('.sbca-root');
-        const organization = toolbar.querySelector('.sbca-organization-tools');
         const panel = toolbar.querySelector('.sbca-organization-tools-panel');
-        organization.open = true;
+        const row = root.querySelector('.sbca-row-button');
         const toolbarStyle = getComputedStyle(toolbar);
         const panelRect = panel.getBoundingClientRect();
         const toolbarRect = toolbar.getBoundingClientRect();
         return {
+            organizationVisible: !panel.hidden,
             panelWidth: panelRect.width,
+            rowBorderWidth: parseFloat(getComputedStyle(row).borderTopWidth),
+            rowRadius: parseFloat(getComputedStyle(row).borderRadius),
             toolbarWidth: toolbarRect.width,
             toolbarOverflowY: toolbarStyle.overflowY,
             toolbarMaxBlockSize: toolbarStyle.maxBlockSize,
@@ -295,10 +608,217 @@ test('keeps filters concise and organization management full width when expanded
         };
     });
 
+    expect(layout.organizationVisible).toBe(true);
     expect(layout.panelWidth).toBeGreaterThan(layout.toolbarWidth * 0.9);
+    expect(layout.rowBorderWidth).toBeGreaterThan(0);
+    expect(layout.rowRadius).toBeGreaterThan(0);
     expect(layout.toolbarOverflowY).not.toBe('auto');
     expect(layout.toolbarMaxBlockSize).toBe('none');
     expect(layout.rootScrollHeight).toBeGreaterThanOrEqual(layout.rootClientHeight);
+    await page.setViewportSize({ width: 820, height: 740 });
+    await page.setViewportSize({ width: 1100, height: 800 });
+    await expect(page.locator('.sbca-organization-tools-panel')).toBeVisible();
+    await expect(page.locator('.sbca-options-panel')).toBeHidden();
+    await page.getByText('Manage organization', { exact: true }).click();
+    await expect(page.locator('.sbca-options-panel')).toBeVisible();
+});
+
+test('keeps organization load recovery contextual to Manage organization', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.route('**/user/files/_sbca_organization.json', route => route.fulfill({ status: 503 }));
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('organization-error-chat'),
+    ], null, null, 1)));
+
+    await openArchive(page);
+    const recoveryMessage = page.getByText('Organization could not be loaded. Retry or import a backup.');
+    await expect(recoveryMessage).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeHidden();
+    await page.getByRole('button', { name: 'Manage organization' }).click();
+    await expect(page.locator('.sbca-organization-backup')).toContainText('Organization could not be loaded. Retry or import a backup.');
+    await expect(page.locator('.sbca-organization-backup').getByRole('button', { name: 'Retry' })).toBeVisible();
+    await expect(recoveryMessage).toBeVisible();
+    await expect(recoveryMessage).toHaveCount(1);
+});
+
+test('synchronizes the viewer Favorite action after organization loads', async ({ page }) => {
+    let releaseOrganization;
+    const organizationGate = new Promise(resolve => { releaseOrganization = resolve; });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.route('**/user/files/_sbca_organization.json', async route => {
+        await organizationGate;
+        const organization = {
+            version: 1,
+            lastView: {},
+            views: [],
+            folders: [],
+            collections: [],
+            chats: {
+                '["character","Alice","delayed-organization-chat"]': { favorite: true },
+            },
+        };
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json; charset=utf-8',
+            body: Buffer.from(JSON.stringify(organization)).toString('base64'),
+        });
+    });
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('delayed-organization-chat'),
+    ], null, null, 1)));
+    await page.route('**/api/chats/export', route => fulfillJson(route, {
+        result: JSON.stringify({ chat_metadata: {} }),
+    }));
+
+    await openArchive(page);
+    await page.getByText('delayed-organization-chat', { exact: true }).click();
+    const favoriteAction = page.locator('.sbca-favorite-action');
+    await expect(favoriteAction).toBeDisabled();
+    await expect(favoriteAction).toHaveAttribute('aria-pressed', 'false');
+    const favoriteFilter = page.locator('.sbca-favorite-filter');
+    const favoriteFilterInput = favoriteFilter.locator('input');
+    await expect(favoriteFilterInput).toBeEnabled();
+    await favoriteFilter.click();
+    await expect(favoriteFilterInput).not.toBeChecked();
+    await expect(page.locator('.sbca-filename', { hasText: 'delayed-organization-chat' })).toBeVisible();
+    releaseOrganization();
+    await expect(page.locator('.sbca-filename', { hasText: 'delayed-organization-chat' })).toHaveCount(0);
+    await favoriteFilter.click();
+    await expect(favoriteFilterInput).toBeChecked();
+    await expect(page.locator('.sbca-filename', { hasText: 'delayed-organization-chat' })).toBeVisible();
+    await expect(favoriteAction).toBeEnabled();
+    await expect(favoriteAction).toHaveAttribute('aria-pressed', 'true');
+    await expect(favoriteAction).toHaveAccessibleName('Favorite');
+});
+
+test('preserves focus and organizer geometry across the desktop-mobile breakpoint', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 800 });
+    await routeOrganization(page, {
+        version: 1,
+        lastView: {},
+        views: [{
+            id: 'breakpoint-view',
+            name: 'Breakpoint saved view',
+            view: {},
+        }],
+        folders: [],
+        collections: [{ id: 'long-collection', name: 'an-extremely-long-unbroken-collection-name-that-must-wrap-without-widening-the-organizer' }],
+        chats: {
+            '["character","Alice","breakpoint-chat"]': {
+                collections: ['long-collection'],
+                tags: ['an-extremely-long-unbroken-tag-that-must-wrap-without-widening-the-organizer-at-the-breakpoint'],
+            },
+        },
+    });
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('breakpoint-chat'),
+    ], null, null, 1)));
+    await page.route('**/api/chats/export', route => fulfillJson(route, {
+        result: JSON.stringify({ chat_metadata: {} }),
+    }));
+
+    await openArchive(page);
+    const dateFilter = page.locator('.sbca-options-panel input[type="date"]').first();
+    await dateFilter.focus();
+    await page.setViewportSize({ width: 820, height: 740 });
+    await expect(page.locator('.sbca-filter-toggle')).toBeFocused();
+    await expect(page.locator('.sbca-options-panel')).toBeHidden();
+
+    await page.setViewportSize({ width: 1100, height: 800 });
+    await expect(page.locator('.sbca-options-panel input, .sbca-options-panel select, .sbca-options-panel button').first()).toBeFocused();
+    await expect(page.locator('.sbca-options-panel')).toBeVisible();
+
+    await page.setViewportSize({ width: 1001, height: 800 });
+    await page.locator('.sbca-row-button').evaluate(button => button.click());
+    await expect(page.locator('.sbca-viewer-content')).toContainText('Organize chat');
+    const geometry = await page.locator('.sbca-dialog').evaluate(dialog => {
+        const organizer = dialog.querySelector('.sbca-organizer');
+        const viewer = dialog.querySelector('.sbca-viewer');
+        const archiveActions = dialog.querySelector('.sbca-archive-actions');
+        const secondaryActions = dialog.querySelector('.sbca-archive-secondary-actions');
+        const orphanActions = dialog.querySelector('.sbca-orphan-actions');
+        const organizationToggle = dialog.querySelector('.sbca-organization-toggle');
+        const archiveRect = archiveActions.getBoundingClientRect();
+        const secondaryRect = secondaryActions.getBoundingClientRect();
+        const orphanRect = orphanActions.getBoundingClientRect();
+        const organizationRect = organizationToggle.getBoundingClientRect();
+        return {
+            actionClusterFits: secondaryActions.scrollWidth <= secondaryActions.clientWidth,
+            actionClusterIsAdjacent: Math.abs(orphanRect.top - organizationRect.top) <= 0.5
+                && orphanRect.right <= organizationRect.left,
+            actionRowsDoNotIntersect: archiveRect.right <= secondaryRect.left,
+            actionClusterVisible: secondaryRect.width > 0,
+            organizerFits: organizer.scrollWidth <= organizer.clientWidth,
+            toolbarFits: dialog.querySelector('.sbca-toolbar').scrollWidth <= dialog.querySelector('.sbca-toolbar').clientWidth,
+            viewerFits: viewer.scrollWidth <= viewer.clientWidth,
+        };
+    });
+    expect(geometry.actionClusterFits).toBe(true);
+    expect(geometry.actionClusterIsAdjacent).toBe(true);
+    expect(geometry.actionRowsDoNotIntersect).toBe(true);
+    expect(geometry.actionClusterVisible).toBe(true);
+    expect(geometry.organizerFits).toBe(true);
+    expect(geometry.toolbarFits).toBe(true);
+    expect(geometry.viewerFits).toBe(true);
+});
+
+test('shows saved views only when available and applies the selected view', async ({ page }) => {
+    let searchRequests = 0;
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await routeOrganization(page, {
+        version: 1,
+        lastView: {},
+        views: [{
+            id: 'compact-by-owner',
+            name: 'Compact by owner',
+            view: { density: 'compact', group: 'owner', query: 'saved query' },
+        }, {
+            id: 'favorite-only',
+            name: 'Favorite',
+            view: { favorite: true },
+        }, {
+            id: 'not-favorite',
+            name: 'Not favorite',
+            view: { favorite: false },
+        }],
+        folders: [],
+        collections: [],
+        chats: {
+            '["character","Alice","favorite-saved-view-chat"]': { favorite: true },
+        },
+    });
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('favorite-saved-view-chat'),
+        linkedRow('ordinary-saved-view-chat'),
+    ], null, null, 2)));
+    await page.route('**/api/chats/search', route => {
+        searchRequests++;
+        return fulfillJson(route, []);
+    });
+
+    await openArchive(page);
+    const savedView = page.locator('.sbca-saved-view select');
+    await expect(savedView).toBeVisible();
+    await expect(savedView.locator('option')).toHaveText(['Current view', 'Compact by owner', 'Favorite', 'Not favorite']);
+    await savedView.selectOption('compact-by-owner');
+    await expect(page.locator('.sbca-root')).toHaveAttribute('data-sbca-density', 'compact');
+    await expect(page.locator('.sbca-view-setting:not(.sbca-saved-view) select').first()).toHaveValue('owner');
+    await expect(page.getByRole('combobox', { name: 'Search indexed chats' })).toHaveValue('saved query');
+    await expect.poll(() => searchRequests).toBe(1);
+    await savedView.selectOption('favorite-only');
+    const favoriteFilter = page.locator('.sbca-favorite-filter');
+    await expect(favoriteFilter.locator('input')).toBeChecked();
+    expect(await favoriteFilter.locator('input').evaluate(input => input.indeterminate)).toBe(false);
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-saved-view-chat', 'ordinary-saved-view-chat']);
+    await savedView.selectOption('not-favorite');
+    await expect(favoriteFilter).toContainText('Favorites');
+    await expect(favoriteFilter.locator('input')).not.toBeChecked();
+    expect(await favoriteFilter.locator('input').evaluate(input => input.indeterminate)).toBe(false);
+    await expect(page.locator('.sbca-filename')).toHaveText(['ordinary-saved-view-chat']);
+    await favoriteFilter.click();
+    await expect(favoriteFilter).toContainText('Favorites');
+    await expect(favoriteFilter.locator('input')).toBeChecked();
+    await expect(page.locator('.sbca-filename')).toHaveText(['favorite-saved-view-chat', 'ordinary-saved-view-chat']);
 });
 
 test('keeps the tablet and Safari popup layout bounded', async ({ page }) => {
@@ -337,6 +857,7 @@ test('keeps the tablet and Safari popup layout bounded', async ({ page }) => {
 
 test('renders the first archive page and progress before the next page resolves', async ({ page }) => {
     let inventoryRequests = 0;
+    let searchRequests = 0;
     let releaseSecondPage;
     let markSecondPageStarted;
     const secondPageStarted = new Promise(resolve => { markSecondPageStarted = resolve; });
@@ -352,6 +873,10 @@ test('renders the first archive page and progress before the next page resolves'
         await secondPageGate;
         await fulfillJson(route, archivePage([linkedRow('second')], null, null, 2));
     });
+    await page.route('**/api/chats/search', route => {
+        searchRequests++;
+        return fulfillJson(route, []);
+    });
 
     await openArchive(page);
     await secondPageStarted;
@@ -360,18 +885,178 @@ test('renders the first archive page and progress before the next page resolves'
     await expect(page.locator('.sbca-status')).toContainText('1 of 2 indexed chat files');
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeEnabled();
     await expect(page.getByText('second', { exact: true })).toHaveCount(0);
+    await page.getByRole('combobox', { name: 'Search indexed chats' }).fill('second');
+    await new Promise(resolve => setTimeout(resolve, SEARCH_CONTENT_DEBOUNCE_MS + 50));
+    expect(searchRequests).toBe(0);
 
     releaseSecondPage();
-    await expect(page.locator('.sbca-filename')).toHaveText(['first', 'second']);
-    await expect(page.locator('.sbca-status')).toContainText('2 indexed chat files');
-    await expect(page.getByRole('button', { name: 'Refresh' })).toBeEnabled();
-    await page.getByRole('searchbox', { name: 'Filter indexed chats' }).fill('second');
     await expect(page.locator('.sbca-filename')).toHaveText(['second']);
+    await expect.poll(() => searchRequests).toBe(1);
+    await expect(page.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+});
+
+test('automatically combines indexed metadata and message-content search results', async ({ page }) => {
+    let inventoryRequests = 0;
+    let searchRequests = 0;
+    let releaseStaleSearch;
+    let markStaleSearchStarted;
+    const staleSearchStarted = new Promise(resolve => { markStaleSearchStarted = resolve; });
+    const staleSearchGate = new Promise(resolve => { releaseStaleSearch = resolve; });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', route => {
+        inventoryRequests++;
+        if (inventoryRequests > 1) {
+            return route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'refresh failed' }) });
+        }
+        return fulfillJson(route, archivePage([
+            linkedRow('needle-metadata'),
+            linkedRow('unrelated'),
+        ], null, null, 2));
+    });
+    await page.route('**/api/chats/search', async route => {
+        searchRequests++;
+        if (route.request().postDataJSON().query === 'stale') {
+            markStaleSearchStarted();
+            await staleSearchGate;
+            await fulfillJson(route, [{
+                file_name: 'stale-content-match',
+                file_size: '2 KB',
+                message_count: 1,
+                last_mes: 1_000,
+                preview_message: 'stale result',
+            }]);
+            return;
+        }
+        expect(route.request().postDataJSON()).toMatchObject({
+            avatar_url: 'Alice.png',
+            query: 'needle',
+        });
+        await fulfillJson(route, [{
+            file_name: 'content-match',
+            file_size: '2 KB',
+            message_count: 4,
+            last_mes: 2_000,
+            preview_message: 'needle appears in an older message',
+        }]);
+    });
+
+    await openArchive(page);
+    await expect(page.getByRole('button', { name: 'Search message content' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Clear filters' })).toHaveCount(0);
+
+    const search = page.getByRole('combobox', { name: 'Search indexed chats' });
+    await search.fill('stale');
+    await staleSearchStarted;
+    await search.fill('needle');
+    await expect(page.locator('.sbca-filename')).toHaveText(['needle-metadata']);
+
+    await expect.poll(() => searchRequests).toBe(2);
+    releaseStaleSearch();
+    await expect.poll(async () => (await page.locator('.sbca-filename').allTextContents()).sort()).toEqual([
+        'content-match',
+        'needle-metadata',
+    ]);
+    await expect(page.getByText('stale-content-match', { exact: true })).toHaveCount(0);
+
+    await page.locator('.sbca-owner-selector > input[type="hidden"]').evaluate(input => {
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await expect.poll(() => searchRequests).toBe(3);
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await expect.poll(() => searchRequests).toBe(4);
+    await expect.poll(async () => (await page.locator('.sbca-filename').allTextContents()).sort()).toEqual([
+        'content-match',
+        'needle-metadata',
+    ]);
+
+    await page.getByRole('button', { name: 'Select chats' }).click();
+    await expect(page.getByRole('button', { name: 'Select all matching (2)' })).toBeVisible();
+    await page.getByRole('button', { name: 'Select all matching (2)' }).click();
+    await expect(page.locator('.sbca-selection-count')).toHaveText('2 selected');
+});
+
+test('fuzzy-matches character mentions and scopes automatic content search', async ({ page }) => {
+    let searchRequests = 0;
+    const searchedAvatars = [];
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('ordinary-chat'),
+    ], null, null, 1)));
+    await page.route('**/api/chats/search', async route => {
+        searchRequests++;
+        searchedAvatars.push(route.request().postDataJSON().avatar_url);
+        expect(route.request().postDataJSON()).toMatchObject({
+            query: 'needle',
+        });
+        await fulfillJson(route, route.request().postDataJSON().avatar_url === 'Alice.png' ? [{
+            file_name: 'mentioned-content-match',
+            file_size: '2 KB',
+            message_count: 2,
+            last_mes: 2_000,
+            preview_message: 'needle in message content',
+        }] : []);
+    });
+
+    await page.goto(`${baseUrl}/?duplicate-characters`);
+    await expect(page.locator('html')).toHaveAttribute('data-archive-ready', 'true');
+    await page.locator('#sbca_drawer_button').click();
+    await expect(page.locator('.sbca-root')).toBeVisible();
+    const search = page.getByRole('combobox', { name: 'Search indexed chats' });
+    await expect(search).toHaveAttribute('placeholder', 'Type to search chats. Mention character names with @.');
+    await search.fill('@Alce');
+    const mentionMenu = page.getByRole('listbox', { name: 'Character mentions' });
+    await expect(mentionMenu).toBeVisible();
+    await expect(mentionMenu.getByRole('option')).toHaveText(['Alice']);
+    await search.press('Escape');
+    await expect(mentionMenu).toBeHidden();
+    await expect(search).toHaveAttribute('aria-expanded', 'false');
+    await search.fill('@');
+    await expect(mentionMenu.getByRole('option')).toHaveCount(4);
+    await search.press('ArrowUp');
+    const lastOption = mentionMenu.getByRole('option', { name: 'Prime "One"' });
+    await expect(lastOption).toHaveAttribute('aria-selected', 'true');
+    await expect(lastOption).toHaveCSS('outline-style', 'solid');
+    await expect(search).toBeFocused();
+    await search.press('ArrowDown');
+    await expect(mentionMenu.getByRole('option', { name: 'Alice' })).toHaveAttribute('aria-selected', 'true');
+    await search.press('Escape');
+    await expect(search).not.toHaveAttribute('aria-activedescendant', /.+/);
+    await search.fill('@Prime');
+    await search.press('ArrowDown');
+    await search.press('Enter');
+    await expect(search).toHaveValue('@"Prime \\"One\\"" ');
+    await new Promise(resolve => setTimeout(resolve, SEARCH_CONTENT_DEBOUNCE_MS + 50));
+    expect(searchRequests).toBe(0);
+    await search.fill('@Path');
+    await search.press('ArrowDown');
+    await search.press('Enter');
+    await expect(search).toHaveValue('@"Path\\\\Finder" ');
+    await new Promise(resolve => setTimeout(resolve, SEARCH_CONTENT_DEBOUNCE_MS + 50));
+    expect(searchRequests).toBe(0);
+    await search.fill('@"Path\\\\Finder" needle');
+    await expect.poll(() => searchRequests).toBe(1);
+    expect(searchedAvatars).toEqual(['Path.png']);
+    await search.fill('@Alce');
+    await expect(mentionMenu).toBeVisible();
+    await search.press('ArrowDown');
+    await expect(mentionMenu.getByRole('option', { name: 'Alice' })).toHaveAttribute('aria-selected', 'true');
+    await expect(search).toHaveAttribute('aria-activedescendant', /sbca_mention_/);
+    await search.press('Enter');
+    await expect(search).toHaveValue('@Alice ');
+    await expect(search).toHaveAttribute('aria-expanded', 'false');
+    await new Promise(resolve => setTimeout(resolve, SEARCH_CONTENT_DEBOUNCE_MS + 50));
+    expect(searchRequests).toBe(1);
+
+    await search.fill('@Alice needle');
+    await expect.poll(() => searchRequests).toBe(3);
+    expect(searchedAvatars.sort()).toEqual(['Alice-copy.png', 'Alice.png', 'Path.png']);
+    await expect(page.locator('.sbca-filename')).toHaveText(['mentioned-content-match']);
 });
 
 test('cancels an incremental archive load, releases its cursor, and ignores the late page', async ({ page }) => {
     const releases = [];
     let inventoryRequests = 0;
+    let searchRequests = 0;
     let releaseLatePage;
     let markLatePageStarted;
     const latePageStarted = new Promise(resolve => { markLatePageStarted = resolve; });
@@ -391,12 +1076,20 @@ test('cancels an incremental archive load, releases its cursor, and ignores the 
         await latePageGate;
         await fulfillJson(route, archivePage([linkedRow('late')], null, null, 2));
     });
+    await page.route('**/api/chats/search', route => {
+        searchRequests++;
+        return fulfillJson(route, []);
+    });
 
     await openArchive(page);
     await latePageStarted;
     await expect(page.locator('.sbca-filename')).toHaveText(['kept']);
+    await page.getByRole('combobox', { name: 'Search indexed chats' }).fill('kept');
+    await new Promise(resolve => setTimeout(resolve, SEARCH_CONTENT_DEBOUNCE_MS + 50));
+    expect(searchRequests).toBe(0);
     await page.getByRole('button', { name: 'Cancel' }).click();
     await expect.poll(() => releases).toContainEqual({ cursor: ARCHIVE_CURSOR });
+    await expect.poll(() => searchRequests).toBe(1);
     releaseLatePage();
 
     await expect(page.locator('.sbca-filename')).toHaveText(['kept']);
@@ -407,6 +1100,7 @@ test('cancels an incremental archive load, releases its cursor, and ignores the 
 test('stops an orphan scan, releases its token and cursor, and rolls back partial rows', async ({ page }) => {
     const releases = [];
     let orphanRequests = 0;
+    let searchRequests = 0;
     let releaseLatePage;
     let markLatePageStarted;
     const latePageStarted = new Promise(resolve => { markLatePageStarted = resolve; });
@@ -415,6 +1109,10 @@ test('stops an orphan scan, releases its token and cursor, and rolls back partia
     await page.route('**/api/chats/archive/release', async route => {
         releases.push(route.request().postDataJSON());
         await route.fulfill({ status: 204 });
+    });
+    await page.route('**/api/chats/search', route => {
+        searchRequests++;
+        return fulfillJson(route, []);
     });
     await page.route('**/api/chats/archive/inventory', async route => {
         const body = route.request().postDataJSON();
@@ -443,9 +1141,12 @@ test('stops an orphan scan, releases its token and cursor, and rolls back partia
     });
 
     await openArchive(page);
+    await page.getByRole('combobox', { name: 'Search indexed chats' }).fill('orphan');
     await expect(page.getByRole('button', { name: 'Find orphaned files' })).toBeEnabled();
     await page.getByRole('button', { name: 'Find orphaned files' }).click();
     await latePageStarted;
+    await new Promise(resolve => setTimeout(resolve, SEARCH_CONTENT_DEBOUNCE_MS + 50));
+    expect(searchRequests).toBe(0);
     await expect(page.getByText('partial-orphan', { exact: true })).toBeVisible();
     await expect(page.locator('.sbca-status')).toContainText('1 of 2 indexed chat files');
     await page.getByRole('button', { name: 'Stop scan' }).click();
@@ -454,8 +1155,7 @@ test('stops an orphan scan, releases its token and cursor, and rolls back partia
 
     await expect(page.getByText('partial-orphan', { exact: true })).toHaveCount(0);
     await expect(page.getByText('late-orphan', { exact: true })).toHaveCount(0);
-    await expect(page.getByText('linked', { exact: true })).toBeVisible();
-    await expect(page.locator('.sbca-status')).toContainText('Scan stopped.');
+    await expect.poll(() => searchRequests).toBe(1);
 });
 
 test('replaces orphan scan tokens and views the active orphan through the archive namespace', async ({ page }) => {
@@ -507,11 +1207,23 @@ test('replaces orphan scan tokens and views the active orphan through the archiv
 
     await page.getByText('current-orphan', { exact: true }).click();
     await expect(page.locator('.sbca-viewer-content')).toContainText('orphan body');
-    const mobileDetail = await page.locator('.sbca-viewer-content').evaluate(content => ({
-        noHorizontalOverflow: content.scrollWidth <= content.clientWidth,
-        order: [...content.children].map(child => child.className),
-    }));
+    const mobileDetail = await page.locator('.sbca-viewer-content').evaluate(content => {
+        const folderStyle = getComputedStyle(content.querySelector('.sbca-organizer-folder'));
+        const collectionsStyle = getComputedStyle(content.querySelector('.sbca-organizer-collections'));
+        const tagsStyle = getComputedStyle(content.querySelector('.sbca-organizer-tags'));
+        return {
+            hasStackedOrganizerPills: parseFloat(folderStyle.borderTopWidth) > 0
+                && parseFloat(collectionsStyle.borderTopWidth) > 0
+                && parseFloat(tagsStyle.borderTopWidth) > 0
+                && parseFloat(folderStyle.borderRadius) > 0
+                && parseFloat(collectionsStyle.borderRadius) > 0
+                && parseFloat(tagsStyle.borderRadius) > 0,
+            noHorizontalOverflow: content.scrollWidth <= content.clientWidth,
+            order: [...content.children].map(child => child.className),
+        };
+    });
     expect(mobileDetail.order).toEqual(['sbca-viewer-actions', 'sbca-organizer', 'sbca-viewer-details']);
+    expect(mobileDetail.hasStackedOrganizerPills).toBe(true);
     expect(mobileDetail.noHorizontalOverflow).toBe(true);
     expect(viewedUrls).toHaveLength(1);
     const viewed = new URL(viewedUrls[0]);
@@ -521,8 +1233,10 @@ test('replaces orphan scan tokens and views the active orphan through the archiv
     expect(dataMaidRequests).toEqual([]);
 });
 
-async function routeOrganization(page) {
-    await page.route('**/user/files/_sbca_organization.json', route => route.fulfill({ status: 404 }));
+async function routeOrganization(page, organization = null) {
+    await page.route('**/user/files/_sbca_organization.json', route => organization
+        ? fulfillJson(route, organization)
+        : route.fulfill({ status: 404 }));
 }
 
 async function openArchive(page) {
@@ -570,10 +1284,19 @@ function fulfillJson(route, value) {
     });
 }
 
-function fixtureHtml(useLongLabel) {
+function fixtureHtml(useLongLabel, duplicateCharacters = false) {
     const translatedLabel = useLongLabel
         ? 'Chat Archive Chat Archive Chat Archive Chat Archive'
         : 'Chat Archive';
+    const characters = [
+        { avatar: 'Alice.png', name: 'Alice' },
+        ...(duplicateCharacters ? [
+            { avatar: 'Alice-copy.png', name: 'Alice' },
+            { avatar: 'Bob.png', name: 'Bob' },
+            { avatar: 'Path.png', name: 'Path\\Finder' },
+            { avatar: 'Prime.png', name: 'Prime "One"' },
+        ] : []),
+    ];
     return `<!doctype html>
 <html>
 <head>
@@ -606,7 +1329,7 @@ function fixtureHtml(useLongLabel) {
         globalThis.SillyTavern = {
             getContext() {
                 return {
-                    characters: [{ avatar: 'Alice.png', name: 'Alice' }],
+                    characters: ${JSON.stringify(characters)},
                     groups: [],
                     eventSource: { on() {}, removeListener() {} },
                     eventTypes: { APP_READY: 'app-ready' },

--- a/tests/sillybunny-chats-archive.e2e.js
+++ b/tests/sillybunny-chats-archive.e2e.js
@@ -18,6 +18,13 @@ const publicRoot = path.resolve(extensionRoot, '..', '..', '..');
 let baseUrl;
 let server;
 
+const ARCHIVE_CURSOR = 'a'.repeat(64);
+const ORPHAN_CURSOR = 'b'.repeat(64);
+const FIRST_READ_TOKEN = 'c'.repeat(64);
+const SECOND_READ_TOKEN = 'd'.repeat(64);
+const FIRST_ORPHAN_HASH = 'e'.repeat(64);
+const SECOND_ORPHAN_HASH = 'f'.repeat(64);
+
 test.describe.configure({ mode: 'serial' });
 test.use({
     viewport: { width: 390, height: 844 },
@@ -106,6 +113,235 @@ test('shows a resilient label with at least a 44px mobile touch target', async (
     expect(control.labelFits).toBe(true);
 });
 
+test('renders the first archive page and progress before the next page resolves', async ({ page }) => {
+    let inventoryRequests = 0;
+    let releaseSecondPage;
+    let markSecondPageStarted;
+    const secondPageStarted = new Promise(resolve => { markSecondPageStarted = resolve; });
+    const secondPageGate = new Promise(resolve => { releaseSecondPage = resolve; });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', async route => {
+        inventoryRequests++;
+        if (inventoryRequests === 1) {
+            await fulfillJson(route, archivePage([linkedRow('first')], ARCHIVE_CURSOR, null, 2));
+            return;
+        }
+        markSecondPageStarted();
+        await secondPageGate;
+        await fulfillJson(route, archivePage([linkedRow('second')], null, null, 2));
+    });
+
+    await openArchive(page);
+    await secondPageStarted;
+
+    await expect(page.locator('.sbca-filename')).toHaveText(['first']);
+    await expect(page.locator('.sbca-status')).toContainText('1 of 2 indexed chat files');
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await expect(page.getByText('second', { exact: true })).toHaveCount(0);
+
+    releaseSecondPage();
+    await expect(page.locator('.sbca-filename')).toHaveText(['first', 'second']);
+    await expect(page.locator('.sbca-status')).toContainText('2 indexed chat files');
+    await expect(page.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+    await page.getByRole('searchbox', { name: 'Filter indexed chats' }).fill('second');
+    await expect(page.locator('.sbca-filename')).toHaveText(['second']);
+});
+
+test('cancels an incremental archive load, releases its cursor, and ignores the late page', async ({ page }) => {
+    const releases = [];
+    let inventoryRequests = 0;
+    let releaseLatePage;
+    let markLatePageStarted;
+    const latePageStarted = new Promise(resolve => { markLatePageStarted = resolve; });
+    const latePageGate = new Promise(resolve => { releaseLatePage = resolve; });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/release', async route => {
+        releases.push(route.request().postDataJSON());
+        await route.fulfill({ status: 204 });
+    });
+    await page.route('**/api/chats/archive/inventory', async route => {
+        inventoryRequests++;
+        if (inventoryRequests === 1) {
+            await fulfillJson(route, archivePage([linkedRow('kept')], ARCHIVE_CURSOR, null, 2));
+            return;
+        }
+        markLatePageStarted();
+        await latePageGate;
+        await fulfillJson(route, archivePage([linkedRow('late')], null, null, 2));
+    });
+
+    await openArchive(page);
+    await latePageStarted;
+    await expect(page.locator('.sbca-filename')).toHaveText(['kept']);
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect.poll(() => releases).toContainEqual({ cursor: ARCHIVE_CURSOR });
+    releaseLatePage();
+
+    await expect(page.locator('.sbca-filename')).toHaveText(['kept']);
+    await expect(page.getByText('late', { exact: true })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+});
+
+test('stops an orphan scan, releases its token and cursor, and rolls back partial rows', async ({ page }) => {
+    const releases = [];
+    let orphanRequests = 0;
+    let releaseLatePage;
+    let markLatePageStarted;
+    const latePageStarted = new Promise(resolve => { markLatePageStarted = resolve; });
+    const latePageGate = new Promise(resolve => { releaseLatePage = resolve; });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/release', async route => {
+        releases.push(route.request().postDataJSON());
+        await route.fulfill({ status: 204 });
+    });
+    await page.route('**/api/chats/archive/inventory', async route => {
+        const body = route.request().postDataJSON();
+        if (body.scope === 'archive') {
+            await fulfillJson(route, archivePage([linkedRow('linked')], null, null, 1));
+            return;
+        }
+        orphanRequests++;
+        if (orphanRequests === 1) {
+            await fulfillJson(route, archivePage(
+                [orphanRow('partial-orphan', FIRST_ORPHAN_HASH)],
+                ORPHAN_CURSOR,
+                FIRST_READ_TOKEN,
+                2,
+            ));
+            return;
+        }
+        markLatePageStarted();
+        await latePageGate;
+        await fulfillJson(route, archivePage(
+            [orphanRow('late-orphan', SECOND_ORPHAN_HASH)],
+            null,
+            FIRST_READ_TOKEN,
+            2,
+        ));
+    });
+
+    await openArchive(page);
+    await expect(page.getByRole('button', { name: 'Find orphaned files' })).toBeEnabled();
+    await page.getByRole('button', { name: 'Find orphaned files' }).click();
+    await latePageStarted;
+    await expect(page.getByText('partial-orphan', { exact: true })).toBeVisible();
+    await expect(page.locator('.sbca-status')).toContainText('1 of 2 indexed chat files');
+    await page.getByRole('button', { name: 'Stop scan' }).click();
+    await expect.poll(() => releases).toContainEqual({ token: FIRST_READ_TOKEN, cursor: ORPHAN_CURSOR });
+    releaseLatePage();
+
+    await expect(page.getByText('partial-orphan', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('late-orphan', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('linked', { exact: true })).toBeVisible();
+    await expect(page.locator('.sbca-status')).toContainText('Scan stopped.');
+});
+
+test('replaces orphan scan tokens and views the active orphan through the archive namespace', async ({ page }) => {
+    const releases = [];
+    const viewedUrls = [];
+    const dataMaidRequests = [];
+    let orphanScans = 0;
+    page.on('request', request => {
+        if (new URL(request.url()).pathname.startsWith('/api/data-maid')) {
+            dataMaidRequests.push(request.url());
+        }
+    });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/release', async route => {
+        releases.push(route.request().postDataJSON());
+        await route.fulfill({ status: 204 });
+    });
+    await page.route('**/api/chats/archive/view?**', async route => {
+        viewedUrls.push(route.request().url());
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/x-ndjson',
+            body: [
+                JSON.stringify({ chat_metadata: { source: 'archive' } }),
+                JSON.stringify({ name: 'Archive', mes: 'orphan body' }),
+            ].join('\n'),
+        });
+    });
+    await page.route('**/api/chats/archive/inventory', async route => {
+        const body = route.request().postDataJSON();
+        if (body.scope === 'archive') {
+            await fulfillJson(route, archivePage([linkedRow('linked')], null, null, 1));
+            return;
+        }
+        orphanScans++;
+        const replacement = orphanScans === 2;
+        await fulfillJson(route, archivePage([
+            orphanRow(replacement ? 'current-orphan' : 'old-orphan', replacement ? SECOND_ORPHAN_HASH : FIRST_ORPHAN_HASH),
+        ], null, replacement ? SECOND_READ_TOKEN : FIRST_READ_TOKEN, 1));
+    });
+
+    await openArchive(page);
+    await page.getByRole('button', { name: 'Find orphaned files' }).click();
+    await expect(page.getByText('old-orphan', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Rescan orphaned files' }).click();
+    await expect(page.getByText('current-orphan', { exact: true })).toBeVisible();
+    await expect(page.getByText('old-orphan', { exact: true })).toHaveCount(0);
+    await expect.poll(() => releases).toContainEqual({ token: FIRST_READ_TOKEN });
+
+    await page.getByText('current-orphan', { exact: true }).click();
+    await expect(page.locator('.sbca-viewer-content')).toContainText('orphan body');
+    expect(viewedUrls).toHaveLength(1);
+    const viewed = new URL(viewedUrls[0]);
+    expect(viewed.pathname).toBe('/api/chats/archive/view');
+    expect(viewed.searchParams.get('token')).toBe(SECOND_READ_TOKEN);
+    expect(viewed.searchParams.get('hash')).toBe(SECOND_ORPHAN_HASH);
+    expect(dataMaidRequests).toEqual([]);
+});
+
+async function routeOrganization(page) {
+    await page.route('**/user/files/_sbca_organization.json', route => route.fulfill({ status: 404 }));
+}
+
+async function openArchive(page) {
+    await page.goto(baseUrl);
+    await expect(page.locator('html')).toHaveAttribute('data-archive-ready', 'true');
+    await page.locator('#sbca_drawer_button').click();
+    await expect(page.locator('.sbca-root')).toBeVisible();
+}
+
+function archivePage(rows, cursor, readToken, total) {
+    return { rows, cursor, read_token: readToken, errors: 0, total };
+}
+
+function linkedRow(name) {
+    return {
+        _source: 'archive-inventory',
+        avatar: 'Alice.png',
+        file_name: `${name}.jsonl`,
+        file_size: '1 KB',
+        chat_items: 1,
+        last_mes: 1_000,
+        mes: `${name} preview`,
+    };
+}
+
+function orphanRow(name, hash) {
+    return {
+        _source: 'archive-orphan',
+        archive_hash: hash,
+        chatFolder: 'Deleted',
+        file_name: `${name}.jsonl`,
+        file_size: '1 KB',
+        chat_items: 1,
+        last_mes: 1_000,
+        mes: `${name} preview`,
+        orphan_type: 'missing-character',
+    };
+}
+
+function fulfillJson(route, value) {
+    return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(value),
+    });
+}
+
 function fixtureHtml(useLongLabel) {
     const translatedLabel = useLongLabel
         ? 'Chat Archive Chat Archive Chat Archive Chat Archive'
@@ -141,9 +377,46 @@ function fixtureHtml(useLongLabel) {
         globalThis.SillyTavern = {
             getContext() {
                 return {
+                    characters: [{ avatar: 'Alice.png', name: 'Alice' }],
+                    groups: [],
                     eventSource: { on() {}, removeListener() {} },
                     eventTypes: { APP_READY: 'app-ready' },
+                    getRequestHeaders() { return { 'Content-Type': 'application/json' }; },
+                    getThumbnailUrl(_type, avatar) { return '/avatar/' + encodeURIComponent(avatar); },
+                    timestampToMoment(value) {
+                        const date = new Date(value);
+                        return {
+                            isValid() { return !Number.isNaN(date.valueOf()); },
+                            valueOf() { return date.valueOf(); },
+                            format() { return date.toISOString(); },
+                        };
+                    },
                     translate(text) { return text === 'Chat Archive' ? label : text; },
+                    Popup: class {
+                        constructor(content) {
+                            this.dlg = document.createElement('dialog');
+                            this.dlg.setAttribute('open', '');
+                            this.dlg.tabIndex = -1;
+                            this.okButton = document.createElement('button');
+                            this.okButton.type = 'button';
+                            this.okButton.className = 'popup-close';
+                            this.okButton.textContent = 'Close';
+                            this.dlg.append(content, this.okButton);
+                            this.shown = new Promise(resolve => { this.resolve = resolve; });
+                            this.okButton.addEventListener('click', () => this.completeCancelled());
+                        }
+                        show() {
+                            document.body.append(this.dlg);
+                            return this.shown;
+                        }
+                        async completeCancelled() {
+                            if (this.dlg.isConnected) {
+                                this.dlg.remove();
+                                this.resolve();
+                            }
+                        }
+                    },
+                    POPUP_TYPE: { TEXT: 'text' },
                 };
             },
         };

--- a/tests/sillybunny-chats-archive.e2e.js
+++ b/tests/sillybunny-chats-archive.e2e.js
@@ -1,4 +1,4 @@
-/* global getComputedStyle */
+/* global getComputedStyle, innerHeight, innerWidth */
 import { expect, test } from '@playwright/test';
 import fs from 'node:fs/promises';
 import http from 'node:http';
@@ -111,6 +111,184 @@ test('shows a resilient label with at least a 44px mobile touch target', async (
     expect(control.labelHeight).toBeGreaterThan(0);
     expect(control.buttonFits).toBe(true);
     expect(control.labelFits).toBe(true);
+});
+
+test('owns the popup frame spacing and keeps mobile controls inside the viewport', async ({ page }) => {
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('a-long-chat-name-that-must-wrap-without-widening-the-popup'),
+    ], null, null, 1)));
+
+    await openArchive(page);
+    const frame = await page.locator('.sbca-dialog').evaluate(dialog => {
+        const body = dialog.querySelector('.popup-body');
+        const content = dialog.querySelector('.popup-content');
+        const root = dialog.querySelector('.sbca-root');
+        const controls = dialog.querySelector('.popup-controls');
+        const close = dialog.querySelector('.popup-button-close');
+        const dialogStyle = getComputedStyle(dialog);
+        const bodyStyle = getComputedStyle(body);
+        const contentStyle = getComputedStyle(content);
+        const rootStyle = getComputedStyle(root);
+        const dialogRect = dialog.getBoundingClientRect();
+        const bodyRect = body.getBoundingClientRect();
+        const rootRect = root.getBoundingClientRect();
+        const controlsRect = controls.getBoundingClientRect();
+        const closeRect = close.getBoundingClientRect();
+        return {
+            bodyPaddingBottom: parseFloat(bodyStyle.paddingBottom),
+            bodyPaddingLeft: parseFloat(bodyStyle.paddingLeft),
+            bodyPaddingRight: parseFloat(bodyStyle.paddingRight),
+            bodyPaddingTop: parseFloat(bodyStyle.paddingTop),
+            closeHeight: closeRect.height,
+            closeRight: dialogRect.right - closeRect.right,
+            closeTop: closeRect.top - dialogRect.top,
+            closeWidth: closeRect.width,
+            contentMarginTop: contentStyle.marginTop,
+            contentPaddingLeft: contentStyle.paddingLeft,
+            controlsInsideBody: controlsRect.bottom <= bodyRect.bottom + 0.5,
+            dialogPadding: dialogStyle.padding,
+            rootGap: rootStyle.gap,
+            rootInsideBody: rootRect.left >= bodyRect.left && rootRect.right <= bodyRect.right,
+            rootNoHorizontalOverflow: root.scrollWidth <= root.clientWidth,
+            viewportFit: dialogRect.left >= 0 && dialogRect.right <= innerWidth,
+        };
+    });
+
+    expect(frame.dialogPadding).toBe('0px');
+    expect(frame.contentMarginTop).toBe('0px');
+    expect(frame.contentPaddingLeft).toBe('0px');
+    expect(frame.rootGap).toBe('16px');
+    expect(frame.bodyPaddingTop).toBeGreaterThanOrEqual(12);
+    expect(frame.bodyPaddingRight).toBeGreaterThanOrEqual(12);
+    expect(frame.bodyPaddingBottom).toBeGreaterThanOrEqual(8);
+    expect(frame.bodyPaddingLeft).toBeGreaterThanOrEqual(12);
+    expect(frame.closeHeight).toBeGreaterThanOrEqual(44);
+    expect(frame.closeWidth).toBeGreaterThanOrEqual(44);
+    expect(frame.closeTop).toBeGreaterThanOrEqual(4);
+    expect(frame.closeRight).toBeGreaterThanOrEqual(4);
+    expect(frame.controlsInsideBody).toBe(true);
+    expect(frame.rootInsideBody).toBe(true);
+    expect(frame.rootNoHorizontalOverflow).toBe(true);
+    expect(frame.viewportFit).toBe(true);
+});
+
+test('keeps a balanced master-detail workspace on desktop', async ({ page }) => {
+    let releaseExport;
+    const exportGate = new Promise(resolve => { releaseExport = resolve; });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('desktop-chat'),
+    ], null, null, 1)));
+    await page.route('**/api/chats/export', async route => {
+        await exportGate;
+        await fulfillJson(route, {
+            result: [
+                JSON.stringify({ chat_metadata: { source: 'desktop' } }),
+                JSON.stringify({ name: 'Alice', mes: 'desktop message' }),
+            ].join('\n'),
+        });
+    });
+
+    await openArchive(page);
+    await page.getByText('desktop-chat', { exact: true }).click();
+    await expect(page.locator('.sbca-viewer-content')).toContainText('Loading chat...');
+    const loadingOrder = await page.locator('.sbca-viewer-content').evaluate(content => (
+        [...content.children].map(child => child.className)
+    ));
+    expect(loadingOrder).toEqual(['sbca-organizer', 'sbca-viewer-details']);
+    releaseExport();
+    await expect(page.locator('.sbca-viewer-content')).toContainText('desktop message');
+    const layout = await page.locator('.sbca-dialog').evaluate(dialog => {
+        const root = dialog.querySelector('.sbca-root');
+        const list = dialog.querySelector('.sbca-list-panel');
+        const viewer = dialog.querySelector('.sbca-viewer');
+        const search = dialog.querySelector('.sbca-search input');
+        const deepSearch = dialog.querySelector('.sbca-deep');
+        const clearFilters = dialog.querySelector('.sbca-clear-filters');
+        const refresh = dialog.querySelector('.sbca-archive-actions > :nth-child(2)');
+        const scan = dialog.querySelector('.sbca-archive-actions > :nth-child(3)');
+        const viewerContent = dialog.querySelector('.sbca-viewer-content');
+        const viewerDetails = dialog.querySelector('.sbca-viewer-details');
+        const organizer = dialog.querySelector('.sbca-organizer');
+        const dialogRect = dialog.getBoundingClientRect();
+        const rootRect = root.getBoundingClientRect();
+        const listRect = list.getBoundingClientRect();
+        const viewerRect = viewer.getBoundingClientRect();
+        const searchRect = search.getBoundingClientRect();
+        const deepSearchRect = deepSearch.getBoundingClientRect();
+        const detailsRect = viewerDetails.getBoundingClientRect();
+        const organizerRect = organizer.getBoundingClientRect();
+        return {
+            actionOrder: [clearFilters, refresh, scan].map(control => control.textContent.trim()),
+            detailOrder: [...viewerContent.children].map(child => child.className),
+            contentInset: rootRect.left - dialogRect.left,
+            controlsAligned: Math.abs(searchRect.top - deepSearchRect.top) <= 0.5
+                && Math.abs(searchRect.bottom - deepSearchRect.bottom) <= 0.5,
+            detailsRadius: parseFloat(getComputedStyle(viewerDetails).borderRadius),
+            dialogHeightRatio: dialogRect.height / innerHeight,
+            dialogWidthRatio: dialogRect.width / innerWidth,
+            listRadius: parseFloat(getComputedStyle(list).borderRadius),
+            listWidth: listRect.width,
+            noHorizontalOverflow: root.scrollWidth <= root.clientWidth,
+            organizerBeforeInformation: organizerRect.bottom <= detailsRect.top,
+            viewerRadius: parseFloat(getComputedStyle(viewer).borderRadius),
+            viewerStartsAfterList: viewerRect.left > listRect.right,
+            viewerWidth: viewerRect.width,
+        };
+    });
+
+    expect(layout.dialogWidthRatio).toBeGreaterThan(0.9);
+    expect(layout.dialogWidthRatio).toBeLessThanOrEqual(0.95);
+    expect(layout.dialogHeightRatio).toBeGreaterThan(0.85);
+    expect(layout.dialogHeightRatio).toBeLessThanOrEqual(0.93);
+    expect(layout.contentInset).toBeGreaterThanOrEqual(16);
+    expect(layout.contentInset).toBeLessThanOrEqual(18);
+    expect(layout.controlsAligned).toBe(true);
+    expect(layout.actionOrder).toEqual(['Clear filters', 'Refresh', 'Find orphaned files']);
+    expect(layout.listRadius).toBeGreaterThan(0);
+    expect(layout.viewerRadius).toBeGreaterThan(0);
+    expect(layout.viewerStartsAfterList).toBe(true);
+    expect(layout.viewerWidth).toBeGreaterThan(layout.listWidth);
+    expect(layout.detailOrder).toEqual(['sbca-viewer-actions', 'sbca-organizer', 'sbca-viewer-details']);
+    expect(layout.detailsRadius).toBeGreaterThan(0);
+    expect(layout.organizerBeforeInformation).toBe(true);
+    expect(layout.noHorizontalOverflow).toBe(true);
+});
+
+test('keeps the tablet and Safari popup layout bounded', async ({ page }) => {
+    await page.setViewportSize({ width: 820, height: 740 });
+    await page.goto(baseUrl);
+    await expect(page.locator('html')).toHaveAttribute('data-archive-ready', 'true');
+    await page.locator('body').evaluate(body => body.classList.add('safari'));
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('tablet-chat'),
+    ], null, null, 1)));
+
+    await page.locator('#sbca_drawer_button').click();
+    await expect(page.locator('.sbca-root')).toBeVisible();
+    const layout = await page.locator('.sbca-dialog').evaluate(dialog => {
+        const body = dialog.querySelector('.popup-body');
+        const root = dialog.querySelector('.sbca-root');
+        const dialogRect = dialog.getBoundingClientRect();
+        const bodyRect = body.getBoundingClientRect();
+        const rootRect = root.getBoundingClientRect();
+        return {
+            bodyHeight: bodyRect.height,
+            dialogHeight: dialogRect.height,
+            rootInsideBody: rootRect.left >= bodyRect.left && rootRect.right <= bodyRect.right,
+            rootNoHorizontalOverflow: root.scrollWidth <= root.clientWidth,
+            viewportFit: dialogRect.top >= 0 && dialogRect.bottom <= innerHeight,
+        };
+    });
+
+    expect(layout.dialogHeight).toBeLessThanOrEqual(740);
+    expect(layout.bodyHeight).toBeLessThanOrEqual(layout.dialogHeight);
+    expect(layout.rootInsideBody).toBe(true);
+    expect(layout.rootNoHorizontalOverflow).toBe(true);
+    expect(layout.viewportFit).toBe(true);
 });
 
 test('renders the first archive page and progress before the next page resolves', async ({ page }) => {
@@ -285,6 +463,12 @@ test('replaces orphan scan tokens and views the active orphan through the archiv
 
     await page.getByText('current-orphan', { exact: true }).click();
     await expect(page.locator('.sbca-viewer-content')).toContainText('orphan body');
+    const mobileDetail = await page.locator('.sbca-viewer-content').evaluate(content => ({
+        noHorizontalOverflow: content.scrollWidth <= content.clientWidth,
+        order: [...content.children].map(child => child.className),
+    }));
+    expect(mobileDetail.order).toEqual(['sbca-viewer-actions', 'sbca-organizer', 'sbca-viewer-details']);
+    expect(mobileDetail.noHorizontalOverflow).toBe(true);
     expect(viewedUrls).toHaveLength(1);
     const viewed = new URL(viewedUrls[0]);
     expect(viewed.pathname).toBe('/api/chats/archive/view');
@@ -351,6 +535,7 @@ function fixtureHtml(useLongLabel) {
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/public/style.css">
+    <link rel="stylesheet" href="/public/css/sillybunny-theme.css">
     <link rel="stylesheet" href="/public/css/mobile-styles.css" media="(max-width: 768px)">
     <link rel="stylesheet" href="/public/css/sillybunny-tabs.css">
     <link rel="stylesheet" href="/public/css/sillybunny-mobile-shell.css" media="(max-width: 768px)">
@@ -395,18 +580,33 @@ function fixtureHtml(useLongLabel) {
                     Popup: class {
                         constructor(content) {
                             this.dlg = document.createElement('dialog');
-                            this.dlg.setAttribute('open', '');
+                            this.dlg.className = 'popup large_dialogue_popup';
                             this.dlg.tabIndex = -1;
+                            this.body = document.createElement('div');
+                            this.body.className = 'popup-body';
+                            this.content = document.createElement('div');
+                            this.content.className = 'popup-content';
+                            this.controls = document.createElement('div');
+                            this.controls.className = 'popup-controls';
                             this.okButton = document.createElement('button');
                             this.okButton.type = 'button';
-                            this.okButton.className = 'popup-close';
+                            this.okButton.className = 'menu_button popup-button-ok';
                             this.okButton.textContent = 'Close';
-                            this.dlg.append(content, this.okButton);
+                            this.closeButton = document.createElement('div');
+                            this.closeButton.className = 'popup-button-close';
+                            this.closeButton.setAttribute('aria-label', 'Close popup');
+                            this.closeButton.tabIndex = 0;
+                            this.content.append(content);
+                            this.controls.append(this.okButton);
+                            this.body.append(this.content, this.controls);
+                            this.dlg.append(this.body, this.closeButton);
                             this.shown = new Promise(resolve => { this.resolve = resolve; });
                             this.okButton.addEventListener('click', () => this.completeCancelled());
+                            this.closeButton.addEventListener('click', () => this.completeCancelled());
                         }
                         show() {
                             document.body.append(this.dlg);
+                            this.dlg.showModal();
                             return this.shown;
                         }
                         async completeCancelled() {

--- a/tests/sillybunny-chats-archive.e2e.js
+++ b/tests/sillybunny-chats-archive.e2e.js
@@ -1,0 +1,156 @@
+/* global getComputedStyle */
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const extensionRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'public',
+    'scripts',
+    'extensions',
+    'sillybunny-chats-archive',
+);
+const publicRoot = path.resolve(extensionRoot, '..', '..', '..');
+
+let baseUrl;
+let server;
+
+test.describe.configure({ mode: 'serial' });
+test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+});
+
+test.beforeAll(async () => {
+    server = http.createServer(async (request, response) => {
+        try {
+            const url = new URL(request.url, 'http://127.0.0.1');
+            if (url.pathname === '/') {
+                response.setHeader('Content-Type', 'text/html; charset=utf-8');
+                response.end(fixtureHtml(url.searchParams.has('long')));
+                return;
+            }
+            const asset = url.pathname.startsWith('/extension/')
+                ? { root: extensionRoot, relativePath: url.pathname.slice('/extension/'.length) }
+                : url.pathname.startsWith('/public/')
+                    ? { root: publicRoot, relativePath: url.pathname.slice('/public/'.length) }
+                    : null;
+            if (!asset) {
+                response.statusCode = 404;
+                response.end();
+                return;
+            }
+
+            const filePath = path.resolve(asset.root, asset.relativePath);
+            if (path.relative(asset.root, filePath).startsWith('..')) {
+                response.statusCode = 403;
+                response.end();
+                return;
+            }
+            response.setHeader('Content-Type', path.extname(filePath) === '.css'
+                ? 'text/css; charset=utf-8'
+                : 'text/javascript; charset=utf-8');
+            response.end(await fs.readFile(filePath));
+        } catch {
+            response.statusCode = 500;
+            response.end();
+        }
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+test.afterAll(async () => {
+    if (server) {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    }
+});
+
+test('shows a resilient label with at least a 44px mobile touch target', async ({ page }) => {
+    await page.goto(`${baseUrl}/?long`);
+    await expect(page.locator('html')).toHaveAttribute('data-archive-ready', 'true');
+
+    const control = await page.locator('#sbca_drawer_button').evaluate(button => {
+        const label = button.querySelector('.sbca-drawer-button-label');
+        const buttonStyle = getComputedStyle(button);
+        const labelStyle = getComputedStyle(label);
+        const buttonRect = button.getBoundingClientRect();
+        const labelRect = label.getBoundingClientRect();
+        return {
+            ariaLabel: button.getAttribute('aria-label'),
+            buttonHeight: buttonRect.height,
+            buttonWidth: buttonRect.width,
+            buttonFits: button.scrollWidth <= button.clientWidth && button.scrollHeight <= button.clientHeight,
+            buttonVisibility: buttonStyle.visibility,
+            labelDisplay: labelStyle.display,
+            labelHeight: labelRect.height,
+            labelText: label.textContent,
+            labelWidth: labelRect.width,
+            labelFits: label.scrollWidth <= label.clientWidth,
+        };
+    });
+
+    expect(control.labelText).toBe('Chat Archive Chat Archive Chat Archive Chat Archive');
+    expect(control.ariaLabel).toBe(control.labelText);
+    expect(control.buttonVisibility).toBe('visible');
+    expect(control.labelDisplay).not.toBe('none');
+    expect(control.buttonHeight).toBeGreaterThanOrEqual(44);
+    expect(control.buttonWidth).toBeGreaterThan(control.buttonHeight);
+    expect(control.labelWidth).toBeGreaterThan(0);
+    expect(control.labelHeight).toBeGreaterThan(0);
+    expect(control.buttonFits).toBe(true);
+    expect(control.labelFits).toBe(true);
+});
+
+function fixtureHtml(useLongLabel) {
+    const translatedLabel = useLongLabel
+        ? 'Chat Archive Chat Archive Chat Archive Chat Archive'
+        : 'Chat Archive';
+    return `<!doctype html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/public/style.css">
+    <link rel="stylesheet" href="/public/css/mobile-styles.css" media="(max-width: 768px)">
+    <link rel="stylesheet" href="/public/css/sillybunny-tabs.css">
+    <link rel="stylesheet" href="/public/css/sillybunny-mobile-shell.css" media="(max-width: 768px)">
+    <link rel="stylesheet" href="/extension/style.css">
+    <style>
+        :root { --mainFontFamily: sans-serif; --sb-mobile-touch-target: 44px; }
+        body { margin: 0; }
+        .menu_button { border: 1px solid currentColor; background: transparent; color: inherit; font: inherit; }
+        .sb-character-create-bar { display: flex; width: 100%; overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <div id="right-nav-panel" class="openDrawer">
+        <div id="charListFixedTop">
+            <div class="sb-character-create-bar">
+                <div id="rm_button_bar">
+                    <div id="rm_buttons_container"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script type="module">
+        const label = ${JSON.stringify(translatedLabel)};
+        globalThis.SillyTavern = {
+            getContext() {
+                return {
+                    eventSource: { on() {}, removeListener() {} },
+                    eventTypes: { APP_READY: 'app-ready' },
+                    translate(text) { return text === 'Chat Archive' ? label : text; },
+                };
+            },
+        };
+        const { activate } = await import('/extension/index.js');
+        await activate();
+        document.documentElement.dataset.archiveReady = 'true';
+    </script>
+</body>
+</html>`;
+}

--- a/tests/sillybunny-chats-archive.e2e.js
+++ b/tests/sillybunny-chats-archive.e2e.js
@@ -206,6 +206,8 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
         const viewer = dialog.querySelector('.sbca-viewer');
         const search = dialog.querySelector('.sbca-search input');
         const deepSearch = dialog.querySelector('.sbca-deep');
+        const ownerSummary = dialog.querySelector('.sbca-owner-summary');
+        const sortPill = dialog.querySelector('.sbca-sortpill');
         const clearFilters = dialog.querySelector('.sbca-clear-filters');
         const refresh = dialog.querySelector('.sbca-archive-actions > :nth-child(2)');
         const scan = dialog.querySelector('.sbca-archive-actions > :nth-child(3)');
@@ -218,6 +220,8 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
         const viewerRect = viewer.getBoundingClientRect();
         const searchRect = search.getBoundingClientRect();
         const deepSearchRect = deepSearch.getBoundingClientRect();
+        const ownerSummaryRect = ownerSummary.getBoundingClientRect();
+        const sortPillRect = sortPill.getBoundingClientRect();
         const detailsRect = viewerDetails.getBoundingClientRect();
         const organizerRect = organizer.getBoundingClientRect();
         return {
@@ -226,6 +230,8 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
             contentInset: rootRect.left - dialogRect.left,
             controlsAligned: Math.abs(searchRect.top - deepSearchRect.top) <= 0.5
                 && Math.abs(searchRect.bottom - deepSearchRect.bottom) <= 0.5,
+            listToolsAligned: Math.abs(ownerSummaryRect.top - sortPillRect.top) <= 0.5
+                && Math.abs(ownerSummaryRect.height - sortPillRect.height) <= 2,
             detailsRadius: parseFloat(getComputedStyle(viewerDetails).borderRadius),
             dialogHeightRatio: dialogRect.height / innerHeight,
             dialogWidthRatio: dialogRect.width / innerWidth,
@@ -246,6 +252,7 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
     expect(layout.contentInset).toBeGreaterThanOrEqual(16);
     expect(layout.contentInset).toBeLessThanOrEqual(18);
     expect(layout.controlsAligned).toBe(true);
+    expect(layout.listToolsAligned).toBe(true);
     expect(layout.actionOrder).toEqual(['Clear filters', 'Refresh', 'Find orphaned files']);
     expect(layout.listRadius).toBeGreaterThan(0);
     expect(layout.viewerRadius).toBeGreaterThan(0);

--- a/tests/sillybunny-chats-archive.e2e.js
+++ b/tests/sillybunny-chats-archive.e2e.js
@@ -257,6 +257,43 @@ test('keeps a balanced master-detail workspace on desktop', async ({ page }) => 
     expect(layout.noHorizontalOverflow).toBe(true);
 });
 
+test('keeps filters concise and organization management full width when expanded', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await routeOrganization(page);
+    await page.route('**/api/chats/archive/inventory', route => fulfillJson(route, archivePage([
+        linkedRow('organization-chat'),
+    ], null, null, 1)));
+
+    await openArchive(page);
+    await expect(page.getByText('Sort', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('List tools', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('Filters', { exact: true })).toBeVisible();
+    await expect(page.getByText('Manage organization', { exact: true })).toBeVisible();
+
+    const layout = await page.locator('.sbca-toolbar').evaluate(toolbar => {
+        const root = toolbar.closest('.sbca-root');
+        const organization = toolbar.querySelector('.sbca-organization-tools');
+        const panel = toolbar.querySelector('.sbca-organization-tools-panel');
+        organization.open = true;
+        const toolbarStyle = getComputedStyle(toolbar);
+        const panelRect = panel.getBoundingClientRect();
+        const toolbarRect = toolbar.getBoundingClientRect();
+        return {
+            panelWidth: panelRect.width,
+            toolbarWidth: toolbarRect.width,
+            toolbarOverflowY: toolbarStyle.overflowY,
+            toolbarMaxBlockSize: toolbarStyle.maxBlockSize,
+            rootScrollHeight: root.scrollHeight,
+            rootClientHeight: root.clientHeight,
+        };
+    });
+
+    expect(layout.panelWidth).toBeGreaterThan(layout.toolbarWidth * 0.9);
+    expect(layout.toolbarOverflowY).not.toBe('auto');
+    expect(layout.toolbarMaxBlockSize).toBe('none');
+    expect(layout.rootScrollHeight).toBeGreaterThanOrEqual(layout.rootClientHeight);
+});
+
 test('keeps the tablet and Safari popup layout bounded', async ({ page }) => {
     await page.setViewportSize({ width: 820, height: 740 });
     await page.goto(baseUrl);

--- a/tests/sillybunny-chats-archive.test.js
+++ b/tests/sillybunny-chats-archive.test.js
@@ -14,6 +14,7 @@ import {
     fetchArchiveFile,
     fetchArchiveInventory,
     fetchOrganization,
+    iterateArchiveInventoryPages,
     ORGANIZATION_FILE_NAME,
     releaseArchiveSession,
     saveOrganization,
@@ -86,8 +87,8 @@ describe('SillyBunny Chats Archive API', () => {
         const requests = [];
         const progress = jest.fn();
         const pages = [
-            { rows: [{ file_name: 'one.jsonl' }], cursor, read_token: null, errors: 1 },
-            { rows: [{ file_name: 'two.jsonl' }, { file_name: 'three.jsonl' }], cursor: null, read_token: null, errors: 0 },
+            { rows: [{ file_name: 'one.jsonl' }], cursor, read_token: null, errors: 1, total: 3 },
+            { rows: [{ file_name: 'two.jsonl' }, { file_name: 'three.jsonl' }], cursor: null, read_token: null, errors: 0, total: 3 },
         ];
         globalThis.fetch = async (url, options) => {
             requests.push({ url, options });
@@ -119,9 +120,73 @@ describe('SillyBunny Chats Archive API', () => {
             { scope: 'archive', page_size: ARCHIVE_PAGE_SIZE, cursor },
         ]);
         expect(progress.mock.calls).toEqual([
-            [{ loaded: 1, errors: 1 }],
-            [{ loaded: 3, errors: 1 }],
+            [expect.objectContaining({ loaded: 1, errors: 1, total: 3 })],
+            [expect.objectContaining({ loaded: 3, errors: 1, total: 3 })],
         ]);
+    });
+
+    test('delivers the first inventory page before a later request resolves and releases early iteration', async () => {
+        const cursor = 'e'.repeat(64);
+        let resolveLaterPage;
+        let laterRequestStarted;
+        const laterRequest = new Promise(resolve => { laterRequestStarted = resolve; });
+        const released = [];
+        let inventoryRequests = 0;
+        globalThis.fetch = async (url, options) => {
+            if (url === '/api/chats/archive/release') {
+                released.push(JSON.parse(options.body));
+                return { ok: true, status: 204 };
+            }
+            inventoryRequests++;
+            if (inventoryRequests === 1) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        rows: [{ file_name: 'first.jsonl' }],
+                        cursor,
+                        read_token: null,
+                        errors: 0,
+                        total: 2,
+                    }),
+                };
+            }
+            laterRequestStarted();
+            return new Promise(resolve => { resolveLaterPage = resolve; });
+        };
+
+        const pages = iterateArchiveInventoryPages({ getRequestHeaders: () => ({}) }, 'archive');
+        await expect(pages.next()).resolves.toMatchObject({
+            done: false,
+            value: { loaded: 1, total: 2, rows: [{ file_name: 'first.jsonl' }] },
+        });
+        const pendingLaterPage = pages.next();
+        await laterRequest;
+        let laterPageSettled = false;
+        void pendingLaterPage.finally(() => { laterPageSettled = true; });
+        await Promise.resolve();
+        expect(laterPageSettled).toBe(false);
+
+        resolveLaterPage({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                rows: [{ file_name: 'second.jsonl' }],
+                cursor: null,
+                read_token: null,
+                errors: 0,
+                total: 2,
+            }),
+        });
+        await expect(pendingLaterPage).resolves.toMatchObject({
+            value: { loaded: 2, rows: [{ file_name: 'second.jsonl' }] },
+        });
+
+        const earlyPages = iterateArchiveInventoryPages({ getRequestHeaders: () => ({}) }, 'archive');
+        inventoryRequests = 0;
+        await earlyPages.next();
+        await earlyPages.return();
+        expect(released).toContainEqual({ cursor });
     });
 
     test('sorts and filters complete metadata from beyond the first archive page', async () => {
@@ -143,8 +208,8 @@ describe('SillyBunny Chats Archive API', () => {
             mes: 'late page metadata',
         };
         const pages = [
-            { rows: firstPage, cursor, read_token: null, errors: 0 },
-            { rows: [qualifying], cursor: null, read_token: null, errors: 0 },
+            { rows: firstPage, cursor, read_token: null, errors: 0, total: ARCHIVE_PAGE_SIZE + 1 },
+            { rows: [qualifying], cursor: null, read_token: null, errors: 0, total: ARCHIVE_PAGE_SIZE + 1 },
         ];
         globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => pages.shift() });
 
@@ -260,21 +325,26 @@ describe('SillyBunny Chats Archive API', () => {
         timedRequest.cleanup();
     });
 
-    test('cancels a later inventory page and retains its read token for cleanup', async () => {
+    test('cancels a later inventory page and releases its cursor and read token', async () => {
         Object.defineProperty(AbortSignal, 'any', { configurable: true, value: undefined, writable: true });
         const cursor = 'b'.repeat(64);
         const readToken = 'c'.repeat(64);
         const controller = new AbortController();
         let requestCount = 0;
+        const releases = [];
         let secondRequestStarted;
         const secondRequest = new Promise(resolve => { secondRequestStarted = resolve; });
-        globalThis.fetch = async (_url, options) => {
+        globalThis.fetch = async (url, options) => {
+            if (url === '/api/chats/archive/release') {
+                releases.push(JSON.parse(options.body));
+                return { ok: true, status: 204 };
+            }
             requestCount++;
             if (requestCount === 1) {
                 return {
                     ok: true,
                     status: 200,
-                    json: async () => ({ rows: [{ file_name: 'one.jsonl' }], cursor, read_token: readToken, errors: 0 }),
+                    json: async () => ({ rows: [{ file_name: 'one.jsonl' }], cursor, read_token: readToken, errors: 0, total: 2 }),
                 };
             }
             secondRequestStarted();
@@ -297,6 +367,7 @@ describe('SillyBunny Chats Archive API', () => {
             archiveReadToken: readToken,
         });
         expect(requestCount).toBe(2);
+        expect(releases).toEqual([{ token: readToken, cursor }]);
     });
 
     test('views and releases orphan files only through the archive namespace', async () => {
@@ -967,7 +1038,6 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/aria-labelledby/);
         expect(ui).toMatch(/aria-current/);
         expect(ui).toMatch(/new AbortController\(\)/);
-        expect(ui).toMatch(/fetchArchiveInventory\(ctx, 'archive'/);
         expect(ui).toMatch(/eventTypes\.CHAT_CHANGED/);
         expect(ui).toMatch(/setActive(?:Character|Group)/);
         expect(ui).toMatch(/aria-expanded/);
@@ -1043,7 +1113,6 @@ describe('SillyBunny Chats Archive integration', () => {
     test('message lists, grouping, scans, and search retain their safety contracts', () => {
         const searchStart = ui.indexOf('search.addEventListener(\'keydown\'', ui.indexOf('const flushQuery'));
         const searchHandler = ui.slice(searchStart, ui.indexOf('\n    });', searchStart));
-        const scan = ui.slice(ui.indexOf('async function scanOrphans'), ui.indexOf('async function releaseArchiveToken'));
         expect(searchHandler).toMatch(/event\.key !== 'Enter' \|\| event\.isComposing/);
         expect(searchHandler).toMatch(/flushQuery\(\)/);
         expect(searchHandler).not.toMatch(/runDeepSearch/);
@@ -1061,12 +1130,6 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/group\.rows\.filter\(row => shownRows\.has\(row\)\)/);
         expect(ui).toMatch(/group\.rows\.length/);
         expect(ui).toMatch(/for \(const row of shownGroupRows\)/);
-        expect(ui).toMatch(/state\.scanAbort\?\.abort\(\)/);
-        expect(scan).toMatch(/fetchArchiveInventory\(ctx, 'orphans', controller\.signal/);
-        expect(scan).toMatch(/state\.archiveReadToken = inventory\.readToken/);
-        expect(scan).toMatch(/releaseArchiveToken\(ctx, previousToken\)/);
-        expect(ui).not.toMatch(/\/api\/data-maid|fetchDataMaid|finalizeDataMaid/);
-        expect(ui).not.toMatch(/AbortSignal\.(?:any|timeout)/);
         expect(ui).toMatch(/ui\.status\.setAttribute\('aria-busy', 'true'\)/);
         expect(ui).toMatch(/ui\.status\.removeAttribute\('aria-busy'\)/);
     });

--- a/tests/sillybunny-chats-archive.test.js
+++ b/tests/sillybunny-chats-archive.test.js
@@ -1048,7 +1048,8 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/sbca-selection-toggle/);
         expect(ui).toMatch(/sbca-organizer/);
         expect(ui).toMatch(/physicalChatKey/);
-        expect(ui).toMatch(/'Character or group'/);
+        expect(ui).toMatch(/summary\.setAttribute\('aria-label', tr\(ctx, 'Character or group'\)\)/);
+        expect(ui).not.toMatch(/el\('span', 'sbca-label', tr\(ctx, 'Character or group'\)\)/);
         expect(ui).toMatch(/'All characters and groups'/);
         expect(ui).toMatch(/sbca-owner-selector/);
         expect(ui).toMatch(/const ownerField = ownerControl\(ctx\)/);

--- a/tests/sillybunny-chats-archive.test.js
+++ b/tests/sillybunny-chats-archive.test.js
@@ -262,7 +262,14 @@ describe('SillyBunny Chats Archive API', () => {
         response = { ok: false, status: 503 };
         await expect(fetchOrganization(ctx)).rejects.toThrow(/_sbca_organization\.json failed with status 503/);
 
-        response = { ok: true, status: 200, json: async () => { throw new SyntaxError('bad sidecar'); } };
+        const organization = { version: 1, folders: [], collections: [], views: [], chats: {} };
+        response = { ok: true, status: 200, text: async () => JSON.stringify(organization) };
+        await expect(fetchOrganization(ctx)).resolves.toEqual(organization);
+
+        response = { ok: true, status: 200, text: async () => btoa(JSON.stringify(organization)) };
+        await expect(fetchOrganization(ctx)).resolves.toEqual(organization);
+
+        response = { ok: true, status: 200, text: async () => 'bad sidecar' };
         await expect(fetchOrganization(ctx)).rejects.toThrow(SyntaxError);
     });
 
@@ -781,6 +788,36 @@ describe('SillyBunny Chats Archive core', () => {
         expect(filterRows(normalized, { text: 'lost', kinds: ['solo'] })).toHaveLength(0);
     });
 
+    test('an active Favorites category outranks deselected chat types', () => {
+        const organization = {
+            folders: [],
+            collections: [],
+            chats: {
+                [physicalChatKey(normalized[0])]: { favorite: true },
+                [physicalChatKey(normalized[2])]: { favorite: true },
+            },
+        };
+
+        expect(filterRows(normalized, { kinds: [], favoritesSelected: true }, organization).map(row => row.file_id))
+            .toEqual(['dragon tavern', 'abc-123']);
+        expect(filterRows(normalized, { kinds: ['orphan'], favoritesSelected: true }, organization).map(row => row.file_id))
+            .toEqual(['dragon tavern', 'lost chat', 'abc-123', 'stray']);
+        expect(filterRows(normalized, { kinds: [], favoritesSelected: true }, null)).toHaveLength(0);
+        expect(filterRows(normalized, { kinds: [] }, organization)).toHaveLength(0);
+        expect(filterRows(normalized, { kinds: ['solo'], favoritesSelected: true }, organization).map(row => row.file_id))
+            .toEqual(['dragon tavern', 'abc-123']);
+        expect(filterRows(normalized, {
+            kinds: [],
+            favoritesSelected: true,
+            owner: 'Tavern Night',
+        }, organization).map(row => row.file_id)).toEqual(['abc-123']);
+        expect(filterRows(normalized, {
+            kinds: [],
+            favorite: false,
+            favoritesSelected: true,
+        }, organization)).toHaveLength(0);
+    });
+
     test('filterRows applies organization labels, facets, and metadata bounds', () => {
         const organization = {
             folders: [{ id: 'quests', name: 'Heroic Quests' }],
@@ -867,7 +904,8 @@ describe('SillyBunny Chats Archive core', () => {
             ['solo', ['dragon tavern']],
             ['orphan', ['stray', 'lost chat']],
         ]);
-        expect(groupRows(rows, 'folder', organization).map(group => [group.label, group.rows.map(row => row.file_id)])).toEqual([
+        const folderRows = [normalized[1], normalized[2], normalized[0], normalized[3]];
+        expect(groupRows(folderRows, 'folder', organization).map(group => [group.label, group.rows.map(row => row.file_id)])).toEqual([
             ['Beta', ['abc-123', 'stray']],
             ['Alpha', ['dragon tavern']],
             ['Unfiled', ['lost chat']],
@@ -1042,13 +1080,14 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/setActive(?:Character|Group)/);
         expect(ui).toMatch(/aria-expanded/);
         expect(ui).toMatch(/aria-pressed/);
-        expect(ui).toMatch(/state\.deepRows === null \? ui\.search\.value : ''/);
+        expect(ui).toMatch(/const search = mentionSearchState\(ui\.search\.value, ui\.characterMentions\);[\s\S]*state\.deepRows === null \? search\.text : ''/);
+        expect(ui).toMatch(/favoritesSelected: ui\.favorite\.checked/);
         expect(ui).toMatch(/ORGANIZATION_FILE_NAME/);
-        expect(ui).toMatch(/Do not delete \{name\} through host Data Maid/);
+        expect(ui).not.toMatch(/Do not delete \{name\} through host Data Maid/);
         expect(ui).toMatch(/sbca-selection-toggle/);
         expect(ui).toMatch(/sbca-organizer/);
         expect(ui).toMatch(/physicalChatKey/);
-        expect(ui).toMatch(/summary\.setAttribute\('aria-label', tr\(ctx, 'Character or group'\)\)/);
+        expect(ui).toMatch(/summary\.setAttribute\('aria-label', `\$\{tr\(ctx, 'Character or group'\)\}: \$\{choice\.label\}`\)/);
         expect(ui).not.toMatch(/el\('span', 'sbca-label', tr\(ctx, 'Character or group'\)\)/);
         expect(ui).toMatch(/'All characters and groups'/);
         expect(ui).toMatch(/sbca-owner-selector/);
@@ -1068,8 +1107,13 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/sbca-sortpill/);
         expect(ui).not.toMatch(/characterChips|sbca-charstrip|sbca-charchip|charSort/);
         expect(ui).toMatch(/enterKeyHint = 'search'/);
-        expect(ui).toMatch(/SEARCH_DEBOUNCE_MS = 150/);
-        expect(ui).toMatch(/search\.addEventListener\('input', \(\) => \{\s*exitDeepSearch\(ctx, state, ui\);\s*noteViewEdit\(\);/);
+        expect(ui).toMatch(/Type to search chats\. Mention character names with @\./);
+        expect(ui).toMatch(/role', 'listbox'/);
+        expect(ui).toMatch(/function fuzzyMentionChoices/);
+        expect(ui).toMatch(/function mentionedRows/);
+        expect(ui).toMatch(/SEARCH_CONTENT_DEBOUNCE_MS = 600/);
+        expect(ui).toMatch(/state\.listState !== 'ready' \|\| state\.scanAbort \|\| state\.searchAbort/);
+        expect(ui).toMatch(/search\.addEventListener\('input',[\s\S]*?applyQuery\(\);[\s\S]*?runDeepSearch/);
         expect(ui).toMatch(/buildSearchScopes\(ctx\.characters, ctx\.groups, ui\.owner\.value\)/);
         expect(ui).toMatch(/findMatchingMessageIndex/);
         expect(ui).toMatch(/First search match/);
@@ -1079,19 +1123,23 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/more\.click\(\)/);
         expect(ui).toMatch(/showPage\(shaped\.messages\.length - MESSAGE_PAGE_SIZE\)/);
         expect(ui).toMatch(/state\.deepRows !== null && state\.deepQuery === matchQuery/);
-        expect(ui).toMatch(/search result verification failed/);
+        expect(ui).not.toMatch(/search result verification failed/);
+        expect(ui).toMatch(/const found = new Map\(filterRows\(mentionedRows\(allRows\(state\), search\.mentions\), \{ text: query \}/);
         expect(ui).toMatch(/search items had errors/);
-        expect(ui).toMatch(/allRows\(state\)\.filter\(row => row\.kind === 'orphan'\)/);
+        expect(ui).toMatch(/mentionedRows\(allRows\(state\), search\.mentions\)\.filter\(row => row\.kind === 'orphan'\)/);
         expect(ui).not.toMatch(/row\.kind === 'orphan' \|\| row\.source === 'inventory'/);
         expect(ui).toMatch(/findMatchingSnippetInJsonlAsync\(raw, query, \{ signal \}\)/);
         expect(ui).not.toMatch(/findExistingGroupFiles/);
-        expect(ui).toMatch(/sbca-browse-options/);
-        expect(ui).toMatch(/options\.append\(el\('summary', undefined, tr\(ctx, 'Filters'\)\)\)/);
-        expect(ui).toMatch(/const organizationTools = el\('details', 'sbca-organization-tools'\)/);
+        expect(ui).toMatch(/savedViewField\.wrap\.hidden = true/);
+        expect(ui).toMatch(/ui\.savedViewWrap\.hidden = organization\.views\.length === 0/);
+        expect(ui).toMatch(/filterToggle\.setAttribute\('aria-controls', optionsPanel\.id\)/);
+        expect(ui).toMatch(/filterToggle\.setAttribute\('aria-expanded'/);
+        expect(ui).toMatch(/organizationToggle\.setAttribute\('aria-controls', organizationPanel\.id\)/);
         expect(ui).toMatch(/Manage organization/);
         expect(ui).not.toMatch(/SORT_OPTIONS/);
         expect(ui).not.toMatch(/sortField/);
-        expect(ui).toMatch(/Clear filters/);
+        expect(ui).not.toMatch(/Clear filters/);
+        expect(ui).not.toMatch(/Search message content/);
         expect(ui).not.toMatch(/sbca-row-selection-label/);
         expect(ui).not.toMatch(/\browKey\(/);
         expect(ui).not.toMatch(/menu_button/);
@@ -1101,7 +1149,7 @@ describe('SillyBunny Chats Archive integration', () => {
     test('archive preserves focus and exposes item-specific actions', () => {
         expect(ui).toMatch(/function preserveArchiveFocus\(ui, update\)/);
         expect(ui).toMatch(/organizationFocusKey\('manager', type, item\.id, 'rename'\)/);
-        expect(ui).toMatch(/organizationFocusKey\('organizer', key, 'favorite'\)/);
+        expect(ui).toMatch(/organizationFocusKey\('viewer-action', key, 'favorite'\)/);
         expect(ui).toMatch(/control\.dataset\.sbcaFocusKey === snapshot\.fallback/);
         expect(ui).toMatch(/snapshot\.viewer \? ui\.viewerTitle : snapshot\.list \? ui\.listHeading/);
         expect(ui).toMatch(/preserveArchiveFocus\(ui, \(\) => \{\s*refreshOrganizationUI/s);
@@ -1109,9 +1157,14 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/Delete \{name\}/);
         expect(ui).toMatch(/Select \{name\} for \{owner\}/);
         expect(ui).toMatch(/Delete saved view \{name\}\?/);
-        expect(ui).toMatch(/const active = document\.activeElement;\s*const focusInBrowse = browseStrip\.contains\(active\);\s*browseOptions\.open/s);
-        expect(ui).toMatch(/focusInBrowse\) \{\s*browseSummary\.focus/s);
-        expect(ui).toMatch(/active === browseSummary\) \{\s*groupField\.select\.focus/s);
+        expect(ui).toMatch(/const focusInFilters = optionsPanel\.contains\(active\);\s*const organizationExpanded = organizationToggle\.getAttribute\('aria-expanded'\) === 'true';\s*const showDesktopFilters = !event\.matches && !organizationExpanded;\s*optionsPanel\.hidden = !showDesktopFilters/s);
+        expect(ui).toMatch(/focusInFilters\) \{[\s\S]*?restoreFilterFocusOnDesktop = true;[\s\S]*?filterToggle\.focus/s);
+        expect(ui).toMatch(/focusInBrowse\) \{\s*groupField\.select\.focus/s);
+        expect(ui).toMatch(/const folder = el\('div', 'sbca-organizer-folder'\)/);
+        expect(ui).toMatch(/folder\.setAttribute\('aria-labelledby', folderLabel\.id\)/);
+        expect(ui).toMatch(/folderLabel\.classList\.add\('sbca-organizer-section-title'\)/);
+        expect(ui).toMatch(/const collectionsField = selectControl\(ctx, 'Collections'/);
+        expect(ui).toMatch(/Remove collection \{name\}/);
         const cancelViewer = ui.slice(ui.indexOf('function cancelViewer'), ui.indexOf('function cancelNavigation'));
         expect(cancelViewer).toMatch(/state\.viewerAbort\?\.abort\(\)/);
         expect(cancelViewer).not.toMatch(/state\.viewerAbort = null/);
@@ -1122,8 +1175,10 @@ describe('SillyBunny Chats Archive integration', () => {
         const searchHandler = ui.slice(searchStart, ui.indexOf('\n    });', searchStart));
         expect(searchHandler).toMatch(/event\.key !== 'Enter' \|\| event\.isComposing/);
         expect(searchHandler).toMatch(/flushQuery\(\)/);
-        expect(searchHandler).not.toMatch(/runDeepSearch/);
-        expect(ui).toMatch(/deepButton\.addEventListener\('click',[\s\S]*?runDeepSearch/);
+        expect(ui).not.toMatch(/deepButton/);
+        expect(ui).toMatch(/control === ui\.owner && mentionSearchState\(ui\.search\.value, ui\.characterMentions\)\.text[\s\S]*state\.listState === 'ready' && !state\.scanAbort/);
+        expect(ui).toMatch(/function applySavedView[\s\S]*mentionSearchState\(ui\.search\.value, ui\.characterMentions\)\.text && state\.listState === 'ready' && !state\.scanAbort[\s\S]*runDeepSearch/);
+        expect(ui).toMatch(/ui\.scanButton\.textContent = tr[\s\S]*if \(mentionSearchState\(ui\.search\.value, ui\.characterMentions\)\.text\) \{[\s\S]*runDeepSearch/);
         expect(ui).toMatch(/const messageList = el\('div', 'sbca-message-list'\);/);
         expect(ui).toMatch(/messageList\.setAttribute\('role', 'list'\)/);
         expect(ui).toMatch(/messages\.append\(messageList, el\('p', 'sbca-placeholder'/);

--- a/tests/sillybunny-chats-archive.test.js
+++ b/tests/sillybunny-chats-archive.test.js
@@ -8,20 +8,20 @@ import path from 'node:path';
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
 
 import {
+    ARCHIVE_PAGE_SIZE,
+    createTimedSignal,
     exportChat,
-    fetchCharacterFiles,
-    fetchDataMaidReport,
+    fetchArchiveFile,
+    fetchArchiveInventory,
     fetchOrganization,
-    fetchRecent,
-    finalizeDataMaid,
     ORGANIZATION_FILE_NAME,
+    releaseArchiveSession,
     saveOrganization,
     searchScope,
 } from '../public/scripts/extensions/sillybunny-chats-archive/src/api.js';
 import {
     buildSearchScopes,
     createDefaultOrganization,
-    dataMaidRecordToRow,
     deepResultToRecentRow,
     filterRows,
     findMatchingMessageIndex,
@@ -59,36 +59,107 @@ jest.unstable_mockModule('../src/util.js', () => ({
 const { DataMaidService } = await import('../src/endpoints/data-maid.js');
 
 const extensionRoot = new URL('../public/scripts/extensions/sillybunny-chats-archive/', import.meta.url);
-const [entry, ui, css, manifestText, extensionsEndpoint] = await Promise.all([
+const [entry, ui, manifestText, extensionsEndpoint] = await Promise.all([
     readFile(new URL('index.js', extensionRoot), 'utf8'),
     readFile(new URL('src/ui.js', extensionRoot), 'utf8'),
-    readFile(new URL('style.css', extensionRoot), 'utf8'),
     readFile(new URL('manifest.json', extensionRoot), 'utf8'),
     readFile(new URL('../src/endpoints/extensions.js', import.meta.url), 'utf8'),
 ]);
 const manifest = JSON.parse(manifestText);
 const entryModule = await import('../public/scripts/extensions/sillybunny-chats-archive/index.js');
 const originalFetch = globalThis.fetch;
-const originalAbortSignalTimeout = AbortSignal.timeout;
+const originalAbortSignalAny = Object.getOwnPropertyDescriptor(AbortSignal, 'any');
 
 afterEach(() => {
     globalThis.fetch = originalFetch;
-    AbortSignal.timeout = originalAbortSignalTimeout;
+    if (originalAbortSignalAny) {
+        Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny);
+    } else {
+        delete AbortSignal.any;
+    }
+    jest.useRealTimers();
 });
 
 describe('SillyBunny Chats Archive API', () => {
-    test('recent chats request covers one list page with a bounded host request', async () => {
-        let request;
+    test('loads every bounded archive page through one inventory endpoint', async () => {
+        const cursor = 'a'.repeat(64);
+        const requests = [];
+        const progress = jest.fn();
+        const pages = [
+            { rows: [{ file_name: 'one.jsonl' }], cursor, read_token: null, errors: 1 },
+            { rows: [{ file_name: 'two.jsonl' }, { file_name: 'three.jsonl' }], cursor: null, read_token: null, errors: 0 },
+        ];
         globalThis.fetch = async (url, options) => {
-            request = { url, options };
-            return { ok: true, status: 200, json: async () => [] };
+            requests.push({ url, options });
+            return { ok: true, status: 200, json: async () => pages.shift() };
         };
 
-        await fetchRecent({ getRequestHeaders: () => ({ authorization: 'test' }) });
+        const result = await fetchArchiveInventory(
+            { getRequestHeaders: () => ({ authorization: 'test' }) },
+            'archive',
+            undefined,
+            progress,
+        );
 
-        expect(request.url).toBe('/api/chats/recent');
-        expect(request.options.method).toBe('POST');
-        expect(request.options.body).toBe('{"max":100}');
+        expect(result).toEqual({
+            rows: [
+                { file_name: 'one.jsonl' },
+                { file_name: 'two.jsonl' },
+                { file_name: 'three.jsonl' },
+            ],
+            errors: 1,
+            readToken: null,
+        });
+        expect(requests.map(request => request.url)).toEqual([
+            '/api/chats/archive/inventory',
+            '/api/chats/archive/inventory',
+        ]);
+        expect(requests.map(request => JSON.parse(request.options.body))).toEqual([
+            { scope: 'archive', page_size: ARCHIVE_PAGE_SIZE },
+            { scope: 'archive', page_size: ARCHIVE_PAGE_SIZE, cursor },
+        ]);
+        expect(progress.mock.calls).toEqual([
+            [{ loaded: 1, errors: 1 }],
+            [{ loaded: 3, errors: 1 }],
+        ]);
+    });
+
+    test('sorts and filters complete metadata from beyond the first archive page', async () => {
+        const cursor = 'd'.repeat(64);
+        const firstPage = Array.from({ length: ARCHIVE_PAGE_SIZE }, (_, index) => ({
+            avatar: 'Scale.png',
+            file_name: `chat-${String(index).padStart(3, '0')}.jsonl`,
+            file_size: '1KB',
+            chat_items: 1,
+            last_mes: index + 1,
+            mes: '',
+        }));
+        const qualifying = {
+            avatar: 'Scale.png',
+            file_name: 'qualifying.jsonl',
+            file_size: '8MB',
+            chat_items: 900,
+            last_mes: 50_000,
+            mes: 'late page metadata',
+        };
+        const pages = [
+            { rows: firstPage, cursor, read_token: null, errors: 0 },
+            { rows: [qualifying], cursor: null, read_token: null, errors: 0 },
+        ];
+        globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => pages.shift() });
+
+        const inventory = await fetchArchiveInventory({ getRequestHeaders: () => ({}) }, 'archive');
+        const rows = inventory.rows.map(row => normalizeRow(row, [{ avatar: 'Scale.png', name: 'Scale' }], []));
+        const filtered = filterRows(rows, {
+            minDate: 40_000,
+            minMessages: 500,
+            minSize: 4 * 1024 * 1024,
+        });
+
+        expect(filtered.map(row => row.file_id)).toEqual(['qualifying']);
+        expect(sortRows(rows, 'count')[0].file_id).toBe('qualifying');
+        expect(sortRows(rows, 'recent')[0].file_id).toBe('qualifying');
+        expect(sortRows(rows, 'size')[0].file_id).toBe('qualifying');
     });
 
     test('POST failures preserve HTTP status for lazy missing-file handling', async () => {
@@ -153,24 +224,10 @@ describe('SillyBunny Chats Archive API', () => {
         expect(decoded).toBe(JSON.stringify(organization));
     });
 
-    test('organization uploads are bounded and caller-cancellable', async () => {
-        const timeoutController = new AbortController();
-        let timeout;
+    test('organization uploads are bounded and caller-cancellable without AbortSignal.any', async () => {
+        Object.defineProperty(AbortSignal, 'any', { configurable: true, value: undefined, writable: true });
         let requestSignal;
-        AbortSignal.timeout = milliseconds => {
-            timeout = milliseconds;
-            return timeoutController.signal;
-        };
-        globalThis.fetch = async (_url, options) => {
-            requestSignal = options.signal;
-            return { ok: true, status: 200, json: async () => ({ uploaded: true }) };
-        };
         const ctx = { getRequestHeaders: () => ({}) };
-
-        await saveOrganization(ctx, { version: 1 });
-        expect(timeout).toBe(15_000);
-        expect(requestSignal).toBe(timeoutController.signal);
-
         const caller = new AbortController();
         globalThis.fetch = (_url, options) => {
             requestSignal = options.signal;
@@ -185,76 +242,83 @@ describe('SillyBunny Chats Archive API', () => {
         expect(requestSignal.aborted).toBe(true);
     });
 
-    test('Data Maid report and finalization forward cancellation signals', async () => {
-        const requests = [];
-        globalThis.fetch = async (url, options) => {
-            requests.push({ url, options });
-            return { ok: true, status: 200, json: async () => ({}) };
-        };
-        const ctx = { getRequestHeaders: () => ({}) };
-        const signal = new AbortController().signal;
+    test('composes caller cancellation and timeouts when AbortSignal.any is absent', async () => {
+        Object.defineProperty(AbortSignal, 'any', { configurable: true, value: undefined, writable: true });
+        const caller = new AbortController();
+        const callerRequest = createTimedSignal(caller.signal, 10_000);
+        const reason = new DOMException('cancelled', 'AbortError');
+        caller.abort(reason);
+        expect(callerRequest.signal.aborted).toBe(true);
+        expect(callerRequest.signal.reason).toBe(reason);
+        callerRequest.cleanup();
 
-        await fetchDataMaidReport(ctx, signal);
-        await finalizeDataMaid(ctx, 'scan-token', signal);
-
-        expect(requests.map(request => [
-            request.url,
-            request.options.body,
-            request.options.signal,
-        ])).toEqual([
-            ['/api/data-maid/report', '{}', signal],
-            ['/api/data-maid/finalize', '{"token":"scan-token"}', signal],
-        ]);
+        jest.useFakeTimers();
+        const timedRequest = createTimedSignal(undefined, 25);
+        jest.advanceTimersByTime(25);
+        expect(timedRequest.signal.aborted).toBe(true);
+        expect(timedRequest.signal.reason).toMatchObject({ name: 'TimeoutError' });
+        timedRequest.cleanup();
     });
 
-    test('character inventory is bounded and preserves partial results', async () => {
-        let active = 0;
-        let maxActive = 0;
-        let slowRequestActive = false;
-        let filledSlowSlot = false;
+    test('cancels a later inventory page and retains its read token for cleanup', async () => {
+        Object.defineProperty(AbortSignal, 'any', { configurable: true, value: undefined, writable: true });
+        const cursor = 'b'.repeat(64);
+        const readToken = 'c'.repeat(64);
+        const controller = new AbortController();
+        let requestCount = 0;
+        let secondRequestStarted;
+        const secondRequest = new Promise(resolve => { secondRequestStarted = resolve; });
         globalThis.fetch = async (_url, options) => {
-            const { avatar_url: avatar } = JSON.parse(options.body);
-            active++;
-            maxActive = Math.max(maxActive, active);
-            if (avatar === '0.png') {
-                slowRequestActive = true;
-            } else if (avatar === '8.png' && slowRequestActive) {
-                filledSlowSlot = true;
+            requestCount++;
+            if (requestCount === 1) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ rows: [{ file_name: 'one.jsonl' }], cursor, read_token: readToken, errors: 0 }),
+                };
             }
-            await new Promise(resolve => setTimeout(resolve, avatar === '0.png' ? 20 : 1));
-            if (avatar === '0.png') {
-                slowRequestActive = false;
-            }
-            active--;
-            if (avatar === '3.png') {
-                return { ok: false, status: 500, json: async () => ({ message: 'failed' }) };
-            }
-            if (avatar === '5.png') {
-                return { ok: true, status: 200, json: async () => ({ error: true }) };
-            }
-            return {
-                ok: true,
-                status: 200,
-                json: async () => avatar === '4.png'
-                    ? [null, { file_name: `${avatar}-chat.jsonl` }]
-                    : [{ file_name: `${avatar}-chat.jsonl` }],
-            };
+            secondRequestStarted();
+            return await new Promise((_resolve, reject) => {
+                options.signal.addEventListener('abort', () => {
+                    const error = new Error('aborted');
+                    error.name = 'AbortError';
+                    reject(error);
+                }, { once: true });
+            });
         };
 
-        const ctx = { getRequestHeaders: () => ({}) };
-        const avatars = Array.from({ length: 10 }, (_, index) => `${index}.png`);
-        const result = await fetchCharacterFiles(ctx, avatars);
+        const pending = fetchArchiveInventory({ getRequestHeaders: () => ({}) }, 'orphans', controller.signal);
+        await secondRequest;
+        controller.abort();
 
-        expect(result.failures).toBe(2);
-        expect(result.rows).toHaveLength(8);
-        expect([...result.failedAvatars]).toEqual(['3.png', '4.png']);
-        expect(maxActive).toBe(8);
-        expect(filledSlowSlot).toBe(true);
-        expect(result.rows[0]).toEqual({
-            file_name: '0.png-chat.jsonl',
-            avatar: '0.png',
-            _source: 'inventory',
+        await expect(pending).rejects.toMatchObject({
+            name: 'AbortError',
+            archiveCursor: cursor,
+            archiveReadToken: readToken,
         });
+        expect(requestCount).toBe(2);
+    });
+
+    test('views and releases orphan files only through the archive namespace', async () => {
+        const requests = [];
+        globalThis.fetch = async (url, options = {}) => {
+            requests.push({ url: String(url), options });
+            if (String(url).includes('/view?')) {
+                return { ok: true, status: 200, text: async () => 'chat body' };
+            }
+            return { ok: true, status: 204 };
+        };
+        const ctx = { getRequestHeaders: () => ({ 'x-test': 'yes' }) };
+        const signal = new AbortController().signal;
+
+        await expect(fetchArchiveFile(ctx, 'token', 'hash', signal)).resolves.toBe('chat body');
+        await releaseArchiveSession(ctx, { token: 'token', cursor: 'cursor' }, signal);
+
+        expect(requests[0].url).toBe('/api/chats/archive/view?token=token&hash=hash');
+        expect(requests[0].options.signal).toBe(signal);
+        expect(requests[1].url).toBe('/api/chats/archive/release');
+        expect(JSON.parse(requests[1].options.body)).toEqual({ token: 'token', cursor: 'cursor' });
+        expect(requests.every(request => !request.url.includes('/api/data-maid'))).toBe(true);
     });
 
     test('successful list endpoints reject malformed JSON and response shapes', async () => {
@@ -264,9 +328,10 @@ describe('SillyBunny Chats Archive API', () => {
             expect(options.headers).toEqual({ 'x-test': 'yes' });
             return { ok: true, status: 200, json: async () => { throw new SyntaxError('bad json'); } };
         };
-        await expect(fetchRecent(ctx)).rejects.toThrow(SyntaxError);
+        await expect(fetchArchiveInventory(ctx, 'archive')).rejects.toThrow(SyntaxError);
 
         globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => ({ results: [] }) });
+        await expect(fetchArchiveInventory(ctx, 'archive')).rejects.toThrow(/invalid response/);
         await expect(searchScope(ctx, 'x', {})).rejects.toThrow(/invalid response/);
     });
 
@@ -276,7 +341,7 @@ describe('SillyBunny Chats Archive API', () => {
             status: 200,
             json: async () => { throw new DOMException('aborted', 'AbortError'); },
         });
-        await expect(fetchRecent({ getRequestHeaders: () => ({}) })).rejects.toMatchObject({ name: 'AbortError' });
+        await expect(fetchArchiveInventory({ getRequestHeaders: () => ({}) }, 'archive')).rejects.toMatchObject({ name: 'AbortError' });
     });
 });
 
@@ -375,7 +440,7 @@ describe('SillyBunny Chats Archive core', () => {
     test('normalizers reject malformed records and keep file identity consistent', () => {
         expect(normalizeRow(null)).toBeNull();
         expect(normalizeRow({ avatar: 1, file_id: 'bad' })).toBeNull();
-        expect(dataMaidRecordToRow([], 'missing-character')).toBeNull();
+        expect(normalizeRow({ orphan_type: 'invalid', file_name: 'bad.jsonl' })).toBeNull();
         expect(deepResultToRecentRow('bad', {})).toBeNull();
         const row = normalizeRow({ file_id: 'wrong', file_name: 'actual.jsonl', chat_items: -3 });
         expect(row.file_id).toBe('actual');
@@ -429,7 +494,13 @@ describe('SillyBunny Chats Archive core', () => {
             normalizeRow({ avatar: 'Alex.png', file_id: 'first' }, duplicateCharacters, duplicateGroups),
             normalizeRow({ avatar: 'Alex_2.png', file_id: 'second' }, duplicateCharacters, duplicateGroups),
             normalizeRow({ group: 'alex-group', file_id: 'group' }, duplicateCharacters, duplicateGroups),
-            dataMaidRecordToRow({ name: 'missing.jsonl', hash: 'hash', parent: 'Alex' }, 'missing-character'),
+            normalizeRow({
+                _source: 'archive-orphan',
+                archive_hash: 'hash',
+                chatFolder: 'Alex',
+                file_name: 'missing.jsonl',
+                orphan_type: 'missing-character',
+            }),
         ];
         const first = ownerFilterKey(rows[0]);
         const second = ownerFilterKey(rows[1]);
@@ -449,8 +520,16 @@ describe('SillyBunny Chats Archive core', () => {
         expect(normalizeSavedView({ owner: second }).owner).toBe(second);
     });
 
-    test('dataMaidRecordToRow preserves orphan source details', () => {
-        const row = dataMaidRecordToRow({ name: 'lost.jsonl', hash: 'abc', parent: 'Deleted', size: 2048, mtime: 123 }, 'missing-character');
+    test('normalizeRow preserves archive orphan source details', () => {
+        const row = normalizeRow({
+            _source: 'archive-orphan',
+            archive_hash: 'abc',
+            chatFolder: 'Deleted',
+            file_name: 'lost.jsonl',
+            file_size: '2KB',
+            last_mes: 123,
+            orphan_type: 'missing-character',
+        });
         expect(row.kind).toBe('orphan');
         expect(row.orphanType).toBe('missing-character');
         expect(row.ownerName).toBe('Deleted');
@@ -458,21 +537,32 @@ describe('SillyBunny Chats Archive core', () => {
         expect(row.file_id).toBe('lost');
         expect(row.sizeText).toBe('2KB');
         expect(row.count).toBeNull();
-        expect(row.dataMaidHash).toBe('abc');
+        expect(row.archiveHash).toBe('abc');
     });
 
-    test('physicalChatKey follows physical file scope instead of owner or Data Maid identity', () => {
+    test('physicalChatKey follows physical file scope instead of owner or archive token identity', () => {
         const linkedGroup = normalizeRow({ group: 'group-1', file_id: 'shared' }, [], groups);
         const missingGroup = normalizeRow({ group: 'deleted-group', file_id: 'shared' });
-        const unlinkedGroup = dataMaidRecordToRow({ name: 'shared.jsonl', hash: 'temporary-a' }, 'unlinked-group');
+        const unlinkedGroup = normalizeRow({
+            _source: 'archive-orphan',
+            archive_hash: 'temporary-a',
+            file_name: 'shared.jsonl',
+            orphan_type: 'unlinked-group',
+        });
         expect(physicalChatKey(linkedGroup)).toBe(physicalChatKey(missingGroup));
         expect(physicalChatKey(missingGroup)).toBe(physicalChatKey(unlinkedGroup));
 
         const linkedCharacter = normalizeRow({ avatar: 'Seraphina.png', file_id: 'solo' }, characters);
-        const missingCharacter = dataMaidRecordToRow({ name: 'solo.jsonl', hash: 'temporary-b', parent: 'Seraphina' }, 'missing-character');
+        const missingCharacter = normalizeRow({
+            _source: 'archive-orphan',
+            archive_hash: 'temporary-b',
+            chatFolder: 'Seraphina',
+            file_name: 'solo.jsonl',
+            orphan_type: 'missing-character',
+        });
         expect(linkedCharacter.chatFolder).toBe('Seraphina');
         expect(physicalChatKey(linkedCharacter)).toBe(physicalChatKey(missingCharacter));
-        expect(physicalChatKey({ ...missingCharacter, dataMaidHash: 'different' })).toBe(physicalChatKey(missingCharacter));
+        expect(physicalChatKey({ ...missingCharacter, archiveHash: 'different' })).toBe(physicalChatKey(missingCharacter));
 
         expect(physicalChatKey({ kind: 'solo', chatFolder: 'a:b', file_id: 'c' }))
             .not.toBe(physicalChatKey({ kind: 'solo', chatFolder: 'a', file_id: 'b:c' }));
@@ -877,10 +967,9 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/aria-labelledby/);
         expect(ui).toMatch(/aria-current/);
         expect(ui).toMatch(/new AbortController\(\)/);
-        expect(ui).toMatch(/fetchCharacterFiles/);
+        expect(ui).toMatch(/fetchArchiveInventory\(ctx, 'archive'/);
         expect(ui).toMatch(/eventTypes\.CHAT_CHANGED/);
         expect(ui).toMatch(/setActive(?:Character|Group)/);
-        expect(ui).toMatch(/group\.chat_id/);
         expect(ui).toMatch(/aria-expanded/);
         expect(ui).toMatch(/aria-pressed/);
         expect(ui).toMatch(/state\.deepRows === null \? ui\.search\.value : ''/);
@@ -904,9 +993,6 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/listTools\.open = true/);
         expect(ui).toMatch(/option\.addEventListener\('pointerdown', event => \{\s*if \(event\.button !== 0 \|\| event\.pointerType === 'touch'\)/);
         expect(ui).toMatch(/option\.addEventListener\('click', select\)/);
-        expect(ui).toMatch(/async function enrichSelectedOwner\(ctx, state, ui\)/);
-        expect(ui).toMatch(/fetchCharacterChatDetails\(ctx, avatar, controller\.signal\)/);
-        expect(ui).toMatch(/state\.enrichedOwners\.has\(avatar\)/);
         expect(ui).toMatch(/sbca-sortpill/);
         expect(ui).not.toMatch(/characterChips|sbca-charstrip|sbca-charchip|charSort/);
         expect(ui).toMatch(/enterKeyHint = 'search'/);
@@ -927,8 +1013,6 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).not.toMatch(/row\.kind === 'orphan' \|\| row\.source === 'inventory'/);
         expect(ui).toMatch(/findMatchingSnippetInJsonlAsync\(raw, query, \{ signal \}\)/);
         expect(ui).not.toMatch(/findExistingGroupFiles/);
-        expect(ui).toMatch(/error\?\.status === 404 && row\.kind === 'group' && row\.source === 'inventory'/);
-        expect(ui).toMatch(/state\.missingGroupFiles\.add\(row\.file_id\)/);
         expect(ui).toMatch(/sbca-browse-options/);
         expect(ui).toMatch(/Clear filters/);
         expect(ui).not.toMatch(/sbca-row-selection-label/);
@@ -959,7 +1043,7 @@ describe('SillyBunny Chats Archive integration', () => {
     test('message lists, grouping, scans, and search retain their safety contracts', () => {
         const searchStart = ui.indexOf('search.addEventListener(\'keydown\'', ui.indexOf('const flushQuery'));
         const searchHandler = ui.slice(searchStart, ui.indexOf('\n    });', searchStart));
-        const scan = ui.slice(ui.indexOf('async function scanOrphans'), ui.indexOf('async function finalizeDataMaidToken'));
+        const scan = ui.slice(ui.indexOf('async function scanOrphans'), ui.indexOf('async function releaseArchiveToken'));
         expect(searchHandler).toMatch(/event\.key !== 'Enter' \|\| event\.isComposing/);
         expect(searchHandler).toMatch(/flushQuery\(\)/);
         expect(searchHandler).not.toMatch(/runDeepSearch/);
@@ -978,13 +1062,11 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/group\.rows\.length/);
         expect(ui).toMatch(/for \(const row of shownGroupRows\)/);
         expect(ui).toMatch(/state\.scanAbort\?\.abort\(\)/);
-        expect(scan).toMatch(/fetchDataMaidReport\(ctx\)/);
-        expect(scan).not.toMatch(/fetchDataMaidReport\(ctx, controller\.signal\)/);
-        expect(scan).toMatch(/if \(controller\.signal\.aborted\)[\s\S]*previousKeys[\s\S]*retainedRows = orphanRows\.filter[\s\S]*state\.dataMaidToken = data\.token;[\s\S]*state\.orphanRows = retainedRows;/);
-        expect(scan).toMatch(/state\.dataMaidToken = data\.token;[\s\S]*state\.orphanRows = orphanRows;/);
-        expect(scan).toMatch(/Previous results are still shown/);
-        expect(scan).toMatch(/state\.scanAbort !== controller/);
-        expect(ui).toMatch(/finalizeDataMaid\([\s\S]*AbortSignal\.timeout\(DATA_MAID_FINALIZE_TIMEOUT_MS\)/);
+        expect(scan).toMatch(/fetchArchiveInventory\(ctx, 'orphans', controller\.signal/);
+        expect(scan).toMatch(/state\.archiveReadToken = inventory\.readToken/);
+        expect(scan).toMatch(/releaseArchiveToken\(ctx, previousToken\)/);
+        expect(ui).not.toMatch(/\/api\/data-maid|fetchDataMaid|finalizeDataMaid/);
+        expect(ui).not.toMatch(/AbortSignal\.(?:any|timeout)/);
         expect(ui).toMatch(/ui\.status\.setAttribute\('aria-busy', 'true'\)/);
         expect(ui).toMatch(/ui\.status\.removeAttribute\('aria-busy'\)/);
     });
@@ -1008,55 +1090,6 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(entry).toMatch(/pending = setTimeout\(\(\) => \{\s*pending = null;\s*install\(\);/);
     });
 
-    test('stylesheet follows theme, layout, focus, touch, and side-stripe contracts', () => {
-        expect(css).toMatch(/--color-border/);
-        expect(css).toMatch(/--sbca-text:\s*var\(--color-text/);
-        expect(css).toMatch(/:focus-visible/);
-        expect(css).toMatch(/@media \(any-pointer: coarse\)/);
-        expect(css).toMatch(/--sb-mobile-touch-target, 44px/);
-        expect(css).toMatch(/--sbca-muted:\s*var\(--sb-muted-fg/);
-        expect(css).toMatch(/\.sbca-heading\s*\{[^}]*border:\s*0/s);
-        expect(css).toMatch(/\[data-sbca-density="compact"\]/);
-        expect(css).toMatch(/\[data-sbca-density="minimal"\]/);
-        expect(css).toMatch(/\.sbca-group-button/);
-        expect(css).toMatch(/\.sbca-organizer/);
-        expect(css).toMatch(/\.sbca-owner-summary\s*\{[^}]*min-block-size:\s*46px;[^}]*border-radius:\s*var\(--sb-radius-button, 14px\)/s);
-        expect(css).toMatch(/\.sbca-owner-option\s*\{[^}]*min-block-size:\s*44px;/s);
-        expect(css).toMatch(/\.sbca-owner-option\s*\{[^}]*content-visibility:\s*auto;[^}]*contain-intrinsic-size:\s*auto 56px;/s);
-        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-dialog\s*\{[^}]*width:\s*94vw !important;[^}]*max-width:\s*94vw !important;[^}]*height:\s*92dvh !important;[^}]*max-height:\s*92dvh !important;/s);
-        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-dialog\s*\{[^}]*min-height:\s*0 !important;/s);
-        expect(css).toMatch(/@media \(max-width: 600px\)\s*\{[\s\S]*\.sbca-dialog\s*\{[^}]*min-height:\s*0 !important;/s);
-        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-root\s*\{[^}]*block-size:\s*100%;[^}]*max-block-size:\s*92dvh;/s);
-        expect(css).toMatch(/@media \(max-width: 600px\)\s*\{[\s\S]*\.sbca-root\s*\{[^}]*block-size:\s*100%;[^}]*max-block-size:\s*100dvh;/s);
-        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-root\s*\{[^}]*block-size:\s*100%;/s);
-        expect(css).toMatch(/\.sbca-owner-options\s*\{[^}]*max-block-size:\s*min\(320px, 45dvh\);[^}]*overflow-y:\s*auto;/s);
-        expect(css).toMatch(/\[data-sbca-density="minimal"\] \.sbca-row-preview\s*\{[^}]*-webkit-line-clamp:\s*1;/s);
-        expect(css).toMatch(/\.sbca-sortpill\s*\{/);
-        expect(css).toMatch(/\.sbca-sortpill\[aria-pressed="true"\]\s*\{[^}]*--sb-selection-bg[^}]*--sb-selection-fg[^}]*text-decoration-line:\s*underline;/s);
-        expect(css).toMatch(/\.sbca-dialog \.popup-body,\s*\.sbca-dialog \.popup-content\s*\{[^}]*overflow:\s*hidden !important;/s);
-        expect(css).toMatch(/\.sbca-owner-selector\s*\{[^}]*inline-size:\s*100%;/s);
-        expect(css).toMatch(/\.sbca-root \[hidden\]\s*\{[^}]*display:\s*none !important;/s);
-        expect(css).toMatch(/\.sbca-list-panel\s*\{[^}]*grid-template-rows:\s*auto minmax\(0,\s*1fr\);[^}]*min-inline-size:\s*0;/s);
-        expect(css).toMatch(/\.sbca-list-tools\[open\]\s*\{[^}]*flex-basis:\s*100%;/s);
-        expect(css).toMatch(/\.sbca-list-tools-panel\s*\{[^}]*display:\s*grid;/s);
-        expect(css).toMatch(/\.sbca-list-tools > summary\s*\{[^}]*color:\s*var\(--sbca-muted\)/s);
-        expect(css).toMatch(/\.sbca-sort,/);
-        expect(css).toMatch(/\.sbca-deep\s*\{[^}]*border-color:\s*var\(--sbca-accent\)/s);
-        expect(css).toMatch(/\.sbca-msg-match\s*\{/);
-        expect(css).toMatch(/\.sbca-msg:focus\s*\{[^}]*outline:\s*2px solid var\(--sbca-focus\)/s);
-        expect(css).toMatch(/\.sbca-root\[data-sbca-density\] \.sbca-row-button/);
-        expect(css).toMatch(/\.sbca-row-selection\s*\{[^}]*min-inline-size:\s*var\(--sb-mobile-touch-target, 44px\)/s);
-        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-toolbar:has\(\.sbca-options\[open\]\)[\s\S]*max-block-size:\s*60%;[\s\S]*overflow-y:\s*auto;[\s\S]*overscroll-behavior:\s*contain;/);
-        expect(css).toMatch(/@media \(max-width: 600px\)/);
-        expect(css).toMatch(/width:\s*100vw !important/);
-        expect(css).toMatch(/height:\s*100dvh !important/);
-        expect(css).toMatch(/font-size:\s*16px/);
-        expect(css).not.toMatch(/rgba?\(/i);
-        expect(css).toMatch(/@media screen and \(max-width: 768px\)\s*\{[\s\S]*#right-nav-panel\.openDrawer \.sb-character-create-bar #sbca_drawer_button\s*\{[^}]*width:\s*38px !important;[^}]*height:\s*38px !important;/);
-        expect(css).not.toMatch(/^\s*color:\s*var\(--sbca-accent\)/m);
-        expect(css).not.toMatch(/sbca-sortpill-active/);
-        expect(css).not.toMatch(/border-(?:left|right)\s*:\s*[2-9]/i);
-    });
 });
 
 describe('Data Maid Chat Archive integration', () => {

--- a/tests/sillybunny-chats-archive.test.js
+++ b/tests/sillybunny-chats-archive.test.js
@@ -1,0 +1,1099 @@
+/* eslint-disable playwright/no-conditional-in-test */
+/* global globalThis */
+import { EventEmitter } from 'node:events';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+
+import {
+    exportChat,
+    fetchCharacterFiles,
+    fetchDataMaidReport,
+    fetchOrganization,
+    fetchRecent,
+    finalizeDataMaid,
+    ORGANIZATION_FILE_NAME,
+    saveOrganization,
+    searchScope,
+} from '../public/scripts/extensions/sillybunny-chats-archive/src/api.js';
+import {
+    buildSearchScopes,
+    createDefaultOrganization,
+    dataMaidRecordToRow,
+    deepResultToRecentRow,
+    filterRows,
+    findMatchingMessageIndex,
+    findMatchingSnippet,
+    findMatchingSnippetInJsonl,
+    findMatchingSnippetInJsonlAsync,
+    formatBytes,
+    groupRows,
+    normalizeRow,
+    normalizeOrganization,
+    normalizeSavedView,
+    matchesQueryFragments,
+    ownerFilterKey,
+    parseChatJsonl,
+    parseHumanSize,
+    parseJsonl,
+    parseLastMes,
+    parseOwnerFilter,
+    parseOrganization,
+    physicalChatKey,
+    recordsToText,
+    shapeChatRecords,
+    sortRows,
+} from '../public/scripts/extensions/sillybunny-chats-archive/src/core.js';
+import { navigateAndConfirm } from '../public/scripts/extensions/sillybunny-chats-archive/src/ui.js';
+
+jest.unstable_mockModule('../src/endpoints/chats.js', () => ({ CHAT_BACKUPS_PREFIX: 'chat_' }));
+jest.unstable_mockModule('../src/endpoints/settings.js', () => ({ getSettingsBackupFilePrefix: () => 'settings_' }));
+jest.unstable_mockModule('../src/util.js', () => ({
+    isPathUnderParent: () => true,
+    recoverFileWriteSync: () => {},
+    tryParse: value => JSON.parse(value),
+}));
+
+const { DataMaidService } = await import('../src/endpoints/data-maid.js');
+
+const extensionRoot = new URL('../public/scripts/extensions/sillybunny-chats-archive/', import.meta.url);
+const [entry, ui, css, manifestText, extensionsEndpoint] = await Promise.all([
+    readFile(new URL('index.js', extensionRoot), 'utf8'),
+    readFile(new URL('src/ui.js', extensionRoot), 'utf8'),
+    readFile(new URL('style.css', extensionRoot), 'utf8'),
+    readFile(new URL('manifest.json', extensionRoot), 'utf8'),
+    readFile(new URL('../src/endpoints/extensions.js', import.meta.url), 'utf8'),
+]);
+const manifest = JSON.parse(manifestText);
+const entryModule = await import('../public/scripts/extensions/sillybunny-chats-archive/index.js');
+const originalFetch = globalThis.fetch;
+const originalAbortSignalTimeout = AbortSignal.timeout;
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    AbortSignal.timeout = originalAbortSignalTimeout;
+});
+
+describe('SillyBunny Chats Archive API', () => {
+    test('recent chats request covers one list page with a bounded host request', async () => {
+        let request;
+        globalThis.fetch = async (url, options) => {
+            request = { url, options };
+            return { ok: true, status: 200, json: async () => [] };
+        };
+
+        await fetchRecent({ getRequestHeaders: () => ({ authorization: 'test' }) });
+
+        expect(request.url).toBe('/api/chats/recent');
+        expect(request.options.method).toBe('POST');
+        expect(request.options.body).toBe('{"max":100}');
+    });
+
+    test('POST failures preserve HTTP status for lazy missing-file handling', async () => {
+        globalThis.fetch = async () => ({
+            ok: false,
+            status: 404,
+            json: async () => ({ message: 'missing chat' }),
+        });
+
+        await expect(exportChat({ getRequestHeaders: () => ({}) }, {})).rejects.toMatchObject({
+            message: 'missing chat',
+            status: 404,
+        });
+    });
+
+    test('organization sidecar GET distinguishes first use from failures', async () => {
+        const signal = new AbortController().signal;
+        const requests = [];
+        let response = { ok: false, status: 404 };
+        globalThis.fetch = async (url, options) => {
+            requests.push({ url, options });
+            return response;
+        };
+        const ctx = { getRequestHeaders: () => ({ 'x-test': 'yes' }) };
+
+        await expect(fetchOrganization(ctx, signal)).resolves.toBeNull();
+        expect(requests[0].url).toBe(`/user/files/${ORGANIZATION_FILE_NAME}`);
+        expect(requests[0].options).toEqual({
+            method: 'GET',
+            headers: { 'x-test': 'yes' },
+            cache: 'no-store',
+            signal,
+        });
+
+        response = { ok: false, status: 503 };
+        await expect(fetchOrganization(ctx)).rejects.toThrow(/_sbca_organization\.json failed with status 503/);
+
+        response = { ok: true, status: 200, json: async () => { throw new SyntaxError('bad sidecar'); } };
+        await expect(fetchOrganization(ctx)).rejects.toThrow(SyntaxError);
+    });
+
+    test('organization upload round-trips Unicode through browser base64 APIs', async () => {
+        let request;
+        globalThis.fetch = async (url, options) => {
+            request = { url, options };
+            return { ok: true, status: 200, json: async () => ({ uploaded: true }) };
+        };
+        const organization = { version: 1, name: '兔子 café', tags: ['竜', '🙂'] };
+
+        await expect(saveOrganization(
+            { getRequestHeaders: () => ({ 'x-csrf-token': 'token' }) },
+            organization,
+        )).resolves.toEqual({ uploaded: true });
+
+        expect(request.url).toBe('/api/files/upload');
+        expect(request.options.headers).toEqual({ 'x-csrf-token': 'token' });
+        const upload = JSON.parse(request.options.body);
+        expect(upload.name).toBe(ORGANIZATION_FILE_NAME);
+        const binary = atob(upload.data);
+        const decoded = new TextDecoder().decode(Uint8Array.from(binary, character => character.charCodeAt(0)));
+        expect(JSON.parse(decoded)).toEqual(organization);
+        expect(decoded).toBe(JSON.stringify(organization));
+    });
+
+    test('organization uploads are bounded and caller-cancellable', async () => {
+        const timeoutController = new AbortController();
+        let timeout;
+        let requestSignal;
+        AbortSignal.timeout = milliseconds => {
+            timeout = milliseconds;
+            return timeoutController.signal;
+        };
+        globalThis.fetch = async (_url, options) => {
+            requestSignal = options.signal;
+            return { ok: true, status: 200, json: async () => ({ uploaded: true }) };
+        };
+        const ctx = { getRequestHeaders: () => ({}) };
+
+        await saveOrganization(ctx, { version: 1 });
+        expect(timeout).toBe(15_000);
+        expect(requestSignal).toBe(timeoutController.signal);
+
+        const caller = new AbortController();
+        globalThis.fetch = (_url, options) => {
+            requestSignal = options.signal;
+            return new Promise((_resolve, reject) => {
+                options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+            });
+        };
+        const pending = saveOrganization(ctx, { version: 1 }, caller.signal);
+        expect(requestSignal).not.toBe(caller.signal);
+        caller.abort();
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+        expect(requestSignal.aborted).toBe(true);
+    });
+
+    test('Data Maid report and finalization forward cancellation signals', async () => {
+        const requests = [];
+        globalThis.fetch = async (url, options) => {
+            requests.push({ url, options });
+            return { ok: true, status: 200, json: async () => ({}) };
+        };
+        const ctx = { getRequestHeaders: () => ({}) };
+        const signal = new AbortController().signal;
+
+        await fetchDataMaidReport(ctx, signal);
+        await finalizeDataMaid(ctx, 'scan-token', signal);
+
+        expect(requests.map(request => [
+            request.url,
+            request.options.body,
+            request.options.signal,
+        ])).toEqual([
+            ['/api/data-maid/report', '{}', signal],
+            ['/api/data-maid/finalize', '{"token":"scan-token"}', signal],
+        ]);
+    });
+
+    test('character inventory is bounded and preserves partial results', async () => {
+        let active = 0;
+        let maxActive = 0;
+        let slowRequestActive = false;
+        let filledSlowSlot = false;
+        globalThis.fetch = async (_url, options) => {
+            const { avatar_url: avatar } = JSON.parse(options.body);
+            active++;
+            maxActive = Math.max(maxActive, active);
+            if (avatar === '0.png') {
+                slowRequestActive = true;
+            } else if (avatar === '8.png' && slowRequestActive) {
+                filledSlowSlot = true;
+            }
+            await new Promise(resolve => setTimeout(resolve, avatar === '0.png' ? 20 : 1));
+            if (avatar === '0.png') {
+                slowRequestActive = false;
+            }
+            active--;
+            if (avatar === '3.png') {
+                return { ok: false, status: 500, json: async () => ({ message: 'failed' }) };
+            }
+            if (avatar === '5.png') {
+                return { ok: true, status: 200, json: async () => ({ error: true }) };
+            }
+            return {
+                ok: true,
+                status: 200,
+                json: async () => avatar === '4.png'
+                    ? [null, { file_name: `${avatar}-chat.jsonl` }]
+                    : [{ file_name: `${avatar}-chat.jsonl` }],
+            };
+        };
+
+        const ctx = { getRequestHeaders: () => ({}) };
+        const avatars = Array.from({ length: 10 }, (_, index) => `${index}.png`);
+        const result = await fetchCharacterFiles(ctx, avatars);
+
+        expect(result.failures).toBe(2);
+        expect(result.rows).toHaveLength(8);
+        expect([...result.failedAvatars]).toEqual(['3.png', '4.png']);
+        expect(maxActive).toBe(8);
+        expect(filledSlowSlot).toBe(true);
+        expect(result.rows[0]).toEqual({
+            file_name: '0.png-chat.jsonl',
+            avatar: '0.png',
+            _source: 'inventory',
+        });
+    });
+
+    test('successful list endpoints reject malformed JSON and response shapes', async () => {
+        const ctx = { getRequestHeaders: () => ({ 'x-test': 'yes' }) };
+        globalThis.fetch = async (_url, options) => {
+            expect(options.method).toBe('POST');
+            expect(options.headers).toEqual({ 'x-test': 'yes' });
+            return { ok: true, status: 200, json: async () => { throw new SyntaxError('bad json'); } };
+        };
+        await expect(fetchRecent(ctx)).rejects.toThrow(SyntaxError);
+
+        globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => ({ results: [] }) });
+        await expect(searchScope(ctx, 'x', {})).rejects.toThrow(/invalid response/);
+    });
+
+    test('body-read aborts remain aborts', async () => {
+        globalThis.fetch = async () => ({
+            ok: true,
+            status: 200,
+            json: async () => { throw new DOMException('aborted', 'AbortError'); },
+        });
+        await expect(fetchRecent({ getRequestHeaders: () => ({}) })).rejects.toMatchObject({ name: 'AbortError' });
+    });
+});
+
+describe('SillyBunny Chats Archive core', () => {
+    const characters = [
+        { avatar: 'Seraphina.png', name: 'Seraphina' },
+        { avatar: 'Nahida.png', name: 'Nahida' },
+    ];
+    const groups = [
+        { id: 'group-1', name: 'Tavern Night' },
+    ];
+    const recentRows = [
+        { avatar: 'Seraphina.png', file_id: 'dragon tavern', file_name: 'dragon tavern.jsonl', file_size: '1.5MB', chat_items: 142, last_mes: 3000, mes: 'The dragon grins.' },
+        { avatar: 'Missing.png', file_id: 'lost chat', file_name: 'lost chat.jsonl', file_size: '800B', chat_items: 3, last_mes: 2000, mes: 'Hello?' },
+        { group: 'group-1', file_id: 'abc-123', file_name: 'abc-123.jsonl', file_size: '2KB', chat_items: 38, last_mes: 4000, mes: 'Cheers!' },
+        { file_id: 'stray', file_name: 'stray.jsonl', file_size: '12B', chat_items: 0, last_mes: 1000, mes: '[The chat is empty]' },
+    ];
+    const normalized = recentRows.map(row => normalizeRow(row, characters, groups));
+
+    test('parseHumanSize handles the host formats', () => {
+        expect(parseHumanSize('800B')).toBe(800);
+        expect(parseHumanSize('1.5MB')).toBe(1.5 * 1024 * 1024);
+        expect(parseHumanSize('1.2 KB')).toBe(1.2 * 1024);
+        expect(parseHumanSize('1.2.3MB')).toBe(0);
+        expect(parseHumanSize(`${Number.MAX_VALUE}TB`)).toBe(0);
+        expect(parseHumanSize('garbage')).toBe(0);
+        expect(parseHumanSize(undefined)).toBe(0);
+    });
+
+    test('formatBytes handles known and invalid byte counts', () => {
+        expect(formatBytes(0)).toBe('0B');
+        expect(formatBytes(1536)).toBe('1.5KB');
+        expect(formatBytes(2 * 1024 * 1024)).toBe('2MB');
+        expect(formatBytes(undefined)).toBe('');
+    });
+
+    test('parseLastMes handles mtimeMs numbers, ISO strings, host formats via toMoment, and garbage', () => {
+        expect(parseLastMes(12345)).toBe(12345);
+        expect(parseLastMes('2026-01-01T00:00:00.000Z')).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
+        expect(parseLastMes(undefined)).toBe(0);
+        expect(parseLastMes('not a date')).toBe(0);
+        expect(parseLastMes(8_640_000_000_000_001)).toBe(0);
+        const toMoment = value => ({ isValid: () => value === 'June 2, 2026 7:49pm', valueOf: () => 777 });
+        expect(parseLastMes('June 2, 2026 7:49pm', toMoment)).toBe(777);
+        expect(parseLastMes('2026-01-01T00:00:00.000Z', toMoment)).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
+        expect(parseLastMes('too large', () => ({ isValid: () => true, valueOf: () => 1e100 }))).toBe(0);
+    });
+
+    test('normalizeRow uses toMoment for string last_mes', () => {
+        const toMoment = () => ({ isValid: () => true, valueOf: () => 999 });
+        const row = normalizeRow({ avatar: 'Seraphina.png', file_id: 'x', last_mes: 'June 2, 2026 7:49pm' }, characters, groups, toMoment);
+        expect(row.mtime).toBe(999);
+    });
+
+    test('normalizeRow classifies solo, group, and both orphan causes', () => {
+        expect(normalized[0].kind).toBe('solo');
+        expect(normalized[0].ownerName).toBe('Seraphina');
+        expect(normalized[1].kind).toBe('orphan');
+        expect(normalized[1].ownerName).toBe('Missing');
+        expect(normalized[1].avatar).toBe('Missing.png');
+        expect(normalized[1].orphanType).toBe('missing-character');
+        expect(normalized[2].kind).toBe('group');
+        expect(normalized[2].ownerName).toBe('Tavern Night');
+        expect(normalized[3].kind).toBe('orphan');
+        expect(normalized[3].avatar).toBeNull();
+        expect(normalized[3].orphanType).toBe('root');
+    });
+
+    test('normalizeRow accepts legacy numeric group IDs', () => {
+        const row = normalizeRow({ group: 42, file_id: 'legacy' }, [], [{ id: '42', name: 'Legacy group' }]);
+        expect(row.kind).toBe('group');
+        expect(row.groupId).toBe('42');
+        expect(row.ownerName).toBe('Legacy group');
+    });
+
+    test('normalizeRow accepts indexed owner maps', () => {
+        const characterMap = new Map(characters.map(character => [character.avatar, character]));
+        const groupMap = new Map(groups.map(group => [String(group.id), group]));
+        expect(normalizeRow({ avatar: 'Seraphina.png', file_id: 'solo' }, characterMap, groupMap).ownerName).toBe('Seraphina');
+        expect(normalizeRow({ group: 'group-1', file_id: 'group' }, characterMap, groupMap).ownerName).toBe('Tavern Night');
+    });
+
+    test('normalizeRow derives file_id from file_name when missing', () => {
+        const row = normalizeRow({ file_name: 'plain.jsonl' }, [], []);
+        expect(row.file_id).toBe('plain');
+        expect(row.count).toBeNull();
+        expect(row.snippet).toBe('');
+    });
+
+    test('normalizeRow turns available message text into a visible one-line preview', () => {
+        expect(normalizeRow({ file_id: 'text', mes: '\n  First line\n\nSecond line  ' }).snippet).toBe('First line Second line');
+        expect(normalizeRow({ file_id: 'blank', mes: ' \n\t ' }).snippet).toBe('');
+        expect(normalizeRow({ file_id: 'long', mes: 'x'.repeat(500) }).snippet).toBe(`${'x'.repeat(397)}...`);
+    });
+
+    test('normalizers reject malformed records and keep file identity consistent', () => {
+        expect(normalizeRow(null)).toBeNull();
+        expect(normalizeRow({ avatar: 1, file_id: 'bad' })).toBeNull();
+        expect(dataMaidRecordToRow([], 'missing-character')).toBeNull();
+        expect(deepResultToRecentRow('bad', {})).toBeNull();
+        const row = normalizeRow({ file_id: 'wrong', file_name: 'actual.jsonl', chat_items: -3 });
+        expect(row.file_id).toBe('actual');
+        expect(row.count).toBe(0);
+    });
+
+    test('deepResultToRecentRow maps search results into the recent-row shape', () => {
+        const mapped = deepResultToRecentRow(
+            { file_name: 'found chat', file_size: '2KB', message_count: 7, last_mes: 5000, preview_message: '…tavern…' },
+            { avatar_url: 'Seraphina.png' },
+        );
+        const row = normalizeRow(mapped, characters, groups);
+        expect(row.kind).toBe('solo');
+        expect(row.file_id).toBe('found chat');
+        expect(row.count).toBe(7);
+        expect(row.snippet).toBe('…tavern…');
+        expect(row.source).toBe('search');
+    });
+
+    test('search scopes cover both wire types for legacy numeric group IDs', () => {
+        expect(buildSearchScopes(
+            [{ avatar: 'Seraphina.png' }],
+            [{ id: '42' }, { id: 'group-1' }, { id: '0042' }, { id: '0' }],
+        )).toEqual([
+            { avatar_url: 'Seraphina.png' },
+            { group_id: '42' },
+            { group_id: 42 },
+            { group_id: 'group-1' },
+            { group_id: '0042' },
+            { group_id: '0' },
+        ]);
+    });
+
+    test('search scopes can be restricted to the selected owner', () => {
+        expect(buildSearchScopes(characters, groups, 'Seraphina')).toEqual([
+            { avatar_url: 'Seraphina.png' },
+        ]);
+        expect(buildSearchScopes(characters, groups, 'Tavern Night')).toEqual([
+            { group_id: 'group-1' },
+        ]);
+        expect(buildSearchScopes(characters, groups, 'missing')).toEqual([]);
+    });
+
+    test('typed owner filters keep duplicate names and owner kinds distinct', () => {
+        const duplicateCharacters = [
+            { avatar: 'Alex.png', name: 'Alex' },
+            { avatar: 'Alex_2.png', name: 'Alex' },
+        ];
+        const duplicateGroups = [{ id: 'alex-group', name: 'Alex' }];
+        const rows = [
+            normalizeRow({ avatar: 'Alex.png', file_id: 'first' }, duplicateCharacters, duplicateGroups),
+            normalizeRow({ avatar: 'Alex_2.png', file_id: 'second' }, duplicateCharacters, duplicateGroups),
+            normalizeRow({ group: 'alex-group', file_id: 'group' }, duplicateCharacters, duplicateGroups),
+            dataMaidRecordToRow({ name: 'missing.jsonl', hash: 'hash', parent: 'Alex' }, 'missing-character'),
+        ];
+        const first = ownerFilterKey(rows[0]);
+        const second = ownerFilterKey(rows[1]);
+        const group = ownerFilterKey(rows[2]);
+
+        expect(first).toBe('@sbca:["character","Alex"]');
+        expect(first).not.toBe(second);
+        expect(parseOwnerFilter(group)).toEqual({ kind: 'group', id: 'alex-group' });
+        expect(parseOwnerFilter('Alex')).toBeNull();
+        expect(parseOwnerFilter('["group","alex-group"]')).toBeNull();
+        expect(filterRows(rows, { owner: first }).map(row => row.file_id)).toEqual(['first', 'missing']);
+        expect(filterRows(rows, { owner: second }).map(row => row.file_id)).toEqual(['second']);
+        expect(filterRows(rows, { owner: group }).map(row => row.file_id)).toEqual(['group']);
+        expect(filterRows(rows, { owner: 'Alex' })).toHaveLength(4);
+        expect(buildSearchScopes(duplicateCharacters, duplicateGroups, second)).toEqual([{ avatar_url: 'Alex_2.png' }]);
+        expect(buildSearchScopes(duplicateCharacters, duplicateGroups, group)).toEqual([{ group_id: 'alex-group' }]);
+        expect(normalizeSavedView({ owner: second }).owner).toBe(second);
+    });
+
+    test('dataMaidRecordToRow preserves orphan source details', () => {
+        const row = dataMaidRecordToRow({ name: 'lost.jsonl', hash: 'abc', parent: 'Deleted', size: 2048, mtime: 123 }, 'missing-character');
+        expect(row.kind).toBe('orphan');
+        expect(row.orphanType).toBe('missing-character');
+        expect(row.ownerName).toBe('Deleted');
+        expect(row.chatFolder).toBe('Deleted');
+        expect(row.file_id).toBe('lost');
+        expect(row.sizeText).toBe('2KB');
+        expect(row.count).toBeNull();
+        expect(row.dataMaidHash).toBe('abc');
+    });
+
+    test('physicalChatKey follows physical file scope instead of owner or Data Maid identity', () => {
+        const linkedGroup = normalizeRow({ group: 'group-1', file_id: 'shared' }, [], groups);
+        const missingGroup = normalizeRow({ group: 'deleted-group', file_id: 'shared' });
+        const unlinkedGroup = dataMaidRecordToRow({ name: 'shared.jsonl', hash: 'temporary-a' }, 'unlinked-group');
+        expect(physicalChatKey(linkedGroup)).toBe(physicalChatKey(missingGroup));
+        expect(physicalChatKey(missingGroup)).toBe(physicalChatKey(unlinkedGroup));
+
+        const linkedCharacter = normalizeRow({ avatar: 'Seraphina.png', file_id: 'solo' }, characters);
+        const missingCharacter = dataMaidRecordToRow({ name: 'solo.jsonl', hash: 'temporary-b', parent: 'Seraphina' }, 'missing-character');
+        expect(linkedCharacter.chatFolder).toBe('Seraphina');
+        expect(physicalChatKey(linkedCharacter)).toBe(physicalChatKey(missingCharacter));
+        expect(physicalChatKey({ ...missingCharacter, dataMaidHash: 'different' })).toBe(physicalChatKey(missingCharacter));
+
+        expect(physicalChatKey({ kind: 'solo', chatFolder: 'a:b', file_id: 'c' }))
+            .not.toBe(physicalChatKey({ kind: 'solo', chatFolder: 'a', file_id: 'b:c' }));
+        expect(physicalChatKey({ kind: 'orphan', orphanType: 'root', file_id: 'solo' })).toBe('["root","solo"]');
+    });
+
+    test('organization normalization is strict, sparse, stable, and reference-safe', () => {
+        expect(createDefaultOrganization()).toEqual({
+            version: 1,
+            lastView: {},
+            views: [],
+            folders: [],
+            collections: [],
+            chats: {},
+        });
+        expect(() => normalizeOrganization(null)).toThrow(/root must be an object/);
+        expect(() => normalizeOrganization([])).toThrow(/root must be an object/);
+        expect(() => normalizeOrganization({})).toThrow(/Unsupported organization version/);
+        expect(() => normalizeOrganization({ version: 2 })).toThrow(/version: 2/);
+
+        const normalizedOrganization = normalizeOrganization({
+            version: 1,
+            unknown: true,
+            lastView: {
+                query: '  tavern  ',
+                kinds: ['solo', 'solo', 'invalid', 'group'],
+                sort: ' oldest ',
+                group: ' folder ',
+                density: ' compact ',
+                favorite: false,
+                folder: ' f1 ',
+                collection: 'missing',
+                minSize: 0,
+                maxMessages: 20,
+                minDate: '2026-01-01',
+                results: [{ deep: true }],
+            },
+            views: [
+                { id: ' view-1 ', name: ' Work ', view: { owner: ' Seraphina ', collection: 'c1', tag: ' Dragon ' } },
+                { id: 'view-2', name: 'work', view: {} },
+                { id: 'view-3', name: 'Broken' },
+            ],
+            folders: [
+                { id: ' f1 ', name: ' Work ' },
+                { id: 'f2', name: 'work' },
+                { id: 'f1', name: 'Other' },
+            ],
+            collections: [
+                { id: 'c1', name: ' Lore ' },
+                { id: 'c2', name: 'lore' },
+                { id: 'c3', name: 'Archive' },
+            ],
+            chats: {
+                ' keep ': {
+                    favorite: true,
+                    folder: ' f1 ',
+                    collections: ['c1', 'c1', 'missing'],
+                    tags: [' Dragon ', 'dragon', 'Lore'],
+                    ignored: true,
+                },
+                stale: { favorite: false, folder: 'missing', collections: ['missing'], tags: [] },
+                retainedWithoutRows: { tags: [' Keep me '] },
+            },
+        });
+
+        expect(normalizedOrganization).toEqual({
+            version: 1,
+            lastView: {
+                query: 'tavern',
+                kinds: ['solo', 'group'],
+                sort: 'oldest',
+                group: 'folder',
+                density: 'compact',
+                favorite: false,
+                folder: 'f1',
+                minSize: 0,
+                maxMessages: 20,
+                minDate: '2026-01-01',
+            },
+            views: [{
+                id: 'view-1',
+                name: 'Work',
+                view: { owner: 'Seraphina', collection: 'c1', tag: 'Dragon' },
+            }],
+            folders: [{ id: 'f1', name: 'Work' }],
+            collections: [{ id: 'c1', name: 'Lore' }, { id: 'c3', name: 'Archive' }],
+            chats: {
+                keep: { favorite: true, folder: 'f1', collections: ['c1'], tags: ['Dragon', 'Lore'] },
+                retainedWithoutRows: { tags: ['Keep me'] },
+            },
+        });
+        expect(parseOrganization(JSON.stringify(normalizedOrganization))).toEqual(normalizedOrganization);
+    });
+
+    test('normalizeSavedView retains only bounded browse state', () => {
+        expect(normalizeSavedView({
+            query: '   ',
+            kinds: [],
+            sort: 'invalid',
+            group: 'owner',
+            density: 'minimal',
+            charSort: 'new',
+            owner: ' Alice ',
+            orphan: 'root',
+            favorite: false,
+            folder: null,
+            collection: ' c1 ',
+            tag: ' History ',
+            minDate: 10,
+            maxDate: '2026-12-31',
+            minSize: 0,
+            maxSize: Infinity,
+            minMessages: 0,
+            maxMessages: 2.5,
+            selection: ['chat'],
+            page: 4,
+            viewer: { raw: true },
+        }, { folders: [], collections: [{ id: 'c1' }] })).toEqual({
+            kinds: [],
+            group: 'owner',
+            density: 'minimal',
+            owner: 'Alice',
+            orphan: 'root',
+            favorite: false,
+            folder: null,
+            collection: 'c1',
+            tag: 'History',
+            minSize: 0,
+            minMessages: 0,
+            minDate: 10,
+            maxDate: '2026-12-31',
+        });
+    });
+
+    test('filterRows matches file name, owner, and snippet case-insensitively', () => {
+        expect(filterRows(normalized, { text: 'DRAGON' })).toHaveLength(1);
+        expect(filterRows(normalized, { text: 'seraphina' })[0].file_id).toBe('dragon tavern');
+        expect(filterRows(normalized, { text: 'cheers' })[0].kind).toBe('group');
+        expect(filterRows(normalized, { text: '' })).toHaveLength(4);
+    });
+
+    test('filterRows applies kind filters', () => {
+        expect(filterRows(normalized, { kinds: ['orphan'] })).toHaveLength(2);
+        expect(filterRows(normalized, { kinds: ['solo', 'group'] })).toHaveLength(2);
+        expect(filterRows(normalized, { text: 'lost', kinds: ['solo'] })).toHaveLength(0);
+    });
+
+    test('filterRows applies organization labels, facets, and metadata bounds', () => {
+        const organization = {
+            folders: [{ id: 'quests', name: 'Heroic Quests' }],
+            collections: [{ id: 'lore', name: 'Lore Shelf' }],
+            chats: {
+                [physicalChatKey(normalized[0])]: {
+                    favorite: true,
+                    folder: 'quests',
+                    collections: ['lore'],
+                    tags: ['Ancient Dragon'],
+                },
+            },
+        };
+        for (const text of ['heroic quests', 'LORE SHELF', 'ancient dragon']) {
+            expect(filterRows(normalized, { text }, organization).map(row => row.file_id)).toEqual(['dragon tavern']);
+        }
+        expect(filterRows(normalized, {
+            kinds: ['solo'],
+            owner: 'Seraphina',
+            favorite: true,
+            folder: 'quests',
+            collection: 'lore',
+            tag: 'ANCIENT DRAGON',
+            minDate: 2500,
+            maxDate: 3500,
+            minSize: 1024,
+            maxSize: 2 * 1024 * 1024,
+            minMessages: 100,
+            maxMessages: 200,
+        }, organization).map(row => row.file_id)).toEqual(['dragon tavern']);
+        expect(filterRows(normalized, { orphan: 'missing-character' }).map(row => row.file_id)).toEqual(['lost chat']);
+        expect(filterRows(normalized, { folder: null }, organization)).toHaveLength(3);
+        expect(filterRows(normalized, { favorite: false }, organization)).toHaveLength(3);
+
+        const unknown = normalizeRow({ file_id: 'unknown' });
+        expect(filterRows([unknown])).toHaveLength(1);
+        expect(filterRows([unknown], { minDate: 0 })).toHaveLength(0);
+        expect(filterRows([unknown], { minSize: 0 })).toHaveLength(0);
+        expect(filterRows([unknown], { minMessages: 0 })).toHaveLength(0);
+    });
+
+    test('sortRows sorts by all four keys', () => {
+        expect(sortRows(normalized, 'recent').map(row => row.file_id)).toEqual(['abc-123', 'dragon tavern', 'lost chat', 'stray']);
+        expect(sortRows(normalized, 'size').map(row => row.file_id)).toEqual(['dragon tavern', 'abc-123', 'lost chat', 'stray']);
+        expect(sortRows(normalized, 'count').map(row => row.file_id)).toEqual(['dragon tavern', 'abc-123', 'lost chat', 'stray']);
+        expect(sortRows(normalized, 'name').map(row => row.file_id)).toEqual(['abc-123', 'dragon tavern', 'lost chat', 'stray']);
+    });
+
+    test('sortRows supports reverse sorts and keeps unknown metadata last', () => {
+        expect(sortRows(normalized, 'oldest').map(row => row.file_id)).toEqual(['stray', 'lost chat', 'dragon tavern', 'abc-123']);
+        expect(sortRows(normalized, 'smallest').map(row => row.file_id)).toEqual(['stray', 'lost chat', 'abc-123', 'dragon tavern']);
+        expect(sortRows(normalized, 'fewest').map(row => row.file_id)).toEqual(['stray', 'lost chat', 'abc-123', 'dragon tavern']);
+        expect(sortRows(normalized, 'name-reverse').map(row => row.file_id)).toEqual(['stray', 'lost chat', 'dragon tavern', 'abc-123']);
+        expect(sortRows(normalized, 'owner').map(row => row.file_id)).toEqual(['stray', 'lost chat', 'dragon tavern', 'abc-123']);
+
+        const rows = [
+            { file_id: 'known-high', mtime: 20, sizeBytes: 20, count: 20 },
+            { file_id: 'z-unknown', mtime: null, sizeBytes: null, count: null },
+            { file_id: 'known-low', mtime: 10, sizeBytes: 10, count: 10 },
+            { file_id: 'a-unknown' },
+        ];
+        for (const key of ['recent', 'size', 'count']) {
+            expect(sortRows(rows, key).map(row => row.file_id)).toEqual(['known-high', 'known-low', 'a-unknown', 'z-unknown']);
+        }
+        for (const key of ['oldest', 'smallest', 'fewest']) {
+            expect(sortRows(rows, key).map(row => row.file_id)).toEqual(['known-low', 'known-high', 'a-unknown', 'z-unknown']);
+        }
+    });
+
+    test('groupRows preserves sorted first-occurrence group order', () => {
+        const rows = [normalized[2], normalized[0], normalized[3], normalized[1]];
+        const organization = {
+            folders: [{ id: 'alpha', name: 'Alpha' }, { id: 'beta', name: 'Beta' }],
+            collections: [],
+            chats: {
+                [physicalChatKey(normalized[2])]: { folder: 'beta' },
+                [physicalChatKey(normalized[0])]: { folder: 'alpha' },
+                [physicalChatKey(normalized[3])]: { folder: 'beta' },
+            },
+        };
+
+        expect(groupRows(rows, 'type').map(group => [group.label, group.rows.map(row => row.file_id)])).toEqual([
+            ['group', ['abc-123']],
+            ['solo', ['dragon tavern']],
+            ['orphan', ['stray', 'lost chat']],
+        ]);
+        expect(groupRows(rows, 'folder', organization).map(group => [group.label, group.rows.map(row => row.file_id)])).toEqual([
+            ['Beta', ['abc-123', 'stray']],
+            ['Alpha', ['dragon tavern']],
+            ['Unfiled', ['lost chat']],
+        ]);
+        expect(groupRows(rows, 'owner').map(group => group.label)).toEqual(['Tavern Night', 'Seraphina', 'Unknown owner', 'Missing']);
+        expect(groupRows(rows, 'flat').map(group => group.rows)).toEqual([rows]);
+    });
+
+    test('shapeChatRecords splits header from messages and shapes them', () => {
+        const records = [
+            { user_name: 'unused', chat_metadata: { integrity: 'uuid', MacroEnhanced: {} } },
+            { name: 'You', is_user: true, send_date: '2026-01-01T00:00:00.000Z', mes: 'Hi' },
+            { name: 'Seraphina', is_user: false, mes: 'Hello', swipe_id: 1, swipes: [null, 'Hello', 'Hey'], extra: { model: 'x', api: 'y' } },
+            { name: 'System', is_system: true, mes: 'note' },
+        ];
+        const shaped = shapeChatRecords(records);
+        expect(shaped.metadataKeys).toEqual(['integrity', 'MacroEnhanced']);
+        expect(shaped.messages).toHaveLength(3);
+        expect(shaped.messages[0].isUser).toBe(true);
+        expect(shaped.messages[1].swipeCount).toBe(1);
+        expect(shaped.messages[1].alternatives).toEqual(['Hey']);
+        expect(shaped.messages[1].extra).toEqual({ model: 'x', api: 'y' });
+        expect(shaped.messages[2].isSystem).toBe(true);
+    });
+
+    test('parseJsonl handles BOMs and blank lines and identifies corrupt lines', () => {
+        expect(parseJsonl('\uFEFF{"chat_metadata":{}}\n\n{"name":"You","mes":"Hi"}\r\n')).toEqual([
+            { chat_metadata: {} },
+            { name: 'You', mes: 'Hi' },
+        ]);
+        expect(() => parseJsonl('{"ok":true}\nnot json')).toThrow(/line 2/);
+    });
+
+    test('findMatchingSnippet uses cross-message AND fragment semantics', () => {
+        const records = [
+            { name: 'A', mes: 'The red dragon left.' },
+            { name: 'B', mes: 'Meet me at the tavern.' },
+            { name: 'C', mes: 'This final preview has neither term.' },
+        ];
+        expect(findMatchingSnippet(records, 'dragon tavern')).toBe('The red dragon left.');
+        expect(findMatchingSnippet(records, 'dragon castle')).toBeNull();
+        expect(findMatchingSnippet([{ mes: '\n  dragon\n\narrives  ' }], 'dragon')).toBe('dragon arrives');
+    });
+
+    test('findMatchingMessageIndex points to the first preview match only when the whole query matches', () => {
+        const messages = [
+            { mes: 'The red dragon left.' },
+            { mes: 'Meet me at the tavern.' },
+        ];
+        expect(findMatchingMessageIndex(messages, 'dragon tavern')).toBe(0);
+        expect(findMatchingMessageIndex(messages, 'dragon castle')).toBe(-1);
+        expect(findMatchingMessageIndex(messages, '   ')).toBe(-1);
+    });
+
+    test('matchesQueryFragments applies host-style AND matching to filenames', () => {
+        expect(matchesQueryFragments('dragon at the tavern', 'DRAGON tavern')).toBe(true);
+        expect(matchesQueryFragments('dragon at the inn', 'dragon tavern')).toBe(false);
+        expect(matchesQueryFragments('anything', '   ')).toBe(false);
+    });
+
+    test('JSONL search keeps readable messages around a corrupt line', () => {
+        const raw = '{"name":"A","mes":"red dragon"}\nnot json\n{"name":"B","mes":"the tavern"}';
+        expect(findMatchingSnippetInJsonl(raw, 'dragon tavern')).toEqual({ snippet: 'red dragon', invalidLines: 1 });
+        expect(findMatchingSnippetInJsonl(raw, 'dragon castle')).toEqual({ snippet: null, invalidLines: 1 });
+    });
+
+    test('chunked JSONL parsing and search preserve behavior and honor cancellation', async () => {
+        const raw = '\uFEFF{"chat_metadata":{"integrity":"ok"}}\n{"name":"A","mes":"red dragon"}\n{"name":"B","mes":"the tavern"}';
+        await expect(parseChatJsonl(raw, { linesPerChunk: 1 })).resolves.toEqual(shapeChatRecords(parseJsonl(raw)));
+        await expect(findMatchingSnippetInJsonlAsync(`${raw}\nnot json`, 'dragon tavern', { linesPerChunk: 1 }))
+            .resolves.toEqual({ snippet: 'red dragon', invalidLines: 1 });
+
+        const controller = new AbortController();
+        const pending = findMatchingSnippetInJsonlAsync(raw.repeat(100), 'dragon', {
+            signal: controller.signal,
+            linesPerChunk: 1,
+        });
+        setTimeout(() => controller.abort(), 0);
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+
+        const parseController = new AbortController();
+        const parsing = parseChatJsonl('{"mes":"ok"}\nnot json', {
+            signal: parseController.signal,
+            linesPerChunk: 1,
+        });
+        parseController.abort();
+        await expect(parsing).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    test('recordsToText skips system messages and honors display text', () => {
+        const text = recordsToText([
+            { name: 'System', is_system: true, mes: 'hidden' },
+            { name: 'You', mes: 'raw', extra: { display_text: 'shown' } },
+            { name: 'You', mes: 'fallback', extra: { display_text: '' } },
+            { name: 'Bot', mes: 'reply' },
+        ]);
+        expect(text).toBe('You: shown\n\nYou: fallback\n\nBot: reply');
+    });
+
+    test('shapeChatRecords tolerates malformed and empty input', () => {
+        expect(shapeChatRecords(null).messages).toEqual([]);
+        expect(shapeChatRecords([]).metadataKeys).toEqual([]);
+        const noHeader = shapeChatRecords([{ name: 'You', mes: 'orphan line' }, null, 'junk']);
+        expect(noHeader.header).toBeNull();
+        expect(noHeader.messages).toHaveLength(1);
+    });
+});
+
+describe('SillyBunny Chats Archive navigation', () => {
+    function context() {
+        return {
+            eventSource: new EventEmitter(),
+            eventTypes: { CHAT_CHANGED: 'chat-changed' },
+        };
+    }
+
+    test('navigation resolves only after the requested host event', async () => {
+        const ctx = context();
+        await navigateAndConfirm(ctx, 'wanted', async () => {
+            ctx.eventSource.emit(ctx.eventTypes.CHAT_CHANGED, 'other');
+            ctx.eventSource.emit(ctx.eventTypes.CHAT_CHANGED, 'wanted');
+        });
+        expect(ctx.eventSource.listenerCount(ctx.eventTypes.CHAT_CHANGED)).toBe(0);
+    });
+
+    test('navigation rejects immediately when the host action finishes unconfirmed', async () => {
+        const ctx = context();
+        await expect(navigateAndConfirm(ctx, 'wanted', async () => {})).rejects.toThrow(/did not confirm/);
+        expect(ctx.eventSource.listenerCount(ctx.eventTypes.CHAT_CHANGED)).toBe(0);
+    });
+
+    test('navigation timeout rejects and removes the host listener when the action hangs', async () => {
+        const ctx = context();
+        let actionSignal;
+        await expect(navigateAndConfirm(ctx, 'wanted', signal => {
+            actionSignal = signal;
+            return new Promise(() => {});
+        }, { timeout: 5 })).rejects.toMatchObject({ name: 'TimeoutError' });
+        expect(actionSignal.aborted).toBe(true);
+        expect(ctx.eventSource.listenerCount(ctx.eventTypes.CHAT_CHANGED)).toBe(0);
+    });
+
+    test('navigation abort rejects and removes the host listener', async () => {
+        const ctx = context();
+        const controller = new AbortController();
+        const pending = navigateAndConfirm(ctx, 'wanted', signal => (
+            new Promise(resolve => signal.addEventListener('abort', resolve, { once: true }))
+        ), { signal: controller.signal });
+        controller.abort();
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+        expect(ctx.eventSource.listenerCount(ctx.eventTypes.CHAT_CHANGED)).toBe(0);
+    });
+});
+
+describe('SillyBunny Chats Archive integration', () => {
+    test('entry point is one host-sized native dialog button, not a fake tab', () => {
+        expect(entry).toMatch(/createElement\('button'\)/);
+        expect(entry).toMatch(/createElement\('i'\)/);
+        expect(entry).toMatch(/fa-box-archive/);
+        expect(entry).toMatch(/aria-haspopup', 'dialog'/);
+        expect(entry).not.toMatch(/role', 'tab'/);
+        expect(entry).not.toMatch(/data-sb-character-tab/);
+        expect(entry).toMatch(/button\.className = 'menu_button sbca-drawer-button'/);
+    });
+
+    test('archive exposes labels, live state, selection, and cancellable work', () => {
+        expect(ui).toMatch(/setAttribute\('role', 'status'\)/);
+        expect(ui).toMatch(/aria-labelledby/);
+        expect(ui).toMatch(/aria-current/);
+        expect(ui).toMatch(/new AbortController\(\)/);
+        expect(ui).toMatch(/fetchCharacterFiles/);
+        expect(ui).toMatch(/eventTypes\.CHAT_CHANGED/);
+        expect(ui).toMatch(/setActive(?:Character|Group)/);
+        expect(ui).toMatch(/group\.chat_id/);
+        expect(ui).toMatch(/aria-expanded/);
+        expect(ui).toMatch(/aria-pressed/);
+        expect(ui).toMatch(/state\.deepRows === null \? ui\.search\.value : ''/);
+        expect(ui).toMatch(/ORGANIZATION_FILE_NAME/);
+        expect(ui).toMatch(/Do not delete \{name\} through host Data Maid/);
+        expect(ui).toMatch(/sbca-selection-toggle/);
+        expect(ui).toMatch(/sbca-organizer/);
+        expect(ui).toMatch(/physicalChatKey/);
+        expect(ui).toMatch(/'Character or group'/);
+        expect(ui).toMatch(/'All characters and groups'/);
+        expect(ui).toMatch(/sbca-owner-selector/);
+        expect(ui).toMatch(/const ownerField = ownerControl\(ctx\)/);
+        expect(ui).toMatch(/ownerFilterKey\(row\)/);
+        expect(ui).toMatch(/getThumbnailUrl\('avatar', choice\.avatar\)/);
+        expect(ui).toMatch(/Search characters and groups/);
+        expect(ui).toMatch(/Character: \{name\}/);
+        expect(ui).toMatch(/listToolsPanel\.append\(ownerField\.wrap, sortPills, selectionBar\)/);
+        expect(ui).toMatch(/listTop\.append\(listHeading, listTools\)/);
+        expect(ui).toMatch(/listPanel\.append\(listTop, list\)/);
+        expect(ui).toMatch(/sbca-list-tools/);
+        expect(ui).toMatch(/listTools\.open = true/);
+        expect(ui).toMatch(/option\.addEventListener\('pointerdown', event => \{\s*if \(event\.button !== 0 \|\| event\.pointerType === 'touch'\)/);
+        expect(ui).toMatch(/option\.addEventListener\('click', select\)/);
+        expect(ui).toMatch(/async function enrichSelectedOwner\(ctx, state, ui\)/);
+        expect(ui).toMatch(/fetchCharacterChatDetails\(ctx, avatar, controller\.signal\)/);
+        expect(ui).toMatch(/state\.enrichedOwners\.has\(avatar\)/);
+        expect(ui).toMatch(/sbca-sortpill/);
+        expect(ui).not.toMatch(/characterChips|sbca-charstrip|sbca-charchip|charSort/);
+        expect(ui).toMatch(/enterKeyHint = 'search'/);
+        expect(ui).toMatch(/SEARCH_DEBOUNCE_MS = 150/);
+        expect(ui).toMatch(/search\.addEventListener\('input', \(\) => \{\s*exitDeepSearch\(ctx, state, ui\);\s*noteViewEdit\(\);/);
+        expect(ui).toMatch(/buildSearchScopes\(ctx\.characters, ctx\.groups, ui\.owner\.value\)/);
+        expect(ui).toMatch(/findMatchingMessageIndex/);
+        expect(ui).toMatch(/First search match/);
+        expect(ui).toMatch(/Latest messages/);
+        expect(ui).toMatch(/event\.key !== 'ArrowDown'/);
+        expect(ui).toMatch(/event\.isComposing/);
+        expect(ui).toMatch(/more\.click\(\)/);
+        expect(ui).toMatch(/showPage\(shaped\.messages\.length - MESSAGE_PAGE_SIZE\)/);
+        expect(ui).toMatch(/state\.deepRows !== null && state\.deepQuery === matchQuery/);
+        expect(ui).toMatch(/search result verification failed/);
+        expect(ui).toMatch(/search items had errors/);
+        expect(ui).toMatch(/allRows\(state\)\.filter\(row => row\.kind === 'orphan'\)/);
+        expect(ui).not.toMatch(/row\.kind === 'orphan' \|\| row\.source === 'inventory'/);
+        expect(ui).toMatch(/findMatchingSnippetInJsonlAsync\(raw, query, \{ signal \}\)/);
+        expect(ui).not.toMatch(/findExistingGroupFiles/);
+        expect(ui).toMatch(/error\?\.status === 404 && row\.kind === 'group' && row\.source === 'inventory'/);
+        expect(ui).toMatch(/state\.missingGroupFiles\.add\(row\.file_id\)/);
+        expect(ui).toMatch(/sbca-browse-options/);
+        expect(ui).toMatch(/Clear filters/);
+        expect(ui).not.toMatch(/sbca-row-selection-label/);
+        expect(ui).not.toMatch(/\browKey\(/);
+        expect(ui).not.toMatch(/menu_button/);
+        expect(ui).not.toMatch(/el\('div', 'sbca-action/);
+    });
+
+    test('archive preserves focus and exposes item-specific actions', () => {
+        expect(ui).toMatch(/function preserveArchiveFocus\(ui, update\)/);
+        expect(ui).toMatch(/organizationFocusKey\('manager', type, item\.id, 'rename'\)/);
+        expect(ui).toMatch(/organizationFocusKey\('organizer', key, 'favorite'\)/);
+        expect(ui).toMatch(/control\.dataset\.sbcaFocusKey === snapshot\.fallback/);
+        expect(ui).toMatch(/snapshot\.viewer \? ui\.viewerTitle : snapshot\.list \? ui\.listHeading/);
+        expect(ui).toMatch(/preserveArchiveFocus\(ui, \(\) => \{\s*refreshOrganizationUI/s);
+        expect(ui).toMatch(/Rename \{name\}/);
+        expect(ui).toMatch(/Delete \{name\}/);
+        expect(ui).toMatch(/Select \{name\} for \{owner\}/);
+        expect(ui).toMatch(/Delete saved view \{name\}\?/);
+        expect(ui).toMatch(/const active = document\.activeElement;\s*const focusInBrowse = browseStrip\.contains\(active\);\s*browseOptions\.open/s);
+        expect(ui).toMatch(/focusInBrowse\) \{\s*browseSummary\.focus/s);
+        expect(ui).toMatch(/active === browseSummary\) \{\s*groupField\.select\.focus/s);
+        const cancelViewer = ui.slice(ui.indexOf('function cancelViewer'), ui.indexOf('function cancelNavigation'));
+        expect(cancelViewer).toMatch(/state\.viewerAbort\?\.abort\(\)/);
+        expect(cancelViewer).not.toMatch(/state\.viewerAbort = null/);
+    });
+
+    test('message lists, grouping, scans, and search retain their safety contracts', () => {
+        const searchStart = ui.indexOf('search.addEventListener(\'keydown\'', ui.indexOf('const flushQuery'));
+        const searchHandler = ui.slice(searchStart, ui.indexOf('\n    });', searchStart));
+        const scan = ui.slice(ui.indexOf('async function scanOrphans'), ui.indexOf('async function finalizeDataMaidToken'));
+        expect(searchHandler).toMatch(/event\.key !== 'Enter' \|\| event\.isComposing/);
+        expect(searchHandler).toMatch(/flushQuery\(\)/);
+        expect(searchHandler).not.toMatch(/runDeepSearch/);
+        expect(ui).toMatch(/deepButton\.addEventListener\('click',[\s\S]*?runDeepSearch/);
+        expect(ui).toMatch(/const messageList = el\('div', 'sbca-message-list'\);/);
+        expect(ui).toMatch(/messageList\.setAttribute\('role', 'list'\)/);
+        expect(ui).toMatch(/messages\.append\(messageList, el\('p', 'sbca-placeholder'/);
+        expect(ui).toMatch(/appendMessagePage\(ctx, shaped\.messages, messageList, messages/);
+        expect(ui).toMatch(/list\.append\(card\)/);
+        expect(ui).toMatch(/controls\.append\(more\)/);
+        expect(ui).toMatch(/showPage\(end\)\?\.focus/);
+        expect(ui).toMatch(/Raw preview truncated\. Download the original file/);
+        expect(ui).toMatch(/const shownRows = new Set\(rows\.slice\(0, state\.visibleLimit\)\)/);
+        expect(ui).toMatch(/groupRows\(rows, ui\.group\.value, state\.organization\)/);
+        expect(ui).toMatch(/group\.rows\.filter\(row => shownRows\.has\(row\)\)/);
+        expect(ui).toMatch(/group\.rows\.length/);
+        expect(ui).toMatch(/for \(const row of shownGroupRows\)/);
+        expect(ui).toMatch(/state\.scanAbort\?\.abort\(\)/);
+        expect(scan).toMatch(/fetchDataMaidReport\(ctx\)/);
+        expect(scan).not.toMatch(/fetchDataMaidReport\(ctx, controller\.signal\)/);
+        expect(scan).toMatch(/if \(controller\.signal\.aborted\)[\s\S]*previousKeys[\s\S]*retainedRows = orphanRows\.filter[\s\S]*state\.dataMaidToken = data\.token;[\s\S]*state\.orphanRows = retainedRows;/);
+        expect(scan).toMatch(/state\.dataMaidToken = data\.token;[\s\S]*state\.orphanRows = orphanRows;/);
+        expect(scan).toMatch(/Previous results are still shown/);
+        expect(scan).toMatch(/state\.scanAbort !== controller/);
+        expect(ui).toMatch(/finalizeDataMaid\([\s\S]*AbortSignal\.timeout\(DATA_MAID_FINALIZE_TIMEOUT_MS\)/);
+        expect(ui).toMatch(/ui\.status\.setAttribute\('aria-busy', 'true'\)/);
+        expect(ui).toMatch(/ui\.status\.removeAttribute\('aria-busy'\)/);
+    });
+
+    test('manifest hooks resolve to exported lifecycle functions', () => {
+        expect(manifest.hooks).toEqual({ activate: 'activate', enable: 'enable', disable: 'disable' });
+        expect(manifest).not.toHaveProperty('bundled_opt_in');
+        expect(manifest).not.toHaveProperty('minimum_client_version');
+        for (const hook of Object.values(manifest.hooks)) {
+            expect(typeof entryModule[hook]).toBe('function');
+        }
+        expect(extensionsEndpoint).toMatch(/const CORE_EXTENSIONS = new Set\(\[[\s\S]*?'sillybunny-chats-archive',[\s\S]*?\]\);/);
+        expect(ui).toContain('import(\'../../../../script.js\')');
+        expect(ui).toContain('import(\'../../../group-chats.js\')');
+    });
+
+    test('entry observer narrows from the document body when the host panel appears', () => {
+        expect(entry).toMatch(/const target = document\.querySelector\(PANEL_SELECTOR\) \?\? document\.body/);
+        expect(entry).toMatch(/observerTarget !== target/);
+        expect(entry).toMatch(/observer\.observe\(target\.parentElement, \{ childList: true \}\)/);
+        expect(entry).toMatch(/pending = setTimeout\(\(\) => \{\s*pending = null;\s*install\(\);/);
+    });
+
+    test('stylesheet follows theme, layout, focus, touch, and side-stripe contracts', () => {
+        expect(css).toMatch(/--color-border/);
+        expect(css).toMatch(/--sbca-text:\s*var\(--color-text/);
+        expect(css).toMatch(/:focus-visible/);
+        expect(css).toMatch(/@media \(any-pointer: coarse\)/);
+        expect(css).toMatch(/--sb-mobile-touch-target, 44px/);
+        expect(css).toMatch(/--sbca-muted:\s*var\(--sb-muted-fg/);
+        expect(css).toMatch(/\.sbca-heading\s*\{[^}]*border:\s*0/s);
+        expect(css).toMatch(/\[data-sbca-density="compact"\]/);
+        expect(css).toMatch(/\[data-sbca-density="minimal"\]/);
+        expect(css).toMatch(/\.sbca-group-button/);
+        expect(css).toMatch(/\.sbca-organizer/);
+        expect(css).toMatch(/\.sbca-owner-summary\s*\{[^}]*min-block-size:\s*46px;[^}]*border-radius:\s*var\(--sb-radius-button, 14px\)/s);
+        expect(css).toMatch(/\.sbca-owner-option\s*\{[^}]*min-block-size:\s*44px;/s);
+        expect(css).toMatch(/\.sbca-owner-option\s*\{[^}]*content-visibility:\s*auto;[^}]*contain-intrinsic-size:\s*auto 56px;/s);
+        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-dialog\s*\{[^}]*width:\s*94vw !important;[^}]*max-width:\s*94vw !important;[^}]*height:\s*92dvh !important;[^}]*max-height:\s*92dvh !important;/s);
+        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-dialog\s*\{[^}]*min-height:\s*0 !important;/s);
+        expect(css).toMatch(/@media \(max-width: 600px\)\s*\{[\s\S]*\.sbca-dialog\s*\{[^}]*min-height:\s*0 !important;/s);
+        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-root\s*\{[^}]*block-size:\s*100%;[^}]*max-block-size:\s*92dvh;/s);
+        expect(css).toMatch(/@media \(max-width: 600px\)\s*\{[\s\S]*\.sbca-root\s*\{[^}]*block-size:\s*100%;[^}]*max-block-size:\s*100dvh;/s);
+        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-root\s*\{[^}]*block-size:\s*100%;/s);
+        expect(css).toMatch(/\.sbca-owner-options\s*\{[^}]*max-block-size:\s*min\(320px, 45dvh\);[^}]*overflow-y:\s*auto;/s);
+        expect(css).toMatch(/\[data-sbca-density="minimal"\] \.sbca-row-preview\s*\{[^}]*-webkit-line-clamp:\s*1;/s);
+        expect(css).toMatch(/\.sbca-sortpill\s*\{/);
+        expect(css).toMatch(/\.sbca-sortpill\[aria-pressed="true"\]\s*\{[^}]*--sb-selection-bg[^}]*--sb-selection-fg[^}]*text-decoration-line:\s*underline;/s);
+        expect(css).toMatch(/\.sbca-dialog \.popup-body,\s*\.sbca-dialog \.popup-content\s*\{[^}]*overflow:\s*hidden !important;/s);
+        expect(css).toMatch(/\.sbca-owner-selector\s*\{[^}]*inline-size:\s*100%;/s);
+        expect(css).toMatch(/\.sbca-root \[hidden\]\s*\{[^}]*display:\s*none !important;/s);
+        expect(css).toMatch(/\.sbca-list-panel\s*\{[^}]*grid-template-rows:\s*auto minmax\(0,\s*1fr\);[^}]*min-inline-size:\s*0;/s);
+        expect(css).toMatch(/\.sbca-list-tools\[open\]\s*\{[^}]*flex-basis:\s*100%;/s);
+        expect(css).toMatch(/\.sbca-list-tools-panel\s*\{[^}]*display:\s*grid;/s);
+        expect(css).toMatch(/\.sbca-list-tools > summary\s*\{[^}]*color:\s*var\(--sbca-muted\)/s);
+        expect(css).toMatch(/\.sbca-sort,/);
+        expect(css).toMatch(/\.sbca-deep\s*\{[^}]*border-color:\s*var\(--sbca-accent\)/s);
+        expect(css).toMatch(/\.sbca-msg-match\s*\{/);
+        expect(css).toMatch(/\.sbca-msg:focus\s*\{[^}]*outline:\s*2px solid var\(--sbca-focus\)/s);
+        expect(css).toMatch(/\.sbca-root\[data-sbca-density\] \.sbca-row-button/);
+        expect(css).toMatch(/\.sbca-row-selection\s*\{[^}]*min-inline-size:\s*var\(--sb-mobile-touch-target, 44px\)/s);
+        expect(css).toMatch(/@media \(min-width: 1001px\)\s*\{[\s\S]*\.sbca-toolbar:has\(\.sbca-options\[open\]\)[\s\S]*max-block-size:\s*60%;[\s\S]*overflow-y:\s*auto;[\s\S]*overscroll-behavior:\s*contain;/);
+        expect(css).toMatch(/@media \(max-width: 600px\)/);
+        expect(css).toMatch(/width:\s*100vw !important/);
+        expect(css).toMatch(/height:\s*100dvh !important/);
+        expect(css).toMatch(/font-size:\s*16px/);
+        expect(css).not.toMatch(/rgba?\(/i);
+        expect(css).toMatch(/@media screen and \(max-width: 768px\)\s*\{[\s\S]*#right-nav-panel\.openDrawer \.sb-character-create-bar #sbca_drawer_button\s*\{[^}]*width:\s*38px !important;[^}]*height:\s*38px !important;/);
+        expect(css).not.toMatch(/^\s*color:\s*var\(--sbca-accent\)/m);
+        expect(css).not.toMatch(/sbca-sortpill-active/);
+        expect(css).not.toMatch(/border-(?:left|right)\s*:\s*[2-9]/i);
+    });
+});
+
+describe('Data Maid Chat Archive integration', () => {
+    test('keeps the organization sidecar out of loose user files', async () => {
+        const root = await mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-archive-'));
+        const directories = {
+            root,
+            userImages: path.join(root, 'user-images'),
+            files: path.join(root, 'files'),
+            chats: path.join(root, 'chats'),
+            groupChats: path.join(root, 'group-chats'),
+            groups: path.join(root, 'groups'),
+            characters: path.join(root, 'characters'),
+            thumbnailsAvatar: path.join(root, 'thumbnails-avatar'),
+            backgrounds: path.join(root, 'backgrounds'),
+            thumbnailsBg: path.join(root, 'thumbnails-bg'),
+            thumbnailsBgMobile: path.join(root, 'thumbnails-bg-mobile'),
+            avatars: path.join(root, 'avatars'),
+            thumbnailsPersona: path.join(root, 'thumbnails-persona'),
+            backups: path.join(root, 'backups'),
+        };
+
+        try {
+            await Promise.all(Object.values(directories).map(directory => mkdir(directory, { recursive: true })));
+            const sidecar = path.join(directories.files, ORGANIZATION_FILE_NAME);
+            const ordinaryFile = path.join(directories.files, 'notes.txt');
+            await Promise.all([
+                writeFile(sidecar, '{"version":1}'),
+                writeFile(ordinaryFile, 'loose file'),
+            ]);
+
+            const report = await new DataMaidService('test-user', directories).generateReport();
+
+            expect(report.files).toEqual([ordinaryFile]);
+            expect(report.files).not.toContain(sidecar);
+        } finally {
+            await rm(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/sillybunny-chats-archive.test.js
+++ b/tests/sillybunny-chats-archive.test.js
@@ -1056,11 +1056,12 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/getThumbnailUrl\('avatar', choice\.avatar\)/);
         expect(ui).toMatch(/Search characters and groups/);
         expect(ui).toMatch(/Character: \{name\}/);
-        expect(ui).toMatch(/listToolsPanel\.append\(ownerField\.wrap, sortPills, selectionBar\)/);
+        expect(ui).toMatch(/const listTools = el\('div', 'sbca-list-tools'\)/);
+        expect(ui).toMatch(/listTools\.append\(ownerField\.wrap, sortPills, selectionBar\)/);
         expect(ui).toMatch(/listTop\.append\(listHeading, listTools\)/);
         expect(ui).toMatch(/listPanel\.append\(listTop, list\)/);
         expect(ui).toMatch(/sbca-list-tools/);
-        expect(ui).toMatch(/listTools\.open = true/);
+        expect(ui).not.toMatch(/listTools\.open/);
         expect(ui).toMatch(/option\.addEventListener\('pointerdown', event => \{\s*if \(event\.button !== 0 \|\| event\.pointerType === 'touch'\)/);
         expect(ui).toMatch(/option\.addEventListener\('click', select\)/);
         expect(ui).toMatch(/sbca-sortpill/);
@@ -1084,6 +1085,11 @@ describe('SillyBunny Chats Archive integration', () => {
         expect(ui).toMatch(/findMatchingSnippetInJsonlAsync\(raw, query, \{ signal \}\)/);
         expect(ui).not.toMatch(/findExistingGroupFiles/);
         expect(ui).toMatch(/sbca-browse-options/);
+        expect(ui).toMatch(/options\.append\(el\('summary', undefined, tr\(ctx, 'Filters'\)\)\)/);
+        expect(ui).toMatch(/const organizationTools = el\('details', 'sbca-organization-tools'\)/);
+        expect(ui).toMatch(/Manage organization/);
+        expect(ui).not.toMatch(/SORT_OPTIONS/);
+        expect(ui).not.toMatch(/sortField/);
         expect(ui).toMatch(/Clear filters/);
         expect(ui).not.toMatch(/sbca-row-selection-label/);
         expect(ui).not.toMatch(/\browKey\(/);


### PR DESCRIPTION
Adds the extension I was drafting, Chats Archive, as a Core Extension.

## Where Does It Live
Next to the new character icon in the character menu. It looks like an archive button.
<img width="269" height="210" alt="image" src="https://github.com/user-attachments/assets/c3fc782b-2102-4bbf-97db-fe1d20ad879c" />

## What it does
- Lists linked character and group chats plus root-level JSONL files in one place, including filename-only entries when a linked file is malformed.
- Groups by owner, type, or folder; sorts by date, owner, name, size, or message count (full dropdown or quick pills)
- UI you can customise to: comfortable, compact, and minimal list densities.
- Filters to one character or group at a time from a searchable avatar selector that puts same named characters with their actual file names and specific character avatars to differentiate them.
- Has multiple types of filters including name, tag, size, etc.
- Has organisation features such as folders and favourites.
- Can select multiple chats and applies favorite, folder, collection, or tag changes in one batch.
- Exports and imports the organization sidecar as a backup.
- Finds deleted-character and unlinked-group chats when you choose **Find orphaned files**.
- Searches message content across linked chats and every orphan currently shown. Search can be stopped, and partial failures are reported with a warning.
- Inspects the original JSONL through read-only export/view routes, including root and scanned orphan files.
- Shows system/user/assistant roles, response alternatives, chat metadata, extension-data values, and the original raw file. Has short truncated previews for each file.
- Downloads the selected chat as its original JSONL or plain text file.
- Opens linked character or group chats. Orphan files cannot be opened as active chats without relinking them.
- Renders long archives and chats in batches of 100 items.

Inspection, search, organization, and download do not modify chat files. Organization data is stored separately in the user-scoped `_sbca_organization.json` file. That's what the organization sidecar is for.

## Tested
Used on both mobile and desktop. Performance is fairly robust and UI is simple.
I have over 20,000 chats and over 300 characters, so the stress testing went well.
