### PR TITLE
fix(generation): allow upstream responses to continue and finish

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -330,6 +330,7 @@ import { compressRequest, setRequestCompressionConfig } from './scripts/request-
 import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker } from './scripts/swipe-picker.js';
 import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-send-button.js';
 import { formatMobileStreamingPreview, getMobileStreamingBottomPinBehavior, getStreamingUpdateInterval, isAndroidStreamingPlatform, shouldReduceStreamingDomWork, shouldUsePlainTextStreamingPreview } from './scripts/mobile-streaming.js';
+import { fetchResumable } from './scripts/resumable-generation.js';
 import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_RENDER_LIFECYCLE_ROUTE,
@@ -6696,7 +6697,7 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
             data = await sendOpenAIRequest('quiet', generateData, abortController.signal, { jsonSchema, cacheScope });
         } else {
             const generateUrl = getGenerateUrl(api);
-            const response = await fetch(generateUrl, {
+            const response = await fetchResumable(generateUrl, {
                 method: 'POST',
                 headers: getRequestHeaders(),
                 cache: 'no-cache',
@@ -9121,7 +9122,7 @@ export async function sendGenerationRequest(type, data, options = {}) {
         return await generateHorde(data.prompt, data, abortController.signal, true);
     }
 
-    const response = await fetch(getGenerateUrl(main_api), {
+    const response = await fetchResumable(getGenerateUrl(main_api), {
         method: 'POST',
         headers: getRequestHeaders(),
         cache: 'no-cache',

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -5,6 +5,7 @@ import { extractReasoningFromData } from './reasoning.js';
 import { formatInstructModeChat, formatInstructModePrompt, getInstructStoppingSequences } from './instruct-mode.js';
 import { chat_completion_sources, getStreamingReply, tryParseStreamingError, createGenerationParameters, settingsToUpdate, oai_settings } from './openai.js';
 import EventSourceStream from './sse-stream.js';
+import { fetchResumable } from './resumable-generation.js';
 
 const BOOLEAN_CHAT_COMPLETION_FIELDS = [
     'include_reasoning',
@@ -164,7 +165,7 @@ export class TextCompletionService {
      */
     static async sendRequest(data, extractData = true, signal = null) {
         if (!data.stream) {
-            const response = await fetch(getGenerateUrl(this.TYPE), {
+            const response = await fetchResumable(getGenerateUrl(this.TYPE), {
                 method: 'POST',
                 headers: getRequestHeaders(),
                 cache: 'no-cache',
@@ -191,7 +192,7 @@ export class TextCompletionService {
             };
         }
 
-        const response = await fetch('/api/backends/text-completions/generate', {
+        const response = await fetchResumable('/api/backends/text-completions/generate', {
             method: 'POST',
             headers: getRequestHeaders(),
             cache: 'no-cache',
@@ -523,7 +524,7 @@ export class ChatCompletionService {
     static async sendRequest(data, extractData = true, signal = null) {
         delete data.__connectionProfileRequestFields;
         delete data.modelOverride;
-        const response = await fetch('/api/backends/chat-completions/generate', {
+        const response = await fetchResumable('/api/backends/chat-completions/generate', {
             method: 'POST',
             headers: getRequestHeaders(),
             cache: 'no-cache',

--- a/public/scripts/horde.js
+++ b/public/scripts/horde.js
@@ -15,6 +15,7 @@ import { autoSelectInstructPreset } from './instruct-mode.js';
 import { t } from './i18n.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
 import { kai_settings } from './kai-settings.js';
+import { fetchResumable } from './resumable-generation.js';
 
 export {
     MIN_LENGTH,
@@ -218,10 +219,11 @@ export async function generateHorde(prompt, params, signal, reportProgress) {
         'models': horde_settings.models,
     };
 
-    const response = await fetch('/api/horde/generate-text', {
+    const response = await fetchResumable('/api/horde/generate-text', {
         method: 'POST',
         headers: getRequestHeaders(),
         body: JSON.stringify(payload),
+        signal,
     });
 
     if (!response.ok) {

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -20,6 +20,7 @@ import {
     power_user,
 } from './power-user.js';
 import { getEventSourceStream } from './sse-stream.js';
+import { fetchResumable } from './resumable-generation.js';
 import { getSortableDelay, versionCompare } from './utils.js';
 
 export let koboldai_settings;
@@ -262,7 +263,7 @@ function tryParseStreamingError(response, decoded) {
 }
 
 export async function generateKoboldWithStreaming(generate_data, signal) {
-    const response = await fetch('/api/backends/kobold/generate', {
+    const response = await fetchResumable('/api/backends/kobold/generate', {
         headers: getRequestHeaders(),
         body: JSON.stringify(generate_data),
         method: 'POST',

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -13,6 +13,7 @@ import {
 import { MAX_CONTEXT_DEFAULT, MAX_RESPONSE_DEFAULT, power_user } from './power-user.js';
 import { getTextTokens, tokenizers } from './tokenizers.js';
 import { getEventSourceStream } from './sse-stream.js';
+import { fetchResumable } from './resumable-generation.js';
 import {
     getSortableDelay,
     getStringHash,
@@ -772,7 +773,7 @@ function tryParseStreamingError(response, decoded) {
 export async function generateNovelWithStreaming(generate_data, signal) {
     generate_data.streaming = nai_settings.streaming_novel;
 
-    const response = await fetch('/api/novelai/generate', {
+    const response = await fetchResumable('/api/novelai/generate', {
         headers: getRequestHeaders(),
         body: JSON.stringify(generate_data),
         method: 'POST',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -48,6 +48,7 @@ import { forceCharacterEditorTokenize, getCustomStoppingStrings, persona_descrip
 import { rotateSecret, SECRET_KEYS, secret_state, writeSecret } from './secrets.js';
 
 import { getEventSourceStream } from './sse-stream.js';
+import { fetchResumable } from './resumable-generation.js';
 import {
     createThumbnail,
     delay,
@@ -5707,7 +5708,7 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, ca
     console.log(`[OpenAI frontend] sendOpenAIRequest: type=${type} source=${generate_data.chat_completion_source} model=${generate_data.model} stream=${generate_data.stream}`);
 
     const generate_url = '/api/backends/chat-completions/generate';
-    const response = await fetch(generate_url, {
+    const response = await fetchResumable(generate_url, {
         method: 'POST',
         body: JSON.stringify(generate_data),
         headers: getRequestHeaders(),

--- a/public/scripts/resumable-generation.js
+++ b/public/scripts/resumable-generation.js
@@ -334,7 +334,9 @@ if (typeof document !== 'undefined') {
 }
 
 if (typeof window !== 'undefined') {
-    // Desktop browsers fire this on reload and close. iOS Safari never does, which is exactly right:
-    // a backgrounded page keeps its reply, a closed tab does not keep the model busy.
+    // Desktop browsers fire beforeunload on reload and close. iOS Safari never does, but it does
+    // fire pagehide when the tab is actually going away - backgrounding only flips visibility,
+    // which stays silent here so a frozen tab keeps its reply.
     window.addEventListener('beforeunload', cancelActiveGenerations);
+    window.addEventListener('pagehide', cancelActiveGenerations);
 }

--- a/public/scripts/resumable-generation.js
+++ b/public/scripts/resumable-generation.js
@@ -1,0 +1,340 @@
+/**
+ * SillyBunny: generation requests that survive the connection dropping.
+ *
+ * The server keeps a copy of every tagged reply (src/resumable-generations.js). This wrapper tags
+ * each generation request with an id and, when the connection dies or the page wakes up with a
+ * stalled stream, reattaches from the last byte it received. The streaming code above it sees one
+ * uninterrupted response. Aborting the request's signal cancels the generation for real.
+ */
+
+const GENERATION_ID_HEADER = 'X-Generation-Id';
+const RESUME_URL = '/api/resumable-generations/resume';
+const CANCEL_URL = '/api/resumable-generations/cancel';
+const RESUME_RETRY_DELAYS_MS = Object.freeze([0, 1000, 2000, 5000]);
+const MAX_RESUME_ATTEMPTS = 60;
+/** A stream with no bytes for this long when the page becomes visible again gets reconnected. */
+const STALE_STREAM_MS = 5000;
+const SKIPPED_RESPONSE_HEADERS = new Set(['content-encoding', 'content-length', 'transfer-encoding']);
+
+/** @type {Map<string, ResumableRequest>} */
+const activeRequests = new Map();
+
+/**
+ * @returns {string} Random id; crypto.randomUUID needs a secure context, this does not.
+ */
+function createGenerationId() {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * @param {AbortSignal|null} signal Aborted signal
+ * @returns {any} What fetch would have rejected with
+ */
+function abortError(signal) {
+    return signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+}
+
+/**
+ * @param {number} ms Delay
+ * @param {AbortSignal|null} signal Cuts the wait short
+ * @returns {Promise<void>}
+ */
+function sleep(ms, signal) {
+    return new Promise(resolve => {
+        const finish = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener('abort', finish);
+            resolve();
+        };
+        const timer = setTimeout(finish, ms);
+        signal?.addEventListener('abort', finish, { once: true });
+    });
+}
+
+/**
+ * @param {HeadersInit|undefined|null} headers Request headers in any fetch-accepted shape
+ * @returns {Record<string, string>}
+ */
+function headersToObject(headers) {
+    if (!headers) {
+        return {};
+    }
+    if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+        return Object.fromEntries(headers.entries());
+    }
+    if (Array.isArray(headers)) {
+        return Object.fromEntries(headers);
+    }
+    return { ...headers };
+}
+
+/**
+ * @param {Headers} headers Response headers
+ * @returns {Record<string, string>} The same headers minus the ones that describe the wire, not the body
+ */
+function copyResponseHeaders(headers) {
+    /** @type {Record<string, string>} */
+    const copy = {};
+    headers?.forEach?.((value, name) => {
+        if (!SKIPPED_RESPONSE_HEADERS.has(name.toLowerCase())) {
+            copy[name] = value;
+        }
+    });
+    return copy;
+}
+
+class ResumableRequest {
+    /**
+     * @param {string} url Generation endpoint
+     * @param {RequestInit} init Fetch options as the caller passed them
+     */
+    constructor(url, init) {
+        this.id = createGenerationId();
+        this.url = url;
+        this.init = init;
+        this.outerSignal = init.signal ?? null;
+        this.requestHeaders = { ...headersToObject(init.headers), [GENERATION_ID_HEADER]: this.id };
+        // Same CSRF token for the resume/cancel calls, but no generation id: that would register a new one.
+        this.controlHeaders = Object.fromEntries(Object.entries(this.requestHeaders)
+            .filter(([name]) => name.toLowerCase() !== GENERATION_ID_HEADER.toLowerCase()));
+        this.controlHeaders['Content-Type'] = 'application/json';
+        this.received = 0;
+        this.lastByteAt = Date.now();
+        this.finished = false;
+        /** @type {AbortController|null} */
+        this.connection = null;
+        this.handleAbort = () => this.cancel();
+        this.outerSignal?.addEventListener('abort', this.handleAbort, { once: true });
+        activeRequests.set(this.id, this);
+    }
+
+    get aborted() {
+        return Boolean(this.outerSignal?.aborted);
+    }
+
+    /**
+     * Opens a connection this request can drop on its own, without touching the caller's signal.
+     * @param {string} url URL
+     * @param {RequestInit} init Fetch options
+     * @returns {Promise<Response>}
+     */
+    connect(url, init) {
+        this.connection?.abort();
+        const connection = new AbortController();
+        this.connection = connection;
+        if (this.aborted) {
+            connection.abort(abortError(this.outerSignal));
+        }
+        return fetch(url, { ...init, signal: connection.signal });
+    }
+
+    /**
+     * @returns {Promise<Response>} Response whose body reconnects on its own
+     */
+    async open() {
+        let response;
+        try {
+            response = await this.connect(this.url, { ...this.init, headers: this.requestHeaders });
+        } catch (error) {
+            if (this.aborted) {
+                this.finish();
+                throw error;
+            }
+            // Nothing came back, but the server may well be working on it: a non-streaming reply
+            // sends nothing until the whole answer is in. Ask for it rather than giving up.
+            response = await this.resume(error);
+        }
+        return this.wrap(response);
+    }
+
+    /**
+     * @param {{ status: number, statusText: string, headers: Headers, body: ReadableStream<Uint8Array>|null }} response First answer
+     * @returns {Response}
+     */
+    wrap(response) {
+        if (!response.body) {
+            this.finish();
+            return response instanceof Response ? response : new Response(null, { status: response.status, statusText: response.statusText });
+        }
+
+        let reader = response.body.getReader();
+        const body = new ReadableStream({
+            pull: async (controller) => {
+                while (true) {
+                    let result;
+                    try {
+                        result = await reader.read();
+                    } catch (error) {
+                        if (this.aborted) {
+                            this.finish();
+                            controller.error(error);
+                            return;
+                        }
+                        let resumed;
+                        try {
+                            resumed = await this.resume(error);
+                        } catch (resumeError) {
+                            this.finish();
+                            controller.error(resumeError);
+                            return;
+                        }
+                        reader = resumed.body.getReader();
+                        continue;
+                    }
+                    if (result.done) {
+                        this.finish();
+                        controller.close();
+                        return;
+                    }
+                    this.received += result.value.byteLength;
+                    this.lastByteAt = Date.now();
+                    controller.enqueue(result.value);
+                    return;
+                }
+            },
+            cancel: (reason) => {
+                this.finish();
+                this.connection?.abort(reason);
+            },
+        });
+
+        return new Response(body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: copyResponseHeaders(response.headers),
+        });
+    }
+
+    /**
+     * Reattaches from the last byte received.
+     * @param {any} cause What broke the previous connection; rethrown if the server no longer has the reply
+     * @returns {Promise<{ status: number, statusText: string, headers: Headers, body: ReadableStream<Uint8Array> }>}
+     */
+    async resume(cause) {
+        for (let attempt = 0; attempt < MAX_RESUME_ATTEMPTS; attempt++) {
+            const delay = RESUME_RETRY_DELAYS_MS[Math.min(attempt, RESUME_RETRY_DELAYS_MS.length - 1)];
+            if (delay) {
+                await sleep(delay, this.outerSignal);
+            }
+            if (this.aborted) {
+                this.finish();
+                throw abortError(this.outerSignal);
+            }
+
+            let response;
+            try {
+                response = await this.connect(RESUME_URL, {
+                    method: 'POST',
+                    headers: this.controlHeaders,
+                    body: JSON.stringify({ id: this.id, offset: this.received }),
+                    cache: 'no-store',
+                });
+            } catch (error) {
+                if (this.aborted) {
+                    this.finish();
+                    throw abortError(this.outerSignal);
+                }
+                continue;
+            }
+
+            if (response.ok && response.body) {
+                return {
+                    status: Number(response.headers.get('X-Generation-Status')) || 200,
+                    statusText: response.headers.get('X-Generation-Status-Text') ?? '',
+                    headers: response.headers,
+                    body: response.body,
+                };
+            }
+            if (response.status >= 500) {
+                continue;
+            }
+            break;
+        }
+
+        // The reply is gone, or never arrived. Let the original failure surface.
+        this.finish();
+        throw cause;
+    }
+
+    /**
+     * Stops the generation server-side and drops the connection.
+     */
+    cancel() {
+        if (this.finished) {
+            return;
+        }
+        this.finish();
+        this.connection?.abort(abortError(this.outerSignal));
+        fetch(CANCEL_URL, {
+            method: 'POST',
+            headers: this.controlHeaders,
+            body: JSON.stringify({ id: this.id }),
+            keepalive: true,
+        }).catch(() => undefined);
+    }
+
+    finish() {
+        if (this.finished) {
+            return;
+        }
+        this.finished = true;
+        activeRequests.delete(this.id);
+        this.outerSignal?.removeEventListener('abort', this.handleAbort);
+    }
+
+    /**
+     * Drops a connection that has gone quiet, so the reader falls into resume().
+     * @param {number} [now] Current time
+     */
+    reconnectIfStale(now = Date.now()) {
+        if (this.finished || this.aborted || now - this.lastByteAt < STALE_STREAM_MS) {
+            return;
+        }
+        this.connection?.abort();
+    }
+}
+
+/**
+ * Reconnects every in-flight generation that has not received anything for a while.
+ * @param {number} [now] Current time
+ */
+export function reconnectStaleGenerations(now = Date.now()) {
+    for (const request of [...activeRequests.values()]) {
+        request.reconnectIfStale(now);
+    }
+}
+
+/**
+ * Cancels every in-flight generation server-side.
+ */
+export function cancelActiveGenerations() {
+    for (const request of [...activeRequests.values()]) {
+        request.cancel();
+    }
+}
+
+/**
+ * fetch() for generation endpoints: the reply survives the connection dropping and the page being
+ * frozen in the background. Abort the signal in `init` to cancel the generation for real.
+ * @param {string} url Generation endpoint
+ * @param {RequestInit} [init] Fetch options; `headers` must be a plain object or Headers instance
+ * @returns {Promise<Response>}
+ */
+export function fetchResumable(url, init = {}) {
+    return new ResumableRequest(url, init).open();
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+            reconnectStaleGenerations();
+        }
+    });
+}
+
+if (typeof window !== 'undefined') {
+    // Desktop browsers fire this on reload and close. iOS Safari never does, which is exactly right:
+    // a backgrounded page keeps its reply, a closed tab does not keep the model busy.
+    window.addEventListener('beforeunload', cancelActiveGenerations);
+}

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -31,6 +31,7 @@ import {
 } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
+import { fetchResumable } from './resumable-generation.js';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from './local-url-utils.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
@@ -1387,7 +1388,7 @@ function setSettingByName(setting, value, trigger) {
 export async function generateTextGenWithStreaming(generate_data, signal) {
     generate_data.stream = true;
 
-    const response = await fetch('/api/backends/text-completions/generate', {
+    const response = await fetchResumable('/api/backends/text-completions/generate', {
         headers: {
             ...getRequestHeaders(),
         },

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -42,6 +42,7 @@ import {
     summarizeLlmPayloadForLog,
 } from '../../util.js';
 import { isRequestCancellationError } from '../../request-cancellation.js';
+import { getResumableGeneration } from '../../resumable-generations.js';
 import {
     convertClaudeMessages,
     convertGooglePrompt,
@@ -2680,9 +2681,15 @@ function forwardResponsesApiStream(fetchResponse, expressResponse, request, onDi
         }
     });
 
-    expressResponse.on('close', () => {
-        closeStream();
-    });
+    const resumableGeneration = getResumableGeneration(request);
+    if (resumableGeneration) {
+        // SillyBunny: a resumable generation finishes without the client; only an explicit cancel stops it.
+        resumableGeneration.onCancel(closeStream);
+    } else {
+        expressResponse.on('close', () => {
+            closeStream();
+        });
+    }
 }
 
 /**

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -99,8 +99,22 @@ async function parseOllamaStream(jsonStream, request, response, onDisconnect = n
             response.end();
         });
 
-        jsonStream.body.on('error', () => {
+        jsonStream.body.on('error', (error) => {
+            if (done) {
+                return;
+            }
+
+            done = true;
             stopPolling();
+            console.error('Ollama streaming request failed:', error);
+            try {
+                jsonStream.body?.destroy?.();
+            } catch {
+                // Best effort; the stream is already failing.
+            }
+            if (!response.writableEnded) {
+                response.end();
+            }
         });
     } catch (error) {
         console.error('Error forwarding streaming response:', error);

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -13,6 +13,7 @@ import {
     OPENAI_KEYS,
 } from '../../constants.js';
 import { abortOnRequestClose, forwardFetchResponse, trimV1, getConfigValue, pollStreamingRequestConnection, summarizeLlmPayloadForLog } from '../../util.js';
+import { getResumableGeneration } from '../../resumable-generations.js';
 import { setAdditionalHeaders } from '../../additional-headers.js';
 import { createHash } from 'node:crypto';
 
@@ -78,7 +79,13 @@ async function parseOllamaStream(jsonStream, request, response, onDisconnect = n
             }
         });
 
-        request.socket.on('close', closeStream);
+        const resumableGeneration = getResumableGeneration(request);
+        if (resumableGeneration) {
+            // SillyBunny: a resumable generation finishes without the client; only an explicit cancel stops it.
+            resumableGeneration.onCancel(closeStream);
+        } else {
+            request.socket.on('close', closeStream);
+        }
 
         jsonStream.body.on('end', () => {
             if (done) {

--- a/src/request-cancellation.js
+++ b/src/request-cancellation.js
@@ -1,4 +1,5 @@
 import { pollSocketConnection } from './connection-state-checker.js';
+import { getResumableGeneration } from './resumable-generations.js';
 
 export const REQUEST_CANCELLATION_ABORT_REASON = 'Client disconnected';
 const DEFAULT_ABORT_HOOK_TIMEOUT_MS = 5000;
@@ -189,21 +190,31 @@ export function observeRequestCancellation(request, response = null, {
         abort('response-close');
     }
 
-    cleanupCallbacks.push(
-        once(request, 'aborted', () => abort('request-aborted')),
-        once(request, 'close', handleRequestClose),
-        once(response, 'close', handleResponseClose),
-        once(response, 'finish', cleanup),
-        once(request?.socket, 'close', () => abort('socket-close')),
-        once(controller.signal, 'abort', cleanup),
-    );
+    const resumableGeneration = getResumableGeneration(request);
+    if (resumableGeneration) {
+        // SillyBunny: a resumable generation outlives its client; only an explicit cancel aborts upstream.
+        cleanupCallbacks.push(
+            resumableGeneration.onCancel(() => abort('resumable-cancel')),
+            once(response, 'finish', cleanup),
+            once(controller.signal, 'abort', cleanup),
+        );
+    } else {
+        cleanupCallbacks.push(
+            once(request, 'aborted', () => abort('request-aborted')),
+            once(request, 'close', handleRequestClose),
+            once(response, 'close', handleResponseClose),
+            once(response, 'finish', cleanup),
+            once(request?.socket, 'close', () => abort('socket-close')),
+            once(controller.signal, 'abort', cleanup),
+        );
 
-    if (pollConnection && request?.socket && typeof startConnectionPolling === 'function') {
-        cleanupCallbacks.push(startConnectionPolling(
-            request.socket,
-            normalizePositiveNumber(pollIntervalMs, DEFAULT_CONNECTION_POLL_INTERVAL_MS),
-            () => abort('socket-poll'),
-        ));
+        if (pollConnection && request?.socket && typeof startConnectionPolling === 'function') {
+            cleanupCallbacks.push(startConnectionPolling(
+                request.socket,
+                normalizePositiveNumber(pollIntervalMs, DEFAULT_CONNECTION_POLL_INTERVAL_MS),
+                () => abort('socket-poll'),
+            ));
+        }
     }
 
     return {

--- a/src/resumable-generations.js
+++ b/src/resumable-generations.js
@@ -150,11 +150,7 @@ export class ResumableGeneration {
         if (this.size + buffer.length > MAX_BUFFER_BYTES) {
             // ponytail: a text reply never gets here; if it does, forget it rather than eat the heap.
             this.overflowed = true;
-            generations.delete(this.key);
-            for (const subscriber of this.subscribers) {
-                subscriber.onFail?.();
-            }
-            this.subscribers.clear();
+            this.forceDiscard();
             return;
         }
         this.chunks.push(buffer);
@@ -175,6 +171,25 @@ export class ResumableGeneration {
             subscriber.onEnd();
         }
         this.subscribers.clear();
+    }
+
+    forceDiscard() {
+        if (generations.get(this.key) === this) {
+            generations.delete(this.key);
+        }
+        if (!this.done) {
+            const subscribers = [...this.subscribers];
+            this.subscribers.clear();
+            for (const subscriber of subscribers) {
+                subscriber.onFail?.();
+            }
+            this.cancel();
+            this.end();
+        } else {
+            this.subscribers.clear();
+        }
+        this.chunks = [];
+        this.size = 0;
     }
 
     /**
@@ -287,7 +302,7 @@ function registerGeneration(key) {
     generations.delete(key);
     generations.set(key, generation);
     while (generations.size > MAX_GENERATIONS) {
-        generations.delete(generations.keys().next().value);
+        generations.values().next().value.forceDiscard();
     }
     if (!sweepTimer) {
         sweepTimer = setInterval(sweepGenerations, SWEEP_INTERVAL_MS);
@@ -346,6 +361,12 @@ function attachResponse(response, generation) {
         }
         generation.captureHeaders(this);
         generation.write(chunk, encoding);
+        if (this.writableEnded) {
+            if (typeof callback === 'function') {
+                callback();
+            }
+            return this;
+        }
         generation.end();
         try {
             return end.call(this, chunk, encoding, callback);
@@ -450,6 +471,8 @@ router.post('/cancel', (request, response) => {
 export const testExports = {
     FINISHED_RETENTION_MS,
     MAX_LIFETIME_MS,
+    MAX_GENERATIONS,
+    MAX_BUFFER_BYTES,
     generations,
     sweepGenerations,
 };

--- a/src/resumable-generations.js
+++ b/src/resumable-generations.js
@@ -1,0 +1,455 @@
+import { Buffer } from 'node:buffer';
+import express from 'express';
+
+/**
+ * SillyBunny: generation replies that outlive the client connection.
+ *
+ * A generation request tagged with the X-Generation-Id header is registered here. Everything the
+ * handler writes to the Express response is also kept in memory, and the disconnect handling in
+ * util.js / request-cancellation.js stops treating a vanished client as a reason to abort the
+ * upstream request. The page can pick the reply back up from any byte offset (POST /resume) or
+ * cancel it for real (POST /cancel). Phones that freeze background tabs are why this exists.
+ */
+
+export const RESUMABLE_GENERATION_HEADER = 'x-generation-id';
+const GENERATION_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+/** A finished reply waits this long for the page to come back for it. */
+const FINISHED_RETENTION_MS = 15 * 60 * 1000;
+/** A reply still running after this long is cancelled, attached client or not. */
+const MAX_LIFETIME_MS = 60 * 60 * 1000;
+const MAX_GENERATIONS = 200;
+const MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+/** @type {Map<string, ResumableGeneration>} */
+const generations = new Map();
+/** @type {ReturnType<typeof setInterval>|null} */
+let sweepTimer = null;
+
+/**
+ * @param {unknown} chunk Anything a handler may pass to response.write()
+ * @param {unknown} encoding Optional string encoding
+ * @returns {Buffer|null}
+ */
+function toBuffer(chunk, encoding) {
+    if (chunk === undefined || chunk === null) {
+        return null;
+    }
+    if (Buffer.isBuffer(chunk)) {
+        return chunk;
+    }
+    if (typeof chunk === 'string') {
+        return Buffer.from(chunk, typeof encoding === 'string' ? /** @type {BufferEncoding} */ (encoding) : 'utf8');
+    }
+    if (ArrayBuffer.isView(chunk)) {
+        return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    }
+    return null;
+}
+
+/**
+ * @param {() => void | Promise<void>} hook Cancel hook
+ */
+function runCancelHook(hook) {
+    try {
+        const result = hook();
+        if (result && typeof result.catch === 'function') {
+            result.catch(error => console.warn('Error cancelling resumable generation:', error));
+        }
+    } catch (error) {
+        console.warn('Error cancelling resumable generation:', error);
+    }
+}
+
+/**
+ * @typedef {object} ResumableSubscriber
+ * @property {(chunk: Buffer) => void} onChunk Called for every byte range, replayed or live
+ * @property {() => void} onEnd Called once the reply is complete
+ * @property {() => void} [onFail] Called if the reply can no longer be served
+ */
+
+export class ResumableGeneration {
+    /**
+     * @param {string} key Registry key
+     */
+    constructor(key) {
+        this.key = key;
+        this.createdAt = Date.now();
+        /** @type {number|null} */
+        this.finishedAt = null;
+        /** @type {number|null} */
+        this.statusCode = null;
+        this.statusMessage = '';
+        /** @type {string|null} */
+        this.contentType = null;
+        this.cancelled = false;
+        this.overflowed = false;
+        /** @type {Buffer[]} */
+        this.chunks = [];
+        this.size = 0;
+        /** @type {Set<() => void | Promise<void>>} */
+        this.cancelHooks = new Set();
+        /** @type {Set<ResumableSubscriber>} */
+        this.subscribers = new Set();
+        /** @type {(() => void)[]} */
+        this.headerWaiters = [];
+    }
+
+    get done() {
+        return this.finishedAt !== null;
+    }
+
+    get headersReady() {
+        return this.statusCode !== null;
+    }
+
+    /**
+     * Remembers the status and content type from the first write so a replay can reproduce them.
+     * @param {import('express').Response} response Express response being written
+     */
+    captureHeaders(response) {
+        if (this.headersReady) {
+            return;
+        }
+        this.statusCode = Number(response?.statusCode) || 200;
+        this.statusMessage = String(response?.statusMessage ?? '');
+        const contentType = response?.getHeader?.('content-type');
+        this.contentType = contentType ? String(contentType) : null;
+        this.releaseHeaderWaiters();
+    }
+
+    releaseHeaderWaiters() {
+        for (const resolve of this.headerWaiters.splice(0)) {
+            resolve();
+        }
+    }
+
+    /**
+     * Resolves once the handler has started answering (or given up).
+     * @returns {Promise<void>}
+     */
+    waitForHeaders() {
+        if (this.headersReady || this.done) {
+            return Promise.resolve();
+        }
+        return new Promise(resolve => this.headerWaiters.push(resolve));
+    }
+
+    /**
+     * @param {unknown} chunk Response bytes
+     * @param {unknown} [encoding] String encoding
+     */
+    write(chunk, encoding) {
+        if (this.done || this.overflowed) {
+            return;
+        }
+        const buffer = toBuffer(chunk, encoding);
+        if (!buffer?.length) {
+            return;
+        }
+        if (this.size + buffer.length > MAX_BUFFER_BYTES) {
+            // ponytail: a text reply never gets here; if it does, forget it rather than eat the heap.
+            this.overflowed = true;
+            generations.delete(this.key);
+            for (const subscriber of this.subscribers) {
+                subscriber.onFail?.();
+            }
+            this.subscribers.clear();
+            return;
+        }
+        this.chunks.push(buffer);
+        this.size += buffer.length;
+        for (const subscriber of this.subscribers) {
+            subscriber.onChunk(buffer);
+        }
+    }
+
+    end() {
+        if (this.done) {
+            return;
+        }
+        this.finishedAt = Date.now();
+        this.cancelHooks.clear();
+        this.releaseHeaderWaiters();
+        for (const subscriber of this.subscribers) {
+            subscriber.onEnd();
+        }
+        this.subscribers.clear();
+    }
+
+    /**
+     * Registers work to run if the generation is cancelled.
+     * @param {() => void | Promise<void>} hook Cancel hook
+     * @returns {() => void} Unregister
+     */
+    onCancel(hook) {
+        if (typeof hook !== 'function' || this.done) {
+            return () => undefined;
+        }
+        if (this.cancelled) {
+            runCancelHook(hook);
+            return () => undefined;
+        }
+        this.cancelHooks.add(hook);
+        return () => this.cancelHooks.delete(hook);
+    }
+
+    /**
+     * Stops the upstream work. Safe to call more than once.
+     * @returns {boolean} Whether there was anything left to cancel
+     */
+    cancel() {
+        if (this.cancelled || this.done) {
+            return false;
+        }
+        this.cancelled = true;
+        const hooks = [...this.cancelHooks];
+        this.cancelHooks.clear();
+        for (const hook of hooks) {
+            runCancelHook(hook);
+        }
+        return true;
+    }
+
+    /**
+     * Replays everything from a byte offset, then forwards live chunks until the reply ends.
+     * @param {number} offset Bytes the subscriber already has
+     * @param {ResumableSubscriber} subscriber Sink
+     * @returns {() => void} Unsubscribe
+     */
+    subscribe(offset, subscriber) {
+        let skip = Math.max(0, Math.min(offset, this.size));
+        for (const chunk of this.chunks) {
+            if (skip >= chunk.length) {
+                skip -= chunk.length;
+                continue;
+            }
+            subscriber.onChunk(skip > 0 ? chunk.subarray(skip) : chunk);
+            skip = 0;
+        }
+        if (this.done) {
+            subscriber.onEnd();
+            return () => undefined;
+        }
+        this.subscribers.add(subscriber);
+        return () => this.subscribers.delete(subscriber);
+    }
+}
+
+/**
+ * @param {import('express').Request} request Express request
+ * @param {string} id Client-chosen generation id
+ * @returns {string}
+ */
+function getGenerationKey(request, id) {
+    return `${request?.user?.profile?.handle ?? ''}:${id}`;
+}
+
+/**
+ * @param {number} [now] Current time
+ */
+function sweepGenerations(now = Date.now()) {
+    for (const [key, generation] of generations) {
+        const expired = generation.done
+            ? now - generation.finishedAt > FINISHED_RETENTION_MS
+            : now - generation.createdAt > MAX_LIFETIME_MS;
+        if (!expired) {
+            continue;
+        }
+        generations.delete(key);
+        if (!generation.done) {
+            generation.cancel();
+            generation.end();
+        }
+    }
+    if (generations.size === 0 && sweepTimer) {
+        clearInterval(sweepTimer);
+        sweepTimer = null;
+    }
+}
+
+/**
+ * @param {string} key Registry key
+ * @returns {ResumableGeneration}
+ */
+function registerGeneration(key) {
+    // A flaky connection can make the browser replay a POST whose response never started. That
+    // arrives as a second registration of the same id, and without this the superseded generation
+    // would keep running upstream with nobody to read it - one client request, two model calls.
+    const superseded = generations.get(key);
+    if (superseded && !superseded.done) {
+        console.info('Superseding an earlier resumable generation for the same id');
+        superseded.cancel();
+        superseded.end();
+    }
+
+    const generation = new ResumableGeneration(key);
+    generations.delete(key);
+    generations.set(key, generation);
+    while (generations.size > MAX_GENERATIONS) {
+        generations.delete(generations.keys().next().value);
+    }
+    if (!sweepTimer) {
+        sweepTimer = setInterval(sweepGenerations, SWEEP_INTERVAL_MS);
+        sweepTimer.unref?.();
+    }
+    return generation;
+}
+
+/**
+ * The generation registered for this request, if the client asked for a resumable one.
+ * @param {import('express').Request|null|undefined} request Express request
+ * @returns {ResumableGeneration|null}
+ */
+export function getResumableGeneration(request) {
+    return request?.resumableGeneration ?? null;
+}
+
+/**
+ * Mirrors every write to the generation, and keeps writes after the client is gone from throwing.
+ * @param {import('express').Response} response Express response
+ * @param {ResumableGeneration} generation Generation to mirror into
+ */
+function attachResponse(response, generation) {
+    const write = response.write;
+    const end = response.end;
+
+    response.write = function (chunk, encoding, callback) {
+        if (typeof encoding === 'function') {
+            callback = encoding;
+            encoding = undefined;
+        }
+        generation.captureHeaders(this);
+        generation.write(chunk, encoding);
+        if (this.writableEnded) {
+            if (typeof callback === 'function') {
+                callback();
+            }
+            return false;
+        }
+        try {
+            return write.call(this, chunk, encoding, callback);
+        } catch (error) {
+            console.warn('Resumable generation client write failed:', error?.message ?? error);
+            return false;
+        }
+    };
+
+    response.end = function (chunk, encoding, callback) {
+        if (typeof chunk === 'function') {
+            callback = chunk;
+            chunk = undefined;
+            encoding = undefined;
+        } else if (typeof encoding === 'function') {
+            callback = encoding;
+            encoding = undefined;
+        }
+        generation.captureHeaders(this);
+        generation.write(chunk, encoding);
+        generation.end();
+        try {
+            return end.call(this, chunk, encoding, callback);
+        } catch (error) {
+            console.warn('Resumable generation client end failed:', error?.message ?? error);
+            return this;
+        }
+    };
+}
+
+/**
+ * Registers a resumable generation when the request carries the X-Generation-Id header.
+ * @param {import('express').Request} request Express request
+ * @param {import('express').Response} response Express response
+ * @param {import('express').NextFunction} next Next middleware
+ */
+export function resumableGenerationMiddleware(request, response, next) {
+    const id = String(request.get?.(RESUMABLE_GENERATION_HEADER) ?? '');
+    if (!GENERATION_ID_PATTERN.test(id)) {
+        return next();
+    }
+    const generation = registerGeneration(getGenerationKey(request, id));
+    request.resumableGeneration = generation;
+    attachResponse(response, generation);
+    return next();
+}
+
+/**
+ * @param {import('express').Request} request Express request
+ * @returns {ResumableGeneration|null}
+ */
+function findGeneration(request) {
+    const id = String(request.body?.id ?? '');
+    if (!GENERATION_ID_PATTERN.test(id)) {
+        return null;
+    }
+    return generations.get(getGenerationKey(request, id)) ?? null;
+}
+
+export const router = express.Router();
+
+router.post('/resume', async (request, response) => {
+    const generation = findGeneration(request);
+    if (!generation) {
+        return response.sendStatus(404);
+    }
+
+    const offset = Number(request.body?.offset ?? 0);
+    if (!Number.isInteger(offset) || offset < 0) {
+        return response.sendStatus(400);
+    }
+
+    await generation.waitForHeaders();
+
+    if (response.destroyed || response.writableEnded) {
+        return;
+    }
+    if (!generation.headersReady) {
+        return response.sendStatus(410);
+    }
+    if (offset > generation.size) {
+        return response.sendStatus(416);
+    }
+
+    response.status(200);
+    response.setHeader('Cache-Control', 'no-store, no-transform');
+    response.setHeader('X-Generation-Status', String(generation.statusCode));
+    const statusText = generation.statusMessage.replace(/[^\x20-\x7E]/g, '').slice(0, 200);
+    if (statusText) {
+        response.setHeader('X-Generation-Status-Text', statusText);
+    }
+    if (generation.contentType) {
+        response.setHeader('Content-Type', generation.contentType);
+    }
+    response.flushHeaders();
+
+    const unsubscribe = generation.subscribe(offset, {
+        onChunk: chunk => {
+            if (!response.writableEnded && !response.destroyed) {
+                response.write(chunk);
+            }
+        },
+        onEnd: () => {
+            if (!response.writableEnded) {
+                response.end();
+            }
+        },
+        onFail: () => response.destroy(),
+    });
+    response.on('close', unsubscribe);
+});
+
+router.post('/cancel', (request, response) => {
+    const generation = findGeneration(request);
+    if (!generation) {
+        return response.sendStatus(404);
+    }
+    generation.cancel();
+    return response.sendStatus(204);
+});
+
+export const testExports = {
+    FINISHED_RETENTION_MS,
+    MAX_LIFETIME_MS,
+    generations,
+    sweepGenerations,
+};

--- a/src/resumable-generations.js
+++ b/src/resumable-generations.js
@@ -18,13 +18,23 @@ const FINISHED_RETENTION_MS = 15 * 60 * 1000;
 /** A reply still running after this long is cancelled, attached client or not. */
 const MAX_LIFETIME_MS = 60 * 60 * 1000;
 const MAX_GENERATIONS = 200;
+/** One profile cannot hold more than this many replies, live or finished. */
+const MAX_GENERATIONS_PER_PROFILE = 20;
 const MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+/** Every buffered reply together stays under this; finished replies hand their bytes back first. */
+const MAX_TOTAL_BUFFER_BYTES = 256 * 1024 * 1024;
+/** A reply serves at most this many concurrent resume readers, queued or attached. */
+const MAX_RESUME_CLIENTS = 8;
+/** A resume reader that falls behind by more than this gets dropped instead of buffered into. */
+const MAX_RESUME_BACKLOG_BYTES = 8 * 1024 * 1024;
 const SWEEP_INTERVAL_MS = 60 * 1000;
 
 /** @type {Map<string, ResumableGeneration>} */
 const generations = new Map();
 /** @type {ReturnType<typeof setInterval>|null} */
 let sweepTimer = null;
+/** Every byte currently mirrored into the registry, across all profiles. */
+let totalBufferedBytes = 0;
 
 /**
  * @param {unknown} chunk Anything a handler may pass to response.write()
@@ -91,7 +101,7 @@ export class ResumableGeneration {
         this.cancelHooks = new Set();
         /** @type {Set<ResumableSubscriber>} */
         this.subscribers = new Set();
-        /** @type {(() => void)[]} */
+        /** @type {{ resolve: () => void }[]} */
         this.headerWaiters = [];
     }
 
@@ -119,20 +129,46 @@ export class ResumableGeneration {
     }
 
     releaseHeaderWaiters() {
-        for (const resolve of this.headerWaiters.splice(0)) {
-            resolve();
+        for (const waiter of this.headerWaiters.splice(0)) {
+            waiter.resolve();
         }
     }
 
     /**
-     * Resolves once the handler has started answering (or given up).
-     * @returns {Promise<void>}
+     * Waits for the handler to start answering, with a handle for giving up when the waiting
+     * client disappears - otherwise an abandoned pre-header resume would hold its resources
+     * until the generation finishes on its own.
+     * @returns {{ promise: Promise<void>, cancel: () => void }}
      */
     waitForHeaders() {
         if (this.headersReady || this.done) {
-            return Promise.resolve();
+            return { promise: Promise.resolve(), cancel: () => undefined };
         }
-        return new Promise(resolve => this.headerWaiters.push(resolve));
+        let resolve;
+        const promise = new Promise(settle => {
+            resolve = settle;
+        });
+        const waiter = { resolve: () => resolve() };
+        this.headerWaiters.push(waiter);
+        return {
+            promise,
+            cancel: () => {
+                const index = this.headerWaiters.indexOf(waiter);
+                if (index !== -1) {
+                    this.headerWaiters.splice(index, 1);
+                    resolve();
+                }
+            },
+        };
+    }
+
+    /**
+     * Gives the buffered reply bytes back to the global budget. Safe to call twice.
+     */
+    freeBuffers() {
+        totalBufferedBytes -= this.size;
+        this.chunks = [];
+        this.size = 0;
     }
 
     /**
@@ -147,7 +183,8 @@ export class ResumableGeneration {
         if (!buffer?.length) {
             return;
         }
-        if (this.size + buffer.length > MAX_BUFFER_BYTES) {
+        if (this.size + buffer.length > MAX_BUFFER_BYTES ||
+            (totalBufferedBytes + buffer.length > MAX_TOTAL_BUFFER_BYTES && !fitGlobalByteBudget(buffer.length))) {
             // ponytail: a text reply never gets here; if it does, forget it rather than eat the heap.
             this.overflowed = true;
             this.forceDiscard();
@@ -155,6 +192,7 @@ export class ResumableGeneration {
         }
         this.chunks.push(buffer);
         this.size += buffer.length;
+        totalBufferedBytes += buffer.length;
         for (const subscriber of this.subscribers) {
             subscriber.onChunk(buffer);
         }
@@ -188,8 +226,7 @@ export class ResumableGeneration {
         } else {
             this.subscribers.clear();
         }
-        this.chunks = [];
-        this.size = 0;
+        this.freeBuffers();
     }
 
     /**
@@ -230,9 +267,12 @@ export class ResumableGeneration {
      * Replays everything from a byte offset, then forwards live chunks until the reply ends.
      * @param {number} offset Bytes the subscriber already has
      * @param {ResumableSubscriber} subscriber Sink
-     * @returns {() => void} Unsubscribe
+     * @returns {(() => void)|null} Unsubscribe, or null when too many readers are attached
      */
     subscribe(offset, subscriber) {
+        if (this.subscribers.size >= MAX_RESUME_CLIENTS) {
+            return null;
+        }
         let skip = Math.max(0, Math.min(offset, this.size));
         for (const chunk of this.chunks) {
             if (skip >= chunk.length) {
@@ -252,29 +292,77 @@ export class ResumableGeneration {
 }
 
 /**
+ * Tries to absorb upcoming bytes by dropping finished replies, oldest first. Live generations are
+ * never touched for the byte budget - losing a cached reply costs a resume, losing a live one
+ * costs the model call.
+ * @param {number} needed Bytes the caller wants to append
+ * @returns {boolean} Whether the budget can take the bytes now
+ */
+function fitGlobalByteBudget(needed) {
+    for (const generation of generations.values()) {
+        if (totalBufferedBytes + needed <= MAX_TOTAL_BUFFER_BYTES) {
+            return true;
+        }
+        if (generation.done) {
+            generation.forceDiscard();
+        }
+    }
+    return totalBufferedBytes + needed <= MAX_TOTAL_BUFFER_BYTES;
+}
+
+/**
+ * @param {import('express').Request} request Express request
+ * @returns {string} Profile handle the request is authenticated as
+ */
+function getProfileHandle(request) {
+    return request?.user?.profile?.handle ?? '';
+}
+
+/**
  * @param {import('express').Request} request Express request
  * @param {string} id Client-chosen generation id
  * @returns {string}
  */
 function getGenerationKey(request, id) {
-    return `${request?.user?.profile?.handle ?? ''}:${id}`;
+    return `${getProfileHandle(request)}:${id}`;
+}
+
+/**
+ * Makes room for a new registration. An over-cap profile gives up its own oldest entries,
+ * finished ones first; globally only finished replies are fair game. Another profile's live
+ * generation is never discarded to make room - that would let anyone cancel anyone else's
+ * model call.
+ * @param {string} handle Profile handle of the incoming registration
+ * @returns {boolean} Whether a new registration fits the global cap
+ */
+function trimRegistry(handle) {
+    const prefix = `${handle}:`;
+    let owned = [...generations.entries()].filter(([key]) => key.startsWith(prefix));
+    while (owned.length >= MAX_GENERATIONS_PER_PROFILE) {
+        const victim = (owned.find(([, generation]) => generation.done) ?? owned[0])[1];
+        victim.forceDiscard();
+        owned = owned.filter(([, generation]) => generation !== victim);
+    }
+    while (generations.size >= MAX_GENERATIONS) {
+        const oldestFinished = [...generations.values()].find(generation => generation.done);
+        if (!oldestFinished) {
+            return false;
+        }
+        oldestFinished.forceDiscard();
+    }
+    return true;
 }
 
 /**
  * @param {number} [now] Current time
  */
 function sweepGenerations(now = Date.now()) {
-    for (const [key, generation] of generations) {
+    for (const generation of generations.values()) {
         const expired = generation.done
             ? now - generation.finishedAt > FINISHED_RETENTION_MS
             : now - generation.createdAt > MAX_LIFETIME_MS;
-        if (!expired) {
-            continue;
-        }
-        generations.delete(key);
-        if (!generation.done) {
-            generation.cancel();
-            generation.end();
+        if (expired) {
+            generation.forceDiscard();
         }
     }
     if (generations.size === 0 && sweepTimer) {
@@ -284,10 +372,12 @@ function sweepGenerations(now = Date.now()) {
 }
 
 /**
+ * @param {string} handle Profile handle
  * @param {string} key Registry key
- * @returns {ResumableGeneration}
+ * @returns {ResumableGeneration|null} The new generation, or null when the registry is full of
+ * live replies and the request has to proceed without resume support
  */
-function registerGeneration(key) {
+function registerGeneration(handle, key) {
     // A flaky connection can make the browser replay a POST whose response never started. That
     // arrives as a second registration of the same id, and without this the superseded generation
     // would keep running upstream with nobody to read it - one client request, two model calls.
@@ -297,13 +387,18 @@ function registerGeneration(key) {
         superseded.cancel();
         superseded.end();
     }
+    if (superseded) {
+        superseded.freeBuffers();
+        generations.delete(key);
+    }
+
+    if (!trimRegistry(handle)) {
+        console.warn('Too many live resumable generations; serving this request without resume support');
+        return null;
+    }
 
     const generation = new ResumableGeneration(key);
-    generations.delete(key);
     generations.set(key, generation);
-    while (generations.size > MAX_GENERATIONS) {
-        generations.values().next().value.forceDiscard();
-    }
     if (!sweepTimer) {
         sweepTimer = setInterval(sweepGenerations, SWEEP_INTERVAL_MS);
         sweepTimer.unref?.();
@@ -388,7 +483,10 @@ export function resumableGenerationMiddleware(request, response, next) {
     if (!GENERATION_ID_PATTERN.test(id)) {
         return next();
     }
-    const generation = registerGeneration(getGenerationKey(request, id));
+    const generation = registerGeneration(getProfileHandle(request), getGenerationKey(request, id));
+    if (!generation) {
+        return next();
+    }
     request.resumableGeneration = generation;
     attachResponse(response, generation);
     return next();
@@ -419,7 +517,16 @@ router.post('/resume', async (request, response) => {
         return response.sendStatus(400);
     }
 
-    await generation.waitForHeaders();
+    // Queued waiters become readers, so they count against the same limit; otherwise a full
+    // queue would graduate into rejections after the headers finally arrive.
+    if (!generation.headersReady && !generation.done &&
+        generation.subscribers.size + generation.headerWaiters.length >= MAX_RESUME_CLIENTS) {
+        return response.sendStatus(503);
+    }
+
+    const wait = generation.waitForHeaders();
+    response.on('close', () => wait.cancel());
+    await wait.promise;
 
     if (response.destroyed || response.writableEnded) {
         return;
@@ -429,6 +536,9 @@ router.post('/resume', async (request, response) => {
     }
     if (offset > generation.size) {
         return response.sendStatus(416);
+    }
+    if (generation.subscribers.size >= MAX_RESUME_CLIENTS) {
+        return response.sendStatus(429);
     }
 
     response.status(200);
@@ -443,10 +553,17 @@ router.post('/resume', async (request, response) => {
     }
     response.flushHeaders();
 
-    const unsubscribe = generation.subscribe(offset, {
+    let unsubscribe = () => undefined;
+    unsubscribe = generation.subscribe(offset, {
         onChunk: chunk => {
-            if (!response.writableEnded && !response.destroyed) {
-                response.write(chunk);
+            if (response.writableEnded || response.destroyed) {
+                return;
+            }
+            response.write(chunk);
+            if (response.writableLength > MAX_RESUME_BACKLOG_BYTES) {
+                // This reader stopped draining; drop it instead of buffering the reply into RAM.
+                unsubscribe();
+                response.destroy();
             }
         },
         onEnd: () => {
@@ -472,7 +589,20 @@ export const testExports = {
     FINISHED_RETENTION_MS,
     MAX_LIFETIME_MS,
     MAX_GENERATIONS,
+    MAX_GENERATIONS_PER_PROFILE,
     MAX_BUFFER_BYTES,
+    MAX_TOTAL_BUFFER_BYTES,
+    MAX_RESUME_CLIENTS,
     generations,
     sweepGenerations,
+    get totalBufferedBytes() {
+        return totalBufferedBytes;
+    },
+    /**
+     * Test seam for simulating a loaded byte budget without allocating hundreds of megabytes.
+     * @param {number} value Absolute byte total to pretend is currently buffered
+     */
+    setTotalBufferedBytes(value) {
+        totalBufferedBytes = value;
+    },
 };

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -59,6 +59,7 @@ import { router as serverAdminRouter } from './endpoints/server-admin.js';
 import { router as inChatAgentsRouter } from './endpoints/in-chat-agents.js';
 // SillyBunny divergence: keep Conversation REST mounted here only; endpoint behavior stays isolated in its fork-owned router for upstream syncs.
 import { router as sillyBunnyConversationRouter } from './endpoints/sillybunny-conversation.js';
+import { resumableGenerationMiddleware, router as resumableGenerationsRouter } from './resumable-generations.js';
 
 /**
  * @typedef {object} ServerStartupResult
@@ -76,6 +77,9 @@ import { router as sillyBunnyConversationRouter } from './endpoints/sillybunny-c
  */
 export function setupPrivateEndpoints(app) {
     app.use('/', userDataRouter);
+    // SillyBunny: resumable generations. The router is mounted first so its own requests never register as generations.
+    app.use('/api/resumable-generations', resumableGenerationsRouter);
+    app.use(resumableGenerationMiddleware);
     app.use('/api/users', usersPrivateRouter);
     app.use('/api/users', usersAdminRouter);
     app.use('/api/moving-ui', movingUIRouter);

--- a/src/util.js
+++ b/src/util.js
@@ -22,6 +22,7 @@ import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { isFirefox } from './express-common.js';
 import { pollSocketConnection } from './connection-state-checker.js';
 import { isRequestCancellationError, observeRequestCancellation } from './request-cancellation.js';
+import { getResumableGeneration } from './resumable-generations.js';
 import { isBunRuntime } from './runtime.js';
 
 const DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS = 150;
@@ -717,6 +718,11 @@ function getStreamingConnectionPollingInterval() {
  * @returns {() => void} Stops polling.
  */
 export function pollStreamingRequestConnection(request, response, onDisconnect) {
+    // SillyBunny: a resumable generation is never aborted by a client disconnect. See resumable-generations.js.
+    if (getResumableGeneration(request)) {
+        return () => undefined;
+    }
+
     if (!request?.socket || response?.writableEnded || response?.destroyed) {
         return () => undefined;
     }
@@ -739,6 +745,62 @@ export function pollStreamingRequestConnection(request, response, onDisconnect) 
         } catch (error) {
             console.warn('Error handling streaming client disconnect:', error);
         }
+    });
+}
+
+/**
+ * SillyBunny: drains the upstream body to the end even after the client has gone, so a resumable
+ * generation (see resumable-generations.js) can be picked up later. Only an explicit cancel stops it.
+ * @param {import('node-fetch').Response} from The Fetch API response to drain.
+ * @param {import('express').Response} to The Express response; writes after the client left are mirrored, not sent.
+ * @param {import('./resumable-generations.js').ResumableGeneration} generation The registered generation.
+ * @param {() => void | Promise<void>} [onDisconnect] Provider-specific abort hook, run on cancel.
+ */
+function forwardResumableFetchBody(from, to, generation, onDisconnect = null) {
+    const unregisterCancel = generation.onCancel(() => {
+        try {
+            const disconnectResult = onDisconnect?.();
+            if (disconnectResult && typeof disconnectResult.catch === 'function') {
+                disconnectResult.catch(error => console.warn('Error cancelling resumable generation:', error));
+            }
+        } catch (error) {
+            console.warn('Error cancelling resumable generation:', error);
+        }
+
+        try {
+            from.body?.destroy?.();
+        } catch {
+            // Best effort; the upstream stream is going away anyway.
+        }
+
+        if (!to.writableEnded) {
+            to.end();
+        }
+    });
+
+    const finish = () => {
+        unregisterCancel();
+        if (!to.writableEnded) {
+            to.end();
+        }
+    };
+
+    from.body.on('data', chunk => {
+        if (!to.writableEnded) {
+            to.write(chunk);
+        }
+    });
+
+    from.body.on('end', () => {
+        console.info('Streaming request finished');
+        finish();
+    });
+
+    from.body.on('error', error => {
+        if (!isRequestCancellationError(error)) {
+            console.warn('Streaming request failed:', error?.message ?? error);
+        }
+        finish();
     });
 }
 
@@ -782,6 +844,12 @@ export async function forwardFetchResponse(from, to, request = null, onDisconnec
     }
 
     if (from.body && to.socket) {
+        const resumableGeneration = getResumableGeneration(request);
+        if (resumableGeneration) {
+            forwardResumableFetchBody(from, to, resumableGeneration, onDisconnect);
+            return;
+        }
+
         const stopPolling = pollStreamingRequestConnection(request, to, () => {
             try {
                 const disconnectResult = onDisconnect?.();

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -223,7 +223,7 @@ describe('OpenAI proxy preset wiring', () => {
         const settingsReadyIndex = sendRequestSource.indexOf('await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);');
         const customSecretGuardIndex = sendRequestSource.indexOf('generate_data.chat_completion_source === chat_completion_sources.CUSTOM && selected_custom_endpoint_preset?.secretId');
         const secretIdIndex = sendRequestSource.indexOf('generate_data.secret_id = selected_custom_endpoint_preset.secretId;');
-        const fetchIndex = sendRequestSource.indexOf('const response = await fetch(generate_url, {');
+        const fetchIndex = sendRequestSource.indexOf('const response = await fetchResumable(generate_url, {');
 
         expect(settingsReadyIndex).toBeGreaterThanOrEqual(0);
         expect(customSecretGuardIndex).toBeGreaterThan(settingsReadyIndex);

--- a/tests/resumable-generation-frontend.test.js
+++ b/tests/resumable-generation-frontend.test.js
@@ -1,7 +1,9 @@
 /* global globalThis */
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
 
 const { fetchResumable, reconnectStaleGenerations } = await import('../public/scripts/resumable-generation.js');
+const customRequestSource = readFileSync(new URL('../public/scripts/custom-request.js', import.meta.url), 'utf8');
 
 const RESUME_URL = '/api/resumable-generations/resume';
 const CANCEL_URL = '/api/resumable-generations/cancel';
@@ -174,4 +176,12 @@ describe('fetchResumable', () => {
         expect(callsTo(RESUME_URL)).toHaveLength(1);
         expect(JSON.parse(callsTo(RESUME_URL)[0][1].body).offset).toBe('data: a\n\n'.length);
     });
+});
+
+test('routes all scoped-profile generation requests through fetchResumable', () => {
+    expect(customRequestSource).toContain('import { fetchResumable } from \'./resumable-generation.js\';');
+    expect(customRequestSource.match(/const response = await fetchResumable\(/g)).toHaveLength(3);
+    expect(customRequestSource).toContain('await fetchResumable(getGenerateUrl(this.TYPE), {');
+    expect(customRequestSource).toContain('await fetchResumable(\'/api/backends/text-completions/generate\', {');
+    expect(customRequestSource).toContain('await fetchResumable(\'/api/backends/chat-completions/generate\', {');
 });

--- a/tests/resumable-generation-frontend.test.js
+++ b/tests/resumable-generation-frontend.test.js
@@ -1,0 +1,177 @@
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const { fetchResumable, reconnectStaleGenerations } = await import('../public/scripts/resumable-generation.js');
+
+const RESUME_URL = '/api/resumable-generations/resume';
+const CANCEL_URL = '/api/resumable-generations/cancel';
+const encoder = new TextEncoder();
+
+/**
+ * A body that hands out the given parts, then either closes, errors, or hangs until the signal aborts.
+ */
+function bodyFrom(parts, { errorAfter = Infinity, error = new TypeError('Load failed'), hang = false, signal = null } = {}) {
+    let index = 0;
+    return new ReadableStream({
+        pull(controller) {
+            if (index < parts.length && index < errorAfter) {
+                controller.enqueue(encoder.encode(parts[index++]));
+                return;
+            }
+            if (index >= errorAfter && index < parts.length) {
+                controller.error(error);
+                return;
+            }
+            if (!hang) {
+                controller.close();
+                return;
+            }
+            return new Promise((_resolve, reject) => {
+                signal?.addEventListener('abort', () => reject(signal.reason ?? new DOMException('aborted', 'AbortError')), { once: true });
+            });
+        },
+    });
+}
+
+function resumeResponse(parts, { status = 200, statusText = '', contentType = null } = {}) {
+    const headers = { 'X-Generation-Status': String(status) };
+    if (statusText) {
+        headers['X-Generation-Status-Text'] = statusText;
+    }
+    if (contentType) {
+        headers['Content-Type'] = contentType;
+    }
+    return new Response(bodyFrom(parts), { status: 200, headers });
+}
+
+const originalFetch = globalThis.fetch;
+let fetchMock;
+
+beforeEach(() => {
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+function callsTo(url) {
+    return fetchMock.mock.calls.filter(([calledUrl]) => calledUrl === url);
+}
+
+describe('fetchResumable', () => {
+    test('passes an uninterrupted reply through and tags the request', async () => {
+        fetchMock.mockResolvedValueOnce(new Response(bodyFrom(['data: a\n\n', 'data: [DONE]\n\n']), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+        }));
+
+        const response = await fetchResumable('/api/backends/chat-completions/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': 'csrf' },
+            body: '{}',
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toBe('text/event-stream');
+        await expect(response.text()).resolves.toBe('data: a\n\ndata: [DONE]\n\n');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe('/api/backends/chat-completions/generate');
+        expect(init.method).toBe('POST');
+        expect(init.body).toBe('{}');
+        expect(init.headers['X-CSRF-Token']).toBe('csrf');
+        expect(init.headers['X-Generation-Id']).toMatch(/^[0-9a-f]{32}$/);
+        expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    test('reattaches from the last byte when the stream breaks', async () => {
+        fetchMock
+            .mockResolvedValueOnce(new Response(bodyFrom(['data: a\n\n', 'data: b\n\n'], { errorAfter: 1 }), { status: 200 }))
+            .mockResolvedValueOnce(resumeResponse(['data: b\n\n', 'data: [DONE]\n\n']));
+
+        const response = await fetchResumable('/generate', { method: 'POST', headers: { 'X-CSRF-Token': 'csrf' }, body: '{}' });
+        await expect(response.text()).resolves.toBe('data: a\n\ndata: b\n\ndata: [DONE]\n\n');
+
+        const generationId = fetchMock.mock.calls[0][1].headers['X-Generation-Id'];
+        const [resumeUrl, resumeInit] = fetchMock.mock.calls[1];
+        expect(resumeUrl).toBe(RESUME_URL);
+        expect(resumeInit.method).toBe('POST');
+        expect(JSON.parse(resumeInit.body)).toEqual({ id: generationId, offset: 'data: a\n\n'.length });
+        expect(resumeInit.headers['X-CSRF-Token']).toBe('csrf');
+        expect(resumeInit.headers['X-Generation-Id']).toBeUndefined();
+        expect(callsTo(CANCEL_URL)).toHaveLength(0);
+    });
+
+    test('asks the server for the reply when the first request dies before answering', async () => {
+        fetchMock
+            .mockRejectedValueOnce(new TypeError('Load failed'))
+            .mockResolvedValueOnce(resumeResponse(['{"choices":[]}'], { status: 400, statusText: 'Bad Request', contentType: 'application/json' }));
+
+        const response = await fetchResumable('/generate', { method: 'POST', headers: {}, body: '{}' });
+
+        expect(response.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect(response.statusText).toBe('Bad Request');
+        expect(response.headers.get('content-type')).toBe('application/json');
+        await expect(response.json()).resolves.toEqual({ choices: [] });
+        expect(JSON.parse(fetchMock.mock.calls[1][1].body).offset).toBe(0);
+    });
+
+    test('surfaces the original failure when the server has no such reply', async () => {
+        const failure = new TypeError('Load failed');
+        fetchMock
+            .mockRejectedValueOnce(failure)
+            .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+        await expect(fetchResumable('/generate', { method: 'POST', headers: {}, body: '{}' })).rejects.toBe(failure);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test('aborting cancels the generation server-side instead of reattaching', async () => {
+        const controller = new AbortController();
+        fetchMock.mockImplementation(async (url, init) => {
+            if (url === CANCEL_URL) {
+                return new Response(null, { status: 204 });
+            }
+            return new Response(bodyFrom(['data: a\n\n'], { hang: true, signal: init.signal }), { status: 200 });
+        });
+
+        const response = await fetchResumable('/generate', { method: 'POST', headers: { 'X-CSRF-Token': 'csrf' }, body: '{}', signal: controller.signal });
+        const text = response.text();
+        await new Promise(resolve => setTimeout(resolve, 10));
+        controller.abort();
+
+        await expect(text).rejects.toBeDefined();
+        expect(callsTo(RESUME_URL)).toHaveLength(0);
+        const cancelCalls = callsTo(CANCEL_URL);
+        expect(cancelCalls).toHaveLength(1);
+        const [, cancelInit] = cancelCalls[0];
+        expect(cancelInit.method).toBe('POST');
+        expect(cancelInit.keepalive).toBe(true);
+        expect(cancelInit.headers['X-CSRF-Token']).toBe('csrf');
+        expect(JSON.parse(cancelInit.body)).toEqual({ id: fetchMock.mock.calls[0][1].headers['X-Generation-Id'] });
+    });
+
+    test('reconnects a stalled stream when the page wakes up', async () => {
+        fetchMock.mockImplementation(async (url, init) => {
+            if (url === RESUME_URL) {
+                return resumeResponse(['data: b\n\n', 'data: [DONE]\n\n']);
+            }
+            return new Response(bodyFrom(['data: a\n\n'], { hang: true, signal: init.signal }), { status: 200 });
+        });
+
+        const response = await fetchResumable('/generate', { method: 'POST', headers: {}, body: '{}' });
+        const text = response.text();
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        reconnectStaleGenerations(Date.now() + 1000);
+        expect(callsTo(RESUME_URL)).toHaveLength(0);
+
+        reconnectStaleGenerations(Date.now() + 10000);
+        await expect(text).resolves.toBe('data: a\n\ndata: b\n\ndata: [DONE]\n\n');
+        expect(callsTo(RESUME_URL)).toHaveLength(1);
+        expect(JSON.parse(callsTo(RESUME_URL)[0][1].body).offset).toBe('data: a\n\n'.length);
+    });
+});

--- a/tests/resumable-generation-frontend.test.js
+++ b/tests/resumable-generation-frontend.test.js
@@ -185,3 +185,16 @@ test('routes all scoped-profile generation requests through fetchResumable', () 
     expect(customRequestSource).toContain('await fetchResumable(\'/api/backends/text-completions/generate\', {');
     expect(customRequestSource).toContain('await fetchResumable(\'/api/backends/chat-completions/generate\', {');
 });
+
+test('routes Horde generation requests through fetchResumable', () => {
+    const hordeSource = readFileSync(new URL('../public/scripts/horde.js', import.meta.url), 'utf8');
+    expect(hordeSource).toContain('import { fetchResumable } from \'./resumable-generation.js\';');
+    expect(hordeSource).toContain('await fetchResumable(\'/api/horde/generate-text\', {');
+    expect(hordeSource).not.toContain('fetch(\'/api/horde/generate-text\'');
+});
+
+test('cancels in-flight generations on pagehide for browsers without beforeunload', () => {
+    const source = readFileSync(new URL('../public/scripts/resumable-generation.js', import.meta.url), 'utf8');
+    expect(source).toContain('window.addEventListener(\'beforeunload\', cancelActiveGenerations)');
+    expect(source).toContain('window.addEventListener(\'pagehide\', cancelActiveGenerations)');
+});

--- a/tests/resumable-generations.test.js
+++ b/tests/resumable-generations.test.js
@@ -103,6 +103,89 @@ describe('resumable generation registry', () => {
         await expect(collected).resolves.toBe('e,two,three');
     });
 
+    test('discards an overflowing generation and releases its buffered bytes', () => {
+        const { generation } = registerGeneration('overflow-1');
+        const subscriber = {
+            onChunk: jest.fn(),
+            onEnd: jest.fn(),
+            onFail: jest.fn(),
+        };
+        generation.subscribe(0, subscriber);
+        const cancelHook = jest.fn();
+        generation.onCancel(cancelHook);
+
+        generation.write(Buffer.alloc(testExports.MAX_BUFFER_BYTES));
+        generation.write('overflow');
+
+        expect(subscriber.onChunk).toHaveBeenCalledTimes(1);
+        expect(subscriber.onFail).toHaveBeenCalledTimes(1);
+        expect(subscriber.onEnd).not.toHaveBeenCalled();
+        expect(cancelHook).toHaveBeenCalledTimes(1);
+        expect(generation.cancelled).toBe(true);
+        expect(generation.done).toBe(true);
+        expect(testExports.generations.has('tester:overflow-1')).toBe(false);
+        expect(generation.chunks).toHaveLength(0);
+        expect(generation.size).toBe(0);
+    });
+
+    test('does not double-end the attached response when overflow cancellation ends it', async () => {
+        const { response, generation } = registerGeneration('overflow-response');
+        const errors = [];
+        response.on('error', error => errors.push(error));
+        generation.onCancel(() => response.end());
+
+        response.write(Buffer.alloc(testExports.MAX_BUFFER_BYTES));
+        response.end('overflow');
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(errors).toHaveLength(0);
+        expect(generation.done).toBe(true);
+    });
+
+    test('evicting an active generation cancels, finishes, and releases it', () => {
+        const { response, generation } = registerGeneration('capacity-active');
+        response.write('buffered');
+        const subscriber = {
+            onChunk: jest.fn(),
+            onEnd: jest.fn(),
+            onFail: jest.fn(),
+        };
+        generation.subscribe(0, subscriber);
+        const cancelHook = jest.fn(() => response.end());
+        generation.onCancel(cancelHook);
+
+        for (let index = 0; index < testExports.MAX_GENERATIONS; index++) {
+            registerGeneration(`capacity-${index}`);
+        }
+
+        expect(cancelHook).toHaveBeenCalledTimes(1);
+        expect(subscriber.onFail).toHaveBeenCalledTimes(1);
+        expect(subscriber.onEnd).not.toHaveBeenCalled();
+        expect(generation.cancelled).toBe(true);
+        expect(generation.done).toBe(true);
+        expect(testExports.generations.has('tester:capacity-active')).toBe(false);
+        expect(generation.chunks).toHaveLength(0);
+        expect(generation.size).toBe(0);
+    });
+
+    test('evicting a finished generation does not cancel it', () => {
+        const { response, generation } = registerGeneration('capacity-finished');
+        const cancelHook = jest.fn();
+        generation.onCancel(cancelHook);
+        response.end('buffered');
+
+        for (let index = 0; index < testExports.MAX_GENERATIONS; index++) {
+            registerGeneration(`finished-${index}`);
+        }
+
+        expect(cancelHook).not.toHaveBeenCalled();
+        expect(generation.cancelled).toBe(false);
+        expect(generation.done).toBe(true);
+        expect(testExports.generations.has('tester:capacity-finished')).toBe(false);
+        expect(generation.chunks).toHaveLength(0);
+        expect(generation.size).toBe(0);
+    });
+
     test('re-registering an id cancels the superseded generation', () => {
         jest.spyOn(console, 'info').mockImplementation(() => undefined);
         const first = registerGeneration('replayed-1');

--- a/tests/resumable-generations.test.js
+++ b/tests/resumable-generations.test.js
@@ -59,6 +59,7 @@ function collect(generation, offset = 0) {
 afterEach(() => {
     jest.restoreAllMocks();
     testExports.generations.clear();
+    testExports.setTotalBufferedBytes(0);
 });
 
 describe('resumable generation registry', () => {
@@ -87,6 +88,7 @@ describe('resumable generation registry', () => {
         expect(generation.statusCode).toBe(201);
         expect(generation.contentType).toBe('text/plain');
         expect(generation.size).toBe(11);
+        expect(testExports.totalBufferedBytes).toBe(11);
         await expect(collect(generation)).resolves.toBe('hello world');
         await expect(collect(generation, 6)).resolves.toBe('world');
         expect(testExports.generations.get('tester:mirror-1')).toBe(generation);
@@ -201,7 +203,7 @@ describe('resumable generation registry', () => {
         expect(testExports.generations.get('tester:replayed-1')).toBe(second.generation);
     });
 
-    test('re-registering an id leaves a finished reply alone', () => {
+    test('re-registering an id drops the finished reply\'s buffered copy', () => {
         const first = registerGeneration('replayed-2');
         first.response.end('all done');
         const cancelHook = jest.fn();
@@ -210,7 +212,9 @@ describe('resumable generation registry', () => {
         registerGeneration('replayed-2');
 
         expect(cancelHook).not.toHaveBeenCalled();
-        expect(first.generation.size).toBe('all done'.length);
+        expect(first.generation.done).toBe(true);
+        expect(first.generation.size).toBe(0);
+        expect(testExports.totalBufferedBytes).toBe(0);
     });
 
     test('cancel runs each hook once and does nothing once the reply finished', () => {
@@ -253,6 +257,141 @@ describe('resumable generation registry', () => {
         expect(hook).toHaveBeenCalledTimes(1);
         expect(running.done).toBe(true);
         expect(finished.done).toBe(true);
+    });
+
+    test('waiting for headers can be cancelled when the waiting client disappears', async () => {
+        const { generation } = registerGeneration('waiter-1');
+        const wait = generation.waitForHeaders();
+        expect(generation.headerWaiters).toHaveLength(1);
+
+        wait.cancel();
+        await expect(wait.promise).resolves.toBeUndefined();
+        expect(generation.headerWaiters).toHaveLength(0);
+
+        const late = generation.waitForHeaders();
+        generation.captureHeaders({ statusCode: 201, statusMessage: '', getHeader: () => undefined });
+        await expect(late.promise).resolves.toBeUndefined();
+        expect(generation.headerWaiters).toHaveLength(0);
+    });
+});
+
+describe('registry capacity', () => {
+    /**
+     * Registers a generation for a synthetic profile, bypassing the tester helper.
+     */
+    function registerFor(handle, id) {
+        const request = createMockRequest(id);
+        request.user = { profile: { handle } };
+        const response = createMockResponse();
+        const next = jest.fn();
+        resumableGenerationMiddleware(request, response, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        return { request, response, generation: request.resumableGeneration };
+    }
+
+    let fillerCount = 0;
+
+    /**
+     * Adds a live filler registration spread over synthetic profiles.
+     */
+    function addLiveFiller() {
+        const bucket = Math.floor(fillerCount / testExports.MAX_GENERATIONS_PER_PROFILE);
+        fillerCount++;
+        return registerFor(`filler-${bucket}`, `filler${String(fillerCount).padStart(6, '0')}`);
+    }
+
+    afterEach(() => {
+        fillerCount = 0;
+    });
+
+    test('a full registry never discards another profile\'s live generation', () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const victim = registerGeneration('victim-1');
+        victim.response.write('live');
+        const cancelHook = jest.fn();
+        victim.generation.onCancel(cancelHook);
+
+        while (testExports.generations.size < testExports.MAX_GENERATIONS) {
+            addLiveFiller();
+        }
+        expect(testExports.generations.size).toBe(testExports.MAX_GENERATIONS);
+
+        const latecomer = registerFor('filler-late', 'latecomer-00001');
+
+        expect(latecomer.generation).toBeUndefined();
+        expect(cancelHook).not.toHaveBeenCalled();
+        expect(victim.generation.cancelled).toBe(false);
+        expect(testExports.generations.has('tester:victim-1')).toBe(true);
+        expect(testExports.generations.size).toBe(testExports.MAX_GENERATIONS);
+    });
+
+    test('an over-cap profile gives up its own oldest live generation', () => {
+        const first = registerGeneration('own-000000');
+        const cancelHook = jest.fn();
+        first.generation.onCancel(cancelHook);
+        for (let index = 1; index < testExports.MAX_GENERATIONS_PER_PROFILE; index++) {
+            registerGeneration(`own-${String(index).padStart(6, '0')}`);
+        }
+        expect(testExports.generations.size).toBe(testExports.MAX_GENERATIONS_PER_PROFILE);
+
+        registerGeneration('own-newest');
+
+        expect(cancelHook).toHaveBeenCalledTimes(1);
+        expect(first.generation.cancelled).toBe(true);
+        expect(first.generation.done).toBe(true);
+        expect(testExports.generations.has('tester:own-000000')).toBe(false);
+        expect(testExports.generations.has('tester:own-newest')).toBe(true);
+        expect(testExports.generations.size).toBe(testExports.MAX_GENERATIONS_PER_PROFILE);
+    });
+
+    test('global pressure drops finished replies before touching live ones', () => {
+        const finished = registerGeneration('finished-spare');
+        finished.response.end('cached');
+        const live = registerGeneration('live-keep');
+        live.response.write('running');
+
+        while (testExports.generations.size < testExports.MAX_GENERATIONS) {
+            addLiveFiller();
+        }
+        addLiveFiller();
+
+        expect(testExports.generations.has('tester:finished-spare')).toBe(false);
+        expect(finished.generation.cancelled).toBe(false);
+        expect(testExports.generations.has('tester:live-keep')).toBe(true);
+        expect(live.generation.cancelled).toBe(false);
+        expect(testExports.generations.size).toBe(testExports.MAX_GENERATIONS);
+    });
+
+    test('the global byte budget frees finished replies before overflowing a live one', () => {
+        const spare = registerGeneration('budget-spare');
+        spare.response.write(Buffer.alloc(1000));
+        spare.response.end();
+
+        const live = registerGeneration('budget-live');
+        testExports.setTotalBufferedBytes(testExports.MAX_TOTAL_BUFFER_BYTES - 500);
+
+        live.response.write(Buffer.alloc(800));
+
+        expect(testExports.generations.has('tester:budget-spare')).toBe(false);
+        expect(live.generation.overflowed).toBe(false);
+        expect(live.generation.size).toBe(800);
+        expect(testExports.totalBufferedBytes).toBe(testExports.MAX_TOTAL_BUFFER_BYTES - 700);
+    });
+
+    test('a live reply overflows instead of breaking the global byte budget', () => {
+        const live = registerGeneration('budget-overflow');
+        const subscriber = { onChunk: jest.fn(), onEnd: jest.fn(), onFail: jest.fn() };
+        live.generation.subscribe(0, subscriber);
+        testExports.setTotalBufferedBytes(testExports.MAX_TOTAL_BUFFER_BYTES);
+
+        live.generation.write('too much');
+
+        expect(live.generation.overflowed).toBe(true);
+        expect(subscriber.onFail).toHaveBeenCalledTimes(1);
+        expect(live.generation.size).toBe(0);
+        // Only the simulated outside pressure remains; the discarded reply gave its bytes back.
+        expect(testExports.totalBufferedBytes).toBe(testExports.MAX_TOTAL_BUFFER_BYTES);
+        expect(testExports.generations.has('tester:budget-overflow')).toBe(false);
     });
 });
 
@@ -326,6 +465,8 @@ describe('resumable generation routes', () => {
     let baseUrl;
     /** @type {Map<string, () => void>} */
     const pendingHandlers = new Map();
+    /** @type {Map<string, () => void>} */
+    const heldReleases = new Map();
     const cancelled = new Set();
 
     beforeAll(async () => {
@@ -345,11 +486,18 @@ describe('resumable generation routes', () => {
             });
             response.status(201);
             response.setHeader('Content-Type', 'text/plain');
-            response.write('first-');
-            pendingHandlers.set(id, () => {
-                response.write('second-');
-                response.end('done');
-            });
+            const release = () => {
+                response.write('first-');
+                pendingHandlers.set(id, () => {
+                    response.write('second-');
+                    response.end('done');
+                });
+            };
+            if (new URL(request.url, 'http://localhost').searchParams.has('hold')) {
+                heldReleases.set(id, release);
+            } else {
+                release();
+            }
         });
 
         await new Promise(resolve => {
@@ -362,12 +510,24 @@ describe('resumable generation routes', () => {
         await new Promise(resolve => server.close(resolve));
     });
 
-    function postJson(path, body) {
+    function postJson(path, body, init = {}) {
         return fetch(`${baseUrl}${path}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
+            ...init,
         });
+    }
+
+    async function startGeneration(id, query = '') {
+        const promise = fetch(`${baseUrl}/generate${query}`, { method: 'POST', headers: { 'X-Generation-Id': id } });
+        if (query) {
+            // A held handler writes nothing, so the response headers only arrive on release.
+            return promise;
+        }
+        const original = await promise;
+        await original.body.getReader().read();
+        return original;
     }
 
     test('resume is a 404 for a reply the server does not have', async () => {
@@ -425,5 +585,70 @@ describe('resumable generation routes', () => {
 
         const unknown = await postJson('/api/resumable-generations/cancel', { id: 'nobody-home' });
         expect(unknown.status).toBe(404);
+    });
+
+    test('a reply serves at most MAX_RESUME_CLIENTS concurrent resumes', async () => {
+        const id = 'route-subscriber-limit';
+        await startGeneration(id);
+
+        const openReaders = Array.from({ length: testExports.MAX_RESUME_CLIENTS }, () =>
+            postJson('/api/resumable-generations/resume', { id, offset: 0 }));
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const rejected = await postJson('/api/resumable-generations/resume', { id, offset: 0 });
+        expect(rejected.status).toBe(429);
+
+        pendingHandlers.get(id)();
+        for (const reader of await Promise.all(openReaders)) {
+            expect(reader.status).toBe(200);
+            await expect(reader.text()).resolves.toBe('first-second-done');
+        }
+    });
+
+    test('at most MAX_RESUME_CLIENTS resumes may queue for a slow handler', async () => {
+        const id = 'route-waiter-limit';
+        const original = startGeneration(id, '?hold=1');
+
+        const waiting = Array.from({ length: testExports.MAX_RESUME_CLIENTS }, () =>
+            postJson('/api/resumable-generations/resume', { id, offset: 0 }));
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const rejected = await postJson('/api/resumable-generations/resume', { id, offset: 0 });
+        expect(rejected.status).toBe(503);
+
+        heldReleases.get(id)();
+        pendingHandlers.get(id)();
+        await (await original).text();
+        for (const reader of await Promise.all(waiting)) {
+            expect(reader.status).toBe(200);
+            await expect(reader.text()).resolves.toBe('first-second-done');
+        }
+    });
+
+    test('a resume whose connection dies while waiting frees its waiter slot', async () => {
+        const id = 'route-waiter-gone';
+        const original = startGeneration(id, '?hold=1');
+
+        const waiting = Array.from({ length: testExports.MAX_RESUME_CLIENTS - 1 }, () =>
+            postJson('/api/resumable-generations/resume', { id, offset: 0 }));
+        const aborter = new AbortController();
+        const doomed = postJson('/api/resumable-generations/resume', { id, offset: 0 }, { signal: aborter.signal });
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        aborter.abort();
+        await expect(doomed).rejects.toThrow();
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // The freed slot must admit a fresh waiter instead of answering 503.
+        const accepted = postJson('/api/resumable-generations/resume', { id, offset: 0 });
+        await new Promise(resolve => setTimeout(resolve, 50));
+        heldReleases.get(id)();
+        pendingHandlers.get(id)();
+        await (await original).text();
+
+        for (const reader of await Promise.all([...waiting, accepted])) {
+            expect(reader.status).toBe(200);
+            await expect(reader.text()).resolves.toBe('first-second-done');
+        }
     });
 });

--- a/tests/resumable-generations.test.js
+++ b/tests/resumable-generations.test.js
@@ -1,0 +1,346 @@
+import { afterAll, afterEach, beforeAll, describe, expect, jest, test } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import express from 'express';
+import { Response } from 'node-fetch';
+
+import { REQUEST_CANCELLATION_ABORT_REASON, observeRequestCancellation } from '../src/request-cancellation.js';
+import {
+    ResumableGeneration,
+    resumableGenerationMiddleware,
+    router,
+    testExports,
+} from '../src/resumable-generations.js';
+import { forwardFetchResponse } from '../src/util.js';
+
+function createMockRequest(id = 'test-generation-1') {
+    const headers = { 'x-generation-id': id };
+    return {
+        headers,
+        socket: new EventEmitter(),
+        user: { profile: { handle: 'tester' } },
+        get(name) {
+            return headers[String(name).toLowerCase()];
+        },
+    };
+}
+
+function createMockResponse() {
+    const response = new PassThrough();
+    response.statusCode = 200;
+    response.statusMessage = '';
+    response.socket = {};
+    response.getHeader = () => undefined;
+    return response;
+}
+
+/**
+ * Runs the middleware and hands back the registered generation.
+ */
+function registerGeneration(id) {
+    const request = createMockRequest(id);
+    const response = createMockResponse();
+    const next = jest.fn();
+    resumableGenerationMiddleware(request, response, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    return { request, response, generation: request.resumableGeneration };
+}
+
+function collect(generation, offset = 0) {
+    return new Promise(resolve => {
+        const chunks = [];
+        generation.subscribe(offset, {
+            onChunk: chunk => chunks.push(chunk),
+            onEnd: () => resolve(Buffer.concat(chunks).toString('utf8')),
+        });
+    });
+}
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    testExports.generations.clear();
+});
+
+describe('resumable generation registry', () => {
+    test('ignores requests without a usable generation id', () => {
+        const request = createMockRequest('not valid!');
+        const response = createMockResponse();
+        const next = jest.fn();
+
+        resumableGenerationMiddleware(request, response, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(request.resumableGeneration).toBeUndefined();
+        expect(testExports.generations.size).toBe(0);
+    });
+
+    test('mirrors everything the handler writes and replays it from an offset', async () => {
+        const { response, generation } = registerGeneration('mirror-1');
+        response.statusCode = 201;
+        const headers = { 'content-type': 'text/plain' };
+        response.getHeader = name => headers[String(name).toLowerCase()];
+
+        response.write('hello ');
+        response.end('world');
+
+        expect(generation.done).toBe(true);
+        expect(generation.statusCode).toBe(201);
+        expect(generation.contentType).toBe('text/plain');
+        expect(generation.size).toBe(11);
+        await expect(collect(generation)).resolves.toBe('hello world');
+        await expect(collect(generation, 6)).resolves.toBe('world');
+        expect(testExports.generations.get('tester:mirror-1')).toBe(generation);
+    });
+
+    test('live subscribers get the bytes written after they attached', async () => {
+        const { response, generation } = registerGeneration('live-stream-1');
+
+        response.write('one,');
+        const collected = collect(generation, 2);
+        response.write('two,');
+        response.end('three');
+
+        await expect(collected).resolves.toBe('e,two,three');
+    });
+
+    test('re-registering an id cancels the superseded generation', () => {
+        jest.spyOn(console, 'info').mockImplementation(() => undefined);
+        const first = registerGeneration('replayed-1');
+        const cancelHook = jest.fn();
+        first.generation.onCancel(cancelHook);
+
+        const second = registerGeneration('replayed-1');
+
+        expect(cancelHook).toHaveBeenCalledTimes(1);
+        expect(first.generation.cancelled).toBe(true);
+        expect(first.generation.done).toBe(true);
+        expect(second.generation).not.toBe(first.generation);
+        expect(testExports.generations.get('tester:replayed-1')).toBe(second.generation);
+    });
+
+    test('re-registering an id leaves a finished reply alone', () => {
+        const first = registerGeneration('replayed-2');
+        first.response.end('all done');
+        const cancelHook = jest.fn();
+        first.generation.onCancel(cancelHook);
+
+        registerGeneration('replayed-2');
+
+        expect(cancelHook).not.toHaveBeenCalled();
+        expect(first.generation.size).toBe('all done'.length);
+    });
+
+    test('cancel runs each hook once and does nothing once the reply finished', () => {
+        const generation = new ResumableGeneration('tester:hooks');
+        const hook = jest.fn();
+        generation.onCancel(hook);
+
+        expect(generation.cancel()).toBe(true);
+        expect(generation.cancel()).toBe(false);
+        expect(hook).toHaveBeenCalledTimes(1);
+
+        const finished = new ResumableGeneration('tester:finished');
+        const lateHook = jest.fn();
+        finished.end();
+        finished.onCancel(lateHook);
+
+        expect(finished.cancel()).toBe(false);
+        expect(lateHook).not.toHaveBeenCalled();
+    });
+
+    test('sweep drops finished replies after retention and cancels ones that ran too long', () => {
+        const { response: finishedResponse, generation: finished } = registerGeneration('sweep-finished');
+        finishedResponse.end('done');
+        const { generation: running } = registerGeneration('sweep-running');
+        const hook = jest.fn();
+        running.onCancel(hook);
+
+        const now = Date.now();
+        testExports.sweepGenerations(now + testExports.FINISHED_RETENTION_MS - 1000);
+        expect(testExports.generations.has('tester:sweep-finished')).toBe(true);
+        expect(testExports.generations.has('tester:sweep-running')).toBe(true);
+
+        testExports.sweepGenerations(now + testExports.FINISHED_RETENTION_MS + 1000);
+        expect(testExports.generations.has('tester:sweep-finished')).toBe(false);
+        expect(testExports.generations.has('tester:sweep-running')).toBe(true);
+        expect(hook).not.toHaveBeenCalled();
+
+        testExports.sweepGenerations(now + testExports.MAX_LIFETIME_MS + 1000);
+        expect(testExports.generations.has('tester:sweep-running')).toBe(false);
+        expect(hook).toHaveBeenCalledTimes(1);
+        expect(running.done).toBe(true);
+        expect(finished.done).toBe(true);
+    });
+});
+
+describe('resumable generations and the disconnect guards', () => {
+    test('forwardFetchResponse keeps draining upstream after the client response closes', async () => {
+        const { request, response, generation } = registerGeneration('forward-1');
+        const upstreamBody = new PassThrough();
+        const destroySpy = jest.spyOn(upstreamBody, 'destroy');
+        const onDisconnect = jest.fn();
+        const collected = collect(generation);
+
+        await forwardFetchResponse(new Response(upstreamBody), response, request, onDisconnect);
+        upstreamBody.write('data: first\n\n');
+        response.emit('close');
+        expect(destroySpy).not.toHaveBeenCalled();
+        expect(onDisconnect).not.toHaveBeenCalled();
+
+        // Everything upstream sends after the client left still lands in the generation.
+        upstreamBody.write('data: second\n\n');
+        upstreamBody.end('data: [DONE]\n\n');
+
+        await expect(collected).resolves.toBe('data: first\n\ndata: second\n\ndata: [DONE]\n\n');
+        expect(onDisconnect).not.toHaveBeenCalled();
+        expect(generation.done).toBe(true);
+    });
+
+    test('cancelling a forwarded generation runs the provider hook and destroys upstream', async () => {
+        const { request, response, generation } = registerGeneration('forward-cancel');
+        const upstreamBody = new PassThrough();
+        const destroySpy = jest.spyOn(upstreamBody, 'destroy');
+        const onDisconnect = jest.fn();
+
+        await forwardFetchResponse(new Response(upstreamBody), response, request, onDisconnect);
+        upstreamBody.write('data: first\n\n');
+        expect(generation.cancel()).toBe(true);
+
+        expect(onDisconnect).toHaveBeenCalledTimes(1);
+        expect(destroySpy).toHaveBeenCalledTimes(1);
+        expect(generation.done).toBe(true);
+        expect(response.writableEnded).toBe(true);
+    });
+
+    test('observeRequestCancellation ignores client disconnects and aborts on an explicit cancel', () => {
+        const { request, response, generation } = registerGeneration('observe-1');
+        const controller = new AbortController();
+
+        observeRequestCancellation(request, response, { controller });
+        response.emit('close');
+        request.socket.emit('close');
+        expect(controller.signal.aborted).toBe(false);
+
+        generation.cancel();
+        expect(controller.signal.aborted).toBe(true);
+        expect(controller.signal.reason).toBe(REQUEST_CANCELLATION_ABORT_REASON);
+    });
+
+    test('observeRequestCancellation still aborts on disconnect for ordinary requests', () => {
+        const request = { socket: new EventEmitter() };
+        const response = createMockResponse();
+        const controller = new AbortController();
+
+        observeRequestCancellation(request, response, { controller });
+        response.emit('close');
+
+        expect(controller.signal.aborted).toBe(true);
+    });
+});
+
+describe('resumable generation routes', () => {
+    let server;
+    let baseUrl;
+    /** @type {Map<string, () => void>} */
+    const pendingHandlers = new Map();
+    const cancelled = new Set();
+
+    beforeAll(async () => {
+        const app = express();
+        app.use(express.json());
+        app.use((request, _response, next) => {
+            request.user = { profile: { handle: 'route-tester' } };
+            next();
+        });
+        app.use('/api/resumable-generations', router);
+        app.use(resumableGenerationMiddleware);
+        app.post('/generate', (request, response) => {
+            const id = request.get('x-generation-id');
+            request.resumableGeneration.onCancel(() => {
+                cancelled.add(id);
+                response.end();
+            });
+            response.status(201);
+            response.setHeader('Content-Type', 'text/plain');
+            response.write('first-');
+            pendingHandlers.set(id, () => {
+                response.write('second-');
+                response.end('done');
+            });
+        });
+
+        await new Promise(resolve => {
+            server = app.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise(resolve => server.close(resolve));
+    });
+
+    function postJson(path, body) {
+        return fetch(`${baseUrl}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+    }
+
+    test('resume is a 404 for a reply the server does not have', async () => {
+        const response = await postJson('/api/resumable-generations/resume', { id: 'never-registered', offset: 0 });
+        expect(response.status).toBe(404);
+    });
+
+    test('replays the rest of a reply whose client went away, with the original status', async () => {
+        const id = 'route-resume-1';
+        const original = await fetch(`${baseUrl}/generate`, { method: 'POST', headers: { 'X-Generation-Id': id } });
+        const reader = original.body.getReader();
+        const first = await reader.read();
+        expect(original.status).toBe(201);
+        expect(new TextDecoder().decode(first.value)).toBe('first-');
+
+        // The client drops off mid-reply; the handler only finishes afterwards.
+        await reader.cancel();
+        pendingHandlers.get(id)();
+
+        const resumed = await postJson('/api/resumable-generations/resume', { id, offset: 6 });
+        expect(resumed.status).toBe(200);
+        expect(resumed.headers.get('x-generation-status')).toBe('201');
+        expect(resumed.headers.get('content-type')).toContain('text/plain');
+        expect(resumed.headers.get('cache-control')).toContain('no-store');
+        await expect(resumed.text()).resolves.toBe('second-done');
+
+        const fromStart = await postJson('/api/resumable-generations/resume', { id, offset: 0 });
+        await expect(fromStart.text()).resolves.toBe('first-second-done');
+
+        const beyond = await postJson('/api/resumable-generations/resume', { id, offset: 999 });
+        expect(beyond.status).toBe(416);
+    });
+
+    test('a resume that attaches before the reply finishes streams the live tail', async () => {
+        const id = 'route-resume-live';
+        const original = await fetch(`${baseUrl}/generate`, { method: 'POST', headers: { 'X-Generation-Id': id } });
+        await original.body.getReader().read();
+
+        const resumedPromise = postJson('/api/resumable-generations/resume', { id, offset: 0 });
+        await new Promise(resolve => setTimeout(resolve, 50));
+        pendingHandlers.get(id)();
+
+        const resumed = await resumedPromise;
+        await expect(resumed.text()).resolves.toBe('first-second-done');
+    });
+
+    test('cancel stops a running reply and reports 404 afterwards for unknown ids', async () => {
+        const id = 'route-cancel-1';
+        const original = await fetch(`${baseUrl}/generate`, { method: 'POST', headers: { 'X-Generation-Id': id } });
+        await original.body.getReader().read();
+
+        const cancel = await postJson('/api/resumable-generations/cancel', { id });
+        expect(cancel.status).toBe(204);
+        expect(cancelled.has(id)).toBe(true);
+
+        const unknown = await postJson('/api/resumable-generations/cancel', { id: 'nobody-home' });
+        expect(unknown.status).toBe(404);
+    });
+});


### PR DESCRIPTION
Since iOS is insane, whenever I switch apps or even tabs for a couple minutes the connection to my remote server ends and it just cancels every response. Which means I have to micromanage it every single time.

## Added
- Generation requests carry an `X-Generation-Id`; the server keeps the reply and only stops on an explicit cancel.
- The page reattaches from its last byte via `POST /api/resumable-generations/resume`.
- Stop and page unload still cancel for real, a replayed POST can't leave two generations running.
- Finished replies are kept 15 minutes, an unused generation is dropped after an hour.