### PR TITLE
fix(server): reworks port handling on Windows+Bun (#710)

### DIFF
--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -46,7 +46,14 @@ import {
     SUPERVISED_ENV as RESTART_SUPERVISED_ENV,
 } from '../server-supervisor.js';
 
-const GIT_OPTIONS = Object.freeze({ timeout: { block: 10 * 60 * 1000 } });
+const GIT_OPTIONS = Object.freeze({
+    timeout: { block: 10 * 60 * 1000 },
+    // Keep update-time git from detaching background maintenance: under
+    // released Bun builds on Windows a detached child inherits the listen
+    // socket handle and keeps the port bound across the restart (#710,
+    // oven-sh/bun#36936).
+    config: ['gc.auto=0', 'maintenance.auto=false'],
+});
 const RESTART_RESPONSE_DELAY_MS = 200;
 const CHAT_COMPLETION_CONFIG_DEFAULTS = Object.freeze({
     claude: Object.freeze({
@@ -422,7 +429,7 @@ function scheduleRestart(response, { reloadSupervisor = false } = {}) {
             const canReloadSupervisor = process.env[RESTART_LAUNCHER_ENV] === '1';
             const exitCode = reloadSupervisor && canReloadSupervisor ? SUPERVISOR_RELOAD_EXIT_CODE : RESTART_EXIT_CODE;
             if (reloadSupervisor && !canReloadSupervisor) {
-                console.warn('No outer launcher detected; restarting the server child, but a top-level restart is required to load updated supervisor code.');
+                console.info('Restarting the server with the updated code now. The lightweight supervisor process keeps its current code until the next full stop/start; launching through Start.bat or start.sh lets updates reload it automatically.');
             }
             console.info(`Restart requested; exiting with code ${exitCode} for relaunch.`);
             requestGracefulExit(exitCode);

--- a/src/server-listen.js
+++ b/src/server-listen.js
@@ -1,12 +1,19 @@
+import { execFile } from 'node:child_process';
+import process from 'node:process';
 import { setTimeout as delay } from 'node:timers/promises';
 
 // A relaunched server races the previous process for the listen port: the old
 // socket can still be encumbered for a moment after that process is gone,
-// especially on Windows where libuv binds with SO_EXCLUSIVEADDRUSE. Retrying
-// for a few seconds turns a permanently broken restart into a short pause.
-export const LISTEN_RETRY_ATTEMPTS = 10;
-export const LISTEN_RETRY_DELAY_MS = 500;
+// especially on Windows where libuv binds with SO_EXCLUSIVEADDRUSE. Worse,
+// released Bun versions create inheritable socket handles on Windows
+// (oven-sh/bun#36936), so a process spawned during an update can keep the port
+// bound until it exits. Retrying for about a minute outlasts the typical
+// straggler instead of permanently breaking the restart after five seconds.
+export const LISTEN_RETRY_ATTEMPTS = 40;
+export const LISTEN_RETRY_DELAY_MS = 1500;
 export const LISTEN_CLOSE_TIMEOUT_MS = 2000;
+export const PORT_HOLDER_LOOKUP_TIMEOUT_MS = 3000;
+export const BUN_SOCKET_INHERIT_ISSUE_URL = 'https://github.com/oven-sh/bun/issues/36936';
 
 /** @type {Set<{ server: import('node:net').Server, sockets: Set<import('node:net').Socket> }>} */
 const trackedListeners = new Set();
@@ -119,5 +126,117 @@ export async function retryOnAddressInUse(attemptFn, {
             onRetry?.(attempt, totalAttempts);
             await delay(delayMs);
         }
+    }
+}
+
+/**
+ * Runs a diagnostic command, resolving with its stdout or an empty string on
+ * any failure. Never rejects and never outlives its timeout.
+ * @param {string} command The executable to run
+ * @param {string[]} args Arguments for the executable
+ * @returns {Promise<string>} Captured stdout, or '' when unavailable
+ */
+function runDiagnosticCommand(command, args) {
+    return new Promise((resolve) => {
+        try {
+            execFile(command, args, { timeout: PORT_HOLDER_LOOKUP_TIMEOUT_MS, windowsHide: true }, (error, stdout) => {
+                resolve(!error || stdout ? String(stdout ?? '') : '');
+            });
+        } catch {
+            resolve('');
+        }
+    });
+}
+
+/**
+ * Extracts the TCP rows of a `netstat -ano` dump that concern one local port.
+ * @param {string} output Raw netstat output
+ * @param {number} port The local port to filter on
+ * @returns {{ local: string, state: string, pid: number }[]} Matching rows
+ */
+export function parseNetstatPortRows(output, port) {
+    const suffix = `:${port}`;
+    const rows = [];
+    for (const line of String(output).split(/\r?\n/)) {
+        const columns = line.trim().split(/\s+/);
+        // TCP rows have 5 columns (proto, local, foreign, state, pid); UDP rows
+        // have no state column and are irrelevant for a listen conflict.
+        if (columns.length !== 5 || columns[0].toUpperCase() !== 'TCP' || !columns[1].endsWith(suffix)) {
+            continue;
+        }
+        rows.push({ local: columns[1], state: columns[3], pid: Number(columns[4]) });
+    }
+    return rows;
+}
+
+/**
+ * Finds a process name in `tasklist /FO CSV /NH` output.
+ * @param {string} output Raw tasklist output
+ * @param {number} pid The process id to look for
+ * @returns {string|null} The image name, or null when the process is gone
+ */
+export function parseTasklistProcessName(output, pid) {
+    for (const line of String(output).split(/\r?\n/)) {
+        const match = line.match(/^"([^"]+)","(\d+)"/);
+        if (match && Number(match[2]) === pid) {
+            return match[1];
+        }
+    }
+    return null;
+}
+
+/**
+ * Builds human-readable lines describing what occupies a local TCP port.
+ * Windows resolves owning processes and calls out the Bun handle-inheritance
+ * bug when the "owner" is already dead; POSIX just relays ss/lsof output.
+ * @param {number} port The port to inspect
+ * @param {object} [options] Dependency injection for tests
+ * @param {typeof runDiagnosticCommand} [options.runCommand] Command runner
+ * @param {string} [options.platform] Platform override
+ * @returns {Promise<string[]>} Diagnostic lines, empty when nothing was found
+ */
+export async function describePortHolders(port, { runCommand = runDiagnosticCommand, platform = process.platform } = {}) {
+    if (platform === 'win32') {
+        const rows = parseNetstatPortRows(await runCommand('netstat', ['-ano']), port);
+        const lines = [];
+        for (const row of rows) {
+            if (row.state.toUpperCase() !== 'LISTENING' || !Number.isFinite(row.pid) || row.pid <= 0) {
+                lines.push(`Port ${port}: ${row.local} is in state ${row.state} (PID ${row.pid}).`);
+                continue;
+            }
+            const name = parseTasklistProcessName(await runCommand('tasklist', ['/FI', `PID eq ${row.pid}`, '/FO', 'CSV', '/NH']), row.pid);
+            if (name) {
+                lines.push(`Port ${port} is held open by "${name}" (PID ${row.pid}).`);
+            } else {
+                lines.push(`Port ${port} is attributed to PID ${row.pid}, which is no longer running: a process spawned by the previous server instance inherited its socket handle (known Bun-on-Windows bug, ${BUN_SOCKET_INHERIT_ISSUE_URL}). The port frees itself once that process exits.`);
+            }
+        }
+        return lines;
+    }
+
+    const ss = await runCommand('ss', ['-tnap', `sport = :${port}`]);
+    const ssRows = ss.split('\n').map(line => line.trim()).filter(line => line && !line.startsWith('State '));
+    if (ssRows.length > 0) {
+        return ssRows.map(row => `Port ${port}: ${row}`);
+    }
+
+    const lsof = await runCommand('lsof', ['-nP', `-iTCP:${port}`]);
+    return lsof.split('\n').map(line => line.trim()).filter(Boolean).map(row => `Port ${port}: ${row}`);
+}
+
+/**
+ * Logs who currently occupies a port, best-effort. Safe to fire and forget:
+ * it never throws and stays silent when nothing conclusive is found.
+ * @param {number} port The port to inspect
+ * @returns {Promise<void>} Resolves once logging is done
+ */
+export async function reportPortHolders(port) {
+    try {
+        const lines = await describePortHolders(port);
+        for (const line of lines) {
+            console.warn(line);
+        }
+    } catch {
+        // Diagnostics must never break startup.
     }
 }

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -2,7 +2,7 @@ import https from 'node:https';
 import http from 'node:http';
 import fs from 'node:fs';
 import { APP_NAME } from './runtime.js';
-import { isAddressInUseError, retryOnAddressInUse, trackListeningServer } from './server-listen.js';
+import { BUN_SOCKET_INHERIT_ISSUE_URL, isAddressInUseError, reportPortHolders, retryOnAddressInUse, trackListeningServer } from './server-listen.js';
 import { color, urlHostnameToIPv6, getHasIP } from './util.js';
 
 // Express routers
@@ -170,7 +170,16 @@ export class ServerStartup {
      */
     #getListenAddress(url, ipVersion) {
         const host = ipVersion === 6 ? urlHostnameToIPv6(url.hostname) : url.hostname;
-        return `${host}:${Number(url.port || (this.cliArgs.ssl ? 443 : 80))}`;
+        return `${host}:${this.#getListenPort(url)}`;
+    }
+
+    /**
+     * Resolves the effective listen port of a URL.
+     * @param {URL} url The URL to inspect
+     * @returns {number}
+     */
+    #getListenPort(url) {
+        return Number(url.port || (this.cliArgs.ssl ? 443 : 80));
     }
 
     /**
@@ -181,7 +190,15 @@ export class ServerStartup {
      */
     #getAddressInUseMessage(url, ipVersion) {
         const listenAddress = this.#getListenAddress(url, ipVersion);
-        return `Address ${listenAddress} is already in use. Another ${APP_NAME} instance may already be running. Stop the other process or change "port" in config.yaml.`;
+        let message = `Address ${listenAddress} is already in use. Another ${APP_NAME} instance may already be running. Stop the other process or change "port" in config.yaml.`;
+        // SillyBunny: released Bun builds create inheritable socket handles on
+        // Windows, so a process spawned by the previous instance (git, package
+        // install, browser launch) can keep the port bound after that instance
+        // exited. Fixed in Bun main but not in any release yet.
+        if (process.platform === 'win32' && process.versions.bun) {
+            message += ` If no other instance is running, this is a known Bun-on-Windows bug (${BUN_SOCKET_INHERIT_ISSUE_URL}): wait a minute and relaunch, or start with Start-Node.bat.`;
+        }
+        return message;
     }
 
     /**
@@ -301,8 +318,12 @@ export class ServerStartup {
         // it out briefly instead of aborting the relaunch on the first failure.
         const listen = (url, ipVersion) => retryOnAddressInUse(() => createFunc(url, ipVersion), {
             onRetry: (attempt, attempts) => {
+                if (attempt === 1 || attempt % 10 === 0) {
+                    console.warn(`${this.#getListenAddress(url, ipVersion)} is still in use; waiting for it to be released (attempt ${attempt} of ${attempts}).`);
+                }
                 if (attempt === 1) {
-                    console.warn(`${this.#getListenAddress(url, ipVersion)} is still in use; waiting for it to be released (up to ${attempts} attempts).`);
+                    // Fire-and-forget: names the holder while the retries run.
+                    void reportPortHolders(this.#getListenPort(url));
                 }
             },
         });
@@ -351,9 +372,19 @@ export class ServerStartup {
      * @param {ServerStartupResult} result The results of the server startup
      * @returns {void}
      */
-    #handleServerListenFail({ v6Failed, v4Failed, v6Error, v4Error, useIPv6, useIPv4 }) {
+    async #handleServerListenFail({ v6Failed, v4Failed, v6Error, v4Error, useIPv6, useIPv4 }) {
+        // A final look at who occupies the port makes the abort actionable: a
+        // still-listed holder after a minute of retries is not a transient race.
+        const reportBeforeFatal = async (...urls) => {
+            const ports = [...new Set(urls.map(url => this.#getListenPort(url)))];
+            for (const port of ports) {
+                await reportPortHolders(port);
+            }
+        };
+
         if (v6Failed && !useIPv4) {
             if (this.#isAddressInUseError(v6Error)) {
+                await reportBeforeFatal(this.cliArgs.getIPv6ListenUrl());
                 this.#fatal('Error: Startup aborted because IPv6 is the only enabled protocol and its listen port is already in use.');
             }
             this.#fatal('Error: Failed to start server on IPv6 and IPv4 disabled');
@@ -361,6 +392,7 @@ export class ServerStartup {
 
         if (v4Failed && !useIPv6) {
             if (this.#isAddressInUseError(v4Error)) {
+                await reportBeforeFatal(this.cliArgs.getIPv4ListenUrl());
                 this.#fatal('Error: Startup aborted because IPv4 is the only enabled protocol and its listen port is already in use.');
             }
             this.#fatal('Error: Failed to start server on IPv4 and IPv6 disabled');
@@ -368,6 +400,7 @@ export class ServerStartup {
 
         if (v6Failed && v4Failed) {
             if (this.#isAddressInUseError(v6Error) && this.#isAddressInUseError(v4Error)) {
+                await reportBeforeFatal(this.cliArgs.getIPv6ListenUrl(), this.cliArgs.getIPv4ListenUrl());
                 this.#fatal('Error: Failed to start server because the configured IPv6 and IPv4 listen ports are already in use.');
             }
             this.#fatal('Error: Failed to start server on both IPv6 and IPv4');
@@ -425,7 +458,7 @@ export class ServerStartup {
 
         const [v6Failed, v4Failed, v6Error, v4Error] = await this.#startHTTPorHTTPS(useIPv6, useIPv4);
         const result = { v6Failed, v4Failed, v6Error, v4Error, useIPv6, useIPv4 };
-        this.#handleServerListenFail(result);
+        await this.#handleServerListenFail(result);
         return result;
     }
 }

--- a/tests/server-listen.test.js
+++ b/tests/server-listen.test.js
@@ -147,7 +147,7 @@ describe('listen retry on an occupied port', () => {
 
         expect(attemptFn).toHaveBeenCalledTimes(3);
         expect(onRetry).toHaveBeenCalledTimes(2);
-        expect(onRetry).toHaveBeenNthCalledWith(1, 1, 10);
+        expect(onRetry).toHaveBeenNthCalledWith(1, 1, 40);
     });
 
     test('gives up after the attempt cap and rethrows the original error', async () => {
@@ -170,11 +170,80 @@ describe('listen retry on an occupied port', () => {
         expect(onRetry).not.toHaveBeenCalled();
     });
 
-    test('defaults to a bounded multi-second window', async () => {
+    test('defaults to a bounded window of about a minute', async () => {
         const { LISTEN_RETRY_ATTEMPTS, LISTEN_RETRY_DELAY_MS } = await loadListenModule();
 
-        expect(LISTEN_RETRY_ATTEMPTS).toBe(10);
-        expect(LISTEN_RETRY_DELAY_MS).toBe(500);
+        expect(LISTEN_RETRY_ATTEMPTS).toBe(40);
+        expect(LISTEN_RETRY_DELAY_MS).toBe(1500);
+        // Long enough to outlast an update straggler holding an inherited
+        // socket handle, short enough that a genuine conflict still surfaces.
+        const windowMs = (LISTEN_RETRY_ATTEMPTS - 1) * LISTEN_RETRY_DELAY_MS;
+        expect(windowMs).toBeGreaterThanOrEqual(45_000);
+        expect(windowMs).toBeLessThanOrEqual(120_000);
+    });
+});
+
+describe('port holder diagnostics', () => {
+    const NETSTAT_OUTPUT = [
+        'Active Connections',
+        '',
+        '  Proto  Local Address          Foreign Address        State           PID',
+        '  TCP    127.0.0.1:4444         0.0.0.0:0              LISTENING       4321',
+        '  TCP    127.0.0.1:4444         127.0.0.1:52001        TIME_WAIT       0',
+        '  TCP    127.0.0.1:44440       0.0.0.0:0              LISTENING       9999',
+        '  TCP    [::1]:4444             [::]:0                 LISTENING       4321',
+        '  UDP    0.0.0.0:5353           *:*                                    777',
+    ].join('\r\n');
+
+    test('parses only the TCP rows of the requested port', async () => {
+        const { parseNetstatPortRows } = await loadListenModule();
+
+        const rows = parseNetstatPortRows(NETSTAT_OUTPUT, 4444);
+
+        expect(rows).toEqual([
+            { local: '127.0.0.1:4444', state: 'LISTENING', pid: 4321 },
+            { local: '127.0.0.1:4444', state: 'TIME_WAIT', pid: 0 },
+            { local: '[::1]:4444', state: 'LISTENING', pid: 4321 },
+        ]);
+    });
+
+    test('reads a process name from tasklist CSV output and misses cleanly', async () => {
+        const { parseTasklistProcessName } = await loadListenModule();
+
+        expect(parseTasklistProcessName('"bun.exe","4321","Console","1","120,000 K"', 4321)).toBe('bun.exe');
+        expect(parseTasklistProcessName('INFO: No tasks are running which match the specified criteria.', 4321)).toBeNull();
+        expect(parseTasklistProcessName('', 4321)).toBeNull();
+    });
+
+    test('names a live Windows holder and flags a dead one as an inherited handle', async () => {
+        const { describePortHolders, BUN_SOCKET_INHERIT_ISSUE_URL } = await loadListenModule();
+        const liveRunner = jest.fn(async (command) => command === 'netstat'
+            ? '  TCP    127.0.0.1:4444    0.0.0.0:0    LISTENING    4321'
+            : '"bun.exe","4321","Console","1","120,000 K"');
+        const deadRunner = jest.fn(async (command) => command === 'netstat'
+            ? '  TCP    127.0.0.1:4444    0.0.0.0:0    LISTENING    4321'
+            : 'INFO: No tasks are running which match the specified criteria.');
+
+        const liveLines = await describePortHolders(4444, { runCommand: liveRunner, platform: 'win32' });
+        expect(liveLines).toEqual(['Port 4444 is held open by "bun.exe" (PID 4321).']);
+
+        const deadLines = await describePortHolders(4444, { runCommand: deadRunner, platform: 'win32' });
+        expect(deadLines).toHaveLength(1);
+        expect(deadLines[0]).toContain('no longer running');
+        expect(deadLines[0]).toContain(BUN_SOCKET_INHERIT_ISSUE_URL);
+    });
+
+    test('relays raw socket tool output on POSIX and stays quiet when tools fail', async () => {
+        const { describePortHolders } = await loadListenModule();
+        const ssRunner = jest.fn(async (command) => command === 'ss'
+            ? 'LISTEN 0 511 127.0.0.1:4444 0.0.0.0:* users:(("node",pid=4321,fd=20))\n'
+            : '');
+        const failingRunner = jest.fn(async () => '');
+
+        const lines = await describePortHolders(4444, { runCommand: ssRunner, platform: 'linux' });
+        expect(lines).toEqual(['Port 4444: LISTEN 0 511 127.0.0.1:4444 0.0.0.0:* users:(("node",pid=4321,fd=20))']);
+
+        await expect(describePortHolders(4444, { runCommand: failingRunner, platform: 'linux' })).resolves.toEqual([]);
     });
 });
 


### PR DESCRIPTION
The root cause is an upstream Bun bug on Windows (oven-sh/bun#36936): programs the server spawns inherit its listening socket, so the port stays held even after the server exits. The real fix has to ship in a Bun release; this PR merely mitigates it (#710).

- Instead of waiting 5 seconds for the port, it now waits ~60 seconds, and shows a progress line every 10 attempts.
- When the port is busy, it now shows specifically what program is holding it. If the "owner" already exited - the Bun bug's fingerprint - it says so and links the upstream issue.
- The 'address already in use' error gains a Windows+Bun line suggesting to wait a minute, or to use Start-Node.bat to run on Node.js instead.
- Stops git from leaving background cleanup processes behind when SB updates. Less likely to make the port stay.
- Rewords 'No outer launcher detected' so it doesn't read like an error, since it isn't one.