### PR TITLE
chore: fix the graphify guard regex matching its own filename

### DIFF
--- a/tests/graphify-artifacts.test.js
+++ b/tests/graphify-artifacts.test.js
@@ -22,6 +22,8 @@ describe('graphify artifacts', () => {
     });
 
     test('no generated graphify output is tracked', () => {
-        expect(trackedFiles.filter(file => /graphify/i.test(file))).toEqual([]);
+        // Match the generated directory, not the word: a bare /graphify/ also matches
+        // this file, so the guard failed on every branch that carried it.
+        expect(trackedFiles.filter(file => /(^|\/)graphify-out\//i.test(file))).toEqual([]);
     });
 });


### PR DESCRIPTION
The guard I added in #757 checks every tracked file for 'graphify', which matches its own filename - so it's been failing on staging and on every open PR since it got merged.

It now looks for the `graphify-out/` folder the artifacts actually are in. Still catches them coming back through a merge without failing the tests unnecessarily.