### PR TITLE
fix(nanogpt): make reasoning types no longer switch to a different one

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2098,6 +2098,9 @@
                                             <div class="toggle-description justifyLeft marginBot5" data-source="moonshot" data-i18n="Only Kimi K3 accepts reasoning efforts: low, high, and max. Minimum is aliased to low, and Medium and Extra High are aliased to high. Reasoning cannot be turned off for K3.">
                                                 Only Kimi K3 accepts reasoning efforts: low, high, and max. Minimum is aliased to low, and Medium and Extra High are aliased to high. Reasoning cannot be turned off for K3.
                                             </div>
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="nanogpt" data-i18n="Reasoning efforts are sent exactly, aside from minimum which is sent as 'minimal'. Maximum is aliased to extra high.">
+                                                Reasoning efforts are sent exactly, aside from minimum which is sent as 'minimal'. Maximum is aliased to extra high.
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">

--- a/src/constants.js
+++ b/src/constants.js
@@ -516,19 +516,20 @@ export const OPENAI_FIXED_REASONING_EFFORT = {
 };
 
 /**
- * NanoGPT's vocabulary is the ladder none < minimal < low < medium < high < xhigh, which has
- * exactly as many rungs as this fork's own min < low < medium < high < xhigh < max, so every
- * level translates one notch down with no collisions.
- * SillyBunny divergence: upstream stops at `max: 'high'`, leaving NanoGPT's `xhigh` ceiling
- * unreachable and this fork's "Extra High" sending an empty reasoning object. Values absent
- * here are omitted entirely by the caller.
+ * NanoGPT's vocabulary is none < minimal < low < medium < high < xhigh. Four of this fork's
+ * six rungs are spelled identically there and are forwarded untouched, so the level the user
+ * picks is the level NanoGPT receives.
+ * SillyBunny divergence: upstream shifted the whole ladder down one rung, which made "Medium"
+ * arrive as `low`. `min` and `max` are the only two names NanoGPT has no equivalent for, so
+ * they resolve to its nearest real rungs; that puts `xhigh` and `max` on the same ceiling.
+ * Values absent here are omitted entirely by the caller.
  */
 export const NANOGPT_REASONING_EFFORT_MAP = {
-    min: 'none',
-    low: 'minimal',
-    medium: 'low',
-    high: 'medium',
-    xhigh: 'high',
+    min: 'minimal',
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    xhigh: 'xhigh',
     max: 'xhigh',
 };
 

--- a/tests/nanogpt-reasoning-effort.test.js
+++ b/tests/nanogpt-reasoning-effort.test.js
@@ -96,15 +96,15 @@ describe('reasoning effort on outgoing chat completions', () => {
         });
     }
 
-    // NanoGPT documents none < minimal < low < medium < high < xhigh, the same number of rungs
-    // as this fork's min < low < medium < high < xhigh < max, so the ladder maps one-to-one and
-    // Maximum reaches NanoGPT's real ceiling rather than stopping a rung short at high.
+    // NanoGPT documents none < minimal < low < medium < high < xhigh. low, medium, high and
+    // xhigh are spelled the same here, so they go out untouched instead of being shifted a rung
+    // down. min and max are the only names NanoGPT does not have, so they take its nearest rungs.
     test.each([
-        ['min', 'none'],
-        ['low', 'minimal'],
-        ['medium', 'low'],
-        ['high', 'medium'],
-        ['xhigh', 'high'],
+        ['min', 'minimal'],
+        ['low', 'low'],
+        ['medium', 'medium'],
+        ['high', 'high'],
+        ['xhigh', 'xhigh'],
         ['max', 'xhigh'],
     ])('NanoGPT sends %s as %s', async (effort, expected) => {
         const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
@@ -131,8 +131,8 @@ describe('reasoning effort on outgoing chat completions', () => {
     });
 
     test.each([
-        ['XHigh', 'high'],
-        [' xhigh ', 'high'],
+        ['XHigh', 'xhigh'],
+        [' xhigh ', 'xhigh'],
         [' Max ', 'xhigh'],
         ['MAX', 'xhigh'],
     ])('NanoGPT normalizes %p before the table lookup and sends %s', async (effort, expected) => {


### PR DESCRIPTION
Exact names will now be sent as parameters. Previously every level was shifted down one level, so Medium was sent as low and High as medium. Minimum and Maximum are the only two NanoGPT has no name of its own for, so they're sent as minimal and xhigh.