### PR TITLE
fix(ui): bulk edit no longer bunches up characters together

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -507,6 +507,7 @@
 
     #rm_print_characters_block.bulk_select > :is(.character_select, .group_select) {
         display: grid;
+        flex: 0 0 auto;
         grid-template-columns: minmax(var(--sb-checkbox-size, 1rem), auto) var(--avatar-base-width) minmax(0, 1fr) !important;
         gap: 8px;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260727b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260814a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260727c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725g">

--- a/tests/mobile-character-drawer-row-css.test.js
+++ b/tests/mobile-character-drawer-row-css.test.js
@@ -59,4 +59,10 @@ describe('mobile character drawer entity row css', () => {
         expect(entityRowRules).toContain('flex: 0 0 auto;');
         expect(entityRowRules).toContain('overflow: hidden;');
     });
+
+    test('keeps bulk-edit rows from shrinking inside the scroller', () => {
+        const bulkEntityRowRule = getRuleBody(mobileStylesCss, '#rm_print_characters_block.bulk_select > :is(.character_select, .group_select)');
+
+        expect(bulkEntityRowRule).toContain('flex: 0 0 auto;');
+    });
 });


### PR DESCRIPTION
Bulk edit on mobile causes characters to overflow on each other, making it difficult to select characters and making it look really ugly.