### PR TITLE
chore: add GLM-5.3 in the ZAI backend dropdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3949,6 +3949,7 @@
                             <h4 data-i18n="Available Models">Available Models</h4>
                             <select id="model_zai_select">
                                 <optgroup label="GLM Models">
+                                    <option value="glm-5.3">glm-5.3</option>
                                     <option value="glm-5.2">glm-5.2</option>
                                     <option value="glm-5.1">glm-5.1</option>
                                     <option value="glm-5-turbo">glm-5-turbo</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -8122,6 +8122,7 @@ function getZaiMaxContext(model, isUnlocked) {
     }
 
     const contextMap = {
+        'glm-5.3': max_1mil,
         'glm-5.2': max_1mil,
         'glm-5.1': max_200k,
         'glm-5-turbo': max_200k,


### PR DESCRIPTION
Adds glm-5.3 for the ZAI(GLM) backend model dropdown, along with its 1M context window.