### PR TITLE
fix(mobile): message box text that says "Type a message, or /? for help" is no longer truncated

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -66,8 +66,11 @@
         border-radius: 0 !important;
     }
 
+    /* The composer's text column is roughly 130px on a 360px phone, so this string cannot fit
+       on one line at any readable size. Upstream sets white-space: nowrap, which clipped it. */
     #send_textarea::placeholder {
         font-size: 14px;
+        white-space: normal;
     }
 
     #nonQRFormItems {


### PR DESCRIPTION
Whenever the mobile resolution is too low, it truncates the message, making the rest unreadable. Now wraps instead.