### PR TITLE
chore: add reasoning effort levels in ZAI and MoonshotAI backends

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2056,7 +2056,7 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,linkapi,deepseek">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,linkapi,deepseek,zai,moonshot">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>
@@ -2091,6 +2091,12 @@
                                             </div>
                                             <div class="toggle-description justifyLeft marginBot5" data-source="deepseek" data-i18n="DeepSeek only accepts low, high, and max reasoning efforts. Medium and xhigh alias to high. Minimum aliases to low.">
                                                 DeepSeek only accepts low, high, and max reasoning efforts. Medium and xhigh alias to high. Minimum aliases to low.
+                                            </div>
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="zai" data-i18n="Only GLM-5.2 and newer accept reasoning efforts. Minimum is aliased to 'minimal'. GLM-5.3 specifically only accepts 'low', 'high', and 'max'.">
+                                                Only GLM-5.2 and newer accept reasoning efforts. Minimum is aliased to 'minimal'. GLM-5.3 specifically only accepts 'low', 'high', and 'max'.
+                                            </div>
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="moonshot" data-i18n="Only Kimi K3 accepts reasoning efforts: low, high, and max. Minimum is aliased to low, and Medium and Extra High are aliased to high. Reasoning cannot be turned off for K3.">
+                                                Only Kimi K3 accepts reasoning efforts: low, high, and max. Minimum is aliased to low, and Medium and Extra High are aliased to high. Reasoning cannot be turned off for K3.
                                             </div>
                                         </div>
                                     </div>

--- a/public/scripts/openai-model-capabilities.js
+++ b/public/scripts/openai-model-capabilities.js
@@ -50,6 +50,27 @@ export function applyGrokModelParameterConstraints(generateData) {
 }
 
 /**
+ * Checks whether a Z.AI model accepts the top-level `reasoning_effort` parameter.
+ * Z.AI documents it from GLM-5.2 onwards; older GLM releases only take `thinking.type`.
+ *
+ * @param {unknown} model Model identifier
+ * @returns {boolean} Whether the model accepts a reasoning effort
+ */
+export function zaiSupportsReasoningEffort(model) {
+    const normalizedModel = String(model ?? '').trim().toLowerCase();
+    const version = normalizedModel.match(/(?:^|[/:])glm-(\d+)(?:\.(\d+))?/);
+
+    if (!version) {
+        return false;
+    }
+
+    const major = Number(version[1]);
+    const minor = Number(version[2] ?? 0);
+
+    return major > 5 || (major === 5 && minor >= 2);
+}
+
+/**
  * Checks whether a model ID targets Kimi K3, including provider-prefixed IDs.
  *
  * @param {unknown} model Model identifier

--- a/src/constants.js
+++ b/src/constants.js
@@ -532,6 +532,21 @@ export const NANOGPT_REASONING_EFFORT_MAP = {
     max: 'xhigh',
 };
 
+/**
+ * Moonshot exposes `reasoning_effort` on Kimi K3 only, and documents just low, high and max.
+ * Unlike DeepSeek it does not advertise aliasing of the rungs it omits, so medium and xhigh
+ * are folded here rather than forwarded as values the API does not list. Values absent from
+ * this table are omitted entirely by the caller.
+ */
+export const MOONSHOT_REASONING_EFFORT_MAP = {
+    min: 'low',
+    low: 'low',
+    medium: 'high',
+    high: 'high',
+    xhigh: 'high',
+    max: 'max',
+};
+
 export const LOG_LEVELS = {
     DEBUG: 0,
     INFO: 1,

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -8,13 +8,14 @@ import fetch from 'node-fetch';
 import urlJoin from 'url-join';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
 import { getLinkApiBaseUrl, getLinkApiRequestFormat } from '../../../public/scripts/linkapi-utils.js';
-import { applyGrokModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model } from '../../../public/scripts/openai-model-capabilities.js';
+import { applyGrokModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model, zaiSupportsReasoningEffort } from '../../../public/scripts/openai-model-capabilities.js';
 
 import {
     AIMLAPI_HEADERS,
     AZURE_OPENAI_KEYS,
     CHAT_COMPLETION_SOURCES,
     GEMINI_SAFETY,
+    MOONSHOT_REASONING_EFFORT_MAP,
     NANOGPT_REASONING_EFFORT_MAP,
     OPENAI_FIXED_REASONING_EFFORT,
     OPENAI_REASONING_EFFORT_MAP,
@@ -3147,6 +3148,11 @@ export async function handleChatCompletionsGenerate(request, response) {
                     type: request.body.include_reasoning ? 'enabled' : 'disabled',
                 },
             };
+            // SillyBunny divergence: K3 always reasons and takes the depth from a top-level
+            // reasoning_effort instead of the thinking object the older Kimi models use.
+            if (isKimiK3Model(request.body.model) && Object.hasOwn(MOONSHOT_REASONING_EFFORT_MAP, request.body.reasoning_effort)) {
+                bodyParams['reasoning_effort'] = MOONSHOT_REASONING_EFFORT_MAP[request.body.reasoning_effort];
+            }
             request.body.json_schema
                 ? setJsonObjectFormat(bodyParams, request.body.messages, request.body.json_schema)
                 : addAssistantPrefix(request.body.messages, [], 'partial');
@@ -3170,6 +3176,12 @@ export async function handleChatCompletionsGenerate(request, response) {
                     type: request.body.include_reasoning ? 'enabled' : 'disabled',
                 },
             };
+            // SillyBunny divergence: Z.AI takes the reasoning depth alongside thinking.type from
+            // GLM-5.2 onwards. Its ladder matches this fork's apart from naming the bottom rung
+            // 'minimal', so only that one is translated.
+            if (zaiSupportsReasoningEffort(request.body.model) && request.body.reasoning_effort && !['auto', 'none'].includes(request.body.reasoning_effort)) {
+                bodyParams['reasoning_effort'] = request.body.reasoning_effort === 'min' ? 'minimal' : request.body.reasoning_effort;
+            }
             if (request.body.json_schema) {
                 setJsonObjectFormat(bodyParams, request.body.messages, request.body.json_schema);
             }

--- a/tests/zai-moonshot-reasoning-effort.test.js
+++ b/tests/zai-moonshot-reasoning-effort.test.js
@@ -1,0 +1,238 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
+import { setConfigFilePath } from '../src/util.js';
+
+const actualNodeFetch = (await import('node-fetch')).default;
+const nodeFetchMock = jest.fn((url, options) => actualNodeFetch(url, options));
+await jest.unstable_mockModule('node-fetch', () => ({
+    default: nodeFetchMock,
+}));
+
+describe('reasoning effort on Z.AI and Moonshot requests', () => {
+    /** @type {import('http').Server} */
+    let appServer;
+    let baseUrl;
+    let capturedBody;
+    const tempDirs = [];
+
+    beforeAll(async () => {
+        const configRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-zai-moonshot-config-'));
+        const configPath = path.join(configRoot, 'config.yaml');
+        const defaultConfig = fs.readFileSync(fileURLToPath(new URL('../default/config.yaml', import.meta.url)), 'utf8');
+        fs.writeFileSync(configPath, defaultConfig);
+        tempDirs.push(configRoot);
+        setConfigFilePath(configPath);
+
+        const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
+        const { SecretManager, SECRET_KEYS } = await import('../src/endpoints/secrets.js');
+        const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-zai-moonshot-user-'));
+        tempDirs.push(userRoot);
+        const secretManager = new SecretManager({ root: userRoot, backups: userRoot });
+        secretManager.writeSecret(SECRET_KEYS.ZAI, 'zai-test-key');
+        secretManager.writeSecret(SECRET_KEYS.MOONSHOT, 'moonshot-test-key');
+
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            req.user = { directories: { root: userRoot, backups: userRoot } };
+            next();
+        });
+        app.use('/api/backends/chat-completions', chatCompletionsRouter);
+
+        await new Promise((resolve) => {
+            appServer = app.listen(0, '127.0.0.1', resolve);
+        });
+        const address = appServer.address();
+        baseUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    beforeEach(() => {
+        capturedBody = undefined;
+        nodeFetchMock.mockClear();
+        nodeFetchMock.mockImplementation(async (_url, options) => {
+            capturedBody = JSON.parse(options?.body ?? '{}');
+            return new Response(JSON.stringify({
+                choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+            }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        });
+    });
+
+    afterAll(async () => {
+        if (appServer) {
+            await new Promise((resolve, reject) => {
+                appServer.close((error) => error ? reject(error) : resolve());
+            });
+        }
+        for (const dir of tempDirs.splice(0)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+        nodeFetchMock.mockImplementation((url, options) => actualNodeFetch(url, options));
+    });
+
+    function makeRequest(source, overrides = {}) {
+        return fetch(`${baseUrl}/api/backends/chat-completions/generate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                chat_completion_source: source,
+                model: 'test-model',
+                stream: false,
+                max_tokens: 128,
+                messages: [{ role: 'user', content: 'Question' }],
+                ...overrides,
+            }),
+        });
+    }
+
+    describe('Z.AI', () => {
+        // Z.AI's ladder is none < minimal < low < medium < high < xhigh < max, which is this
+        // fork's own ladder with the bottom rung named 'minimal' instead of 'min'.
+        test.each([
+            ['min', 'minimal'],
+            ['low', 'low'],
+            ['medium', 'medium'],
+            ['high', 'high'],
+            ['xhigh', 'xhigh'],
+            ['max', 'max'],
+        ])('sends %s as %s on GLM-5.2', async (effort, expected) => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.ZAI, { model: 'glm-5.2', reasoning_effort: effort });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.reasoning_effort).toBe(expected);
+        });
+
+        test('keeps sending the thinking switch alongside the effort', async () => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.ZAI, {
+                model: 'glm-5.2',
+                reasoning_effort: 'high',
+                include_reasoning: true,
+            });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.thinking).toEqual({ type: 'enabled' });
+            expect(capturedBody.reasoning_effort).toBe('high');
+        });
+
+        test.each(['none', 'auto', '   '])('omits the effort entirely for %p', async (effort) => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.ZAI, { model: 'glm-5.2', reasoning_effort: effort });
+
+            expect(response.status).toBe(200);
+            expect(Object.hasOwn(capturedBody, 'reasoning_effort')).toBe(false);
+        });
+
+        // Z.AI documents reasoning_effort from GLM-5.2 onwards; older releases would reject it.
+        test.each(['glm-5.1', 'glm-5', 'glm-5-turbo', 'glm-5v-turbo', 'glm-4.7', 'glm-4-32b-0414-128k', 'autoglm-phone-multilingual'])(
+            'omits the effort on %s, which predates the parameter',
+            async (model) => {
+                const response = await makeRequest(CHAT_COMPLETION_SOURCES.ZAI, { model, reasoning_effort: 'high' });
+
+                expect(response.status).toBe(200);
+                expect(Object.hasOwn(capturedBody, 'reasoning_effort')).toBe(false);
+                expect(capturedBody.thinking).toEqual({ type: 'disabled' });
+            },
+        );
+
+        test.each(['glm-5.3', 'glm-5.10', 'glm-6'])('sends the effort on %s, which is newer than 5.2', async (model) => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.ZAI, { model, reasoning_effort: 'high' });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.reasoning_effort).toBe('high');
+        });
+
+        test('normalizes UI casing before the gate', async () => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.ZAI, { model: 'glm-5.2', reasoning_effort: ' Min ' });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.reasoning_effort).toBe('minimal');
+        });
+    });
+
+    describe('Moonshot', () => {
+        // Moonshot documents low, high and max for Kimi K3 and nothing else, so the rungs it
+        // omits are folded rather than forwarded.
+        test.each([
+            ['min', 'low'],
+            ['low', 'low'],
+            ['medium', 'high'],
+            ['high', 'high'],
+            ['xhigh', 'high'],
+            ['max', 'max'],
+        ])('sends %s as %s on Kimi K3', async (effort, expected) => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT, { model: 'kimi-k3', reasoning_effort: effort });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.reasoning_effort).toBe(expected);
+        });
+
+        test('does not add the thinking object that K3 rejects', async () => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT, {
+                model: 'kimi-k3',
+                reasoning_effort: 'max',
+                include_reasoning: true,
+            });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.thinking).toBeUndefined();
+            expect(capturedBody.reasoning_effort).toBe('max');
+        });
+
+        test.each(['none', 'auto', 'banana', '   '])('omits the effort entirely for %p', async (effort) => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT, { model: 'kimi-k3', reasoning_effort: effort });
+
+            expect(response.status).toBe(200);
+            expect(Object.hasOwn(capturedBody, 'reasoning_effort')).toBe(false);
+        });
+
+        // Only K3 exposes the parameter; the older models keep the thinking object.
+        test.each(['kimi-k2.5', 'kimi-latest', 'moonshot-v1-128k'])('omits the effort on %s and keeps thinking', async (model) => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT, {
+                model,
+                reasoning_effort: 'high',
+                include_reasoning: true,
+            });
+
+            expect(response.status).toBe(200);
+            expect(Object.hasOwn(capturedBody, 'reasoning_effort')).toBe(false);
+            expect(capturedBody.thinking).toEqual({ type: 'enabled' });
+        });
+
+        test('normalizes UI casing before the table lookup', async () => {
+            const response = await makeRequest(CHAT_COMPLETION_SOURCES.MOONSHOT, { model: 'kimi-k3', reasoning_effort: ' XHigh ' });
+
+            expect(response.status).toBe(200);
+            expect(capturedBody.reasoning_effort).toBe('high');
+        });
+    });
+
+    test('the Reasoning Effort control is shown for both sources', () => {
+        const indexSource = fs.readFileSync(fileURLToPath(new URL('../public/index.html', import.meta.url)), 'utf8');
+        const wrapper = indexSource.match(/<div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="([^"]*)">\s*<div class="flex-container oneline-dropdown"[^>]*>\s*<label for="openai_reasoning_effort">/);
+
+        expect(wrapper).not.toBeNull();
+        expect(wrapper[1].split(',')).toEqual(expect.arrayContaining(['zai', 'moonshot']));
+
+        // The generic OpenAI-style caption describes tiers neither provider has, so it must not claim them.
+        const genericCaption = indexSource.match(/data-source="([^"]*)"[^>]*>\s*OpenAI-style options: low, medium, high, xhigh\./);
+        expect(genericCaption).not.toBeNull();
+        expect(genericCaption[1].split(',')).not.toContain('zai');
+        expect(genericCaption[1].split(',')).not.toContain('moonshot');
+    });
+
+    test('keeps both sources out of the string-effort resolver so max is not collapsed to high', () => {
+        const openAiSource = fs.readFileSync(fileURLToPath(new URL('../public/scripts/openai.js', import.meta.url)), 'utf8');
+        const sources = openAiSource.match(/const reasoningEffortSources = \[([\s\S]*?)\];/);
+
+        expect(sources).not.toBeNull();
+        expect(sources[1]).not.toContain('ZAI');
+        expect(sources[1]).not.toContain('MOONSHOT');
+    });
+});


### PR DESCRIPTION
Adds the same type of reasoning effort levels added in Deepseek backend to the ZAI and MoonshotAI ones.