### PR TITLE
fix(linkapi): prevent sending presencePenalty and frequencyPenalty samplers to Grok

### DIFF
--- a/public/scripts/openai-model-capabilities.js
+++ b/public/scripts/openai-model-capabilities.js
@@ -28,6 +28,28 @@ export function applyClaudeModelParameterConstraints(generateData, { preserveRea
 }
 
 /**
+ * Removes penalty samplers that Grok reasoning models reject.
+ * xAI errors the request instead of ignoring them, and proxies that relay Grok through an
+ * OpenAI-compatible endpoint forward whatever they are given. Matches the model set the native
+ * xAI path already strips these for, including provider-prefixed and tag-prefixed IDs.
+ *
+ * @param {Record<string, any>} generateData Chat Completion request data
+ * @returns {Record<string, any>} The request data
+ */
+export function applyGrokModelParameterConstraints(generateData) {
+    const model = String(generateData?.model ?? '').toLowerCase();
+
+    if (!/grok-(?:3-mini|4|code)/.test(model)) {
+        return generateData;
+    }
+
+    delete generateData.frequency_penalty;
+    delete generateData.presence_penalty;
+
+    return generateData;
+}
+
+/**
  * Checks whether a model ID targets Kimi K3, including provider-prefixed IDs.
  *
  * @param {unknown} model Model identifier

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -8,7 +8,7 @@ import fetch from 'node-fetch';
 import urlJoin from 'url-join';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
 import { getLinkApiBaseUrl, getLinkApiRequestFormat } from '../../../public/scripts/linkapi-utils.js';
-import { applyKimiK3ModelParameterConstraints, isKimiK3Model } from '../../../public/scripts/openai-model-capabilities.js';
+import { applyGrokModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model } from '../../../public/scripts/openai-model-capabilities.js';
 
 import {
     AIMLAPI_HEADERS,
@@ -3293,6 +3293,13 @@ export async function handleChatCompletionsGenerate(request, response) {
             'n': request.body.n,
             ...bodyParams,
         };
+
+        // LinkAPI relays Grok verbatim, so penalty samplers reach a reasoning model and error the
+        // request. Stripped here rather than frontend-side to also cover the Conversation REST API,
+        // which forwards a caller-supplied payload straight into this handler.
+        if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.LINKAPI) {
+            applyGrokModelParameterConstraints(requestBody);
+        }
 
         const isKimiK3Request = !isTextCompletion
             && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.MOONSHOT, CHAT_COMPLETION_SOURCES.NANOGPT, CHAT_COMPLETION_SOURCES.OPENROUTER].includes(request.body.chat_completion_source)

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -4,11 +4,13 @@ import { fileURLToPath } from 'node:url';
 
 import {
     applyClaudeModelParameterConstraints,
+    applyGrokModelParameterConstraints,
     applyKimiK3ModelParameterConstraints,
     isKimiK3Model,
 } from '../public/scripts/openai-model-capabilities.js';
 
 const openAiSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/openai.js', import.meta.url)), 'utf8');
+const chatCompletionsSource = fs.readFileSync(fileURLToPath(new URL('../src/endpoints/backends/chat-completions.js', import.meta.url)), 'utf8');
 const indexSource = fs.readFileSync(fileURLToPath(new URL('../public/index.html', import.meta.url)), 'utf8');
 const powerUserSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/power-user.js', import.meta.url)), 'utf8');
 const presetManagerSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/preset-manager.js', import.meta.url)), 'utf8');
@@ -58,6 +60,53 @@ describe('OpenAI-compatible Claude model capabilities', () => {
         expect(openAiSource).toContain('applyClaudeModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model');
         expect(openAiSource).toContain('applyClaudeModelParameterConstraints(generate_data, {');
         expect(openAiSource).toContain('preserveReasoning: [chat_completion_sources.CLAUDE, chat_completion_sources.LINKAPI].includes(settings.chat_completion_source)');
+    });
+});
+
+describe('Grok model capabilities', () => {
+    test('removes penalty samplers from Grok reasoning model requests', () => {
+        for (const model of ['grok-4.6', 'grok-4.5', 'grok-4-0709', 'grok-code-fast-1', 'grok-3-mini', 'x-ai/Grok-4.6', '[SP]grok-4.6']) {
+            const payload = {
+                model,
+                temperature: 0.8,
+                top_p: 0.9,
+                frequency_penalty: 0.2,
+                presence_penalty: 0.3,
+                reasoning_effort: 'high',
+            };
+
+            applyGrokModelParameterConstraints(payload);
+
+            expect(payload).toEqual({
+                model,
+                temperature: 0.8,
+                top_p: 0.9,
+                reasoning_effort: 'high',
+            });
+        }
+    });
+
+    test('leaves payloads for other models unchanged', () => {
+        for (const model of ['grok-3', 'grok-2-vision', 'gpt-5.1', 'claude-sonnet-5', '', undefined]) {
+            const payload = {
+                model,
+                frequency_penalty: 0.2,
+                presence_penalty: 0.3,
+            };
+
+            applyGrokModelParameterConstraints(payload);
+
+            expect(payload).toEqual({
+                model,
+                frequency_penalty: 0.2,
+                presence_penalty: 0.3,
+            });
+        }
+    });
+
+    test('applies Grok constraints to LinkAPI requests only', () => {
+        expect(chatCompletionsSource).toContain('applyGrokModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model');
+        expect(chatCompletionsSource).toContain('if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.LINKAPI) {\n            applyGrokModelParameterConstraints(requestBody);');
     });
 });
 


### PR DESCRIPTION
Strictly for the LinkAPI backend. Grok 4.6 errors out because the aforementioned samplers keep getting sent. This PR prevents that for Grok 4.6 and the other Grok models that reject the same samplers.