### PR TITLE
fix(tokeniser): count every message all at once instead of one by one

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -70,7 +70,7 @@ import {
     textValueMatcher,
     uuidv4,
 } from './utils.js';
-import { countChatCompletionPayloadTokensOpenAIAsync, countTokensOpenAIAsync, getTokenizerModel } from './tokenizers.js';
+import { countChatCompletionPayloadTokensOpenAIAsync, countTokensOpenAIAsync, getTokenizerModel, primeOpenAITokenCache } from './tokenizers.js';
 import { isMobile } from './RossAscends-mods.js';
 import { saveLogprobsForActiveMessage } from './logprobs.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
@@ -1149,6 +1149,44 @@ async function populationInjectionPrompts(prompts, messages) {
 }
 
 /**
+ * How many chat messages are prepared and counted per batched request. Larger windows save
+ * more round trips; smaller ones waste less work when the context budget runs out early.
+ * @type {number}
+ */
+const CHAT_HISTORY_PRIME_WINDOW = 64;
+
+/**
+ * Counts a window of chat history in one request so the per-message counting below hits the cache.
+ * Mirrors the exact message shapes buildChatMessage produces: Message replaces a falsy role
+ * with 'system' and only counts content when it is a non-empty string, and setName counts a
+ * second shape that carries the name. A shape that stops matching costs a cache miss, not a
+ * wrong count - the unbatched path still counts whatever it is actually given.
+ * @param {{prompt: object, prepared: object}[]} preparedChatPrompts - Prompts prepared ahead of the loop.
+ * @returns {Promise<void>}
+ */
+async function primeChatHistoryTokenCache(preparedChatPrompts) {
+    const candidates = [];
+
+    for (const { prompt, prepared } of preparedChatPrompts) {
+        const role = prepared.role || 'system';
+        const content = prepared.content;
+
+        if (typeof content !== 'string' || content.length === 0) {
+            continue;
+        }
+
+        candidates.push({ role, content });
+
+        if (promptManager.serviceSettings.names_behavior === character_names_behavior.COMPLETION && prompt.name) {
+            const name = promptManager.isValidName(prompt.name) ? prompt.name : promptManager.sanitizeName(prompt.name);
+            candidates.push({ role, content, name });
+        }
+    }
+
+    await primeOpenAITokenCache(candidates);
+}
+
+/**
  * Populates the chat history of the conversation.
  * @param {object[]} messages - Array containing all messages.
  * @param {import('./PromptManager').PromptCollection} prompts - Map object containing all prompts where the key is the prompt identifier and the value is the prompt object.
@@ -1220,12 +1258,43 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
 
     // Insert chat messages as long as there is budget available
     const chatPool = [...messages].reverse();
+
+    // SillyBunny divergence from upstream: prepare and count a window of chat prompts at a
+    // time. Upstream prepares and counts inside the loop below, which costs a round trip per
+    // message (two once names are enabled) - free on localhost, but the dominant cost of
+    // building a prompt against a remotely hosted server. Windowing rather than doing the
+    // whole pool matters because the loop stops as soon as the budget is spent, so priming
+    // everything would tokenize a long history that was never going to be used. Preparing
+    // here instead of inside the loop is also what keeps the primed cache keys exact:
+    // substituteParams is macro-driven, so preparing the same prompt twice can produce
+    // different content and the prime would silently miss.
+    const preparedChatPrompts = new Array(chatPool.length);
+    const prepareChatPromptWindow = async (start) => {
+        const end = Math.min(start + CHAT_HISTORY_PRIME_WINDOW, chatPool.length);
+
+        for (let i = start; i < end; i++) {
+            if (preparedChatPrompts[i]) {
+                continue;
+            }
+
+            // We do not want to mutate the prompt
+            const prompt = new Prompt(chatPool[i]);
+            prompt.identifier = `chatHistory-${messages.length - i}`;
+            preparedChatPrompts[i] = { prompt, prepared: promptManager.preparePrompt(prompt) };
+        }
+
+        await primeChatHistoryTokenCache(preparedChatPrompts.slice(start, end));
+    };
+
     for (let index = 0; index < chatPool.length; index++) {
+        if (index % CHAT_HISTORY_PRIME_WINDOW === 0) {
+            await prepareChatPromptWindow(index);
+        }
+
         const chatPrompt = chatPool[index];
 
-        // We do not want to mutate the prompt
-        const prompt = new Prompt(chatPrompt);
-        prompt.identifier = `chatHistory-${messages.length - index}`;
+        const { prompt } = preparedChatPrompts[index];
+        let preparedPrompt = preparedChatPrompts[index].prepared;
         let survivingContributions = Array.isArray(chatPrompt.agentContributions)
             ? structuredClone(chatPrompt.agentContributions)
             : [];
@@ -1254,7 +1323,11 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
         };
 
         const buildChatMessage = async () => {
-            const message = await Message.fromPromptAsync(promptManager.preparePrompt(prompt));
+            // The first build reuses the prompt prepared (and counted) before the loop; the
+            // trimming path below mutates prompt.content, so those rebuilds prepare again.
+            const prepared = preparedPrompt ?? promptManager.preparePrompt(prompt);
+            preparedPrompt = null;
+            const message = await Message.fromPromptAsync(prepared);
             if (survivingContributions.length > 0) {
                 message.agentContributions = survivingContributions;
             }

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -921,6 +921,69 @@ export async function countTokensOpenAIAsync(messages, full = false) {
 }
 
 /**
+ * Counts several messages in one request and stores the results in the token cache.
+ * SillyBunny addition: countTokensOpenAIAsync is awaited once per message by its callers,
+ * so on a remotely hosted server each message costs a full round trip. Priming the cache
+ * first collapses those into a single request; every entry it writes is the same value the
+ * unbatched path would have cached. Failures are swallowed - callers then count individually.
+ * @param {object[]} messages Messages that are about to be counted one at a time.
+ * @returns {Promise<void>}
+ */
+export async function primeOpenAITokenCache(messages) {
+    if (!Array.isArray(messages) || messages.length === 0) {
+        return;
+    }
+
+    const model = getTokenizerModel();
+    const cacheObject = getTokenCacheObject();
+    const pending = new Map();
+
+    for (const message of messages) {
+        const cacheKey = `${model}-${getStringHash(JSON.stringify(message))}`;
+
+        if (typeof cacheObject[cacheKey] === 'number' || pending.has(cacheKey)) {
+            continue;
+        }
+
+        pending.set(cacheKey, message);
+    }
+
+    if (pending.size === 0) {
+        return;
+    }
+
+    const cacheKeys = Array.from(pending.keys());
+    const uncounted = Array.from(pending.values());
+
+    try {
+        const data = await jQuery.ajax({
+            async: true,
+            type: 'POST',
+            url: `/api/tokenizers/openai/count?model=${model}&per_message=1`,
+            data: JSON.stringify(uncounted),
+            dataType: 'json',
+            contentType: 'application/json',
+        });
+
+        const counts = data?.token_counts;
+
+        if (!Array.isArray(counts) || counts.length !== cacheKeys.length) {
+            return;
+        }
+
+        counts.forEach((count, index) => {
+            const tokenCount = Number(count);
+
+            if (Number.isFinite(tokenCount)) {
+                cacheObject[cacheKeys[index]] = tokenCount;
+            }
+        });
+    } catch (error) {
+        console.error('Failed to prime the OpenAI token cache.', error);
+    }
+}
+
+/**
  * Returns the token count for a finalized chat completion payload using the OpenAI tokenizer.
  * @param {object[]} messages Final chat-completion messages.
  * @returns {Promise<number>} Token count.

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -1053,121 +1053,140 @@ router.post('/openai/decode', async function (req, res) {
     }
 });
 
+/**
+ * Counts tokens in an array of chat messages with an OpenAI-compatible tokenizer.
+ * Split out of the /openai/count handler so the same counting can be reused per message.
+ * @param {string} model Resolved tokenizer model
+ * @param {string} queryModel Raw model string from the request query
+ * @param {object[]} messages Messages to count
+ * @returns {Promise<number>} Token count
+ */
+async function countOpenAIChatTokens(model, queryModel, messages) {
+    if (model === 'claude') {
+        const instance = await claude_tokenizer.get();
+        if (!instance) throw new Error('Failed to load the Claude tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    if (model === 'llama3' || model === 'llama-3') {
+        const instance = await llama3_tokenizer.get();
+        if (!instance) throw new Error('Failed to load the Llama3 tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    if (model === 'llama') {
+        return await countSentencepieceArrayTokens(spp_llama, messages);
+    }
+
+    if (model === 'mistral') {
+        return await countSentencepieceArrayTokens(spp_mistral, messages);
+    }
+
+    if (model === 'yi') {
+        return await countSentencepieceArrayTokens(spp_yi, messages);
+    }
+
+    if (model === 'gemma' || model === 'gemini') {
+        return await countSentencepieceArrayTokens(spp_gemma, messages);
+    }
+
+    if (model === 'jamba') {
+        return await countSentencepieceArrayTokens(spp_jamba, messages);
+    }
+
+    if (model === 'qwen2') {
+        const instance = await qwen2Tokenizer.get();
+        if (!instance) throw new Error('Failed to load the Qwen2 tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    if (model === 'command-r') {
+        const instance = await commandRTokenizer.get();
+        if (!instance) throw new Error('Failed to load the Command-R tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    if (model === 'command-a') {
+        const instance = await commandATokenizer.get();
+        if (!instance) throw new Error('Failed to load the Command-A tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    if (model === 'nemo') {
+        const instance = await nemoTokenizer.get();
+        if (!instance) throw new Error('Failed to load the Nemo tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    if (model === 'deepseek') {
+        const instance = await deepseekTokenizer.get();
+        if (!instance) throw new Error('Failed to load the DeepSeek tokenizer');
+        return countWebTokenizerTokens(instance, messages);
+    }
+
+    const tokensPerName = queryModel.includes('gpt-3.5-turbo-0301') ? -1 : 1;
+    const tokensPerMessage = queryModel.includes('gpt-3.5-turbo-0301') ? 4 : 3;
+    const tokensPadding = 3;
+
+    const tokenizer = getTiktokenTokenizer(model);
+
+    let num_tokens = 0;
+
+    for (const msg of messages) {
+        try {
+            num_tokens += tokensPerMessage;
+            for (const [key, value] of Object.entries(msg)) {
+                num_tokens += tokenizer.encode(value).length;
+                if (key == 'name') {
+                    num_tokens += tokensPerName;
+                }
+            }
+        } catch {
+            console.warn('Error tokenizing message:', msg);
+        }
+    }
+    num_tokens += tokensPadding;
+
+    // NB: Since 2023-10-14, the GPT-3.5 Turbo 0301 model shoves in 7-9 extra tokens to every message.
+    // More details: https://community.openai.com/t/gpt-3-5-turbo-0301-showing-different-behavior-suddenly/431326/14
+    if (queryModel.includes('gpt-3.5-turbo-0301')) {
+        num_tokens += 9;
+    }
+
+    // not needed for cached tokenizers
+    //tokenizer.free();
+
+    return num_tokens;
+}
+
 router.post('/openai/count', async function (req, res) {
     try {
         if (!req.body) return res.sendStatus(400);
 
-        let num_tokens = 0;
         const queryModel = String(req.query.model || '');
         const model = getTokenizerModel(queryModel);
 
-        if (model === 'claude') {
-            const instance = await claude_tokenizer.get();
-            if (!instance) throw new Error('Failed to load the Claude tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'llama3' || model === 'llama-3') {
-            const instance = await llama3_tokenizer.get();
-            if (!instance) throw new Error('Failed to load the Llama3 tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'llama') {
-            num_tokens = await countSentencepieceArrayTokens(spp_llama, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'mistral') {
-            num_tokens = await countSentencepieceArrayTokens(spp_mistral, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'yi') {
-            num_tokens = await countSentencepieceArrayTokens(spp_yi, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'gemma' || model === 'gemini') {
-            num_tokens = await countSentencepieceArrayTokens(spp_gemma, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'jamba') {
-            num_tokens = await countSentencepieceArrayTokens(spp_jamba, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'qwen2') {
-            const instance = await qwen2Tokenizer.get();
-            if (!instance) throw new Error('Failed to load the Qwen2 tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'command-r') {
-            const instance = await commandRTokenizer.get();
-            if (!instance) throw new Error('Failed to load the Command-R tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'command-a') {
-            const instance = await commandATokenizer.get();
-            if (!instance) throw new Error('Failed to load the Command-A tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'nemo') {
-            const instance = await nemoTokenizer.get();
-            if (!instance) throw new Error('Failed to load the Nemo tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        if (model === 'deepseek') {
-            const instance = await deepseekTokenizer.get();
-            if (!instance) throw new Error('Failed to load the DeepSeek tokenizer');
-            num_tokens = countWebTokenizerTokens(instance, req.body);
-            return res.send({ 'token_count': num_tokens });
-        }
-
-        const tokensPerName = queryModel.includes('gpt-3.5-turbo-0301') ? -1 : 1;
-        const tokensPerMessage = queryModel.includes('gpt-3.5-turbo-0301') ? 4 : 3;
-        const tokensPadding = 3;
-
-        const tokenizer = getTiktokenTokenizer(model);
-
-        for (const msg of req.body) {
-            try {
-                num_tokens += tokensPerMessage;
-                for (const [key, value] of Object.entries(msg)) {
-                    num_tokens += tokenizer.encode(value).length;
-                    if (key == 'name') {
-                        num_tokens += tokensPerName;
-                    }
-                }
-            } catch {
-                console.warn('Error tokenizing message:', msg);
+        // SillyBunny divergence from upstream: `per_message=1` answers with one count per
+        // message instead of a single total, so a caller that would otherwise count a chat
+        // history one message at a time can prime its cache in a single request. Each entry
+        // is counted exactly as a single-message request would be, which keeps the values
+        // interchangeable with the ones the unbatched path caches.
+        if (req.query.per_message) {
+            const token_counts = [];
+            for (const message of req.body) {
+                token_counts.push(await countOpenAIChatTokens(model, queryModel, [message]));
             }
-        }
-        num_tokens += tokensPadding;
-
-        // NB: Since 2023-10-14, the GPT-3.5 Turbo 0301 model shoves in 7-9 extra tokens to every message.
-        // More details: https://community.openai.com/t/gpt-3-5-turbo-0301-showing-different-behavior-suddenly/431326/14
-        if (queryModel.includes('gpt-3.5-turbo-0301')) {
-            num_tokens += 9;
+            return res.send({ 'token_counts': token_counts });
         }
 
-        // not needed for cached tokenizers
-        //tokenizer.free();
-
+        const num_tokens = await countOpenAIChatTokens(model, queryModel, req.body);
         res.send({ 'token_count': num_tokens });
     } catch (error) {
         console.error('An error counting tokens, using fallback estimation method', error);
+        if (req.query.per_message && Array.isArray(req.body)) {
+            const token_counts = req.body.map(message => guesstimate(JSON.stringify(message)));
+            return res.send({ 'token_counts': token_counts });
+        }
         const jsonBody = JSON.stringify(req.body);
         const num_tokens = guesstimate(jsonBody);
         res.send({ 'token_count': num_tokens });

--- a/tests/tokenizer-cache-priming.test.js
+++ b/tests/tokenizer-cache-priming.test.js
@@ -1,0 +1,167 @@
+/* global globalThis */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const mockOaiSettings = {
+    chat_completion_source: 'openai',
+    openai_model: 'gpt-4-turbo',
+};
+
+await jest.unstable_mockModule('../public/lib.js', () => ({
+    localforage: {
+        createInstance: () => ({
+            getItem: jest.fn(async () => ({})),
+            setItem: jest.fn(async () => undefined),
+        }),
+    },
+}));
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    characters: [],
+    event_types: {},
+    eventSource: { on: jest.fn() },
+    main_api: 'openai',
+    nai_settings: {},
+    online_status: 'no_connection',
+    this_chid: undefined,
+}));
+
+await jest.unstable_mockModule('../public/scripts/power-user.js', () => ({
+    power_user: { tokenizer: 0 },
+    registerDebugFunction: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/openai.js', () => ({
+    chat_completion_sources: { OPENAI: 'openai' },
+    model_list: [],
+    oai_settings: mockOaiSettings,
+}));
+
+await jest.unstable_mockModule('../public/scripts/group-chats.js', () => ({
+    groups: [],
+    selected_group: null,
+}));
+
+// A real (if crude) hash, so distinct messages get distinct cache keys. The point of these
+// tests is that priming and counting agree on the key, which a constant hash would hide.
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    getStringHash: jest.fn((value) => {
+        let hash = 0;
+        for (let i = 0; i < String(value).length; i++) {
+            hash = (Math.imul(31, hash) + String(value).charCodeAt(i)) | 0;
+        }
+        return hash;
+    }),
+}));
+
+await jest.unstable_mockModule('../public/scripts/kai-settings.js', () => ({
+    kai_flags: {},
+    kai_settings: {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/textgen-settings.js', () => ({
+    textgen_types: {},
+    textgenerationwebui_settings: { type: 'ooba' },
+    getTextGenServer: jest.fn(() => ''),
+    getTextGenModel: jest.fn(() => ''),
+}));
+
+await jest.unstable_mockModule('../public/scripts/textgen-models.js', () => ({
+    getCurrentDreamGenModelTokenizer: jest.fn(),
+    getCurrentOpenRouterModelTokenizer: jest.fn(),
+    openRouterModels: [],
+}));
+
+const {
+    countTokensOpenAIAsync,
+    primeOpenAITokenCache,
+} = await import('../public/scripts/tokenizers.js');
+
+/**
+ * Distinct messages, so every one of them needs its own cache entry. The token cache is
+ * module state that outlives a single test, so each test passes its own tag to stay isolated.
+ */
+function makeMessages(count, tag) {
+    return Array.from({ length: count }, (_, i) => ({ role: 'assistant', content: `${tag} message number ${i}` }));
+}
+
+describe('OpenAI token cache priming', () => {
+    beforeEach(() => {
+        globalThis.jQuery = { ajax: jest.fn() };
+    });
+
+    test('counts a whole batch of messages in a single request', async () => {
+        const messages = makeMessages(25, 'batch');
+        globalThis.jQuery.ajax.mockResolvedValue({ token_counts: messages.map(() => 7) });
+
+        await primeOpenAITokenCache(messages);
+
+        expect(globalThis.jQuery.ajax).toHaveBeenCalledTimes(1);
+        const request = globalThis.jQuery.ajax.mock.calls[0][0];
+        expect(request.url).toContain('per_message=1');
+        expect(JSON.parse(request.data)).toHaveLength(25);
+    });
+
+    test('primed counts are reused by countTokensOpenAIAsync without further requests', async () => {
+        const messages = makeMessages(3, 'reuse');
+        globalThis.jQuery.ajax.mockResolvedValue({ token_counts: [11, 22, 33] });
+
+        await primeOpenAITokenCache(messages);
+        expect(globalThis.jQuery.ajax).toHaveBeenCalledTimes(1);
+
+        // This is the contract that matters: the key primeOpenAITokenCache writes has to be
+        // the key countTokensOpenAIAsync looks up, or priming silently does nothing.
+        const counts = [];
+        for (const message of messages) {
+            counts.push(await countTokensOpenAIAsync(message, true));
+        }
+
+        expect(globalThis.jQuery.ajax).toHaveBeenCalledTimes(1);
+        expect(counts).toEqual([-1 + 11, -1 + 22, -1 + 33]);
+    });
+
+    test('skips messages that are already cached', async () => {
+        const messages = makeMessages(2, 'skip');
+        globalThis.jQuery.ajax.mockResolvedValue({ token_counts: [5, 6] });
+
+        await primeOpenAITokenCache(messages);
+        await primeOpenAITokenCache(messages);
+
+        expect(globalThis.jQuery.ajax).toHaveBeenCalledTimes(1);
+    });
+
+    test('sends each distinct message once even when the history repeats one', async () => {
+        const repeated = { role: 'user', content: 'same text' };
+        globalThis.jQuery.ajax.mockResolvedValue({ token_counts: [9] });
+
+        await primeOpenAITokenCache([repeated, { ...repeated }, { ...repeated }]);
+
+        expect(JSON.parse(globalThis.jQuery.ajax.mock.calls[0][0].data)).toHaveLength(1);
+    });
+
+    test('a failed prime leaves counting to the unbatched path', async () => {
+        const messages = makeMessages(2, 'failed');
+        globalThis.jQuery.ajax.mockRejectedValue({ status: 500, statusText: 'Server Error', readyState: 4 });
+
+        await expect(primeOpenAITokenCache(messages)).resolves.toBeUndefined();
+
+        globalThis.jQuery.ajax.mockResolvedValue({ token_count: 4 });
+        expect(await countTokensOpenAIAsync(messages[0], true)).toBe(-1 + 4);
+    });
+
+    test('ignores a response that does not line up with the request', async () => {
+        const messages = makeMessages(3, 'mismatch');
+        globalThis.jQuery.ajax.mockResolvedValue({ token_counts: [1, 2] });
+
+        await primeOpenAITokenCache(messages);
+
+        globalThis.jQuery.ajax.mockResolvedValue({ token_count: 8 });
+        expect(await countTokensOpenAIAsync(messages[0], true)).toBe(-1 + 8);
+    });
+
+    test('does nothing when given no messages', async () => {
+        await primeOpenAITokenCache([]);
+        await primeOpenAITokenCache(undefined);
+
+        expect(globalThis.jQuery.ajax).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Upstream ST issue where the tokeniser counts each message one at a time instead of all at once. Normally this is fine locally, but if you're like me and you're in the Philippines and your oracle VM is in Singapore, every count is a separate 47ms round trip - and it's two per message once names are on, not one per token. A 200-message history is about 400 waits, so after you hit send you're sat there for roughly 19 seconds while it counts its way through the prompt, before the reply even starts.

Now it counts a window of messages per request instead, so that same 200-message history is 4 requests - about a fifth of a second. Matters a lot more if you're not running SillyBunny on the same machine as your browser.

Note: You will not notice a change at all if you run locally, same PC and all that, the tokeniser is instant already.
In my case however the speed has significantly increased.

Reviewed independently with Sol Max - no blockers.
