### PR TITLE
fix(mobile): prevent streaming and new content to cause the screen to jump up constantly

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2103,7 +2103,7 @@ function requestMobileChatBottomPin({ requireNearBottom = true, durationMs = MOB
 }
 
 function shouldPinMobileChatToBottom() {
-    if (!shouldGuardMobileChatScroll() || isMobileChatManualScrollSuppressionActive()) {
+    if (!power_user.auto_scroll_chat_to_bottom || !shouldGuardMobileChatScroll() || isMobileChatManualScrollSuppressionActive()) {
         return false;
     }
 
@@ -6084,10 +6084,11 @@ class StreamingProcessor {
     async onProgressStreaming(messageId, text, isFinal) {
         const isImpersonate = this.type == 'impersonate';
         const isContinue = this.type == 'continue';
-        const shouldReduceIntermediateStreamingWork = !isFinal && shouldReduceStreamingDomWork(globalThis.navigator, {
+        const shouldReduceStreamingWork = shouldReduceStreamingDomWork(globalThis.navigator, {
             iosEnabled: power_user.ios_webkit_reduce_streaming_work,
             androidEnabled: power_user.android_reduce_streaming_work,
         });
+        const shouldReduceIntermediateStreamingWork = !isFinal && shouldReduceStreamingWork;
         const shouldBypassStreamingFadeIn = shouldReduceStreamingDomWork(globalThis.navigator, {
             iosEnabled: power_user.ios_webkit_disable_stream_fade_in,
             androidEnabled: power_user.android_disable_stream_fade_in,
@@ -6237,12 +6238,17 @@ class StreamingProcessor {
             }
         }
 
+        // SillyBunny: instant intermediate pins visibly jump on reduced-work mobile platforms; settle once when streaming finishes.
+        if (shouldReduceIntermediateStreamingWork && shouldUseMobileStreamingPin) {
+            return;
+        }
+
         if (shouldPinMobileBottom && shouldPinMobileChatToBottom()) {
             scheduleMobileStreamingBottomPin({ isFinal });
         } else if (!scrollLock && (!shouldUseMobileStreamingPin || !isMobileChatManualScrollSuppressionActive())) {
             scrollChatToBottom({
                 waitForFrame: true,
-                isNearBottom: shouldUseMobileStreamingPin ? shouldPinMobileBottom : true,
+                isNearBottom: shouldUseMobileStreamingPin ? shouldPinMobileBottom || (isFinal && shouldReduceStreamingWork) : true,
             });
         }
     }

--- a/public/scripts/chat-render-lifecycle/anchor.js
+++ b/public/scripts/chat-render-lifecycle/anchor.js
@@ -19,9 +19,10 @@ function getMessageElements(scrollElement, messageSelector = DEFAULT_MESSAGE_SEL
  * @param {Element} scrollElement Scroll container that owns message elements.
  * @param {object} [options] Options.
  * @param {string} [options.messageSelector] Message selector to anchor against.
+ * @param {string} [options.keyAttribute] Attribute that identifies the anchor element.
  * @returns {{messageId: string, offsetTop: number}|null}
  */
-export function captureVisibleMessageAnchor(scrollElement, { messageSelector = DEFAULT_MESSAGE_SELECTOR } = {}) {
+export function captureVisibleMessageAnchor(scrollElement, { messageSelector = DEFAULT_MESSAGE_SELECTOR, keyAttribute = 'mesid' } = {}) {
     if (!canReadElementRect(scrollElement)) {
         return null;
     }
@@ -40,7 +41,7 @@ export function captureVisibleMessageAnchor(scrollElement, { messageSelector = D
         return null;
     }
 
-    const messageId = anchorElement.getAttribute('mesid');
+    const messageId = anchorElement.getAttribute(keyAttribute);
 
     if (!messageId) {
         return null;
@@ -58,14 +59,15 @@ export function captureVisibleMessageAnchor(scrollElement, { messageSelector = D
  * @param {{messageId: string, offsetTop: number}|null} anchor Anchor captured before mutation.
  * @param {object} [options] Options.
  * @param {string} [options.messageSelector] Message selector to anchor against.
+ * @param {string} [options.keyAttribute] Attribute that identifies the anchor element.
  */
-export function restoreVisibleMessageAnchor(scrollElement, anchor, { messageSelector = DEFAULT_MESSAGE_SELECTOR } = {}) {
+export function restoreVisibleMessageAnchor(scrollElement, anchor, { messageSelector = DEFAULT_MESSAGE_SELECTOR, keyAttribute = 'mesid' } = {}) {
     if (!canReadElementRect(scrollElement) || !anchor?.messageId || typeof scrollElement.scrollTop !== 'number') {
         return;
     }
 
     const anchorElement = getMessageElements(scrollElement, messageSelector)
-        .find(message => typeof message.getAttribute === 'function' && message.getAttribute('mesid') === String(anchor.messageId));
+        .find(message => typeof message.getAttribute === 'function' && message.getAttribute(keyAttribute) === String(anchor.messageId));
 
     if (!canReadElementRect(anchorElement)) {
         return;
@@ -84,17 +86,19 @@ export function restoreVisibleMessageAnchor(scrollElement, anchor, { messageSele
  * @param {number} [options.frames=8] Number of animation frames to settle over.
  * @param {(callback: FrameRequestCallback) => number|void} [options.requestAnimationFrameRef] Frame scheduler.
  * @param {string} [options.messageSelector] Message selector to anchor against.
+ * @param {string} [options.keyAttribute] Attribute that identifies the anchor element.
  */
 export async function settleVisibleMessageAnchor(scrollElement, anchor, {
     frames = 8,
     requestAnimationFrameRef = globalThis.requestAnimationFrame,
     messageSelector = DEFAULT_MESSAGE_SELECTOR,
+    keyAttribute = 'mesid',
 } = {}) {
     if (!anchor || typeof requestAnimationFrameRef !== 'function') {
         return;
     }
 
-    await runSettledFrames(() => restoreVisibleMessageAnchor(scrollElement, anchor, { messageSelector }), {
+    await runSettledFrames(() => restoreVisibleMessageAnchor(scrollElement, anchor, { messageSelector, keyAttribute }), {
         frames,
         requestAnimationFrameRef,
     });

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -1,5 +1,6 @@
 import { chat } from '../../../../script.js';
 import { hideChatMessageRange } from '../../../chats.js';
+import { captureVisibleMessageAnchor, restoreVisibleMessageAnchor } from '../../../chat-render-lifecycle/anchor.js';
 import { eventSource, event_types } from '../../../events.js';
 import { Popup, POPUP_RESULT, POPUP_TYPE } from '../../../popup.js';
 import { accountStorage } from '../../../util/AccountStorage.js';
@@ -55,6 +56,10 @@ const HANDLE_POSITION_STORAGE_KEY = 'ica--tracker-panel-handle-top-v2';
 const PANEL_LOCK_STORAGE_KEY = 'ica--tracker-panel-locked';
 const HANDLE_DRAG_THRESHOLD_PX = 6;
 const HANDLE_EDGES = ['right', 'left', 'top', 'bottom'];
+const PANEL_ANCHOR_OPTIONS = {
+    messageSelector: '.ica--tpanel-agent[data-agent-id]',
+    keyAttribute: 'data-agent-id',
+};
 
 let panelInitialized = false;
 let panelOpen = false;
@@ -741,7 +746,23 @@ export function buildPanelHtml() {
 
 function renderPanel() {
     const panelElement = $('#ica--tracker-panel');
+    const panel = panelElement[0];
+    const anchor = captureVisibleMessageAnchor(panel, PANEL_ANCHOR_OPTIONS);
+    const previousHeights = new Map(Array.from(panel?.querySelectorAll(PANEL_ANCHOR_OPTIONS.messageSelector) ?? [], section => [
+        section.getAttribute(PANEL_ANCHOR_OPTIONS.keyAttribute),
+        section.getBoundingClientRect().height,
+    ]));
+
     panelElement.html(buildPanelHtml());
+
+    for (const section of panel?.querySelectorAll(PANEL_ANCHOR_OPTIONS.messageSelector) ?? []) {
+        const previousHeight = previousHeights.get(section.getAttribute(PANEL_ANCHOR_OPTIONS.keyAttribute));
+        if (previousHeight && section.querySelector('.ica--companion-pending')) {
+            section.style.minHeight = `${previousHeight}px`;
+        }
+    }
+
+    restoreVisibleMessageAnchor(panel, anchor, PANEL_ANCHOR_OPTIONS);
     setupPanelSortable();
 }
 

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -422,16 +422,21 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('isFinal,');
     });
 
-    test('streaming progress throttles mobile bottom pins through the streaming scheduler', () => {
+    test('streaming progress skips reduced-work intermediate pins and settles once at completion', () => {
         const onProgressStreaming = findNode(scriptAst, node => node.type === 'MethodDefinition'
             && node.key?.name === 'onProgressStreaming');
         const source = getSource(onProgressStreaming.value);
 
         expect(source).toContain('const shouldUseMobileStreamingPin = !isImpersonate && shouldGuardMobileChatScroll();');
         expect(source).toContain('const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();');
+        expect(source).toContain('if (shouldReduceIntermediateStreamingWork && shouldUseMobileStreamingPin)');
         expect(source).toContain('if (shouldPinMobileBottom && shouldPinMobileChatToBottom())');
         expect(source).toContain('scheduleMobileStreamingBottomPin({ isFinal });');
+        expect(source).toContain('isNearBottom: shouldUseMobileStreamingPin ? shouldPinMobileBottom || (isFinal && shouldReduceStreamingWork) : true');
         expect(source).not.toContain('pinMobileChatToBottom({ waitForFrame: true, settle: isFinal });');
+
+        const shouldPinMobileChatToBottom = findFunctionDeclaration('shouldPinMobileChatToBottom');
+        expect(getSource(shouldPinMobileChatToBottom)).toContain('!power_user.auto_scroll_chat_to_bottom');
     });
 
     test('mobile streaming bottom pin scheduling coalesces smooth intermediate pins', () => {

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -317,6 +317,90 @@ describe('companion tracker panel', () => {
         expect(html).toMatch(/<section class="ica--tpanel-agent"[\s\S]*?data-message-index="0"[\s\S]*?data-action="panel-run-latest"[\s\S]*?<\/section>/);
     });
 
+    test('keeps the visible companion anchored while pending cards replace completed content', async () => {
+        const agentIds = ['agent-a', 'agent-b', 'agent-c', 'agent-d'];
+        agents = agentIds.map((id, index) => ({
+            id,
+            name: `Agent ${index + 1}`,
+            execution: 'companion',
+            enabled: true,
+            companion: { displayMode: 'panel' },
+        }));
+        const message = { is_user: false, is_system: false, mes: 'reply' };
+        chat.push(message);
+        const setResults = status => companionResultsByMessage.set(message, Object.fromEntries(agentIds.map(id => [id, {
+            status,
+            content: `${id} state`,
+            agentName: id,
+        }])));
+        setResults('done');
+        const panel = await importPanel();
+
+        let naturalHeights = [150, 150, 150, 150];
+        let sections = [];
+        let hasPendingCards = false;
+        let scrollTop = 0;
+        const panelNode = {
+            clientHeight: 200,
+            getBoundingClientRect: () => ({ top: 0, bottom: 200, height: 200 }),
+            querySelectorAll: () => sections,
+        };
+        const pendingNodes = [null, {}];
+        const getSectionHeight = section => Math.max(section.naturalHeight, Number.parseFloat(section.style.minHeight) || 0);
+        const getTotalHeight = () => sections.reduce((total, section) => total + getSectionHeight(section), 0);
+        Object.defineProperty(panelNode, 'scrollTop', {
+            get: () => scrollTop,
+            set: value => {
+                scrollTop = Math.max(0, Math.min(Number(value), Math.max(0, getTotalHeight() - panelNode.clientHeight)));
+            },
+        });
+        const createSection = (agentId, index) => {
+            const section = {
+                naturalHeight: naturalHeights[index],
+                style: {},
+                getAttribute: () => agentId,
+                querySelector: () => pendingNodes[Number(hasPendingCards)],
+                getBoundingClientRect: () => {
+                    const top = sections.slice(0, index).reduce((total, item) => total + getSectionHeight(item), 0) - panelNode.scrollTop;
+                    const height = getSectionHeight(section);
+                    return { top, bottom: top + height, height };
+                },
+            };
+            return section;
+        };
+        const panelElement = {
+            0: panelNode,
+            length: 1,
+            html: jest.fn(html => {
+                hasPendingCards = html.includes('ica--companion-pending');
+                sections = agentIds.map(createSection);
+                panelNode.scrollTop = scrollTop;
+                return panelElement;
+            }),
+            attr: jest.fn(() => panelElement),
+            addClass: jest.fn(() => panelElement),
+        };
+        const jqueryElements = new Map([['#ica--tracker-panel', panelElement]]);
+        globalThis.$ = jest.fn(selector => jqueryElements.get(selector) ?? { length: 0 });
+
+        panel.openCompanionPanel();
+        panelNode.scrollTop = 320;
+        const anchorOffset = sections[2].getBoundingClientRect().top;
+        expect(anchorOffset).toBe(-20);
+
+        naturalHeights = [40, 40, 40, 40];
+        setResults('pending');
+        panel.refreshCompanionPanel();
+        expect(sections[2].getBoundingClientRect().top).toBe(anchorOffset);
+        expect(sections.map(section => section.style.minHeight)).toEqual(['150px', '150px', '150px', '150px']);
+
+        naturalHeights = [90, 200, 100, 170];
+        setResults('done');
+        panel.refreshCompanionPanel();
+        expect(sections[2].getBoundingClientRect().top).toBe(anchorOffset);
+        expect(sections.map(section => section.style.minHeight)).toEqual([undefined, undefined, undefined, undefined]);
+    });
+
     test('keeps hidden companions unhideable from the collapsed panel row', async () => {
         const tracker = { id: 'tracker-1', name: 'Scene Tracker', execution: 'companion', enabled: true, companion: { displayMode: 'panel' } };
         agents = [tracker];


### PR DESCRIPTION
Unsure if this is strictly an iOS WebKit problem, but whenever streaming is enabled and whenever new content shows up, the viewport jumps up.

## Fixed
- Stopped repeated iOS/mobile streaming bottom-pins; the chat now settles once when streaming finishes and respects Auto-scroll Chat.
- Stabilized the companion panel by preserving the visible agent and card height during pending/result rerenders.