### PR TITLE
feat(kimi): add a Partial Prefill field that only Kimi K3 uses

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2095,10 +2095,13 @@
                                         </div>
                                     </div>
                                     <div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">
-                                        <label for="openai_start_reply_with" class="range-block-title justifyLeft">
-                                            <span data-i18n="Start Reply With">Start Reply With</span>
+                                        <label for="openai_kimi_partial_prefill" class="range-block-title justifyLeft">
+                                            <span data-i18n="Partial Prefill">Partial Prefill</span>
                                         </label>
-                                        <textarea id="openai_start_reply_with" data-macros class="start-reply-with-input text_pole textarea_compact autoSetHeight" rows="2" aria-label="Start Reply With" data-i18n="[aria-label]Start Reply With"></textarea>
+                                        <textarea id="openai_kimi_partial_prefill" data-macros class="text_pole textarea_compact autoSetHeight" rows="2" aria-label="Partial Prefill" placeholder="Write your partial prefill text here..." data-i18n="[aria-label]Partial Prefill;[placeholder]Write your partial prefill text here..."></textarea>
+                                        <div class="toggle-description justifyLeft marginBot5" data-i18n="This sends a partial prefill with the parameter 'partial: true' that only Kimi K3 accepts as of time of writing.">
+                                            This sends a partial prefill with the parameter 'partial: true' that only Kimi K3 accepts as of time of writing.
+                                        </div>
                                     </div>
                                     <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,openrouter,claude,linkapi">
                                         <div class="flex-container oneline-dropdown sb-setting-inline-help sb-setting-inline-center">

--- a/public/script.js
+++ b/public/script.js
@@ -120,6 +120,7 @@ import {
     chat_completion_sources,
     getChatCompletionModel,
     getCurrentReasoningEffort,
+    getEffectivePromptBias,
     proxies,
     loadProxyPresets,
     selected_proxy,
@@ -3631,7 +3632,9 @@ function prepareMessageDisplayText(mes, ch_name, isSystem, isUser, messageId, is
     }
 
     // Prompt bias replacement should be applied on the raw message
-    const replacedPromptBias = power_user.user_prompt_bias && substituteParams(power_user.user_prompt_bias);
+    // SillyBunny: read the prefill actually in effect, which is Kimi K3's own field on K3.
+    const promptBiasSource = getEffectivePromptBias();
+    const replacedPromptBias = promptBiasSource && substituteParams(promptBiasSource);
     if (!power_user.show_user_prompt_bias && ch_name && !isUser && !isSystem && replacedPromptBias && mes.startsWith(replacedPromptBias)) {
         mes = mes.slice(replacedPromptBias.length);
     }
@@ -8804,8 +8807,11 @@ export function getBiasStrings(textareaText, type) {
         }
     }
 
-    promptBias = messageBias || promptBias || power_user.user_prompt_bias || '';
-    const isUserPromptBias = promptBias === power_user.user_prompt_bias;
+    // SillyBunny: Kimi K3 draws its prefill from its own preset-scoped field instead of the
+    // global Start Reply With, so that value stops leaking into every other model.
+    const userPromptBias = getEffectivePromptBias();
+    promptBias = messageBias || promptBias || userPromptBias || '';
+    const isUserPromptBias = promptBias === userPromptBias;
 
     // Substitute params for everything
     messageBias = substituteParams(messageBias);
@@ -9557,14 +9563,17 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
     }
 
     // Add the prompt bias before anything else
+    // SillyBunny: a partial-mode model returns only the continuation, so this has to prepend
+    // the same prefill that was sent -- Kimi K3's own field on K3, the global one elsewhere.
+    const userPromptBias = getEffectivePromptBias();
     if (
         includeUserPromptBias &&
-        power_user.user_prompt_bias &&
+        userPromptBias &&
         !isImpersonate &&
         !isContinue &&
-        power_user.user_prompt_bias.length !== 0
+        userPromptBias.length !== 0
     ) {
-        getMessage = substituteParams(power_user.user_prompt_bias) + getMessage;
+        getMessage = substituteParams(userPromptBias) + getMessage;
     }
 
     // Allow for caching of stopping strings. getStoppingStrings is an expensive function, especially with macros

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -511,6 +511,7 @@ export const settingsToUpdate = {
     show_external_models: ['#openai_show_external_models', 'show_external_models', true, true],
     proxy_password: ['#openai_proxy_password', 'proxy_password', false, true],
     assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false, false],
+    kimi_partial_prefill: ['#openai_kimi_partial_prefill', 'kimi_partial_prefill', false, false],
     assistant_impersonation: ['#claude_assistant_impersonation', 'assistant_impersonation', false, false],
     use_sysprompt: ['#use_sysprompt', 'use_sysprompt', true, false],
     vertexai_auth_mode: ['#vertexai_auth_mode', 'vertexai_auth_mode', false, true],
@@ -628,6 +629,7 @@ const default_settings = {
     show_external_models: false,
     proxy_password: '',
     assistant_prefill: '',
+    kimi_partial_prefill: '',
     assistant_impersonation: default_assistant_impersonation,
     use_sysprompt: false,
     vertexai_auth_mode: 'express',
@@ -3701,7 +3703,7 @@ function groupOpenAISettingsIntoDrawers() {
                 '#openai_settings > div > .range-block:has(#openai_show_thoughts)',
                 '#openai_settings > div > .range-block:has(#openai_auto_append_reasoning_tags)',
                 '#openai_settings > div > .flex-container:has(#openai_reasoning_effort)',
-                '#openai_settings > div > .range-block:has(#openai_start_reply_with)',
+                '#openai_settings > div > .range-block:has(#openai_kimi_partial_prefill)',
                 '#openai_settings > div > .range-block:has(#openai_reasoning_tag_style)',
                 '#openai_settings > div > .flex-container:has(#openai_verbosity)',
                 '#openai_settings > div > .range-block:has(#claude_assistant_prefill)',
@@ -3770,10 +3772,30 @@ function updateOpenAISettingsGroupVisibility() {
     });
 }
 
-function updateKimiK3PrefillVisibility() {
+function isKimiK3PartialPrefillActive() {
     const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT, chat_completion_sources.OPENROUTER];
     const isSupportedSource = supportedSources.includes(oai_settings.chat_completion_source);
-    $('#openai_start_reply_with').closest('.range-block').toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()));
+    return isSupportedSource && isKimiK3Model(getChatCompletionModel());
+}
+
+function updateKimiK3PrefillVisibility() {
+    $('#openai_kimi_partial_prefill').closest('.range-block').toggle(isKimiK3PartialPrefillActive());
+}
+
+/**
+ * Gets the prefill that should be sent ahead of the model's reply, and prepended back onto it.
+ * SillyBunny divergence: Kimi K3's partial prefill is a preset-scoped field of its own rather
+ * than the global Start Reply With, so it never reaches the models that reject a prefill.
+ * K3 falls back to the global value when its own field is empty, so setups that predate the
+ * field keep working until their text is moved across.
+ * @returns {string} The prefill in effect for the current API and model
+ */
+export function getEffectivePromptBias() {
+    if (main_api === 'openai' && isKimiK3PartialPrefillActive()) {
+        return oai_settings.kimi_partial_prefill || power_user.user_prompt_bias;
+    }
+
+    return power_user.user_prompt_bias;
 }
 
 function updateServerChatCompletionConfigSourceVisibility() {
@@ -10711,6 +10733,11 @@ export function initOpenAI() {
 
     $('#claude_assistant_prefill').on('input', function () {
         oai_settings.assistant_prefill = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#openai_kimi_partial_prefill').on('input', function () {
+        oai_settings.kimi_partial_prefill = String($(this).val());
         saveSettingsDebounced();
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4192,9 +4192,7 @@ jQuery(async () => {
     });
 
     $('.start-reply-with-input').on('input', function () {
-        const value = String($(this).val());
-        power_user.user_prompt_bias = value;
-        $('.start-reply-with-input').not(this).val(value);
+        power_user.user_prompt_bias = String($(this).val());
         saveSettingsDebounced();
     });
 

--- a/tests/kimi-k3-partial-prefill.test.js
+++ b/tests/kimi-k3-partial-prefill.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { buildChatCompletionPreset } from '../public/scripts/openai-preset-utils.js';
+
+const readSource = (relativePath) => fs.readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const indexSource = readSource('../public/index.html');
+const openAiSource = readSource('../public/scripts/openai.js');
+const scriptSource = readSource('../public/script.js');
+
+const SETTING_ENTRY = "kimi_partial_prefill: ['#openai_kimi_partial_prefill', 'kimi_partial_prefill', false, false],";
+
+describe('Kimi K3 partial prefill field', () => {
+    test('is registered in the preset setting map as a plain, non-connection value', () => {
+        const map = openAiSource.match(/export const settingsToUpdate = \{([\s\S]*?)\n\};/);
+
+        expect(map).not.toBeNull();
+        expect(map[1]).toContain(SETTING_ENTRY);
+    });
+
+    test('defaults to empty so no existing install starts sending a prefill', () => {
+        const defaults = openAiSource.match(/const default_settings = \{([\s\S]*?)\n\};/);
+
+        expect(defaults).not.toBeNull();
+        expect(defaults[1]).toContain("kimi_partial_prefill: '',");
+    });
+
+    test('writes back to settings on input', () => {
+        expect(openAiSource).toMatch(/\$\('#openai_kimi_partial_prefill'\)\.on\('input', function \(\) \{\s*oai_settings\.kimi_partial_prefill = String\(\$\(this\)\.val\(\)\);\s*saveSettingsDebounced\(\);/);
+    });
+
+    test('is claimed by a settings drawer group, or it is orphaned when the panel is rebuilt', () => {
+        expect(openAiSource).toContain("'#openai_settings > div > .range-block:has(#openai_kimi_partial_prefill)',");
+    });
+
+    test('round-trips through a preset save', () => {
+        // The map entry is what makes a setting persist; a plain value is neither a connection
+        // nor a sampling field, so it survives both linked-preset modes.
+        const settingsMap = { kimi_partial_prefill: ['#openai_kimi_partial_prefill', 'kimi_partial_prefill', false, false] };
+        const settings = { kimi_partial_prefill: 'Understood.' };
+
+        expect(buildChatCompletionPreset(settings, settingsMap)).toEqual({ kimi_partial_prefill: 'Understood.' });
+        expect(buildChatCompletionPreset(settings, settingsMap, { includeConnection: false, includeSampling: false }))
+            .toEqual({ kimi_partial_prefill: 'Understood.' });
+    });
+
+    test('the field is gated to the four K3-capable sources', () => {
+        expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">[\s\S]*?id="openai_kimi_partial_prefill"/);
+    });
+});
+
+describe('effective prompt bias', () => {
+    test('only diverges from the global value in chat completion mode on a K3 model', () => {
+        const helper = openAiSource.match(/export function getEffectivePromptBias\(\) \{([\s\S]*?)\n\}/);
+
+        expect(helper).not.toBeNull();
+        expect(helper[1]).toContain("if (main_api === 'openai' && isKimiK3PartialPrefillActive()) {");
+        // The fallback is what keeps installs that predate the field working untouched.
+        expect(helper[1]).toContain('return oai_settings.kimi_partial_prefill || power_user.user_prompt_bias;');
+        expect(helper[1]).toContain('return power_user.user_prompt_bias;');
+    });
+
+    // Outbound and inbound must agree: a partial-mode model returns only the continuation, so
+    // whatever was sent has to be prepended back. Reading the global value in one place and the
+    // K3 field in the other would paste a prefill onto a reply that never contained it.
+    test('is the single source for every prefill consumer in script.js', () => {
+        expect(scriptSource.match(/getEffectivePromptBias\(\)/g)).toHaveLength(3);
+
+        const getBiasStrings = scriptSource.match(/export function getBiasStrings\(textareaText, type\) \{([\s\S]*?)\n\}/);
+        expect(getBiasStrings).not.toBeNull();
+        expect(getBiasStrings[1]).toContain('const userPromptBias = getEffectivePromptBias();');
+        expect(getBiasStrings[1]).toContain("promptBias = messageBias || promptBias || userPromptBias || '';");
+        expect(getBiasStrings[1]).toContain('const isUserPromptBias = promptBias === userPromptBias;');
+
+        const cleanUpMessage = scriptSource.match(/export function cleanUpMessage\(\{[\s\S]*?\n\}\n/);
+        expect(cleanUpMessage).not.toBeNull();
+        expect(cleanUpMessage[0]).toContain('const userPromptBias = getEffectivePromptBias();');
+        expect(cleanUpMessage[0]).toContain('getMessage = substituteParams(userPromptBias) + getMessage;');
+    });
+
+    test('leaves no direct prefill reads behind', () => {
+        // show_user_prompt_bias and its own assignment still read power_user directly; the three
+        // prefill reads that decide what is sent and displayed must not.
+        expect(scriptSource).not.toContain('substituteParams(power_user.user_prompt_bias)');
+        expect(scriptSource).not.toContain("promptBias || power_user.user_prompt_bias");
+        expect(scriptSource).not.toContain('promptBias === power_user.user_prompt_bias');
+    });
+});

--- a/tests/openai-model-capabilities.test.js
+++ b/tests/openai-model-capabilities.test.js
@@ -167,16 +167,20 @@ describe('Kimi K3 model capabilities', () => {
         expect(openAiSource).toContain('&& !isKimiK3Request;');
     });
 
-    test('exposes a synchronized Start Reply With control only for K3 models', () => {
-        expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">[\s\S]*?id="openai_start_reply_with"/);
-        expect(indexSource).toContain('for="openai_start_reply_with" class="range-block-title justifyLeft"');
-        expect(indexSource.match(/class="start-reply-with-input [^"]*"/g)).toHaveLength(2);
-        expect(openAiSource).toContain('.range-block:has(#openai_start_reply_with)');
+    test('exposes a dedicated Partial Prefill control only for K3 models', () => {
+        expect(indexSource).toMatch(/<div class="range-block" data-source="custom,moonshot,nanogpt,openrouter">[\s\S]*?id="openai_kimi_partial_prefill"/);
+        expect(indexSource).toContain('for="openai_kimi_partial_prefill" class="range-block-title justifyLeft"');
+        expect(openAiSource).toContain('.range-block:has(#openai_kimi_partial_prefill)');
         expect(openAiSource).toContain('const supportedSources = [chat_completion_sources.CUSTOM, chat_completion_sources.MOONSHOT, chat_completion_sources.NANOGPT, chat_completion_sources.OPENROUTER];');
-        expect(openAiSource).toContain('.toggle(isSupportedSource && isKimiK3Model(getChatCompletionModel()))');
+        expect(openAiSource).toContain('return isSupportedSource && isKimiK3Model(getChatCompletionModel());');
+        expect(openAiSource).toContain('.toggle(isKimiK3PartialPrefillActive())');
         expect(openAiSource.match(/updateKimiK3PrefillVisibility\(\);/g)).toHaveLength(3);
+
+        // The K3 field replaced the chat completion mirror of Start Reply With, so only the
+        // Advanced Formatting input carries the class that keeps the global value in sync.
+        expect(indexSource.match(/class="start-reply-with-input [^"]*"/g)).toHaveLength(1);
+        expect(indexSource).toContain('id="start_reply_with"');
         expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.on\('input', function \(\) \{/);
-        expect(powerUserSource).toMatch(/\$\('\.start-reply-with-input'\)\.not\(this\)\.val\(value\);/);
         expect(presetManagerSource).toMatch(/\$\('\.start-reply-with-input'\)\.val\(power_user\.user_prompt_bias\);/);
     });
 });


### PR DESCRIPTION
Due to the nature of Start Reply With..., whenever you switch models it gets used by other models, or 'used' as some like Gemini 3.7 Flash don't accept them. Kimi K3 now has its own Partial Prefill field in that slot, so what you write for K3 never reaches anything else.

If the field is left empty, K3 falls back to the global Start Reply With, so existing setups keep working until the text is moved across. The Start Reply With in Advanced Formatting is untouched.
