### PR TITLE
feat: add the model name and reasoning effort after the icon

### DIFF
--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -360,6 +360,7 @@ body.documentstyle #chat .mes .mesAvatarWrapper,
 body.documentstyle #chat .mes .mes_block .ch_name .name_text,
 body.documentstyle #chat .mes .mes_block .ch_name .timestamp,
 body.documentstyle #chat .mes .mes_block .ch_name .timestamp-icon,
+body.documentstyle #chat .mes .mes_block .ch_name .timestamp-model,
 body.documentstyle .mes:not(.last_mes) .ch_name .mes_buttons {
     display: none !important;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -5385,6 +5385,14 @@
                                     <input id="messageModelIconEnabled" type="checkbox" />
                                     <small data-i18n="Model Icon">Model Icons</small>
                                 </label>
+                                <label for="messageModelNameEnabled" class="checkbox_label" title="Write the exact model name after the message icon." data-i18n="[title]Write the exact model name after the message icon">
+                                    <input id="messageModelNameEnabled" type="checkbox" />
+                                    <small data-i18n="Model Name After Icon">Model Name After Icon</small>
+                                </label>
+                                <label for="messageReasoningEffortEnabled" class="checkbox_label" title="Write the reasoning effort used after the model name." data-i18n="[title]Write the reasoning effort used after the model name">
+                                    <input id="messageReasoningEffortEnabled" type="checkbox" />
+                                    <small data-i18n="Reasoning Effort After Model">Reasoning Effort After Model</small>
+                                </label>
                                 <label for="mesIDDisplayEnabled" class="checkbox_label" title="Show sequential message numbers in the chat log." data-i18n="[title]Show sequential message numbers in the chat log">
                                     <input id="mesIDDisplayEnabled" type="checkbox" />
                                     <small data-i18n="Message IDs">Message IDs</small>

--- a/public/script.js
+++ b/public/script.js
@@ -119,6 +119,7 @@ import {
     openai_messages_count,
     chat_completion_sources,
     getChatCompletionModel,
+    getCurrentReasoningEffort,
     proxies,
     loadProxyPresets,
     selected_proxy,
@@ -3875,7 +3876,8 @@ function insertSVGIcon(mes, extra) {
 
     const insertOrReplaceSVG = (image, className, targetSelector, insertBefore) => {
         image.onload = async function () {
-            let existingSVG = insertBefore ? mes.find(targetSelector).prev(`.${className}`) : mes.find(targetSelector).next(`.${className}`);
+            // The model name label can sit between the timestamp and its icon, so match past it.
+            let existingSVG = insertBefore ? mes.find(targetSelector).prevAll(`.${className}`).first() : mes.find(targetSelector).nextAll(`.${className}`).first();
             if (existingSVG.length) {
                 existingSVG.replaceWith(image);
             } else {
@@ -3956,6 +3958,46 @@ function inferCustomModelIconName(model) {
     return '';
 }
 
+/**
+ * Writes the model name label after a message's timestamp icon, or after the
+ * timestamp itself when icons are turned off.
+ *
+ * @param {JQuery<HTMLElement>} mes - The message element.
+ * @param {ChatMessageExtra} [extra] - Contains the API, model and reasoning effort details.
+ */
+function insertModelLabel(mes, extra) {
+    mes.find('.timestamp-model').remove();
+
+    const label = getMessageIconLabel(extra);
+
+    if (!label) {
+        return;
+    }
+
+    const icon = mes.find('.timestamp-icon').first();
+    $('<small class="timestamp-model"></small>').text(label).insertAfter(icon.length ? icon : mes.find('.timestamp'));
+}
+
+/**
+ * Builds the text written after a message's timestamp icon.
+ *
+ * @param {ChatMessageExtra} [extra] - Contains the API, model and reasoning effort details.
+ * @returns {string} Label text, empty when nothing should be written
+ */
+function getMessageIconLabel(extra) {
+    const parts = [];
+
+    if (power_user.timestamp_model_name) {
+        parts.push(String(extra?.model ?? '').trim());
+    }
+
+    if (power_user.timestamp_reasoning_effort && extra?.reasoning_effort) {
+        parts.push(`(${extra.reasoning_effort})`);
+    }
+
+    return parts.filter(Boolean).join(' ');
+}
+
 function getMessageIconName(extra) {
     const apiName = String(extra?.api ?? '').trim().toLowerCase();
 
@@ -3976,13 +4018,13 @@ export function refreshMessageModelIcons() {
         const messageId = Number.parseInt(String(messageElement.attr('mesid') ?? ''), 10);
         const message = Number.isInteger(messageId) ? chat[messageId] : null;
 
-        messageElement.find('.timestamp-icon, .thinking-icon').remove();
+        messageElement.find('.timestamp-icon, .thinking-icon, .timestamp-model').remove();
 
-        if (!power_user.timestamp_model_icon || !message?.extra?.api) {
-            return;
+        if (power_user.timestamp_model_icon && message?.extra?.api) {
+            insertSVGIcon(messageElement, message.extra);
         }
 
-        insertSVGIcon(messageElement, message.extra);
+        insertModelLabel(messageElement, message?.extra);
     });
 }
 
@@ -4738,6 +4780,8 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     if (power_user.timestamp_model_icon && mes.extra?.api) {
         insertSVGIcon(messageElement, mes.extra);
     }
+
+    insertModelLabel(messageElement, mes.extra);
 
     if (mes?.extra?.isSmallSys === true) {
         messageElement.addClass('smallSysMes');
@@ -9720,6 +9764,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             lastMessage.send_date = getMessageTimeStamp();
             lastMessage.extra.api = getGeneratingApi();
             lastMessage.extra.model = getGeneratingModel();
+            lastMessage.extra.reasoning_effort = getCurrentReasoningEffort();
             lastMessage.extra.reasoning = reasoning;
             lastMessage.extra.reasoning_duration = null;
             lastMessage.extra.reasoning_signature = reasoningSignature;
@@ -9744,6 +9789,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.send_date = getMessageTimeStamp();
         lastMessage.extra.api = getGeneratingApi();
         lastMessage.extra.model = getGeneratingModel();
+        lastMessage.extra.reasoning_effort = getCurrentReasoningEffort();
         lastMessage.extra.reasoning = reasoning;
         lastMessage.extra.reasoning_duration = null;
         lastMessage.extra.reasoning_signature = reasoningSignature;
@@ -9763,6 +9809,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.send_date = getMessageTimeStamp();
         lastMessage.extra.api = getGeneratingApi();
         lastMessage.extra.model = getGeneratingModel();
+        lastMessage.extra.reasoning_effort = getCurrentReasoningEffort();
         lastMessage.extra.reasoning += reasoning;
         lastMessage.extra.reasoning_signature = reasoningSignature;
         await processImageAttachment(lastMessage, { imageUrls });
@@ -9785,6 +9832,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         newMessage.send_date = getMessageTimeStamp();
         newMessage.extra.api = getGeneratingApi();
         newMessage.extra.model = getGeneratingModel();
+        newMessage.extra.reasoning_effort = getCurrentReasoningEffort();
         newMessage.extra.reasoning = reasoning;
         newMessage.extra.reasoning_duration = null;
         newMessage.extra.reasoning_signature = reasoningSignature;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5197,6 +5197,19 @@ function getReasoningEffort(settings = null, model = null) {
 }
 
 /**
+ * Get the reasoning effort a chat completion request would send right now.
+ * Stamped onto received messages so the UI can show what a message was generated with.
+ * @returns {string} Reasoning effort, empty when none is sent
+ */
+export function getCurrentReasoningEffort() {
+    if (main_api !== 'openai') {
+        return '';
+    }
+
+    return String(getReasoningEffort() ?? '');
+}
+
+/**
  * Get the verbosity from chat completion settings
  * @param {ChatCompletionSettings} settings Chat completion settings
  * @returns {string} Verbosity level, if present

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -35,6 +35,7 @@ import {
     settingsReady,
     updateMessageMetaBadges,
     updateMessageTokenAccounting,
+    refreshMessageModelIcons,
 } from '../script.js';
 import { isMobile, initMovingUI, favsToHotswap } from './RossAscends-mods.js';
 import { normalizeContextRetentionDepth } from './ooc-blocks.js';
@@ -391,6 +392,8 @@ export const power_user = {
     timer_enabled: true,
     timestamps_enabled: true,
     timestamp_model_icon: false,
+    timestamp_model_name: false,
+    timestamp_reasoning_effort: false,
     mesIDDisplay_enabled: false,
     hideChatAvatars_enabled: false,
     max_context_unlocked: true,
@@ -2491,6 +2494,8 @@ export async function loadPowerUserSettings(settings, data) {
     $('#messageTimerEnabled').prop('checked', power_user.timer_enabled);
     $('#messageTimestampsEnabled').prop('checked', power_user.timestamps_enabled);
     $('#messageModelIconEnabled').prop('checked', power_user.timestamp_model_icon);
+    $('#messageModelNameEnabled').prop('checked', power_user.timestamp_model_name);
+    $('#messageReasoningEffortEnabled').prop('checked', power_user.timestamp_reasoning_effort);
     $('#mesIDDisplayEnabled').prop('checked', power_user.mesIDDisplay_enabled);
     $('#hideChatAvatarsEnabled').prop('checked', power_user.hideChatAvatars_enabled);
     $('#prefer_character_prompt').prop('checked', power_user.prefer_character_prompt);
@@ -4723,6 +4728,18 @@ jQuery(async () => {
         const value = !!$(this).prop('checked');
         power_user.timestamp_model_icon = value;
         switchIcons();
+        saveSettingsDebounced();
+    });
+
+    $('#messageModelNameEnabled').on('input', function () {
+        power_user.timestamp_model_name = !!$(this).prop('checked');
+        refreshMessageModelIcons();
+        saveSettingsDebounced();
+    });
+
+    $('#messageReasoningEffortEnabled').on('input', function () {
+        power_user.timestamp_reasoning_effort = !!$(this).prop('checked');
+        refreshMessageModelIcons();
         saveSettingsDebounced();
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -6650,7 +6650,8 @@ body:not(.movingUI) .drawer-content.maximized {
 
 
 
-.timestamp {
+.timestamp,
+.timestamp-model {
     font-size: calc(var(--mainFontSize) * 0.7);
     font-weight: 400;
 }

--- a/tests/message-model-icon-label.test.js
+++ b/tests/message-model-icon-label.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = file => readFileSync(path.join(repoRoot, file), 'utf8').replace(/\r\n/g, '\n');
+
+const indexHtml = read('public/index.html');
+const scriptJs = read('public/script.js');
+const powerUserJs = read('public/scripts/power-user.js');
+
+const TOGGLES = [
+    ['messageModelNameEnabled', 'timestamp_model_name'],
+    ['messageReasoningEffortEnabled', 'timestamp_reasoning_effort'],
+];
+
+describe('message model icon label', () => {
+    test('both toggles sit with the model icon toggle in Visual Toggles', () => {
+        const themeToggles = indexHtml.indexOf('<div name="themeToggles">');
+        expect(themeToggles).toBeGreaterThan(-1);
+
+        for (const [id] of TOGGLES) {
+            expect(indexHtml).toContain(`<input id="${id}" type="checkbox" />`);
+            expect(indexHtml.indexOf(id)).toBeGreaterThan(themeToggles);
+        }
+
+        expect(indexHtml).toMatch(/messageModelIconEnabled[\s\S]{0,500}?messageModelNameEnabled[\s\S]{0,500}?messageReasoningEffortEnabled/);
+    });
+
+    test('both toggles are wired to the power user settings', () => {
+        for (const [id, setting] of TOGGLES) {
+            expect(powerUserJs).toContain(`${setting}: false,`);
+            expect(powerUserJs).toContain(`$('#${id}').prop('checked', power_user.${setting});`);
+
+            const handler = powerUserJs.match(new RegExp(`\\$\\('#${id}'\\)\\.on\\('input', function \\(\\) \\{([\\s\\S]*?)\\n    \\}\\);`));
+            expect(handler?.[1]).toContain(`power_user.${setting} = !!$(this).prop('checked');`);
+            // Toggling has to repaint already rendered messages, not just save.
+            expect(handler?.[1]).toContain('refreshMessageModelIcons();');
+        }
+    });
+
+    test('the label is written whether or not model icons are on', () => {
+        // Rendering it from inside the icon insert would silently do nothing with icons off.
+        expect(scriptJs).toContain(`    if (power_user.timestamp_model_icon && mes.extra?.api) {
+        insertSVGIcon(messageElement, mes.extra);
+    }
+
+    insertModelLabel(messageElement, mes.extra);`);
+        expect(scriptJs).toContain('insertAfter(icon.length ? icon : mes.find(\'.timestamp\'))');
+    });
+
+    test('the label is cleared before messages are repainted', () => {
+        expect(scriptJs).toContain('.timestamp-icon, .thinking-icon, .timestamp-model\').remove()');
+    });
+
+    test('every generated reply records the reasoning effort next to its model', () => {
+        // The effort is only known while generating, so a stamp site that forgets it
+        // leaves those messages unable to ever show one.
+        const modelStamps = [...scriptJs.matchAll(/^([ \t]*)(\w+)\.extra\.model = getGeneratingModel\(\);$/gm)];
+        expect(modelStamps.length).toBeGreaterThan(0);
+
+        const missingEffort = modelStamps.filter(([line, indent, target]) =>
+            !scriptJs.includes(`${line}\n${indent}${target}.extra.reasoning_effort = getCurrentReasoningEffort();`));
+
+        expect(missingEffort.map(match => match[0].trim())).toEqual([]);
+    });
+});


### PR DESCRIPTION
A new checkbox in Settings -> Visual Toggles, right under "Model Icons", called "Model Name After Icon", so e.g. it says "Gemma-4-31B-Melinoe" after the butterfly icon. And a second one under that, "Reasoning Effort After Model", which puts the effort in brackets right after it: "Gemma-4-31B-Melinoe (high)".

Works for every model and backend, with or without Model Icons turned on. With the icons off the text simply goes after the timestamp instead. The effort shown is the one recorded when the message was generated, so messages from before this change do not show one, and backends that have no reasoning effort never show one.

**The two new toggles**

<img width="688" height="442" alt="1-visual-toggles" src="https://github.com/user-attachments/assets/9339d566-1adc-4042-8fe2-80c7db1d7160" />