### PR TITLE
chore: gitignore the Quick Image Gen sync's leftover merge folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ test-results/
 .local-worklog/
 /output/
 /graphify-out/
+# SillyBunny: conflict scratch output from scripts/sync-quick-image-gen.sh; keep it out of git status so it cannot block the in-app updater
+/.quick-image-gen-merge/
 
 # Local UI/performance screenshots
 screenshots/layout-clean-desktop-workspace-20260505.png


### PR DESCRIPTION
Makes sure a failed Quick Image Gen update through Extensions no longer blocks updating SillyBunny. When the sync hits a conflict it leaves its merge output in `.quick-image-gen-merge/` at the repo root, and Git counted that as local changes - so Customize > Server kept showing 'Changed files: 34 (...)' and you needed auto-stash on just to get past it (which put the folder straight back after pulling). Ignoring the folder fixes that. The sync script itself is unchanged.
