### PR TITLE
fix: hardens save path for remote servers

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -50,17 +50,17 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-06-06 in-chat agent stop-button wiring. |
 | Owner | Refactor integrator. |
 
-### `src/endpoints/chats.js`, `public/script.js`, and `public/scripts/group-chats.js` - chat save integrity
+### `src/endpoints/chats.js`, `public/script.js`, `public/scripts/group-chats.js`, and `public/scripts/extensions.js` - chat save integrity
 | Field | Value |
 | --- | --- |
 | Area | Chat persistence and data-loss prevention. |
 | Divergence reason | SillyBunny must reject stale cross-device chat saves instead of allowing last-write-wins overwrites that destroy newer messages. |
 | Target seam | None yet; keep the save-contract adapter minimal until chat persistence has a dedicated fork seam. |
-| Adapter shape | Rotate chat metadata integrity in `trySaveChat()`, return the new token from normal and group save routes, and store the returned token in the active client metadata after successful saves. |
+| Adapter shape | Rotate chat metadata integrity in `trySaveChat()`, return the new token from normal and group save routes, store the returned token in the active client metadata after successful saves, and bind debounced metadata saves to the active chat generation. |
 | Protecting tests | `tests/chat-integrity-rotation.test.js`; manual two-instance stale-save smoke before release. |
-| Validation | `npm run test:unit --prefix tests -- chat-integrity-rotation.test.js`, `node --check src/endpoints/chats.js`, `node --check public/script.js`, `node --check public/scripts/group-chats.js`, `npm run lint`, Node/Bun server smoke. |
+| Validation | `npm run test:unit --prefix tests -- chat-integrity-rotation.test.js chat-save-guard.test.js`, `node --check src/endpoints/chats.js`, `node --check public/script.js`, `node --check public/scripts/group-chats.js`, `node --check public/scripts/extensions.js`, `npm run lint`, Node/Bun server smoke. |
 | Rollback path | Revert the integrity rotation response contract and client adoption to the prior per-load integrity behavior. |
-| Last reviewed | 2026-06-06 chat integrity rotation fix. |
+| Last reviewed | 2026-08-11 PR #754 remote-save integrity fix. |
 | Owner | Bugfix integrator. |
 
 ### `public/index.html`, `public/style.css`, `public/css/mobile-styles.css`, `public/script.js`, and `public/scripts/group-chats.js` - group chat branch creation

--- a/public/script.js
+++ b/public/script.js
@@ -3364,6 +3364,10 @@ export function incrementChatGeneration() {
     chatGeneration++;
 }
 
+export function getChatGeneration() {
+    return chatGeneration;
+}
+
 function setChatSaveActive(isActive) {
     chatSaveActivityCount += isActive ? 1 : -1;
     chatSaveActivityCount = Math.max(0, chatSaveActivityCount);

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,6 +1,6 @@
 import { DOMPurify, Popper } from '../lib.js';
 
-import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
+import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION, getChatGeneration } from '../script.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
 import { delay, deleteValueByPath, equalsIgnoreCaseAndAccents, escapeHtml, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
@@ -250,6 +250,7 @@ export function saveMetadataDebounced() {
     const groupId = context.groupId;
     const characterId = context.characterId;
     const chatId = context.chatId;
+    const generation = getChatGeneration();
 
     cancelDebouncedMetadataSave();
 
@@ -268,6 +269,14 @@ export function saveMetadataDebounced() {
 
         if (!groupId && characterId !== newContext.characterId) {
             console.warn('Character changed, not saving metadata');
+            return;
+        }
+
+        // SillyBunny: reopening or reloading the same chat keeps every check above satisfied while
+        // the messages are cleared and not yet reloaded. Saving there writes an empty chat over the
+        // populated file, which the server refuses. The generation changes on every chat load.
+        if (generation !== getChatGeneration()) {
+            console.warn('Chat reloaded, not saving metadata');
             return;
         }
 

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -1142,6 +1142,19 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
 
         const currentChatData = currentSnapshot?.data ?? null;
         const existingIntegrity = currentChatData === null ? '' : getSerializedChatIntegrity(currentChatData);
+        const destructiveReason = currentChatData ? getDestructiveChatSaveReason(savedChatData, currentChatData) : '';
+
+        // SillyBunny: classify a history-destroying save before the integrity check, so the client is
+        // told what is actually wrong with it. A client that lost its slug and a client sending an
+        // unloaded chat both fail the slug comparison, but only the second is destructive, and
+        // reporting it as a slug mismatch sends the client into a reload loop it cannot resolve:
+        // reloading never repopulates the chat it failed to send.
+        // Reject before the pre-write ring runs, so a rejected save cannot evict the last good state.
+        // Deliberate message deletion sets allowShrink, which is not the same confirmation as an integrity overwrite.
+        if (destructiveReason && !skipIntegrityCheck && !allowShrink) {
+            throw new DestructiveChatSaveError(destructiveReason, `Refused a destructive chat save for "${cardName}" (${destructiveReason}): incoming payload has ${savedChatData.length} JSONL rows, existing file has ${countSerializedChatLines(currentChatData)} rows.`);
+        }
+
         // SillyBunny: the slug rotates on every save and only reaches the client in the response
         // body, so a dropped response leaves a remote client holding the previous slug forever.
         // Accept that retry when it merely appends to what is on disk, because a superset save
@@ -1152,14 +1165,7 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
         }
 
         if (currentChatData) {
-            const destructiveReason = getDestructiveChatSaveReason(savedChatData, currentChatData);
             const existingLines = countSerializedChatLines(currentChatData);
-
-            // SillyBunny: reject before the pre-write ring runs, so a rejected save cannot evict the last good state.
-            // Deliberate message deletion sets allowShrink, which is not the same confirmation as an integrity overwrite.
-            if (destructiveReason && !skipIntegrityCheck && !allowShrink) {
-                throw new DestructiveChatSaveError(destructiveReason, `Refused a destructive chat save for "${cardName}" (${destructiveReason}): incoming payload has ${savedChatData.length} JSONL rows, existing file has ${existingLines} rows.`);
-            }
 
             // SillyBunny: compare parsed records because loading canonicalizes legacy JSONL formatting.
             // Replacing equivalent content through atomic temp-and-rename would swap the file identity

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -281,6 +281,22 @@ function isSameChatSaveContent(left, right, options = {}) {
     return leftRecords !== null && rightRecords !== null && isDeepStrictEqual(leftRecords, rightRecords);
 }
 
+// SillyBunny: true when the incoming save keeps every existing message unchanged and in order,
+// so it can only append. Messages are compared without the header record because chat_metadata
+// legitimately drifts between saves while history must not.
+function isChatSaveExtension(newSerializedChat, existingSerializedChat, options = {}) {
+    const incomingRecords = getChatSaveComparisonRecords(newSerializedChat, options);
+    const existingRecords = getChatSaveComparisonRecords(existingSerializedChat, options);
+    if (incomingRecords === null || existingRecords === null) {
+        return false;
+    }
+
+    const incomingMessages = incomingRecords.slice(1);
+    const existingMessages = existingRecords.slice(1);
+    return incomingMessages.length >= existingMessages.length
+        && isDeepStrictEqual(incomingMessages.slice(0, existingMessages.length), existingMessages);
+}
+
 function getLatestBackupFilePath(directory, prefix) {
     const backupFiles = fs.readdirSync(directory)
         .filter(fileName => fileName.startsWith(prefix))
@@ -1126,7 +1142,12 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
 
         const currentChatData = currentSnapshot?.data ?? null;
         const existingIntegrity = currentChatData === null ? '' : getSerializedChatIntegrity(currentChatData);
-        if (doIntegrityCheck && existingIntegrity && existingIntegrity !== chatIntegritySlug) {
+        // SillyBunny: the slug rotates on every save and only reaches the client in the response
+        // body, so a dropped response leaves a remote client holding the previous slug forever.
+        // Accept that retry when it merely appends to what is on disk, because a superset save
+        // cannot lose history; a genuinely divergent save still fails the check.
+        if (doIntegrityCheck && existingIntegrity && existingIntegrity !== chatIntegritySlug
+            && !isChatSaveExtension(jsonlData, currentChatData, { ignoreDerivedMetadata: !persistDerivedMetadata })) {
             throw new IntegrityMismatchError(`Chat integrity check failed for "${filePath}". The expected integrity slug was "${chatIntegritySlug}".`);
         }
 

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -281,9 +281,8 @@ function isSameChatSaveContent(left, right, options = {}) {
     return leftRecords !== null && rightRecords !== null && isDeepStrictEqual(leftRecords, rightRecords);
 }
 
-// SillyBunny: true when the incoming save keeps every existing message unchanged and in order,
-// so it can only append. Messages are compared without the header record because chat_metadata
-// legitimately drifts between saves while history must not.
+// SillyBunny: true when the incoming save keeps the existing metadata and every message unchanged
+// and in order, so it can only append without rolling back another client's metadata changes.
 function isChatSaveExtension(newSerializedChat, existingSerializedChat, options = {}) {
     const incomingRecords = getChatSaveComparisonRecords(newSerializedChat, options);
     const existingRecords = getChatSaveComparisonRecords(existingSerializedChat, options);
@@ -291,9 +290,10 @@ function isChatSaveExtension(newSerializedChat, existingSerializedChat, options 
         return false;
     }
 
-    const incomingMessages = incomingRecords.slice(1);
-    const existingMessages = existingRecords.slice(1);
-    return incomingMessages.length >= existingMessages.length
+    const [incomingHeader, ...incomingMessages] = incomingRecords;
+    const [existingHeader, ...existingMessages] = existingRecords;
+    return isDeepStrictEqual(incomingHeader, existingHeader)
+        && incomingMessages.length >= existingMessages.length
         && isDeepStrictEqual(incomingMessages.slice(0, existingMessages.length), existingMessages);
 }
 

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -96,6 +96,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "getCharacterSource",
   "getCharacters",
   "getChat",
+  "getChatGeneration",
   "getChatsFromFiles",
   "getCurrentChatDetails",
   "getCurrentChatId",

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -715,6 +715,32 @@ describe('chat integrity rotation', () => {
         expect((await readHeader(chatFile)).chat_metadata.integrity).toBe(result.integrity);
     });
 
+    test('reports an unloaded chat save as destructive rather than as an integrity mismatch', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-unloaded-save-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const originalContent = chatWithMessages('current-integrity', ['one', 'two', 'three']).map(JSON.stringify).join('\n');
+        await fs.writeFile(chatFile, originalContent);
+
+        // A client that has cleared the old chat and not yet loaded the new one sends a bare header
+        // with no slug. That fails the slug comparison too, but calling it an integrity mismatch makes
+        // the client reload, which cannot repopulate the chat it failed to send, so it loops forever.
+        await expect(trySaveChat(
+            [{ chat_metadata: {}, user_name: 'unused', character_name: 'unused' }],
+            chatFile,
+            false,
+            'unloaded-save-user',
+            'Test Card',
+            backupDir,
+        )).rejects.toMatchObject({ reason: 'emptied' });
+
+        await expect(fs.readFile(chatFile, 'utf8')).resolves.toBe(originalContent);
+        await expect(fs.readdir(backupDir)).resolves.toHaveLength(0);
+    });
+
     test('still rejects a stale writer that rewrites an existing message', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-stale-divergent-'));

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -656,7 +656,7 @@ describe('chat integrity rotation', () => {
         )).rejects.toThrow(/integrity/i);
     });
 
-    test('still rejects a stale writer whose payload matches the file', async () => {
+    test('resyncs a stale writer whose payload matches the file without writing', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-unchanged-stale-'));
         const chatFile = path.join(tempDir, 'chat.jsonl');
@@ -666,16 +666,77 @@ describe('chat integrity rotation', () => {
         const { payload, serialized } = noncanonicalChat('current-integrity');
         payload[0].chat_metadata.integrity = 'stale-integrity';
         await fs.writeFile(chatFile, serialized);
+        const before = await fs.stat(chatFile);
 
-        // The integrity check runs before the content comparison, so identical content cannot bypass it.
-        await expect(trySaveChat(
+        // A client that lost the response to its own save holds the previous slug while its history
+        // already matches the file, so it is handed the real slug rather than a forced page reload.
+        const result = await trySaveChat(
             payload,
             chatFile,
             false,
             'stale-writer-user',
             'Test Card',
             backupDir,
+        );
+        jest.runOnlyPendingTimers();
+        const after = await fs.stat(chatFile);
+
+        expect(result).toEqual({ integrity: 'current-integrity' });
+        await expect(fs.readFile(chatFile, 'utf8')).resolves.toBe(serialized);
+        expect(after.ino).toBe(before.ino);
+        expect(after.mtimeMs).toBe(before.mtimeMs);
+    });
+
+    test('accepts a stale writer that only appends to the chat on disk', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-stale-append-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const onDisk = chatWithMessages('current-integrity', ['one', 'two', 'three']);
+        await fs.writeFile(chatFile, onDisk.map(JSON.stringify).join('\n'));
+
+        const result = await trySaveChat(
+            chatWithMessages('stale-integrity', ['one', 'two', 'three', 'four']),
+            chatFile,
+            false,
+            'stale-append-user',
+            'Test Card',
+            backupDir,
+        );
+
+        expect(result.integrity).toEqual(expect.any(String));
+        expect(result.integrity).not.toBe('current-integrity');
+        expect(result.integrity).not.toBe('stale-integrity');
+        const saved = await fs.readFile(chatFile, 'utf8');
+        expect(saved).toContain('"mes":"four"');
+        expect(saved).toContain('"mes":"one"');
+        expect((await readHeader(chatFile)).chat_metadata.integrity).toBe(result.integrity);
+    });
+
+    test('still rejects a stale writer that rewrites an existing message', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-stale-divergent-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const originalContent = chatWithMessages('current-integrity', ['one', 'two', 'three']).map(JSON.stringify).join('\n');
+        await fs.writeFile(chatFile, originalContent);
+
+        // Appending is safe because it cannot drop history; editing an existing message can.
+        await expect(trySaveChat(
+            chatWithMessages('stale-integrity', ['one', 'rewritten by another device', 'three', 'four']),
+            chatFile,
+            false,
+            'stale-divergent-user',
+            'Test Card',
+            backupDir,
         )).rejects.toThrow(/integrity/i);
+
+        await expect(fs.readFile(chatFile, 'utf8')).resolves.toBe(originalContent);
+        await expect(fs.readdir(backupDir)).resolves.toHaveLength(0);
     });
 
     test('still rejects a stale writer when the existing chat body is corrupt', async () => {

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -715,6 +715,33 @@ describe('chat integrity rotation', () => {
         expect((await readHeader(chatFile)).chat_metadata.integrity).toBe(result.integrity);
     });
 
+    test('rejects a stale append that would overwrite newer chat metadata', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-stale-metadata-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const onDisk = chatWithMessages('current-integrity', ['one', 'two', 'three']);
+        onDisk[0].chat_metadata.variables = { owner: 'newer-client' };
+        const originalContent = onDisk.map(JSON.stringify).join('\n');
+        await fs.writeFile(chatFile, originalContent);
+
+        const staleAppend = chatWithMessages('stale-integrity', ['one', 'two', 'three', 'four']);
+        staleAppend[0].chat_metadata.variables = { owner: 'stale-client' };
+        await expect(trySaveChat(
+            staleAppend,
+            chatFile,
+            false,
+            'stale-metadata-user',
+            'Test Card',
+            backupDir,
+        )).rejects.toThrow(/integrity/i);
+
+        await expect(fs.readFile(chatFile, 'utf8')).resolves.toBe(originalContent);
+        await expect(fs.readdir(backupDir)).resolves.toHaveLength(0);
+    });
+
     test('reports an unloaded chat save as destructive rather than as an integrity mismatch', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-unloaded-save-'));

--- a/tests/chat-save-guard.test.js
+++ b/tests/chat-save-guard.test.js
@@ -1,5 +1,27 @@
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, test } from '@jest/globals';
 import { getDebouncedChatSaveAbortReason } from '../public/scripts/chat-save-guard.js';
+
+describe('debounced metadata save', () => {
+    test('aborts when a chat load happens between scheduling and firing', async () => {
+        const extensionsSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/extensions.js', import.meta.url)), 'utf8');
+        const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
+        const debouncedBody = extensionsSource.slice(
+            extensionsSource.indexOf('export function saveMetadataDebounced()'),
+            extensionsSource.indexOf('}', extensionsSource.indexOf('}, debounce_timeout.relaxed);')),
+        );
+
+        // Reopening the same chat leaves group, character and chat id all unchanged while the
+        // messages are cleared, so only the generation distinguishes a loaded chat from a loading one.
+        expect(scriptSource).toContain('export function getChatGeneration()');
+        expect(debouncedBody).toContain('const generation = getChatGeneration();');
+        expect(debouncedBody).toContain('if (generation !== getChatGeneration()) {');
+        expect(debouncedBody.indexOf('const generation = getChatGeneration();'))
+            .toBeLessThan(debouncedBody.indexOf('saveMetadataTimeout = setTimeout'));
+    });
+});
 
 describe('getDebouncedChatSaveAbortReason', () => {
     test('allows saves when the scheduled target still matches', () => {

--- a/tests/extensions-disable.test.js
+++ b/tests/extensions-disable.test.js
@@ -49,6 +49,7 @@ function installExtensionModuleMocks() {
         animation_duration: 0,
         eventSource: { emit: jest.fn(async () => {}) },
         event_types: { EXTENSIONS_FIRST_LOAD: 'extensions_first_load', EXTRAS_CONNECTED: 'extras_connected', EXTENSION_SETTINGS_LOADED: 'extension_settings_loaded' },
+        getChatGeneration: jest.fn(() => 0),
         getRequestHeaders: jest.fn(() => ({})),
         saveSettings: jest.fn(async () => {}),
         saveSettingsDebounced,


### PR DESCRIPTION
I usually use a remote VM to access SillyBunny.

The problem is when the connection drops mid-save. My phone sends the chat, the server saves it to disk and generates a new integrity token, but the connection dies before that token makes it back to my phone. So the file on disk has moved on and my phone hasn't, and there's no way for it to catch up, because that reply was the only place the new token existed.

From then on every save gets rejected with Chat Integrity Failed, and it keeps happening until you reload the page.

This makes it so if the phone's copy has every message that's already on disk plus additional ones, the server accepts it instead of rejecting it outright, a save that only adds messages can't lose anything. If an existing message was edited or removed, it still gets rejected.

Also prevents Chat Integrity Failed check loops where you enter a chat, click OK, refresh, then enter the chat, does the same thing, again and again... making you unable to use that chat.

Fixes the browser sending an empty chat when a pending metadata save fires in the middle of reopening a chat. The save's checks all pass because the character, chat and group haven't changed, but the messages have been cleared for reloading, so it tries to write a chat with no messages over the real one.