### PR TITLE
fix(connection_profiles): harden custom endpoint switches and additional parameter saving

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -42,11 +42,15 @@ const ALLOW_EMPTY = [
     'custom-reasoning-param-name',
     'custom-reasoning-enabled-value',
     'custom-reasoning-disabled-value',
+    'custom-include-body',
+    'custom-exclude-body',
+    'custom-include-headers',
 ];
 
 const CLEAR_ON_EMPTY_RESULT = [
     'api-url',
     'secret-id',
+    'custom-endpoint-profile',
 ];
 
 const CC_COMMANDS = [
@@ -55,6 +59,9 @@ const CC_COMMANDS = [
     // Do not fix; CC needs to set the API twice because it could be overridden by the preset
     'api',
     'secret-id',
+    // SillyBunny: re-select the Custom endpoint profile by name after the secret (secret ids are shared between
+    // endpoint profiles) and before the URL/model so the recorded values win over the endpoint profile's.
+    'custom-endpoint-profile',
     'api-url',
     'model',
     'proxy',
@@ -74,6 +81,9 @@ const CC_COMMANDS = [
     'custom-reasoning-param-name',
     'custom-reasoning-enabled-value',
     'custom-reasoning-disabled-value',
+    'custom-include-body',
+    'custom-exclude-body',
+    'custom-include-headers',
     'prompt-post-processing',
     'regex-preset',
 ];
@@ -102,6 +112,7 @@ const FANCY_NAMES = {
     'preset': 'Settings Preset',
     'model': 'Model',
     'proxy': 'Proxy Preset',
+    'custom-endpoint-profile': 'Custom Endpoint Profile',
     'sysprompt-state': 'Use System Prompt',
     'sysprompt': 'System Prompt Name',
     'instruct-state': 'Instruct Mode',
@@ -123,6 +134,9 @@ const FANCY_NAMES = {
     'custom-reasoning-param-name': 'Custom Reasoning Parameter Name',
     'custom-reasoning-enabled-value': 'Custom Reasoning Enabled Value',
     'custom-reasoning-disabled-value': 'Custom Reasoning Disabled Value',
+    'custom-include-body': 'Custom Include Body Parameters',
+    'custom-exclude-body': 'Custom Exclude Body Parameters',
+    'custom-include-headers': 'Custom Include Request Headers',
     'prompt-post-processing': 'Prompt Post-Processing',
     'secret-id': 'Secret',
     'regex-preset': 'Regex Preset',
@@ -228,6 +242,7 @@ const profilesProvider = () => [
  * @property {string} [preset] Settings Preset
  * @property {string} [model] Model
  * @property {string} [proxy] Proxy Preset
+ * @property {string} [custom-endpoint-profile] Custom endpoint profile name
  * @property {string} [instruct] Instruct Template
  * @property {string} [context] Context Template
  * @property {string} [instruct-state] Instruct Mode
@@ -247,6 +262,9 @@ const profilesProvider = () => [
  * @property {string} [custom-reasoning-param-name] Custom reasoning parameter name
  * @property {string} [custom-reasoning-enabled-value] Custom reasoning enabled value
  * @property {string} [custom-reasoning-disabled-value] Custom reasoning disabled value
+ * @property {string} [custom-include-body] Custom endpoint include body parameters (YAML)
+ * @property {string} [custom-exclude-body] Custom endpoint exclude body parameters (YAML)
+ * @property {string} [custom-include-headers] Custom endpoint include request headers (YAML)
  * @property {string} [prompt-post-processing] Prompt Post-Processing
  * @property {string} [sysprompt] System Prompt Name
  * @property {string} [sysprompt-state] Use System Prompt

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -20,6 +20,9 @@ const CHAT_COMPLETION_PROFILE_REQUEST_FIELDS = {
     'custom-reasoning-param-name': ['custom_reasoning_param_name', value => String(value ?? '')],
     'custom-reasoning-enabled-value': ['custom_reasoning_enabled_value', value => String(value ?? '')],
     'custom-reasoning-disabled-value': ['custom_reasoning_disabled_value', value => String(value ?? '')],
+    'custom-include-body': ['custom_include_body', value => String(value ?? '')],
+    'custom-exclude-body': ['custom_exclude_body', value => String(value ?? '')],
+    'custom-include-headers': ['custom_include_headers', value => String(value ?? '')],
 };
 
 export function getChatCompletionProfileRequestOverrides(profile, overridePayload) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -9745,7 +9745,8 @@ export async function loadCustomEndpointPresets(settings) {
 
     $('#custom_endpoint_preset').val(selected_custom_endpoint_preset?.name || 'None');
 
-    if (selected_custom_endpoint_preset) {
+    // SillyBunny: 'None' means "use the URL/model typed in the fields"; applying it at load would blank them.
+    if (selected_custom_endpoint_preset && selected_custom_endpoint_preset.name !== 'None') {
         // SillyBunny: load-time apply must not rotate or write secrets; requests send secret_id explicitly.
         await setCustomEndpointPreset(
             selected_custom_endpoint_preset.name,
@@ -9789,7 +9790,11 @@ async function activateCustomEndpointPresetSecret(preset, { forceWrite = false }
 
     if (preset.secretId && (!forceWrite || !preset.key)) {
         // SillyBunny: rotate to the bound profile secret instead of writing duplicate or accidental empty keys.
-        await rotateSecret(SECRET_KEYS.CUSTOM, preset.secretId);
+        // Skip when it is already active (e.g. a connection profile just rotated it): rotating re-triggers a full API reconnect.
+        const isAlreadyActive = secret_state[SECRET_KEYS.CUSTOM]?.some(secret => secret.id === preset.secretId && secret.active);
+        if (!isAlreadyActive) {
+            await rotateSecret(SECRET_KEYS.CUSTOM, preset.secretId);
+        }
         return;
     }
 
@@ -9949,6 +9954,32 @@ $('#delete_custom_endpoint').on('click', async function () {
     }
 });
 
+// SillyBunny: connection profiles record the selected Custom endpoint profile by name, like /proxy does for
+// reverse proxies. Secret ids are not unique across endpoint profiles (saving one without retyping the key binds it
+// to the active secret), so re-selecting by secret alone lands on the first profile that shares it.
+async function runCustomEndpointPresetCallback(_, value) {
+    if (!value) {
+        return oai_settings.chat_completion_source === chat_completion_sources.CUSTOM
+            ? (selected_custom_endpoint_preset?.name || 'None')
+            : '';
+    }
+
+    const name = String(value).trim();
+    // Exact match only: a fuzzy hit could silently route a profile to a different endpoint.
+    const preset = custom_endpoint_presets.find(p => p.name === name)
+        ?? (name.toLowerCase() === 'none' ? custom_endpoint_presets.find(p => p.name === 'None') : undefined);
+
+    if (!preset) {
+        toastr.warning(t`Custom endpoint profile '${name}' not found`);
+        return '';
+    }
+
+    $('#custom_endpoint_preset').val(preset.name);
+    await setCustomEndpointPreset(preset.name, preset.url, preset.key, preset.model, { secretId: preset.secretId });
+    saveSettingsDebounced();
+    return preset.name;
+}
+
 function runProxyCallback(_, value) {
     if (!value) {
         return selected_proxy?.name || '';
@@ -10099,6 +10130,21 @@ function runStringChatCompletionSettingCallback(commandName, settingName, select
     };
 }
 
+// SillyBunny: the Custom endpoint additional parameters are YAML, which is indentation-sensitive, so unlike the
+// other string settings the value is stored verbatim instead of trimmed.
+function runCustomEndpointParameterCallback(settingName, selector) {
+    return (args, value) => {
+        if (!hasSlashCommandValue(args, value)) {
+            return getSlashCommandStringValue(oai_settings[settingName]);
+        }
+
+        oai_settings[settingName] = getSlashCommandStringValue(value);
+        $(selector).val(oai_settings[settingName]);
+        saveSettingsDebounced();
+        return oai_settings[settingName];
+    };
+}
+
 const REQUEST_IMAGE_RESOLUTION_VALUES = ['', '1K', '2K', '4K'];
 const REQUEST_IMAGE_ASPECT_RATIO_VALUES = ['', '1:1', '9:16', '16:9', '3:4', '4:3', '3:2', '2:3', '5:4', '4:5', '21:9'];
 
@@ -10202,6 +10248,21 @@ function registerChatCompletionProfileSlashCommands() {
         name: 'custom-reasoning-disabled-value',
         callback: runStringChatCompletionSettingCallback('custom-reasoning-disabled-value', 'custom_reasoning_disabled_value', '#custom_reasoning_disabled_value', markCustomReasoningPresetForManualCommand),
         description: 'custom reasoning disabled value',
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-include-body',
+        callback: runCustomEndpointParameterCallback('custom_include_body', '#custom_include_body'),
+        description: 'custom endpoint include body parameters (YAML)',
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-exclude-body',
+        callback: runCustomEndpointParameterCallback('custom_exclude_body', '#custom_exclude_body'),
+        description: 'custom endpoint exclude body parameters (YAML)',
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-include-headers',
+        callback: runCustomEndpointParameterCallback('custom_include_headers', '#custom_include_headers'),
+        description: 'custom endpoint include request headers (YAML)',
     });
 }
 
@@ -10370,6 +10431,21 @@ export function initOpenAI() {
             }),
         ],
         helpString: 'Sets a proxy preset by name.',
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'custom-endpoint-profile',
+        callback: runCustomEndpointPresetCallback,
+        returns: 'current custom endpoint profile',
+        namedArgumentList: [],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: false,
+                enumProvider: () => custom_endpoint_presets.map(preset => new SlashCommandEnumValue(preset.name, preset.url)),
+            }),
+        ],
+        helpString: 'Sets a Custom OpenAI-compatible endpoint profile by name. Gets the current one if no name is provided.',
     }));
     // SillyBunny: Connection Manager snapshots Chat Completion request behavior via slash commands.
     registerChatCompletionProfileSlashCommands();

--- a/tests/connection-manager-profile-save.test.js
+++ b/tests/connection-manager-profile-save.test.js
@@ -7,6 +7,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const normalizeSource = source => source.replace(/\r\n/g, '\n');
 const connectionManagerSource = normalizeSource(readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'connection-manager', 'index.js'), 'utf8'));
 const openAiSource = normalizeSource(readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8'));
+const sharedSource = normalizeSource(readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'shared.js'), 'utf8'));
 
 function getFunctionSourceFrom(source, name) {
     const marker = `function ${name}(`;
@@ -54,7 +55,7 @@ describe('connection manager profile save wiring', () => {
     test('clears stale endpoint and secret fields when updating to providers without values', () => {
         const readSource = getFunctionSource('readProfileFromCommands');
 
-        expect(connectionManagerSource).toContain('const CLEAR_ON_EMPTY_RESULT = [\n    \'api-url\',\n    \'secret-id\',\n];');
+        expect(connectionManagerSource).toContain('const CLEAR_ON_EMPTY_RESULT = [\n    \'api-url\',\n    \'secret-id\',\n    \'custom-endpoint-profile\',\n];');
         expect(readSource).toContain('if (cleanUp && CLEAR_ON_EMPTY_RESULT.includes(command)) {');
         expect(readSource).toContain('delete profile[command];');
     });
@@ -112,5 +113,37 @@ describe('connection manager profile save wiring', () => {
         expect(commandResultIndex).toBeGreaterThanOrEqual(0);
         expect(secretGuardIndex).toBeGreaterThan(commandResultIndex);
         expect(syncIndex).toBeGreaterThan(secretGuardIndex);
+    });
+
+    test('re-selects the Custom endpoint profile by name after the secret and before the URL and model', () => {
+        const ccCommandsStart = connectionManagerSource.indexOf('const CC_COMMANDS = [');
+        const tcCommandsStart = connectionManagerSource.indexOf('const TC_COMMANDS = [');
+        const ccCommandsSource = connectionManagerSource.slice(ccCommandsStart, tcCommandsStart);
+        const secretCommandIndex = ccCommandsSource.indexOf('\'secret-id\'');
+        const endpointProfileIndex = ccCommandsSource.indexOf('\'custom-endpoint-profile\'');
+        const apiUrlCommandIndex = ccCommandsSource.indexOf('\'api-url\'');
+        const modelCommandIndex = ccCommandsSource.indexOf('\'model\'');
+
+        expect(endpointProfileIndex).toBeGreaterThan(secretCommandIndex);
+        expect(apiUrlCommandIndex).toBeGreaterThan(endpointProfileIndex);
+        expect(modelCommandIndex).toBeGreaterThan(endpointProfileIndex);
+        expect(connectionManagerSource).toContain('\'custom-endpoint-profile\': \'Custom Endpoint Profile\',');
+    });
+
+    test('records Custom endpoint additional parameters, including empty values, in Chat Completion profiles', () => {
+        const ccCommandsStart = connectionManagerSource.indexOf('const CC_COMMANDS = [');
+        const tcCommandsStart = connectionManagerSource.indexOf('const TC_COMMANDS = [');
+        const ccCommandsSource = connectionManagerSource.slice(ccCommandsStart, tcCommandsStart);
+        const allowEmptyStart = connectionManagerSource.indexOf('const ALLOW_EMPTY = [');
+        const allowEmptySource = connectionManagerSource.slice(allowEmptyStart, connectionManagerSource.indexOf('];', allowEmptyStart));
+
+        for (const command of ['custom-include-body', 'custom-exclude-body', 'custom-include-headers']) {
+            expect(ccCommandsSource).toContain(`'${command}',`);
+            expect(allowEmptySource).toContain(`'${command}',`);
+            expect(sharedSource).toContain(`'${command}': ['${command.replaceAll('-', '_')}', value => String(value ?? '')],`);
+        }
+        expect(connectionManagerSource).toContain('\'custom-include-body\': \'Custom Include Body Parameters\',');
+        expect(connectionManagerSource).toContain('\'custom-exclude-body\': \'Custom Exclude Body Parameters\',');
+        expect(connectionManagerSource).toContain('\'custom-include-headers\': \'Custom Include Request Headers\',');
     });
 });

--- a/tests/connection-profile-request-fields.test.js
+++ b/tests/connection-profile-request-fields.test.js
@@ -66,6 +66,9 @@ const mappedRequestFieldNames = [
     'custom_reasoning_param_name',
     'custom_reasoning_enabled_value',
     'custom_reasoning_disabled_value',
+    'custom_include_body',
+    'custom_exclude_body',
+    'custom_include_headers',
 ];
 
 function createReasoningProfile(overrides = {}) {
@@ -87,6 +90,9 @@ function createReasoningProfile(overrides = {}) {
         'custom-reasoning-param-name': 'thinking',
         'custom-reasoning-enabled-value': 'enabled',
         'custom-reasoning-disabled-value': 'disabled',
+        'custom-include-body': '  top_k: 20\n  min_p: 0.05',
+        'custom-exclude-body': '- frequency_penalty',
+        'custom-include-headers': '',
         ...overrides,
     };
 }
@@ -142,6 +148,9 @@ describe('Connection Profile chat-completion request field mapping', () => {
                 custom_reasoning_param_name: 'thinking',
                 custom_reasoning_enabled_value: 'enabled',
                 custom_reasoning_disabled_value: 'disabled',
+                custom_include_body: '  top_k: 20\n  min_p: 0.05',
+                custom_exclude_body: '- frequency_penalty',
+                custom_include_headers: '',
             },
             profileFieldNames: mappedRequestFieldNames,
         });
@@ -166,6 +175,9 @@ describe('Connection Profile chat-completion request field mapping', () => {
             custom_reasoning_param_format: 'thinking_object',
             custom_reasoning_enabled_value: 'enabled',
             custom_reasoning_disabled_value: 'disabled',
+            custom_include_body: '  top_k: 20\n  min_p: 0.05',
+            custom_exclude_body: '- frequency_penalty',
+            custom_include_headers: '',
         });
         expect(result.profileFieldNames).toEqual(mappedRequestFieldNames.filter(field => !Object.hasOwn(overridePayload, field)));
         expect({ ...result.overrides, ...overridePayload }).toEqual(expect.objectContaining(overridePayload));

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -257,7 +257,7 @@ describe('OpenAI proxy preset wiring', () => {
     test('preserves legacy Custom endpoint settings until a profile is selected', () => {
         const loadCustomEndpointSource = getFunctionSource('loadCustomEndpointPresets');
         const selectedAssignmentIndex = loadCustomEndpointSource.indexOf('selected_custom_endpoint_preset = savedSelectedName');
-        const applyBranchIndex = loadCustomEndpointSource.indexOf('if (selected_custom_endpoint_preset) {');
+        const applyBranchIndex = loadCustomEndpointSource.indexOf('if (selected_custom_endpoint_preset && selected_custom_endpoint_preset.name !== \'None\') {');
         const applyPresetIndex = loadCustomEndpointSource.indexOf('await setCustomEndpointPreset(', applyBranchIndex);
         const fallbackNameIndex = loadCustomEndpointSource.indexOf('$(\'#custom_endpoint_preset_name\').val(\'\');');
 
@@ -287,5 +287,44 @@ describe('OpenAI proxy preset wiring', () => {
         const initSource = getFunctionSource('initOpenAI');
 
         expect(initSource).toContain('$(\'#custom_endpoint_preset\').on(\'change\', onCustomEndpointPresetChange);');
+    });
+
+    test('skips the load-time apply for the None profile so typed URL and model survive reloads', () => {
+        const loadCustomEndpointSource = getFunctionSource('loadCustomEndpointPresets');
+
+        expect(loadCustomEndpointSource).toContain('if (selected_custom_endpoint_preset && selected_custom_endpoint_preset.name !== \'None\') {');
+    });
+
+    test('does not rotate a Custom endpoint profile secret that is already active', () => {
+        const activationSource = getFunctionSource('activateCustomEndpointPresetSecret');
+        const activeCheckIndex = activationSource.indexOf('secret_state[SECRET_KEYS.CUSTOM]?.some(secret => secret.id === preset.secretId && secret.active)');
+        const rotateIndex = activationSource.indexOf('await rotateSecret(SECRET_KEYS.CUSTOM, preset.secretId);');
+
+        expect(activeCheckIndex).toBeGreaterThanOrEqual(0);
+        expect(rotateIndex).toBeGreaterThan(activeCheckIndex);
+        expect(activationSource).toContain('if (!isAlreadyActive) {');
+    });
+
+    test('exposes /custom-endpoint-profile that selects saved profiles by exact name', () => {
+        const callbackSource = getFunctionSource('runCustomEndpointPresetCallback');
+        const initSource = getFunctionSource('initOpenAI');
+
+        expect(initSource).toContain('name: \'custom-endpoint-profile\',');
+        expect(initSource).toContain('callback: runCustomEndpointPresetCallback,');
+        expect(callbackSource).toContain('oai_settings.chat_completion_source === chat_completion_sources.CUSTOM');
+        expect(callbackSource).toContain('custom_endpoint_presets.find(p => p.name === name)');
+        expect(callbackSource).not.toContain('new Fuse(');
+        expect(callbackSource).toContain('$(\'#custom_endpoint_preset\').val(preset.name);');
+        expect(callbackSource).toContain('await setCustomEndpointPreset(preset.name, preset.url, preset.key, preset.model, { secretId: preset.secretId });');
+    });
+
+    test('stores Custom endpoint additional parameters verbatim through their slash commands', () => {
+        const callbackSource = getFunctionSource('runCustomEndpointParameterCallback');
+
+        expect(callbackSource).toContain('oai_settings[settingName] = getSlashCommandStringValue(value);');
+        expect(callbackSource).not.toContain('.trim()');
+        expect(openAiSource).toContain('name: \'custom-include-body\',\n        callback: runCustomEndpointParameterCallback(\'custom_include_body\', \'#custom_include_body\'),');
+        expect(openAiSource).toContain('name: \'custom-exclude-body\',\n        callback: runCustomEndpointParameterCallback(\'custom_exclude_body\', \'#custom_exclude_body\'),');
+        expect(openAiSource).toContain('name: \'custom-include-headers\',\n        callback: runCustomEndpointParameterCallback(\'custom_include_headers\', \'#custom_include_headers\'),');
     });
 });


### PR DESCRIPTION
Whenever I switch between Connection Profiles and have multiple Custom Endpoint Profiles, it seems to default to the first custom endpoint profile I was using, which means I need to keep switching over to the one I intended even though I'd clicked Save on the Connection Profile.

Turns out the Connection Profile only remembered the API key, and endpoint profiles can share a key (saving one without retyping the key binds it to whichever key is active), so on switch it just grabbed the first endpoint profile with that key. Now the profile remembers the endpoint profile by name and re-selects it. Existing profiles need one Update to pick this up. Also stopped the 'None' endpoint profile from wiping a typed URL/model on reload, and there's a `/custom-endpoint-profile` command for the same reason `/proxy` exists.

This also saves the Additional Parameters for the Custom OpenAI-compatible backend into the Connection Profile (include body, exclude body, include headers - same as the reasoning fields already were), so switching profiles restores them instead of keeping whatever was used last.
