### PR TITLE
fix: hardens chat scroll jumping

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -629,6 +629,7 @@ const MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS = 500;
 const MOBILE_CHAT_BOTTOM_PIN_MS = 1500;
 const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = 750;
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;
+const CHAT_TAP_RESIZE_GRACE_MS = 400;
 const CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS = 250;
 const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900, 1600, 2400]);
 const SHOW_MORE_DUPLICATE_EVENT_GUARD_MS = 750;
@@ -672,6 +673,13 @@ let mobileStreamingBottomPinSmooth = false;
 let lastMobileStreamingBottomPinAt = 0;
 let chatLoadBottomLockUntil = 0;
 let chatLoadBottomPinFrame = 0;
+let chatLastBottomPinScrollTop = 0;
+let lastChatPointerUpAt = 0;
+
+// ponytail: pointerup only — a touch scroll ends in pointercancel, so scrolling never arms the window.
+function isRecentChatTap() {
+    return Date.now() - lastChatPointerUpAt < CHAT_TAP_RESIZE_GRACE_MS;
+}
 export let abortStatusCheck = new AbortController();
 export let charDragDropHandler = null;
 export let chatDragDropHandler = null;
@@ -1988,6 +1996,8 @@ function isChatLoadBottomLockActive() {
 
 function clearChatLoadBottomLock() {
     chatLoadBottomLockUntil = 0;
+    // SillyBunny: leaving the load lock means user intent took over; do not let the scroll handler immediately re-arm autoscroll.
+    scrollLockImmunityUntil = 0;
 
     if (chatLoadBottomPinFrame) {
         cancelAnimationFrame(chatLoadBottomPinFrame);
@@ -2580,7 +2590,10 @@ async function applyChatMessageResizeAction(element, entry, metadata) {
 
     if (shouldApplyChatBottomScrollAction(action)) {
         // SillyBunny: coalesce media resize pins with the shared bottom-scroll rAF lane.
-        scrollChatToBottom({ waitForFrame: true, isNearBottom: true });
+        // ponytail: growth right after a completed tap is user-caused, not late media; pinning then drags the view. Keyboard-toggled details still pin, and late media landing inside the 400 ms window won't.
+        if (!isRecentChatTap()) {
+            scrollChatToBottom({ waitForFrame: true, isNearBottom: true });
+        }
         requestAnimationFrame(() => refreshChatMessageResizeState(element, metadata, entry));
         return;
     }
@@ -2910,6 +2923,9 @@ function pruneRenderedChatMessagesToWindow({ windowSize, pruneFrom }) {
         return;
     }
 
+    // SillyBunny: pin the first visible message so a top prune cannot shift the view.
+    const anchor = pruneFrom === 'start' ? captureVisibleChatMessageAnchor() : null;
+
     const removedMessages = pruneFrom === 'end'
         ? renderedMessages.slice(-excessMessageCount)
         : renderedMessages.slice(0, excessMessageCount);
@@ -2919,6 +2935,7 @@ function pruneRenderedChatMessagesToWindow({ windowSize, pruneFrom }) {
     removedMessageElements.remove();
     syncRenderedChatLastMessageClass();
     syncChatHistoryWindowControls();
+    restoreVisibleChatMessageAnchor(anchor);
 }
 
 function removeRenderedChatMessages() {
@@ -4262,6 +4279,10 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
     const chatHeight = (hasMedia || hasFiles) ? chatElement.prop('scrollHeight') : 0;
     const scrollPosition = (hasMedia || hasFiles) ? chatElement.scrollTop() : 0;
     const doAdjustScroll = () => {
+        // SillyBunny: the block's resize observer already keeps the viewport; a late relative restore would revert it.
+        if (chatMessageResizeStates.has(getMessageBlockElement(messageElement))) {
+            return;
+        }
         if (!hasMedia && !hasFiles) {
             return;
         }
@@ -4992,10 +5013,12 @@ function scrollChatElementToBottom({ behavior = 'auto' } = {}) {
     const element = chatElement[0];
     if (behavior === 'smooth' && typeof element?.scrollTo === 'function') {
         element.scrollTo({ top: position, behavior });
+        chatLastBottomPinScrollTop = position;
         return;
     }
 
     chatElement.scrollTop(position);
+    chatLastBottomPinScrollTop = element.scrollTop;
 }
 
 /**
@@ -12583,7 +12606,8 @@ export async function messageEdit(editMessageId) {
         markMobileChatManualScroll();
     }
 
-    const shouldRestoreChatScroll = shouldGuardMobileChatScroll() || Number(this_edit_mes_id) === chat.length - 1;
+    // SillyBunny: on desktop the message resize observer owns the edit-open layout change and focus already has preventScroll; restoring here reverts it.
+    const shouldRestoreChatScroll = shouldGuardMobileChatScroll();
     const restoreChatScroll = () => {
         if (shouldRestoreChatScroll) {
             chatElement.scrollTop(chatScrollPosition);
@@ -16518,6 +16542,7 @@ jQuery(async function () {
     chatElementScroll.addEventListener('touchend', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('touchcancel', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('wheel', markMobileChatWheelScroll, { passive: true });
+    chatElementScroll.addEventListener('pointerup', () => { lastChatPointerUpAt = Date.now(); }, { passive: true, capture: true });
     document.addEventListener('wheel', routeShellWheelToChat, { passive: false, capture: true });
     setupMobileChatViewportObserver(markMobileViewportScroll);
 
@@ -16525,8 +16550,13 @@ jQuery(async function () {
         refreshObservedChatMessageResizeViewportStates();
 
         if (isChatLoadBottomLockActive() && !isChatScrolledNearBottom()) {
-            pinChatLoadToBottom();
-            return;
+            // SillyBunny: load pins only ever land at the bottom; sitting above the last pin means the user (or a jump) took over.
+            if (chatElementScroll.scrollTop < chatLastBottomPinScrollTop) {
+                clearChatLoadBottomLock();
+            } else {
+                pinChatLoadToBottom();
+                return;
+            }
         }
 
         if (power_user.waifuMode) {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2302,7 +2302,7 @@ export function initChatUtilities() {
         if ($('.edit_textarea').length) return;
         $(this).closest('.mes').find('.mes_edit').trigger('click');
         if ($(event.target).closest('.mes_reasoning').length) {
-            $('.reasoning_edit_textarea').trigger('focus');
+            $('.reasoning_edit_textarea')[0]?.focus({ preventScroll: true }); // SillyBunny: reasoning.js already reveals the textarea; a scrolling focus double-jumps.
         }
     });
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -17430,6 +17430,9 @@ function initAll() {
     applyTopbarIconsOnlyPreference();
     bindLandingPageObserver();
     buildBottomChatBar();
+    // SillyBunny: user input ends the ⬇ scroll-to-bottom ladder so a mid-ladder flick is not snapped back.
+    getChatScrollElement()?.addEventListener('wheel', cancelPendingBottomChatScroll, { passive: true });
+    getChatScrollElement()?.addEventListener('touchstart', cancelPendingBottomChatScroll, { passive: true });
     // Refresh again after the current JS task — APP_READY may have already
     // fired before this listener was registered, so the initial call in
     // buildBottomChatBar() may have found no active chat yet.

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -191,6 +191,7 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('pruneRenderedChatMessagesToWindow({ windowSize, pruneFrom: \'start\' });');
         expect(source).toContain('syncRenderedChatLastMessageClass();');
         expect(source).toContain('syncChatHistoryWindowControls();');
+        expect(getSource(findFunctionDeclaration('pruneRenderedChatMessagesToWindow'))).toContain('captureVisibleChatMessageAnchor()');
         expect(source).toContain('applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });');
         expect(source).toContain('refreshSwipeButtons();');
         expect(source).toContain('applyStylePins();');
@@ -582,6 +583,7 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll()');
         expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
         expect(source).toContain('scrollChatToBottom({ waitForFrame: true, isNearBottom: true });');
+        expect(source).toContain('isRecentChatTap()');
         expect(source).toContain('action.action === CHAT_SCROLL_ACTION.PRESERVE_ANCHOR');
         expect(source).toContain('await settleVisibleChatMessageAnchor(resizeState.anchor);');
         expect(source).toContain('refreshChatMessageResizeState(element, metadata, entry);');
@@ -686,6 +688,10 @@ describe('chat render lifecycle script wiring', () => {
         expect(initSource).toContain('clearChatLoadBottomLock();');
         expect(initSource).toContain('if (isChatLoadBottomLockActive() && !isChatScrolledNearBottom())');
         expect(initSource).toContain('pinChatLoadToBottom();');
+        expect(initSource).toContain('lastChatPointerUpAt = Date.now();');
+
+        const clearLockSource = getSource(findFunctionDeclaration('clearChatLoadBottomLock'));
+        expect(clearLockSource).toContain('scrollLockImmunityUntil = 0;');
     });
 
     test('mobile viewport lifecycle route preserves existing scroll suppression policy', () => {

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -137,6 +137,74 @@ test.describe('issue 167 chat scroll regressions', () => {
 
         expect(after.scrollTop).toBeGreaterThan(before.scrollTop + 100);
     });
+
+    test('chat-load bottom lock yields when the view moves above the last pin', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 96, visibleCount: 24 });
+        const renderedIds = await getRenderedMessageIds(page);
+        const anchorId = renderedIds.at(6);
+
+        await scrollMessageNearTop(page, anchorId, 32);
+        const before = await getChatScrollSnapshot(page);
+        await waitForAnimationFrames(page, 6);
+        await page.waitForTimeout(500);
+        const after = await getChatScrollSnapshot(page);
+
+        expect(after.firstVisibleMesId).toBe(before.firstVisibleMesId);
+        expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(3);
+        expect(after.bottomDelta).toBeGreaterThan(200);
+    });
+
+    test('message growth right after a tap keeps the bottom-pinned view still', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 48 });
+        await page.waitForTimeout(2800);
+        const renderedIds = await getRenderedMessageIds(page);
+        const lastId = renderedIds.at(-1);
+
+        await page.locator(`#chat .mes[mesid="${lastId}"] .mes_text`).click();
+
+        const before = await getChatScrollSnapshot(page);
+        await growMessageBlockAboveViewport(page, lastId, { height: 300 });
+        const after = await getChatScrollSnapshot(page);
+
+        expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(3);
+        expect(after.bottomDelta).toBeGreaterThanOrEqual(250);
+
+        await page.evaluate(() => window.SillyTavern.getContext().scrollChatToBottom({ force: true }));
+        await page.waitForTimeout(450);
+        await growMessageBlockAboveViewport(page, lastId, { height: 300 });
+        await waitForAnimationFrames(page, 4);
+        const settled = await getChatScrollSnapshot(page);
+
+        expect(settled.bottomDelta).toBeLessThanOrEqual(16);
+    });
+
+    test('tail append prunes the top without shifting the view', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 96, visibleCount: 24 });
+        const renderedIds = await getRenderedMessageIds(page);
+        const anchorId = renderedIds.at(6);
+
+        await scrollMessageNearTop(page, anchorId, 32);
+
+        const before = await getChatScrollSnapshot(page);
+        await page.evaluate(() => {
+            const context = window.SillyTavern.getContext();
+            const messageId = context.chat.length;
+            context.chat.push({
+                name: 'Bunny Guide',
+                is_user: false,
+                is_system: false,
+                send_date: new Date().toISOString(),
+                mes: `issue 167 tail append ${messageId}`,
+                extra: {},
+            });
+            context.addOneMessage(context.chat.at(-1), { scroll: false });
+        });
+        await waitForAnimationFrames(page, 6);
+        const after = await getChatScrollSnapshot(page);
+
+        expect(after.firstVisibleMesId).toBe(before.firstVisibleMesId);
+        expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(3);
+    });
 });
 
 test.describe('issue 167 mobile chat scroll regressions', () => {
@@ -171,5 +239,29 @@ test.describe('issue 167 mobile chat scroll regressions', () => {
         expect(after.firstVisibleMesId).toBe(before.firstVisibleMesId);
         expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(12);
         expect(after.bottomDelta).toBeGreaterThan(96);
+    });
+
+    test('message growth right after a tap keeps the bottom-pinned mobile view still', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 48 });
+        await page.waitForTimeout(2800);
+        const renderedIds = await getRenderedMessageIds(page);
+        const lastId = renderedIds.at(-1);
+
+        await page.locator(`#chat .mes[mesid="${lastId}"] .mes_text`).tap();
+
+        const before = await getChatScrollSnapshot(page);
+        await growMessageBlockAboveViewport(page, lastId, { height: 300 });
+        const after = await getChatScrollSnapshot(page);
+
+        expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(3);
+        expect(after.bottomDelta).toBeGreaterThanOrEqual(250);
+
+        await page.evaluate(() => window.SillyTavern.getContext().scrollChatToBottom({ force: true }));
+        await page.waitForTimeout(1500);
+        await growMessageBlockAboveViewport(page, lastId, { height: 300 });
+        await waitForAnimationFrames(page, 4);
+        const settled = await getChatScrollSnapshot(page);
+
+        expect(settled.bottomDelta).toBeLessThanOrEqual(16);
     });
 });


### PR DESCRIPTION
Fixes the scrolling bug. This PR addresses it by:
1. When you scroll up to read during loading, it stops forcing you back to the bottom.
2. When a message grows (like an image finishing loading) right after you tap, it no longer yanks the view away from you.
3. When old messages get cleaned up to save memory, your reading position stays put.
4. When you start scrolling or tapping, any pending "jump to bottom" is cancelled.