### PR TITLE
fix: no redundant ICA toasts when updating bundled agents

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -785,6 +785,15 @@ export function getBundledAgentLatestTemplatePlan(agentList = [], templateList =
             }
         }
 
+        const keepAgentVersion = Number(keepAgent?.version ?? 1);
+        const templateVersion = Number(template?.version ?? 1);
+        if (
+            (Number.isFinite(keepAgentVersion) ? keepAgentVersion : 1) >=
+            (Number.isFinite(templateVersion) ? templateVersion : 1)
+        ) {
+            continue;
+        }
+
         const latestAgent = buildLatestBundledAgentSnapshot(keepAgent, template);
         if (normalizedAgentJson(latestAgent) !== normalizedAgentJson(keepAgent)) {
             updates.push({

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -858,7 +858,7 @@ describe('in-chat agent scoped enabled state', () => {
             author: 'SillyBunny',
             category: 'companion',
             execution: 'companion',
-            version: 1,
+            version: 2,
             companion: {
                 trigger: 'auto',
                 displayMode: 'panel',
@@ -881,6 +881,7 @@ describe('in-chat agent scoped enabled state', () => {
             category: 'companion',
             execution: 'companion',
             sourceTemplateId: 'tpl-chatroom-companion',
+            version: 1,
             enabled: true,
             favorite: true,
             connectionProfile: 'sidecar-profile',
@@ -937,6 +938,7 @@ describe('in-chat agent scoped enabled state', () => {
             author: 'SillyBunny',
             category: 'companion',
             execution: 'companion',
+            version: 2,
             companion: {
                 includeCharacterCard: true,
                 includePersona: true,
@@ -952,6 +954,7 @@ describe('in-chat agent scoped enabled state', () => {
                 category: 'companion',
                 execution: 'companion',
                 sourceTemplateId: 'tpl-relationship-lens-companion',
+                version: 1,
                 enabled: true,
             },
             {
@@ -962,6 +965,7 @@ describe('in-chat agent scoped enabled state', () => {
                 category: 'companion',
                 execution: 'companion',
                 sourceTemplateId: 'tpl-relationship-lens-companion',
+                version: 1,
                 enabled: false,
             },
             {
@@ -972,6 +976,7 @@ describe('in-chat agent scoped enabled state', () => {
                 category: 'companion',
                 execution: 'companion',
                 sourceTemplateId: 'tpl-relationship-lens-companion',
+                version: 1,
                 phaseLocked: true,
             },
         ];
@@ -987,6 +992,49 @@ describe('in-chat agent scoped enabled state', () => {
             includePersona: true,
             includeWorldInfo: true,
         }));
+    });
+
+    test('does not refresh same-version bundled agents while still removing duplicates', async () => {
+        const store = await importStore();
+        const templates = [{
+            id: 'tpl-current-agent',
+            name: 'Current Agent',
+            prompt: 'current bundled prompt',
+            author: 'SillyBunny',
+            category: 'companion',
+            execution: 'companion',
+            version: 2,
+        }];
+        const agents = [
+            {
+                id: 'current-agent',
+                name: 'Current Agent',
+                prompt: 'stale bundled prompt',
+                author: 'SillyBunny',
+                category: 'companion',
+                execution: 'companion',
+                sourceTemplateId: 'tpl-current-agent',
+                version: 2,
+                enabled: true,
+                settings: { runtimeState: 'preserve' },
+            },
+            {
+                id: 'duplicate-current-agent',
+                name: 'Current Agent',
+                prompt: 'stale bundled prompt',
+                author: 'SillyBunny',
+                category: 'companion',
+                execution: 'companion',
+                sourceTemplateId: 'tpl-current-agent',
+                version: 2,
+                enabled: false,
+            },
+        ];
+
+        const plan = store.getBundledAgentLatestTemplatePlan(agents, templates);
+
+        expect(plan.updates).toEqual([]);
+        expect(plan.redundantIds).toEqual(['duplicate-current-agent']);
     });
 
     test('does not mark phase-locked same-template duplicates redundant', async () => {


### PR DESCRIPTION
Whenever you reload SillyBunny, it says "Restored 2 bundled agent defaults" every single time, which is annoying, because they're already updated. Adds a guard to make sure this doesn't regress in the future.
