### PR TITLE
fix(mobile): stop the viewport jumping while typing on mobile

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -110,12 +110,6 @@ function isEditableFocusTarget(element) {
         || (element instanceof HTMLElement && element.isContentEditable);
 }
 
-function isMobileShellPanelEditable(element) {
-    return isEditableFocusTarget(element)
-        && element instanceof HTMLElement
-        && Boolean(element.closest('.sb-shell-panel-scroller'));
-}
-
 function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {
     let resetScheduled = false;
 
@@ -124,10 +118,36 @@ function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {
     const isComposerHeldAboveKeyboard = () => isLegacyIOSWebKitPlatform()
         && document.documentElement.classList.contains('sb-ios-composer-keyboard-inset-active');
 
+    // SillyBunny: this anchor undoes the caret-reveal scroll a virtual keyboard
+    // provokes, which only stays safe while the focused field remains visible
+    // without it. Resetting a load-bearing scroll makes the browser reveal the
+    // caret again, and the two fight for the whole edit. Keyboard thresholds
+    // mirror MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX in sillybunny-tabs.js, which
+    // cannot be imported here: it pulls in script.js, which imports this file.
+    const wouldResetHideFocusedEditable = () => {
+        const viewport = window.visualViewport;
+        const activeElement = document.activeElement;
+
+        if (!viewport || !(activeElement instanceof HTMLElement)) {
+            return false;
+        }
+
+        if ((window.innerHeight || 0) - viewport.height <= 80 && viewport.offsetTop <= 2) {
+            return false;
+        }
+
+        // Resetting shifts client rects down by the removed scroll and leaves
+        // [0, viewport.height] visible. The margin stays under the clearance
+        // syncMobileFocusedInputScroll parks fields at, so a field that machinery
+        // already revealed reads as visible and the reset still runs.
+        const scrollTop = Math.max(window.scrollY || 0, document.scrollingElement?.scrollTop || 0);
+        return activeElement.getBoundingClientRect().bottom + scrollTop > viewport.height - 8;
+    };
+
     const shouldSuspendDocumentScrollReset = () => suspendWhileEditing
         && isEditableFocusTarget(document.activeElement)
-        && !isMobileShellPanelEditable(document.activeElement)
-        && !isComposerHeldAboveKeyboard();
+        && !isComposerHeldAboveKeyboard()
+        && wouldResetHideFocusedEditable();
 
     const resetDocumentScroll = () => {
         if (shouldSuspendDocumentScrollReset()) {
@@ -178,7 +198,7 @@ function applyBrowserFixes() {
     const isMobileViewport = isMobile();
     const isIOSWebKit = isIOSWebKitPlatform();
 
-    addDocumentViewportAnchorPatch({ suspendWhileEditing: isIOSWebKit });
+    addDocumentViewportAnchorPatch({ suspendWhileEditing: true });
 
     if (isMobileViewport) {
         const viewport = window.visualViewport;

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -597,18 +597,18 @@ describe('mobile shell lifecycle wiring', () => {
     test('settles mobile viewport reset without reapplying the fixed-position workaround', () => {
         expect(browserFixesSource).toContain('import { isIOSWebKitPlatform, isLegacyIOSWebKitPlatform } from \'./mobile-send-button.js\';');
         expect(browserFixesSource).toContain('function addDocumentViewportAnchorPatch({ suspendWhileEditing = false } = {}) {');
-        expect(browserFixesSource).toContain('function isMobileShellPanelEditable(element) {');
+        expect(browserFixesSource).toContain('const wouldResetHideFocusedEditable = () => {');
         expect(browserFixesSource).toContain('const shouldSuspendDocumentScrollReset = () => suspendWhileEditing');
         expect(browserFixesSource).toContain('&& isEditableFocusTarget(document.activeElement)');
-        expect(browserFixesSource).toContain('&& !isMobileShellPanelEditable(document.activeElement)');
         expect(browserFixesSource).toContain('const isComposerHeldAboveKeyboard = () => isLegacyIOSWebKitPlatform()');
-        expect(browserFixesSource).toContain('&& !isComposerHeldAboveKeyboard();');
+        expect(browserFixesSource).toContain('&& !isComposerHeldAboveKeyboard()');
+        expect(browserFixesSource).toContain('&& wouldResetHideFocusedEditable();');
         expect(browserFixesSource).toContain('if (shouldSuspendDocumentScrollReset()) {');
         expect(browserFixesSource).toContain('if (resetScheduled || shouldSuspendDocumentScrollReset()) {');
         expect(browserFixesSource).toContain('document.addEventListener(\'focusout\', scheduleDocumentScrollReset, true);');
         expect(browserFixesSource).toContain('const isMobileViewport = isMobile();');
         expect(browserFixesSource).toContain('const isIOSWebKit = isIOSWebKitPlatform();');
-        expect(browserFixesSource).toContain('addDocumentViewportAnchorPatch({ suspendWhileEditing: isIOSWebKit });');
+        expect(browserFixesSource).toContain('addDocumentViewportAnchorPatch({ suspendWhileEditing: true });');
         expect(browserFixesSource).toContain('const viewportResetSettleMs = 360;');
         expect(browserFixesSource).toContain('const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {');
         expect(browserFixesSource).toContain('const scheduleViewportReset = ({ restoreScroll = false } = {}) => {');
@@ -617,6 +617,18 @@ describe('mobile shell lifecycle wiring', () => {
         expect(browserFixesSource).toContain('resetTransientViewportPosition({ restoreScroll });');
         expect(browserFixesSource).toContain('if (!force && viewportResetScheduled) {');
         expect(browserFixesSource).toContain('}, viewportResetSettleMs);');
+    });
+
+    test('keeps the document anchor from fighting the virtual keyboard', () => {
+        // Suspending by container let the anchor undo a caret reveal the focused
+        // field still depended on, so the browser revealed it again every
+        // keystroke. Visibility decides instead, and no container may reintroduce
+        // a blanket carve-out.
+        expect(browserFixesSource).not.toContain('isMobileShellPanelEditable');
+        expect(browserFixesSource).not.toContain('sb-shell-panel-scroller');
+        expect(browserFixesSource).toContain('if ((window.innerHeight || 0) - viewport.height <= 80 && viewport.offsetTop <= 2) {');
+        expect(browserFixesSource).toContain('const scrollTop = Math.max(window.scrollY || 0, document.scrollingElement?.scrollTop || 0);');
+        expect(browserFixesSource).toContain('return activeElement.getBoundingClientRect().bottom + scrollTop > viewport.height - 8;');
     });
 
     test('dedupes rail quick actions against all built-in rail actions', () => {


### PR DESCRIPTION
Typing in a settings panel on a phone made the whole app jump on nearly every keystroke, and the field ended up behind the keyboard anyway.

The anchor that keeps the app pinned to the top was fighting the browser. Safari scrolls the page to bring the caret into view, the anchor snapped it straight back, and that made Safari do it all over again. The anchor now check first - if the scroll would hide the field you're typing in, it doesn't try to jump up and down every time. Every other reset still runs as before, and it should harden viewport on Android now too.

So it shouldn't jump while you type. Either the field lifts above the keyboard and the top bar stays put, or it decides what to do and stays there until you tap away.