### PR TITLE
fix(mobile): prevent overflow in mobile devices + giving the chat list more screen space in Chat History

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -3033,6 +3033,44 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     body.ripplestyle #chat .mes:not(.smallSysMes) .mes_block {
         padding: 8px 16px 28px 12px !important;
     }
+
+    /* SillyBunny: use one mobile scroller so Chat History controls can leave the viewport. */
+    #select_chat_popup {
+        align-items: stretch;
+        left: max(10px, env(safe-area-inset-left, 0px));
+        right: max(10px, env(safe-area-inset-right, 0px));
+        width: auto;
+        max-width: none;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    #select_chat_div {
+        flex: 0 0 auto;
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        height: auto;
+        overflow: visible;
+    }
+
+    #select_chat_popup .chat_cleanup_group {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    #select_chat_popup .chat_cleanup_field {
+        min-width: 0;
+        grid-template-columns: minmax(0, 1fr) minmax(4.5rem, 5.5rem);
+    }
+
+    #select_chat_popup :is(.chat_cleanup_field, .chat_cleanup_checkbox) span {
+        white-space: normal;
+    }
+
+    #select_chat_popup :is(.select_chat_block_filename, .chat_cleanup_status) {
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
 }
 
 /* SillyBunny: streaming display (generation toast) density pass for phone. */

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260727c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-paper-theme.css?v=20260622g" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260725g">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260725g" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260821a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/script.js
+++ b/public/script.js
@@ -13588,8 +13588,8 @@ async function displayChats(searchQuery, currentChat, displayName, avatarImg, se
             $('#select_chat_div').append(template);
 
             if (Array.isArray(highlightNames) && highlightNames.includes(chat.file_name)) {
-                const templateOffset = template.offset().top - template.parent().offset().top;
-                $('#select_chat_div').scrollTop(templateOffset);
+                // SillyBunny: Chat History scrolls the popup on mobile and the list on desktop.
+                template[0].scrollIntoView({ block: 'nearest' });
                 flashHighlight(template, debounce_timeout.extended);
             }
         }


### PR DESCRIPTION
In mobile (at least in iOS Safari), the chat list overflows to the right. Scrolling down the chat list also makes it stay there instead of scrolling up and hiding the above screen, which makes the screen for scrolling really small.