### PR TITLE
fix(markdown): ensure markdown text wraps around as usual

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1824,18 +1824,12 @@ body.bubblechat .mes[is_user='true'] .mes_block {
 }
 
 /* A bare <pre> keeps the UA `white-space: pre`, so a message wrapped in one
-   runs past the message block in every chat style. Fenced code keeps its own
-   horizontal scroll from style.css instead of wrapping. */
+   runs past the message block in every chat style. */
 .mes_text pre,
 .mes_reasoning pre {
     white-space: pre-wrap;
     overflow-wrap: break-word;
     max-width: 100%;
-}
-
-.mes_text pre code,
-.mes_reasoning pre code {
-    white-space: pre;
 }
 
 @media screen and (max-width: 1000px) {


### PR DESCRIPTION
A regression was introduced in the `<pre>` wraparound fix that has affected markdown tags (```). This restores the previous wraparound behaviour of markdown.