### PR TITLE
fix(html2canvas): preserves gradient text colours for extension compatibility

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -12086,6 +12086,18 @@ async function inlineMessageScreenshotImages(container) {
     }));
 }
 
+let messageScreenshotIconFontStylePromise = null;
+
+async function getMessageScreenshotIconFontStyle() {
+    messageScreenshotIconFontStylePromise ??= fetch('/webfonts/fa-solid-900.woff2')
+        .then(response => response.ok ? response.blob() : Promise.reject())
+        .then(getBase64Async)
+        .then(source => `@font-face { font-family: 'Font Awesome 6 Free'; font-style: normal; font-weight: 900; src: url('${source}') format('woff2'); }`)
+        .catch(() => '');
+
+    return await messageScreenshotIconFontStylePromise;
+}
+
 let messageScreenshotLibraryPromise = null;
 
 async function getMessageScreenshotLibrary() {
@@ -12149,6 +12161,7 @@ async function renderMessageScreenshotCanvas(startId, endId) {
         await delay(50);
         await waitForMessageScreenshotAssets(surface);
         await inlineMessageScreenshotImages(surface);
+        const iconFontStyle = await getMessageScreenshotIconFontStyle();
 
         return await html2canvas(surface, {
             backgroundColor: null,
@@ -12168,6 +12181,12 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                     .querySelectorAll('.mes, .mes_block, .mes_text, .mes_reasoning, :is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)')
                     .forEach(element => element.style.height = 'auto');
                 clonedSurface.querySelectorAll('.mes').forEach(element => element.style.gridTemplateRows = 'auto');
+                clonedSurface.querySelectorAll('.mes_reasoning_header_title').forEach(element => element.style.width = 'auto');
+                if (iconFontStyle) {
+                    const style = clonedDocument.createElement('style');
+                    style.textContent = iconFontStyle;
+                    clonedSurface.prepend(style);
+                }
                 // Keep html2canvas's pseudo-element suppression inside the serialized subtree.
                 clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'));
                 clonedDocument.body.replaceChildren(clonedSurface);

--- a/public/script.js
+++ b/public/script.js
@@ -12162,11 +12162,12 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                 clonedSurface.style.inset = '0';
                 clonedSurface.style.margin = '0';
                 clonedSurface.style.transform = 'none';
-                // Foreign-object fonts can reflow after html2canvas freezes computed block heights.
+                // Foreign-object fonts can reflow after html2canvas freezes computed heights and grid tracks.
                 clonedSurface.style.height = 'auto';
                 clonedSurface
                     .querySelectorAll('.mes, .mes_block, .mes_text, .mes_reasoning, :is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)')
                     .forEach(element => element.style.height = 'auto');
+                clonedSurface.querySelectorAll('.mes').forEach(element => element.style.gridTemplateRows = 'auto');
                 // Keep html2canvas's pseudo-element suppression inside the serialized subtree.
                 clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'));
                 clonedDocument.body.replaceChildren(clonedSurface);

--- a/public/script.js
+++ b/public/script.js
@@ -12162,6 +12162,8 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                 clonedSurface.style.inset = '0';
                 clonedSurface.style.margin = '0';
                 clonedSurface.style.transform = 'none';
+                // Keep html2canvas's pseudo-element suppression inside the serialized subtree.
+                clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'));
                 clonedDocument.body.replaceChildren(clonedSurface);
             },
             scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),

--- a/public/script.js
+++ b/public/script.js
@@ -12150,20 +12150,22 @@ async function renderMessageScreenshotCanvas(startId, endId) {
         await waitForMessageScreenshotAssets(surface);
         await inlineMessageScreenshotImages(surface);
 
-        const bounds = surface.getBoundingClientRect();
         return await html2canvas(surface, {
             backgroundColor: null,
             foreignObjectRendering: true,
             ignoreElements: element => !element.contains(surface) && !surface.contains(element),
             logging: false,
-            onclone: clonedDocument => {
+            onclone: (clonedDocument, clonedSurface) => {
                 clonedDocument.documentElement.style.backgroundColor = 'transparent';
-                clonedDocument.body.style.backgroundColor = 'transparent';
+                clonedDocument.body.style.cssText = 'margin: 0; background: transparent;';
+                clonedSurface.style.position = 'relative';
+                clonedSurface.style.inset = '0';
+                clonedSurface.style.margin = '0';
+                clonedSurface.style.transform = 'none';
+                clonedDocument.body.replaceChildren(clonedSurface);
             },
             scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),
             useCORS: true,
-            x: -bounds.left,
-            y: -bounds.top,
         });
     } finally {
         shell.remove();

--- a/public/script.js
+++ b/public/script.js
@@ -12078,14 +12078,16 @@ async function inlineMessageScreenshotImages(container) {
             try {
                 const response = await fetch(source, { signal: abortController.signal });
                 if (!response.ok) {
-                    return;
+                    throw new Error(`Unexpected ${response.status} response for ${source}`);
                 }
 
                 image.srcset = '';
                 image.src = await getBase64Async(await response.blob());
                 await image.decode?.().catch(() => undefined);
             } catch {
-                // Keep the original URL when the asset does not permit CORS fetching.
+                // Foreign-object SVG cannot load external images, and a pending one stalls the capture clone.
+                image.removeAttribute('srcset');
+                image.removeAttribute('src');
             }
         }));
     } finally {
@@ -12096,11 +12098,16 @@ async function inlineMessageScreenshotImages(container) {
 let messageScreenshotIconFontStylePromise = null;
 
 async function getMessageScreenshotIconFontStyle() {
-    messageScreenshotIconFontStylePromise ??= fetch('/webfonts/fa-solid-900.woff2')
-        .then(response => response.ok ? response.blob() : Promise.reject())
-        .then(getBase64Async)
-        .then(source => `@font-face { font-family: 'Font Awesome 6 Free'; font-style: normal; font-weight: 900; src: url('${source}') format('woff2'); }`)
-        .catch(() => '');
+    if (!messageScreenshotIconFontStylePromise) {
+        const abortController = new AbortController();
+        const abortTimer = setTimeout(() => abortController.abort(), 2000);
+        messageScreenshotIconFontStylePromise = fetch('/webfonts/fa-solid-900.woff2', { signal: abortController.signal })
+            .then(response => response.ok ? response.blob() : Promise.reject())
+            .then(getBase64Async)
+            .then(source => `@font-face { font-family: 'Font Awesome 6 Free'; font-style: normal; font-weight: 900; src: url('${source}') format('woff2'); }`)
+            .catch(() => '')
+            .finally(() => clearTimeout(abortTimer));
+    }
 
     return await messageScreenshotIconFontStylePromise;
 }
@@ -12148,6 +12155,18 @@ async function renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captu
     const markedSvgDataUrl = `data:image/svg+xml;charset=utf-8,${svgMarker}`;
     const existingCloneContainers = new Set(document.querySelectorAll('.html2canvas-container'));
     let serializedSvg = '';
+
+    // SB: html2canvas awaits the clone's fonts.ready and, on WebKit, every cloned image with no
+    // timeout, which stalls iOS captures forever. The capture is already decoded before cloning.
+    const cloneObserver = new MutationObserver(mutations => mutations.forEach(mutation => mutation.addedNodes.forEach(node => {
+        const cloneDocument = node instanceof HTMLIFrameElement && node.classList.contains('html2canvas-container')
+            ? node.contentDocument
+            : null;
+        if (cloneDocument) {
+            Object.defineProperty(cloneDocument, 'fonts', { configurable: true, value: { ready: Promise.resolve() } });
+            Object.defineProperty(cloneDocument, 'images', { configurable: true, value: [] });
+        }
+    })));
 
     function ScreenshotImage(...args) {
         const image = new NativeImage(...args);
@@ -12236,9 +12255,16 @@ async function renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captu
     // SB: html2canvas's unbounded percent-encoded SVG image load can stall indefinitely in Safari.
     window.Image = ScreenshotImage;
     window.encodeURIComponent = encodeURIComponentWithSvgData;
+    cloneObserver.observe(document.body, { childList: true });
+    let watchdog;
     try {
-        return await html2canvas(surface, captureOptions);
+        return await Promise.race([
+            html2canvas(surface, captureOptions),
+            new Promise((_, reject) => watchdog = setTimeout(() => reject(new Error('Timed out capturing the screenshot')), 30000)),
+        ]);
     } finally {
+        clearTimeout(watchdog);
+        cloneObserver.disconnect();
         if (window.Image === ScreenshotImage) {
             window.Image = NativeImage;
         }

--- a/public/script.js
+++ b/public/script.js
@@ -12270,6 +12270,15 @@ function normalizeMessageScreenshotStyles(container) {
         }
 
         const computedStyle = getComputedStyle(element);
+
+        // html2canvas ignores background-clip: text and paints the gradient over the whole box,
+        // hiding the text. Flatten to the solid text color (gradient extensions set it as fallback).
+        const backgroundClip = `${computedStyle.backgroundClip || ''} ${computedStyle.webkitBackgroundClip || ''}`;
+        if (computedStyle.backgroundImage !== 'none' && backgroundClip.includes('text')) {
+            element.style.setProperty('-webkit-text-fill-color', computedStyle.color);
+            element.style.setProperty('background-image', 'none');
+        }
+
         for (const propertyName of computedStyle) {
             if (propertyName.startsWith('--')) {
                 continue;

--- a/public/script.js
+++ b/public/script.js
@@ -12094,22 +12094,6 @@ async function getMessageScreenshotLibrary() {
     return await messageScreenshotLibraryPromise;
 }
 
-function normalizeSrgbChannel(channel) {
-    const trimmedChannel = channel.trim();
-
-    if (trimmedChannel.endsWith('%')) {
-        const percent = Number.parseFloat(trimmedChannel.slice(0, -1));
-        return Number.isFinite(percent) ? Math.round(clamp(percent, 0, 100) * 2.55) : null;
-    }
-
-    const numericChannel = Number.parseFloat(trimmedChannel);
-    if (!Number.isFinite(numericChannel)) {
-        return null;
-    }
-
-    return Math.round(clamp(numericChannel, 0, 1) * 255);
-}
-
 function normalizeSrgbAlpha(alpha) {
     const trimmedAlpha = alpha.trim();
 
@@ -12159,7 +12143,7 @@ function normalizeCssHueToDegrees(hue) {
         return 0;
     }
 
-    const numericHue = Number.parseFloat(trimmedHue);
+    const numericHue = Number.parseFloat(hue);
     if (!Number.isFinite(numericHue)) {
         return null;
     }
@@ -12204,61 +12188,188 @@ function oklabToRgbString(lightness, a, b, alpha) {
         : `rgba(${red}, ${green}, ${blue}, ${alpha})`;
 }
 
-function normalizeOklchFunctionString(value) {
-    return value.replace(/oklch\(\s*([^()]+?)\s*\)/gi, (_match, contents) => {
-        const [channelSection, alphaSection] = contents.split('/').map(section => section.trim());
-        const channels = channelSection.split(/\s+/).filter(Boolean);
+const MODERN_COLOR_TOKEN_PATTERN = /\b(?:color|oklch|oklab|lab|lch)\([^()]*\)/gi;
+const MODERN_COLOR_FUNCTION_TEST = /(?:\b(?:color|oklch|oklab|lab|lch)\s*\()/i;
 
-        if (channels.length < 2) {
-            return _match;
-        }
+// ponytail: nested parens inside color args (calc()) are left unconverted; recurse if capture ever hits one.
+function splitColorFunctionArgs(token) {
+    const openIndex = token.indexOf('(');
+    const name = token.slice(0, openIndex).trim().toLowerCase();
+    const contents = token.slice(openIndex + 1, token.lastIndexOf(')'));
+    const [channelSection, alphaSection] = contents.split('/').map(section => section.trim());
+    const channels = channelSection.split(/[\s,]+/).filter(Boolean);
+    return { name, channels, alpha: alphaSection ? normalizeSrgbAlpha(alphaSection) : 1 };
+}
 
+function normalizeColorChannel(channel, percentScale = 1) {
+    const trimmed = String(channel).trim().toLowerCase();
+    if (trimmed === 'none' || trimmed === '') {
+        return 0;
+    }
+
+    if (trimmed.endsWith('%')) {
+        const percent = Number.parseFloat(trimmed.slice(0, -1));
+        return Number.isFinite(percent) ? (percent / 100) * percentScale : null;
+    }
+
+    const numeric = Number.parseFloat(trimmed);
+    return Number.isFinite(numeric) ? numeric : null;
+}
+
+function applyMatrix3(matrix, vector) {
+    return matrix.map(row => row[0] * vector[0] + row[1] * vector[1] + row[2] * vector[2]);
+}
+
+// CSS Color 4 reference matrices; fractions kept verbatim from the spec sample code.
+const XYZ_D65_TO_LINEAR_SRGB = [
+    [12831 / 3959, -329 / 214, 1978 / 95947],
+    [-851781 / 878810, 1648619 / 878810, 36519 / 878810],
+    [705 / 12673, -2585 / 12673, 705 / 667],
+];
+const BRADFORD_D50_TO_D65 = [
+    [1.0478112, 0.0228866, -0.0501270],
+    [0.0295424, 0.9904844, -0.0170491],
+    [-0.0092345, 0.0150436, 0.7521316],
+];
+const LINEAR_SPACE_TO_XYZ_D65 = {
+    'display-p3': [
+        [0.4865709, 0.2656677, 0.1982173],
+        [0.2289746, 0.6917385, 0.0792869],
+        [0.0000000, 0.0451134, 1.0439444],
+    ],
+    'rec2020': [
+        [0.6369580, 0.1446169, 0.1688810],
+        [0.2627002, 0.6779981, 0.0593017],
+        [0.0000000, 0.0280727, 1.0609851],
+    ],
+    'a98-rgb': [
+        [0.5766690, 0.1855582, 0.1882287],
+        [0.2973469, 0.6273679, 0.0752900],
+        [0.0270329, 0.0706879, 0.9912373],
+    ],
+};
+const A98_GAMMA = 563 / 256;
+
+function decodeSrgbGamma(channel) {
+    const sign = Math.sign(channel);
+    const magnitude = Math.abs(channel);
+    const linear = magnitude <= 0.04045 ? magnitude / 12.92 : ((magnitude + 0.055) / 1.055) ** 2.4;
+    return sign * linear;
+}
+
+function linearToRgbString(linearChannels, alpha) {
+    const [red, green, blue] = linearChannels.map(linearSrgbToRgbChannel);
+    return alpha >= 1
+        ? `rgb(${red}, ${green}, ${blue})`
+        : `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}
+
+function labToLinearSrgb(lightness, aAxis, bAxis) {
+    const fy = (lightness + 16) / 116;
+    const fx = fy + aAxis / 500;
+    const fz = fy - bAxis / 200;
+    const epsilon = 216 / 24389;
+    const kappa = 24389 / 27;
+    const decode = (f) => (f ** 3 > epsilon ? f ** 3 : (116 * f - 16) / kappa);
+    const xyzD50 = [0.9642957 * decode(fx), decode(fy), 0.8251046 * decode(fz)];
+    return applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, applyMatrix3(BRADFORD_D50_TO_D65, xyzD50));
+}
+
+function lchToLinearSrgb(lightness, chroma, hueDegrees) {
+    const hueRadians = hueDegrees * Math.PI / 180;
+    return labToLinearSrgb(lightness, chroma * Math.cos(hueRadians), chroma * Math.sin(hueRadians));
+}
+
+function convertModernColorToken(token) {
+    const { name, channels, alpha } = splitColorFunctionArgs(token);
+
+    if (channels.length < 3 || !Number.isFinite(alpha)) {
+        return token;
+    }
+
+    if (name === 'oklch') {
         const lightness = normalizeOklabLightness(channels[0]);
         const chroma = normalizeOklchChroma(channels[1]);
-        const hue = normalizeCssHueToDegrees(channels[2] ?? '0');
-        const alpha = alphaSection ? normalizeSrgbAlpha(alphaSection) : 1;
-        if ([lightness, chroma, hue, alpha].some(channel => channel === null)) {
-            return _match;
+        const hue = normalizeCssHueToDegrees(channels[2]);
+        if ([lightness, chroma, hue].some(channel => channel === null)) {
+            return token;
+        }
+        const hueRadians = hue * Math.PI / 180;
+        return oklabToRgbString(lightness, chroma * Math.cos(hueRadians), chroma * Math.sin(hueRadians), alpha);
+    }
+
+    if (name === 'oklab') {
+        const lightness = normalizeOklabLightness(channels[0]);
+        const aAxis = normalizeColorChannel(channels[1], 0.4);
+        const bAxis = normalizeColorChannel(channels[2], 0.4);
+        if ([lightness, aAxis, bAxis].some(channel => channel === null)) {
+            return token;
+        }
+        return oklabToRgbString(lightness, aAxis, bAxis, alpha);
+    }
+
+    if (name === 'lab') {
+        const lightness = normalizeColorChannel(channels[0], 100);
+        const aAxis = normalizeColorChannel(channels[1], 125);
+        const bAxis = normalizeColorChannel(channels[2], 125);
+        if ([lightness, aAxis, bAxis].some(channel => channel === null)) {
+            return token;
+        }
+        return linearToRgbString(labToLinearSrgb(lightness, aAxis, bAxis), alpha);
+    }
+
+    if (name === 'lch') {
+        const lightness = normalizeColorChannel(channels[0], 100);
+        const chroma = normalizeColorChannel(channels[1], 150);
+        const hue = normalizeCssHueToDegrees(channels[2]);
+        if ([lightness, chroma, hue].some(channel => channel === null)) {
+            return token;
+        }
+        return linearToRgbString(lchToLinearSrgb(lightness, chroma, hue), alpha);
+    }
+
+    if (name === 'color') {
+        const space = String(channels[0]).toLowerCase();
+        const values = channels.slice(1, 4).map(channel => normalizeColorChannel(channel, 1));
+        if (values.some(channel => channel === null)) {
+            return token;
         }
 
-        const hueRadians = hue * Math.PI / 180;
-        const a = chroma * Math.cos(hueRadians);
-        const b = chroma * Math.sin(hueRadians);
-        return oklabToRgbString(lightness, a, b, alpha);
-    });
+        let linear;
+        if (space === 'srgb') {
+            linear = values.map(value => clamp(value, 0, 1));
+        } else if (space === 'srgb-linear') {
+            linear = values.map(value => clamp(value, 0, 1));
+        } else if (space === 'xyz-d50') {
+            linear = applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, applyMatrix3(BRADFORD_D50_TO_D65, values));
+        } else if (space.startsWith('xyz')) {
+            linear = applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, values);
+        } else if (LINEAR_SPACE_TO_XYZ_D65[space]) {
+            let gammaDecoded;
+            if (space === 'a98-rgb') {
+                gammaDecoded = values.map(value => Math.sign(value) * Math.abs(value) ** A98_GAMMA);
+            } else if (space === 'display-p3' || space === 'rec2020') {
+                gammaDecoded = values.map(decodeSrgbGamma);
+            } else {
+                gammaDecoded = values;
+            }
+            linear = applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, applyMatrix3(LINEAR_SPACE_TO_XYZ_D65[space], gammaDecoded));
+        } else {
+            // ponytail: unknown color spaces fall back to plain sRGB numbers rather than crashing capture.
+            linear = values.map(value => clamp(value, 0, 1));
+        }
+        return linearToRgbString(linear, alpha);
+    }
+
+    return token;
 }
 
 function normalizeColorFunctionString(value) {
-    if (!/(?:color\(srgb|oklch\()/i.test(value)) {
+    if (!MODERN_COLOR_FUNCTION_TEST.test(value)) {
         return value;
     }
 
-    const normalizedSrgbValue = value.replace(/color\(srgb\s+([^()]+?)\)/gi, (_match, contents) => {
-        const [channelSection, alphaSection] = contents.split('/').map(section => section.trim());
-        const channels = channelSection.split(/\s+/).filter(Boolean);
-
-        if (channels.length < 3) {
-            return _match;
-        }
-
-        const [red, green, blue] = channels.slice(0, 3).map(normalizeSrgbChannel);
-        if ([red, green, blue].some(channel => channel === null)) {
-            return _match;
-        }
-
-        if (!alphaSection) {
-            return `rgb(${red}, ${green}, ${blue})`;
-        }
-
-        const alpha = normalizeSrgbAlpha(alphaSection);
-        if (alpha === null) {
-            return _match;
-        }
-
-        return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-    });
-
-    return normalizeOklchFunctionString(normalizedSrgbValue);
+    return value.replace(MODERN_COLOR_TOKEN_PATTERN, convertModernColorToken);
 }
 
 function normalizeMessageScreenshotStyles(container) {
@@ -12271,21 +12382,13 @@ function normalizeMessageScreenshotStyles(container) {
 
         const computedStyle = getComputedStyle(element);
 
-        // html2canvas ignores background-clip: text and paints the gradient over the whole box,
-        // hiding the text. Flatten to the solid text color (gradient extensions set it as fallback).
-        const backgroundClip = `${computedStyle.backgroundClip || ''} ${computedStyle.webkitBackgroundClip || ''}`;
-        if (computedStyle.backgroundImage !== 'none' && backgroundClip.includes('text')) {
-            element.style.setProperty('-webkit-text-fill-color', computedStyle.color);
-            element.style.setProperty('background-image', 'none');
-        }
-
         for (const propertyName of computedStyle) {
             if (propertyName.startsWith('--')) {
                 continue;
             }
 
             const propertyValue = computedStyle.getPropertyValue(propertyName);
-            if (!/(?:color\(srgb|oklch\()/i.test(propertyValue)) {
+            if (!/(?:\b(?:color|oklch|oklab|lab|lch)\s*\()/i.test(propertyValue)) {
                 continue;
             }
 
@@ -12294,7 +12397,85 @@ function normalizeMessageScreenshotStyles(container) {
                 element.style.setProperty(propertyName, normalizedValue, computedStyle.getPropertyPriority(propertyName));
             }
         }
+
+        // html2canvas ignores background-clip: text and paints the gradient over the whole box,
+        // hiding the text. Flatten to the solid text color (gradient extensions set it as fallback).
+        // Runs after the loop so the loop cannot re-write background-image.
+        const backgroundClip = `${computedStyle.backgroundClip || ''} ${computedStyle.webkitBackgroundClip || ''}`;
+        if (computedStyle.backgroundImage !== 'none' && backgroundClip.includes('text')) {
+            element.style.setProperty('-webkit-text-fill-color', normalizeColorFunctionString(computedStyle.color));
+            element.style.setProperty('background-image', 'none');
+        }
     }
+}
+
+// Pseudo-element styles cannot be patched inline, so generated rules override any
+// modern color functions html2canvas would choke on. Lives inside the capture
+// shell and is discarded with it.
+function normalizePseudoElementCaptureStyles(container) {
+    const styleElement = document.createElement('style');
+    const rules = [];
+    let ruleIndex = 0;
+
+    for (const element of [container, ...container.querySelectorAll('*')]) {
+        for (const pseudoName of ['::before', '::after']) {
+            const pseudoStyle = getComputedStyle(element, pseudoName);
+            const contentValue = pseudoStyle.getPropertyValue('content');
+            if (!contentValue || contentValue === 'none' || contentValue === 'normal') {
+                continue;
+            }
+
+            let declarations = '';
+            for (const propertyName of pseudoStyle) {
+                if (propertyName.startsWith('--')) {
+                    continue;
+                }
+
+                const propertyValue = pseudoStyle.getPropertyValue(propertyName);
+                if (!MODERN_COLOR_FUNCTION_TEST.test(propertyValue)) {
+                    continue;
+                }
+
+                const normalizedValue = normalizeColorFunctionString(propertyValue);
+                if (normalizedValue !== propertyValue) {
+                    declarations += `${propertyName}:${normalizedValue} !important;`;
+                }
+            }
+
+            if (!declarations) {
+                continue;
+            }
+
+            const markerAttribute = `data-sb-capture-pseudo-${ruleIndex}`;
+            element.setAttribute(markerAttribute, '');
+            rules.push(`[${markerAttribute}]${pseudoName}{${declarations}}`);
+            ruleIndex++;
+        }
+    }
+
+    styleElement.textContent = rules.join('');
+    container.appendChild(styleElement);
+}
+
+// html2canvas throws on any color function outside rgb/hsl. Normalizing the
+// main-document styles is not enough because its iframe recomputes the cascade
+// from raw stylesheets, so every computed read during capture is filtered.
+function createLegacyColorComputedStyleProxy(computedStyle) {
+    return new Proxy(computedStyle, {
+        get(target, property) {
+            // Native declaration getters require the real object as receiver.
+            const value = Reflect.get(target, property, target);
+            if (typeof value === 'function') {
+                return value.bind(target);
+            }
+
+            if (typeof value === 'string') {
+                return MODERN_COLOR_FUNCTION_TEST.test(value) ? normalizeColorFunctionString(value) : value;
+            }
+
+            return value;
+        },
+    });
 }
 
 async function renderMessageScreenshotCanvas(startId, endId) {
@@ -12330,13 +12511,42 @@ async function renderMessageScreenshotCanvas(startId, endId) {
         await delay(50);
         await waitForMessageScreenshotAssets(surface);
         normalizeMessageScreenshotStyles(surface);
+        normalizePseudoElementCaptureStyles(surface);
 
-        return await html2canvas(surface, {
-            backgroundColor: null,
-            logging: false,
-            scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),
-            useCORS: true,
-        });
+        const originalGetComputedStyle = window.getComputedStyle;
+        window.getComputedStyle = function (node, pseudoElement) {
+            return createLegacyColorComputedStyleProxy(originalGetComputedStyle.call(window, node, pseudoElement));
+        };
+
+        try {
+            return await html2canvas(surface, {
+                backgroundColor: null,
+                logging: false,
+                scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),
+                useCORS: true,
+                onclone: (_clonedDocument, clonedSurface) => {
+                    if (!clonedSurface || clonedSurface.nodeType !== 1) {
+                        return;
+                    }
+
+                    // The iframe recomputes the cascade from raw stylesheets, so copy
+                    // the normalized inline declarations positionally; pseudo-element
+                    // fixes ride along via their cloned markers and <style> tag.
+                    const originals = [surface, ...surface.querySelectorAll('*')];
+                    const clones = [clonedSurface, ...clonedSurface.querySelectorAll('*')];
+                    // ponytail: assumes DocumentCloner emits a 1:1 ordered tree
+                    const sharedCount = Math.min(originals.length, clones.length);
+                    for (let index = 0; index < sharedCount; index++) {
+                        const cssText = originals[index].style && originals[index].style.cssText;
+                        if (cssText) {
+                            clones[index].style.cssText = cssText;
+                        }
+                    }
+                },
+            });
+        } finally {
+            window.getComputedStyle = originalGetComputedStyle;
+        }
     } finally {
         shell.remove();
     }

--- a/public/script.js
+++ b/public/script.js
@@ -12162,6 +12162,11 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                 clonedSurface.style.inset = '0';
                 clonedSurface.style.margin = '0';
                 clonedSurface.style.transform = 'none';
+                // Foreign-object fonts can reflow after html2canvas freezes computed block heights.
+                clonedSurface.style.height = 'auto';
+                clonedSurface
+                    .querySelectorAll('.mes, .mes_block, .mes_text, .mes_reasoning, :is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)')
+                    .forEach(element => element.style.height = 'auto');
                 // Keep html2canvas's pseudo-element suppression inside the serialized subtree.
                 clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'));
                 clonedDocument.body.replaceChildren(clonedSurface);

--- a/public/script.js
+++ b/public/script.js
@@ -12064,6 +12064,28 @@ async function waitForMessageScreenshotAssets(container) {
     ]);
 }
 
+async function inlineMessageScreenshotImages(container) {
+    await Promise.all(Array.from(container.querySelectorAll('img')).map(async (image) => {
+        const source = image.currentSrc || image.src;
+        if (!source || isDataURL(source)) {
+            return;
+        }
+
+        try {
+            const response = await fetch(source);
+            if (!response.ok) {
+                return;
+            }
+
+            image.srcset = '';
+            image.src = await getBase64Async(await response.blob());
+            await image.decode?.().catch(() => undefined);
+        } catch {
+            // Keep the original URL when the asset does not permit CORS fetching.
+        }
+    }));
+}
+
 let messageScreenshotLibraryPromise = null;
 
 async function getMessageScreenshotLibrary() {
@@ -12092,393 +12114,6 @@ async function getMessageScreenshotLibrary() {
     }
 
     return await messageScreenshotLibraryPromise;
-}
-
-function normalizeSrgbAlpha(alpha) {
-    const trimmedAlpha = alpha.trim();
-
-    if (trimmedAlpha.endsWith('%')) {
-        const percent = Number.parseFloat(trimmedAlpha.slice(0, -1));
-        return Number.isFinite(percent) ? clamp(percent / 100, 0, 1) : null;
-    }
-
-    const numericAlpha = Number.parseFloat(trimmedAlpha);
-    return Number.isFinite(numericAlpha) ? clamp(numericAlpha, 0, 1) : null;
-}
-
-function normalizeOklabLightness(lightness) {
-    const trimmedLightness = lightness.trim();
-
-    if (trimmedLightness.endsWith('%')) {
-        const percent = Number.parseFloat(trimmedLightness.slice(0, -1));
-        return Number.isFinite(percent) ? clamp(percent / 100, 0, 1) : null;
-    }
-
-    const numericLightness = Number.parseFloat(trimmedLightness);
-    if (!Number.isFinite(numericLightness)) {
-        return null;
-    }
-
-    return clamp(numericLightness > 1 ? numericLightness / 100 : numericLightness, 0, 1);
-}
-
-function normalizeOklchChroma(chroma) {
-    const trimmedChroma = chroma.trim();
-    if (trimmedChroma === 'none') {
-        return 0;
-    }
-
-    if (trimmedChroma.endsWith('%')) {
-        const percent = Number.parseFloat(trimmedChroma.slice(0, -1));
-        return Number.isFinite(percent) ? Math.max(0, percent / 100 * 0.4) : null;
-    }
-
-    const numericChroma = Number.parseFloat(trimmedChroma);
-    return Number.isFinite(numericChroma) ? Math.max(0, numericChroma) : null;
-}
-
-function normalizeCssHueToDegrees(hue) {
-    const trimmedHue = hue.trim().toLowerCase();
-    if (trimmedHue === 'none') {
-        return 0;
-    }
-
-    const numericHue = Number.parseFloat(hue);
-    if (!Number.isFinite(numericHue)) {
-        return null;
-    }
-
-    if (trimmedHue.endsWith('turn')) {
-        return numericHue * 360;
-    }
-
-    if (trimmedHue.endsWith('rad')) {
-        return numericHue * 180 / Math.PI;
-    }
-
-    if (trimmedHue.endsWith('grad')) {
-        return numericHue * 0.9;
-    }
-
-    return numericHue;
-}
-
-function linearSrgbToRgbChannel(channel) {
-    const clampedChannel = clamp(channel, 0, 1);
-    const srgbChannel = clampedChannel <= 0.0031308
-        ? 12.92 * clampedChannel
-        : 1.055 * Math.pow(clampedChannel, 1 / 2.4) - 0.055;
-
-    return Math.round(clamp(srgbChannel, 0, 1) * 255);
-}
-
-function oklabToRgbString(lightness, a, b, alpha) {
-    const lPrime = lightness + 0.3963377774 * a + 0.2158037573 * b;
-    const mPrime = lightness - 0.1055613458 * a - 0.0638541728 * b;
-    const sPrime = lightness - 0.0894841775 * a - 1.2914855480 * b;
-    const l = lPrime ** 3;
-    const m = mPrime ** 3;
-    const s = sPrime ** 3;
-    const red = linearSrgbToRgbChannel(+4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s);
-    const green = linearSrgbToRgbChannel(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s);
-    const blue = linearSrgbToRgbChannel(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s);
-
-    return alpha >= 1
-        ? `rgb(${red}, ${green}, ${blue})`
-        : `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-}
-
-const MODERN_COLOR_TOKEN_PATTERN = /\b(?:color|oklch|oklab|lab|lch)\([^()]*\)/gi;
-const MODERN_COLOR_FUNCTION_TEST = /(?:\b(?:color|oklch|oklab|lab|lch)\s*\()/i;
-
-// ponytail: nested parens inside color args (calc()) are left unconverted; recurse if capture ever hits one.
-function splitColorFunctionArgs(token) {
-    const openIndex = token.indexOf('(');
-    const name = token.slice(0, openIndex).trim().toLowerCase();
-    const contents = token.slice(openIndex + 1, token.lastIndexOf(')'));
-    const [channelSection, alphaSection] = contents.split('/').map(section => section.trim());
-    const channels = channelSection.split(/[\s,]+/).filter(Boolean);
-    return { name, channels, alpha: alphaSection ? normalizeSrgbAlpha(alphaSection) : 1 };
-}
-
-function normalizeColorChannel(channel, percentScale = 1) {
-    const trimmed = String(channel).trim().toLowerCase();
-    if (trimmed === 'none' || trimmed === '') {
-        return 0;
-    }
-
-    if (trimmed.endsWith('%')) {
-        const percent = Number.parseFloat(trimmed.slice(0, -1));
-        return Number.isFinite(percent) ? (percent / 100) * percentScale : null;
-    }
-
-    const numeric = Number.parseFloat(trimmed);
-    return Number.isFinite(numeric) ? numeric : null;
-}
-
-function applyMatrix3(matrix, vector) {
-    return matrix.map(row => row[0] * vector[0] + row[1] * vector[1] + row[2] * vector[2]);
-}
-
-// CSS Color 4 reference matrices; fractions kept verbatim from the spec sample code.
-const XYZ_D65_TO_LINEAR_SRGB = [
-    [12831 / 3959, -329 / 214, 1978 / 95947],
-    [-851781 / 878810, 1648619 / 878810, 36519 / 878810],
-    [705 / 12673, -2585 / 12673, 705 / 667],
-];
-const BRADFORD_D50_TO_D65 = [
-    [1.0478112, 0.0228866, -0.0501270],
-    [0.0295424, 0.9904844, -0.0170491],
-    [-0.0092345, 0.0150436, 0.7521316],
-];
-const LINEAR_SPACE_TO_XYZ_D65 = {
-    'display-p3': [
-        [0.4865709, 0.2656677, 0.1982173],
-        [0.2289746, 0.6917385, 0.0792869],
-        [0.0000000, 0.0451134, 1.0439444],
-    ],
-    'rec2020': [
-        [0.6369580, 0.1446169, 0.1688810],
-        [0.2627002, 0.6779981, 0.0593017],
-        [0.0000000, 0.0280727, 1.0609851],
-    ],
-    'a98-rgb': [
-        [0.5766690, 0.1855582, 0.1882287],
-        [0.2973469, 0.6273679, 0.0752900],
-        [0.0270329, 0.0706879, 0.9912373],
-    ],
-};
-const A98_GAMMA = 563 / 256;
-
-function decodeSrgbGamma(channel) {
-    const sign = Math.sign(channel);
-    const magnitude = Math.abs(channel);
-    const linear = magnitude <= 0.04045 ? magnitude / 12.92 : ((magnitude + 0.055) / 1.055) ** 2.4;
-    return sign * linear;
-}
-
-function linearToRgbString(linearChannels, alpha) {
-    const [red, green, blue] = linearChannels.map(linearSrgbToRgbChannel);
-    return alpha >= 1
-        ? `rgb(${red}, ${green}, ${blue})`
-        : `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-}
-
-function labToLinearSrgb(lightness, aAxis, bAxis) {
-    const fy = (lightness + 16) / 116;
-    const fx = fy + aAxis / 500;
-    const fz = fy - bAxis / 200;
-    const epsilon = 216 / 24389;
-    const kappa = 24389 / 27;
-    const decode = (f) => (f ** 3 > epsilon ? f ** 3 : (116 * f - 16) / kappa);
-    const xyzD50 = [0.9642957 * decode(fx), decode(fy), 0.8251046 * decode(fz)];
-    return applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, applyMatrix3(BRADFORD_D50_TO_D65, xyzD50));
-}
-
-function lchToLinearSrgb(lightness, chroma, hueDegrees) {
-    const hueRadians = hueDegrees * Math.PI / 180;
-    return labToLinearSrgb(lightness, chroma * Math.cos(hueRadians), chroma * Math.sin(hueRadians));
-}
-
-function convertModernColorToken(token) {
-    const { name, channels, alpha } = splitColorFunctionArgs(token);
-
-    if (channels.length < 3 || !Number.isFinite(alpha)) {
-        return token;
-    }
-
-    if (name === 'oklch') {
-        const lightness = normalizeOklabLightness(channels[0]);
-        const chroma = normalizeOklchChroma(channels[1]);
-        const hue = normalizeCssHueToDegrees(channels[2]);
-        if ([lightness, chroma, hue].some(channel => channel === null)) {
-            return token;
-        }
-        const hueRadians = hue * Math.PI / 180;
-        return oklabToRgbString(lightness, chroma * Math.cos(hueRadians), chroma * Math.sin(hueRadians), alpha);
-    }
-
-    if (name === 'oklab') {
-        const lightness = normalizeOklabLightness(channels[0]);
-        const aAxis = normalizeColorChannel(channels[1], 0.4);
-        const bAxis = normalizeColorChannel(channels[2], 0.4);
-        if ([lightness, aAxis, bAxis].some(channel => channel === null)) {
-            return token;
-        }
-        return oklabToRgbString(lightness, aAxis, bAxis, alpha);
-    }
-
-    if (name === 'lab') {
-        const lightness = normalizeColorChannel(channels[0], 100);
-        const aAxis = normalizeColorChannel(channels[1], 125);
-        const bAxis = normalizeColorChannel(channels[2], 125);
-        if ([lightness, aAxis, bAxis].some(channel => channel === null)) {
-            return token;
-        }
-        return linearToRgbString(labToLinearSrgb(lightness, aAxis, bAxis), alpha);
-    }
-
-    if (name === 'lch') {
-        const lightness = normalizeColorChannel(channels[0], 100);
-        const chroma = normalizeColorChannel(channels[1], 150);
-        const hue = normalizeCssHueToDegrees(channels[2]);
-        if ([lightness, chroma, hue].some(channel => channel === null)) {
-            return token;
-        }
-        return linearToRgbString(lchToLinearSrgb(lightness, chroma, hue), alpha);
-    }
-
-    if (name === 'color') {
-        const space = String(channels[0]).toLowerCase();
-        const values = channels.slice(1, 4).map(channel => normalizeColorChannel(channel, 1));
-        if (values.some(channel => channel === null)) {
-            return token;
-        }
-
-        let linear;
-        if (space === 'srgb') {
-            const [red, green, blue] = values.map(value => Math.round(clamp(value, 0, 1) * 255));
-            return alpha >= 1
-                ? `rgb(${red}, ${green}, ${blue})`
-                : `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-        } else if (space === 'srgb-linear') {
-            linear = values.map(value => clamp(value, 0, 1));
-        } else if (space === 'xyz-d50') {
-            linear = applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, applyMatrix3(BRADFORD_D50_TO_D65, values));
-        } else if (space.startsWith('xyz')) {
-            linear = applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, values);
-        } else if (LINEAR_SPACE_TO_XYZ_D65[space]) {
-            let gammaDecoded;
-            if (space === 'a98-rgb') {
-                gammaDecoded = values.map(value => Math.sign(value) * Math.abs(value) ** A98_GAMMA);
-            } else if (space === 'display-p3' || space === 'rec2020') {
-                gammaDecoded = values.map(decodeSrgbGamma);
-            } else {
-                gammaDecoded = values;
-            }
-            linear = applyMatrix3(XYZ_D65_TO_LINEAR_SRGB, applyMatrix3(LINEAR_SPACE_TO_XYZ_D65[space], gammaDecoded));
-        } else {
-            // ponytail: unknown color spaces fall back to plain sRGB numbers rather than crashing capture.
-            linear = values.map(value => clamp(value, 0, 1));
-        }
-        return linearToRgbString(linear, alpha);
-    }
-
-    return token;
-}
-
-function normalizeColorFunctionString(value) {
-    if (!MODERN_COLOR_FUNCTION_TEST.test(value)) {
-        return value;
-    }
-
-    return value.replace(MODERN_COLOR_TOKEN_PATTERN, convertModernColorToken);
-}
-
-function normalizeMessageScreenshotStyles(container) {
-    const elements = [container, ...container.querySelectorAll('*')];
-
-    for (const element of elements) {
-        if (!(element instanceof HTMLElement)) {
-            continue;
-        }
-
-        const computedStyle = getComputedStyle(element);
-
-        for (const propertyName of computedStyle) {
-            if (propertyName.startsWith('--')) {
-                continue;
-            }
-
-            const propertyValue = computedStyle.getPropertyValue(propertyName);
-            if (!/(?:\b(?:color|oklch|oklab|lab|lch)\s*\()/i.test(propertyValue)) {
-                continue;
-            }
-
-            const normalizedValue = normalizeColorFunctionString(propertyValue);
-            if (normalizedValue !== propertyValue) {
-                element.style.setProperty(propertyName, normalizedValue, computedStyle.getPropertyPriority(propertyName));
-            }
-        }
-
-        // html2canvas ignores background-clip: text and paints the gradient over the whole box,
-        // hiding the text. Flatten to the solid text color (gradient extensions set it as fallback).
-        // Runs after the loop so the loop cannot re-write background-image.
-        const backgroundClip = `${computedStyle.backgroundClip || ''} ${computedStyle.webkitBackgroundClip || ''}`;
-        if (computedStyle.backgroundImage !== 'none' && backgroundClip.includes('text')) {
-            element.style.setProperty('-webkit-text-fill-color', normalizeColorFunctionString(computedStyle.color));
-            element.style.setProperty('background-image', 'none');
-        }
-    }
-}
-
-// Pseudo-element styles cannot be patched inline, so generated rules override any
-// modern color functions html2canvas would choke on. Lives inside the capture
-// shell and is discarded with it.
-function normalizePseudoElementCaptureStyles(container) {
-    const styleElement = document.createElement('style');
-    const rules = [];
-    let ruleIndex = 0;
-
-    for (const element of [container, ...container.querySelectorAll('*')]) {
-        for (const pseudoName of ['::before', '::after']) {
-            const pseudoStyle = getComputedStyle(element, pseudoName);
-            const contentValue = pseudoStyle.getPropertyValue('content');
-            if (!contentValue || contentValue === 'none' || contentValue === 'normal') {
-                continue;
-            }
-
-            let declarations = '';
-            for (const propertyName of pseudoStyle) {
-                if (propertyName.startsWith('--')) {
-                    continue;
-                }
-
-                const propertyValue = pseudoStyle.getPropertyValue(propertyName);
-                if (!MODERN_COLOR_FUNCTION_TEST.test(propertyValue)) {
-                    continue;
-                }
-
-                const normalizedValue = normalizeColorFunctionString(propertyValue);
-                if (normalizedValue !== propertyValue) {
-                    declarations += `${propertyName}:${normalizedValue} !important;`;
-                }
-            }
-
-            if (!declarations) {
-                continue;
-            }
-
-            const markerAttribute = `data-sb-capture-pseudo-${ruleIndex}`;
-            element.setAttribute(markerAttribute, '');
-            rules.push(`[${markerAttribute}]${pseudoName}{${declarations}}`);
-            ruleIndex++;
-        }
-    }
-
-    styleElement.textContent = rules.join('');
-    container.appendChild(styleElement);
-}
-
-// html2canvas throws on any color function outside rgb/hsl. Normalizing the
-// main-document styles is not enough because its iframe recomputes the cascade
-// from raw stylesheets, so every computed read during capture is filtered.
-function createLegacyColorComputedStyleProxy(computedStyle) {
-    return new Proxy(computedStyle, {
-        get(target, property) {
-            // Native declaration getters require the real object as receiver.
-            const value = Reflect.get(target, property, target);
-            if (typeof value === 'function') {
-                return value.bind(target);
-            }
-
-            if (typeof value === 'string') {
-                return MODERN_COLOR_FUNCTION_TEST.test(value) ? normalizeColorFunctionString(value) : value;
-            }
-
-            return value;
-        },
-    });
 }
 
 async function renderMessageScreenshotCanvas(startId, endId) {
@@ -12513,43 +12148,23 @@ async function renderMessageScreenshotCanvas(startId, endId) {
 
         await delay(50);
         await waitForMessageScreenshotAssets(surface);
-        normalizeMessageScreenshotStyles(surface);
-        normalizePseudoElementCaptureStyles(surface);
+        await inlineMessageScreenshotImages(surface);
 
-        const originalGetComputedStyle = window.getComputedStyle;
-        window.getComputedStyle = function (node, pseudoElement) {
-            return createLegacyColorComputedStyleProxy(originalGetComputedStyle.call(window, node, pseudoElement));
-        };
-
-        try {
-            return await html2canvas(surface, {
-                backgroundColor: null,
-                logging: false,
-                scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),
-                useCORS: true,
-                onclone: (_clonedDocument, clonedSurface) => {
-                    if (!clonedSurface || clonedSurface.nodeType !== 1) {
-                        return;
-                    }
-
-                    // The iframe recomputes the cascade from raw stylesheets, so copy
-                    // the normalized inline declarations positionally; pseudo-element
-                    // fixes ride along via their cloned markers and <style> tag.
-                    const originals = [surface, ...surface.querySelectorAll('*')];
-                    const clones = [clonedSurface, ...clonedSurface.querySelectorAll('*')];
-                    // ponytail: assumes DocumentCloner emits a 1:1 ordered tree
-                    const sharedCount = Math.min(originals.length, clones.length);
-                    for (let index = 0; index < sharedCount; index++) {
-                        const cssText = originals[index].style && originals[index].style.cssText;
-                        if (cssText) {
-                            clones[index].style.cssText = cssText;
-                        }
-                    }
-                },
-            });
-        } finally {
-            window.getComputedStyle = originalGetComputedStyle;
-        }
+        const bounds = surface.getBoundingClientRect();
+        return await html2canvas(surface, {
+            backgroundColor: null,
+            foreignObjectRendering: true,
+            ignoreElements: element => !element.contains(surface) && !surface.contains(element),
+            logging: false,
+            onclone: clonedDocument => {
+                clonedDocument.documentElement.style.backgroundColor = 'transparent';
+                clonedDocument.body.style.backgroundColor = 'transparent';
+            },
+            scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),
+            useCORS: true,
+            x: -bounds.left,
+            y: -bounds.top,
+        });
     } finally {
         shell.remove();
     }

--- a/public/script.js
+++ b/public/script.js
@@ -12337,7 +12337,10 @@ function convertModernColorToken(token) {
 
         let linear;
         if (space === 'srgb') {
-            linear = values.map(value => clamp(value, 0, 1));
+            const [red, green, blue] = values.map(value => Math.round(clamp(value, 0, 1) * 255));
+            return alpha >= 1
+                ? `rgb(${red}, ${green}, ${blue})`
+                : `rgba(${red}, ${green}, ${blue}, ${alpha})`;
         } else if (space === 'srgb-linear') {
             linear = values.map(value => clamp(value, 0, 1));
         } else if (space === 'xyz-d50') {

--- a/public/script.js
+++ b/public/script.js
@@ -12106,6 +12106,7 @@ async function getMessageScreenshotIconFontStyle() {
 }
 
 let messageScreenshotLibraryPromise = null;
+let messageScreenshotDownloadQueue = Promise.resolve();
 
 async function getMessageScreenshotLibrary() {
     const hydrationState = resolveLazyToolingLibraryHydration({
@@ -12133,6 +12134,123 @@ async function getMessageScreenshotLibrary() {
     }
 
     return await messageScreenshotLibraryPromise;
+}
+
+async function renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captureOptions) {
+    const NativeImage = window.Image;
+    const nativeEncodeURIComponent = window.encodeURIComponent;
+    const nativeImageSource = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src');
+    if (!nativeImageSource?.get || !nativeImageSource.set) {
+        return await html2canvas(surface, captureOptions);
+    }
+
+    const svgMarker = '__sillybunny_html2canvas_foreign_object__';
+    const markedSvgDataUrl = `data:image/svg+xml;charset=utf-8,${svgMarker}`;
+    const existingCloneContainers = new Set(document.querySelectorAll('.html2canvas-container'));
+    let serializedSvg = '';
+
+    function ScreenshotImage(...args) {
+        const image = new NativeImage(...args);
+        Object.defineProperty(image, 'src', {
+            configurable: true,
+            get: () => nativeImageSource.get.call(image),
+            set: (source) => {
+                if (source !== markedSvgDataUrl || !serializedSvg) {
+                    nativeImageSource.set.call(image, source);
+                    return;
+                }
+
+                const reader = new FileReader();
+                const onload = image.onload;
+                const onerror = image.onerror;
+                let settled = false;
+                const svg = new Blob([serializedSvg], { type: 'image/svg+xml;charset=utf-8' });
+                serializedSvg = '';
+
+                const cleanup = () => {
+                    image.onload = null;
+                    image.onerror = null;
+                    reader.onload = null;
+                    reader.onerror = null;
+                };
+                const fail = (error) => {
+                    if (settled) {
+                        return;
+                    }
+
+                    settled = true;
+                    clearTimeout(timeout);
+                    cleanup();
+                    if (reader.readyState === FileReader.LOADING) {
+                        reader.abort();
+                    }
+                    try {
+                        nativeImageSource.set.call(image, '');
+                    } catch {
+                        // The saved error handler still releases html2canvas if image cancellation fails.
+                    }
+                    onerror?.call(image, error instanceof Error ? error : new Error('Failed to render screenshot SVG'));
+                };
+                const timeout = setTimeout(() => fail(new Error('Timed out rendering screenshot SVG')), 15000);
+
+                image.onload = (event) => {
+                    if (settled) {
+                        return;
+                    }
+
+                    settled = true;
+                    clearTimeout(timeout);
+                    cleanup();
+                    onload?.call(image, event);
+                };
+                image.onerror = fail;
+                reader.onerror = () => fail(reader.error ?? new Error('Failed to encode screenshot SVG'));
+                reader.onload = () => {
+                    try {
+                        nativeImageSource.set.call(image, reader.result);
+                    } catch (error) {
+                        fail(error);
+                    }
+                };
+
+                try {
+                    reader.readAsDataURL(svg);
+                } catch (error) {
+                    fail(error);
+                }
+            },
+        });
+        return image;
+    }
+
+    ScreenshotImage.prototype = NativeImage.prototype;
+    const encodeURIComponentWithSvgData = (value) => {
+        if (typeof value === 'string' && value.startsWith('<svg') && value.includes('<foreignObject')) {
+            serializedSvg = value;
+            return svgMarker;
+        }
+
+        return nativeEncodeURIComponent(value);
+    };
+
+    // SB: html2canvas's unbounded percent-encoded SVG image load can stall indefinitely in Safari.
+    window.Image = ScreenshotImage;
+    window.encodeURIComponent = encodeURIComponentWithSvgData;
+    try {
+        return await html2canvas(surface, captureOptions);
+    } finally {
+        if (window.Image === ScreenshotImage) {
+            window.Image = NativeImage;
+        }
+        if (window.encodeURIComponent === encodeURIComponentWithSvgData) {
+            window.encodeURIComponent = nativeEncodeURIComponent;
+        }
+        document.querySelectorAll('.html2canvas-container').forEach(container => {
+            if (!existingCloneContainers.has(container)) {
+                container.remove();
+            }
+        });
+    }
 }
 
 async function renderMessageScreenshotCanvas(startId, endId) {
@@ -12210,7 +12328,7 @@ async function renderMessageScreenshotCanvas(startId, endId) {
             useCORS: true,
         };
 
-        return await html2canvas(surface, captureOptions);
+        return await renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captureOptions);
     } finally {
         shell.remove();
     }
@@ -12316,6 +12434,11 @@ async function openMessageScreenshotDialog(messageId) {
         return;
     }
 
+    const previousDownload = messageScreenshotDownloadQueue;
+    let releaseDownload;
+    messageScreenshotDownloadQueue = new Promise(resolve => releaseDownload = resolve);
+    await previousDownload;
+
     try {
         await downloadMessageScreenshot(range.startId, range.endId);
         const successText = range.startId === range.endId
@@ -12325,6 +12448,8 @@ async function openMessageScreenshotDialog(messageId) {
     } catch (error) {
         console.error('Failed to create message screenshot', error);
         toastr.error(t`Couldn't create the screenshot. Check the browser console for details.`, t`Screenshot failed`);
+    } finally {
+        releaseDownload();
     }
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -12065,25 +12065,32 @@ async function waitForMessageScreenshotAssets(container) {
 }
 
 async function inlineMessageScreenshotImages(container) {
-    await Promise.all(Array.from(container.querySelectorAll('img')).map(async (image) => {
-        const source = image.currentSrc || image.src;
-        if (!source || isDataURL(source)) {
-            return;
-        }
+    const abortController = new AbortController();
+    const abortTimer = setTimeout(() => abortController.abort(), 2000);
 
-        try {
-            const response = await fetch(source);
-            if (!response.ok) {
+    try {
+        await Promise.all(Array.from(container.querySelectorAll('img')).map(async (image) => {
+            const source = image.currentSrc || image.src;
+            if (!source || isDataURL(source)) {
                 return;
             }
 
-            image.srcset = '';
-            image.src = await getBase64Async(await response.blob());
-            await image.decode?.().catch(() => undefined);
-        } catch {
-            // Keep the original URL when the asset does not permit CORS fetching.
-        }
-    }));
+            try {
+                const response = await fetch(source, { signal: abortController.signal });
+                if (!response.ok) {
+                    return;
+                }
+
+                image.srcset = '';
+                image.src = await getBase64Async(await response.blob());
+                await image.decode?.().catch(() => undefined);
+            } catch {
+                // Keep the original URL when the asset does not permit CORS fetching.
+            }
+        }));
+    } finally {
+        clearTimeout(abortTimer);
+    }
 }
 
 let messageScreenshotIconFontStylePromise = null;
@@ -12155,7 +12162,7 @@ async function renderMessageScreenshotCanvas(startId, endId) {
         const html2canvas = await getMessageScreenshotLibrary();
 
         if (document.fonts?.ready) {
-            await document.fonts.ready;
+            await Promise.race([document.fonts.ready, delay(2000)]);
         }
 
         await delay(50);

--- a/public/script.js
+++ b/public/script.js
@@ -12162,8 +12162,11 @@ async function renderMessageScreenshotCanvas(startId, endId) {
         await waitForMessageScreenshotAssets(surface);
         await inlineMessageScreenshotImages(surface);
         const iconFontStyle = await getMessageScreenshotIconFontStyle();
+        const mobileCapture = isMobile();
+        const preferredScale = mobileCapture ? 1 : Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+        const pixelBudget = mobileCapture ? 4_000_000 : 16_000_000;
 
-        return await html2canvas(surface, {
+        const captureOptions = {
             backgroundColor: null,
             foreignObjectRendering: true,
             ignoreElements: element => !element.contains(surface) && !surface.contains(element),
@@ -12192,10 +12195,15 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                 // Keep html2canvas's pseudo-element suppression inside the serialized subtree.
                 clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'));
                 clonedDocument.body.replaceChildren(clonedSurface);
+                // SB: html2canvas resolves scale after onclone, when the reflowed capture size is known.
+                const captureArea = Math.max(1, clonedSurface.scrollWidth * clonedSurface.scrollHeight);
+                captureOptions.scale = Math.min(preferredScale, Math.sqrt(pixelBudget / captureArea));
             },
-            scale: Math.max(1, Math.min(window.devicePixelRatio || 1, 2)),
+            scale: preferredScale,
             useCORS: true,
-        });
+        };
+
+        return await html2canvas(surface, captureOptions);
     } finally {
         shell.remove();
     }
@@ -12214,6 +12222,8 @@ async function downloadMessageScreenshot(startId, endId) {
         }, 'image/png');
     });
 
+    canvas.width = 0;
+    canvas.height = 0;
     download(blob, buildMessageScreenshotFilename(startId, endId), 'image/png');
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -12181,7 +12181,9 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                     .querySelectorAll('.mes, .mes_block, .mes_text, .mes_reasoning, :is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)')
                     .forEach(element => element.style.height = 'auto');
                 clonedSurface.querySelectorAll('.mes').forEach(element => element.style.gridTemplateRows = 'auto');
-                clonedSurface.querySelectorAll('.mes_reasoning_header_title').forEach(element => element.style.width = 'auto');
+                clonedSurface
+                    .querySelectorAll('.mes_reasoning_header_title, .ica--companion-title, .ica--companion-title > span, .ica--companion-meta, .ica--companion-summary-spacer')
+                    .forEach(element => element.style.width = 'auto');
                 if (iconFontStyle) {
                     const style = clonedDocument.createElement('style');
                     style.textContent = iconFontStyle;

--- a/public/script.js
+++ b/public/script.js
@@ -12069,27 +12069,71 @@ async function inlineMessageScreenshotImages(container) {
     const abortTimer = setTimeout(() => abortController.abort(), 2000);
 
     try {
-        await Promise.all(Array.from(container.querySelectorAll('img')).map(async (image) => {
-            const source = image.currentSrc || image.src;
-            if (!source || isDataURL(source)) {
-                return;
+        const fetchInlineSource = async (source) => {
+            const response = await fetch(source, { signal: abortController.signal });
+            if (!response.ok) {
+                throw new Error(`Unexpected ${response.status} response for ${source}`);
             }
 
-            try {
-                const response = await fetch(source, { signal: abortController.signal });
-                if (!response.ok) {
-                    throw new Error(`Unexpected ${response.status} response for ${source}`);
+            return await getBase64Async(await response.blob());
+        };
+        const pseudoImages = [];
+        // SB: html2canvas materializes generated-content images after its normal image wait.
+        [container, ...container.querySelectorAll('*')].forEach(element => {
+            ['::before', '::after'].forEach(pseudoElement => {
+                const content = getComputedStyle(element, pseudoElement).content;
+                const sources = Array.from(content.matchAll(/url\((?:"([^"]*)"|'([^']*)'|([^)]*))\)/g));
+                if (sources.length > 0) {
+                    pseudoImages.push({ content, element, pseudoElement, sources });
+                }
+            });
+        });
+
+        const pseudoStyleRules = [];
+        await Promise.all([
+            ...Array.from(container.querySelectorAll('img')).map(async (image) => {
+                const source = image.currentSrc || image.src;
+                if (!source || isDataURL(source)) {
+                    return;
                 }
 
-                image.srcset = '';
-                image.src = await getBase64Async(await response.blob());
-                await image.decode?.().catch(() => undefined);
-            } catch {
-                // Foreign-object SVG cannot load external images, and a pending one stalls the capture clone.
-                image.removeAttribute('srcset');
-                image.removeAttribute('src');
-            }
-        }));
+                try {
+                    image.srcset = '';
+                    image.src = await fetchInlineSource(source);
+                    await image.decode?.().catch(() => undefined);
+                } catch {
+                    // Foreign-object SVG cannot load external images, and a pending one stalls the capture clone.
+                    image.removeAttribute('srcset');
+                    image.removeAttribute('src');
+                }
+            }),
+            ...pseudoImages.map(async ({ content, element, pseudoElement, sources }, index) => {
+                let inlineContent = content;
+                try {
+                    for (const sourceMatch of sources) {
+                        const source = sourceMatch[1] ?? sourceMatch[2] ?? sourceMatch[3]?.trim();
+                        if (!source || isDataURL(source)) {
+                            continue;
+                        }
+
+                        inlineContent = inlineContent.replace(sourceMatch[0], `url("${await fetchInlineSource(source)}")`);
+                    }
+                } catch {
+                    inlineContent = 'none';
+                }
+
+                const pseudoName = pseudoElement.slice(2);
+                const attribute = `data-sb-screenshot-pseudo-${pseudoName}`;
+                element.setAttribute(attribute, String(index));
+                pseudoStyleRules.push(`[${attribute}="${index}"]${pseudoElement} { content: ${inlineContent} !important; }`);
+            }),
+        ]);
+
+        if (pseudoStyleRules.length > 0) {
+            const style = document.createElement('style');
+            style.textContent = pseudoStyleRules.join('\n');
+            container.prepend(style);
+        }
     } finally {
         clearTimeout(abortTimer);
     }
@@ -12316,6 +12360,7 @@ async function renderMessageScreenshotCanvas(startId, endId) {
         const mobileCapture = isMobile();
         const preferredScale = mobileCapture ? 1 : Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
         const pixelBudget = mobileCapture ? 4_000_000 : 16_000_000;
+        const maxCanvasSide = mobileCapture ? 16_384 : 32_767;
 
         const captureOptions = {
             backgroundColor: null,
@@ -12346,9 +12391,14 @@ async function renderMessageScreenshotCanvas(startId, endId) {
                 // Keep html2canvas's pseudo-element suppression inside the serialized subtree.
                 clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'));
                 clonedDocument.body.replaceChildren(clonedSurface);
-                // SB: html2canvas resolves scale after onclone, when the reflowed capture size is known.
+                // SB: bound the reflowed capture by both raster area and browser canvas-side limits.
                 const captureArea = Math.max(1, clonedSurface.scrollWidth * clonedSurface.scrollHeight);
-                captureOptions.scale = Math.min(preferredScale, Math.sqrt(pixelBudget / captureArea));
+                captureOptions.scale = Math.min(
+                    preferredScale,
+                    Math.sqrt(pixelBudget / captureArea),
+                    maxCanvasSide / Math.max(1, clonedSurface.scrollWidth),
+                    maxCanvasSide / Math.max(1, clonedSurface.scrollHeight),
+                );
             },
             scale: preferredScale,
             useCORS: true,

--- a/public/style.css
+++ b/public/style.css
@@ -5129,6 +5129,10 @@ input[type="range"]::-webkit-slider-thumb {
     padding-bottom: 0 !important;
 }
 
+.sb-message-screenshot-surface .mes_reasoning_header {
+    flex: 1;
+}
+
 .sb-message-screenshot-surface :is(.mes_button, .mes_buttons, .extraMesButtons, .extraMesButtonsHint, .mes_edit_buttons, .mes_reasoning_actions, .for_checkbox, .del_checkbox, .swipe_left, .swipe_right, .swipeRightBlock, .swipes-counter, .right_menu_button, .code-copy) {
     display: none !important;
 }

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -316,6 +316,24 @@ test.describe('message screenshots', () => {
         await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
         await dismissOnboardingIfPresent(page);
         await installScreenshotMessage(page, 'single screenshot oklch regression');
+        await page.evaluate(() => {
+            const imageSource = Object.getOwnPropertyDescriptor(window.HTMLImageElement.prototype, 'src');
+            if (!imageSource?.get || !imageSource.set) {
+                throw new Error('Image source descriptor unavailable');
+            }
+
+            window.messageScreenshotSvgDataCount = 0;
+            Object.defineProperty(window.HTMLImageElement.prototype, 'src', {
+                configurable: true,
+                get: imageSource.get,
+                set(value) {
+                    if (/^data:image\/svg\+xml.*;base64,/.test(String(value))) {
+                        window.messageScreenshotSvgDataCount++;
+                    }
+                    imageSource.set.call(this, value);
+                },
+            });
+        });
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
@@ -335,6 +353,7 @@ test.describe('message screenshots', () => {
         expect(companionMetaWidth).toBeGreaterThan(100);
         expect(redPixels).toBeLessThan(totalPixels * 0.01);
         expect(bluePixels).toBeLessThan(totalPixels * 0.01);
+        expect(await page.evaluate(() => window.messageScreenshotSvgDataCount)).toBeGreaterThan(0);
 
         const rangeDownload = await exportScreenshotFromMessage(page, 0, 0, 1);
         expect(rangeDownload.suggestedFilename()).toContain('messages-0-1.png');
@@ -378,5 +397,47 @@ test.describe('mobile message screenshots', () => {
         expect(width).toBeLessThanOrEqual(400);
         expect(width * height).toBeLessThanOrEqual(4_100_000);
         expect(height).toBeGreaterThan(8000);
+    });
+
+    test('reports a stalled foreign-object render instead of hanging', async ({ page }) => {
+        const screenshotErrors = [];
+        page.on('console', message => {
+            if (message.type() === 'error' && /screenshot/i.test(message.text())) {
+                screenshotErrors.push(message.text());
+            }
+        });
+
+        await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+        await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+        await dismissOnboardingIfPresent(page);
+        await installScreenshotMessage(page, 'stalled mobile screenshot regression');
+        await page.evaluate(() => {
+            const imageSource = Object.getOwnPropertyDescriptor(window.HTMLImageElement.prototype, 'src');
+            if (!imageSource?.get || !imageSource.set) {
+                throw new Error('Image source descriptor unavailable');
+            }
+
+            Object.defineProperty(window.HTMLImageElement.prototype, 'src', {
+                configurable: true,
+                get: imageSource.get,
+                set(value) {
+                    if (!/^data:image\/svg\+xml.*;base64,/.test(String(value))) {
+                        imageSource.set.call(this, value);
+                    }
+                },
+            });
+
+            const nativeSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, timeout, ...args) => nativeSetTimeout(callback, timeout === 15000 ? 20 : timeout, ...args);
+        });
+
+        await page.locator('#chat .mes').first().locator('.mes_screenshot').dispatchEvent('click');
+        await page.locator('#message_screenshot_start_id').fill('0');
+        await page.locator('#message_screenshot_end_id').fill('0');
+        await page.locator('.message_screenshot_popup .popup-button-ok').dispatchEvent('click');
+
+        await expect(page.locator('.toast-error').filter({ hasText: 'Screenshot failed' })).toBeVisible({ timeout: 5000 });
+        expect(screenshotErrors).toHaveLength(1);
+        expect(await page.locator('.html2canvas-container').count()).toBe(0);
     });
 });

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -399,6 +399,22 @@ test.describe('mobile message screenshots', () => {
         expect(height).toBeGreaterThan(8000);
     });
 
+    test('completes capture when a cloned image never finishes loading', async ({ page }) => {
+        await page.route('**/screenshot-hang.png', () => new Promise(() => {}));
+        await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+        await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+        await dismissOnboardingIfPresent(page);
+        await installScreenshotMessage(page, 'hanging clone image regression');
+        await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
+            const hangingImage = document.createElement('img');
+            hangingImage.src = '/screenshot-hang.png';
+            element.append(hangingImage);
+        });
+
+        const download = await exportScreenshotFromMessage(page, 0, 0, 0);
+        expect(download.suggestedFilename()).toContain('message-0.png');
+    });
+
     test('reports a stalled foreign-object render instead of hanging', async ({ page }) => {
         const screenshotErrors = [];
         page.on('console', message => {

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -95,6 +95,7 @@ async function installScreenshotMessage(page, messageText) {
             .message-screenshot-grid-probe > .mesAvatarWrapper { grid-area: 1 / 1 !important; }
             .message-screenshot-grid-probe > .mes_block { grid-area: 1 / 2 !important; }
             .message-screenshot-reflow-probe::first-line { font-size: 4px; }
+            .message-screenshot-card-width-probe::first-line { font-size: 4px; }
         `;
         document.head.appendChild(reflowStyle);
 
@@ -141,6 +142,25 @@ async function installScreenshotMessage(page, messageText) {
         }
         messageTextElement.append(overlapProbe, reflowProbe);
 
+        const companionLedger = document.createElement('div');
+        companionLedger.className = 'ica--companion-ledger';
+        companionLedger.style.cssText = 'width:520px;max-width:100%;';
+        companionLedger.innerHTML = `
+            <details class="ica--companion-card ica--companion-card--done" open>
+                <summary class="ica--companion-summary">
+                    <span class="ica--companion-title"><i class="fa-solid fa-user-astronaut"></i><span class="message-screenshot-card-width-probe" style="background:rgb(0 180 140)">World Details</span></span>
+                    <span class="ica--companion-summary-spacer"></span>
+                    <span class="ica--companion-meta message-screenshot-card-width-probe" style="background:rgb(180 80 180);opacity:1">companion-profile-label</span>
+                    <span class="ica--companion-status">Ready</span>
+                    <span class="ica--companion-actions">
+                        ${['fa-rotate-right', 'fa-pen-to-square', 'fa-copy', 'fa-trash'].map(icon => `<button class="ica--companion-action"><i class="fa-solid ${icon}"></i></button>`).join('')}
+                    </span>
+                </summary>
+                <div class="ica--companion-body">Companion content must remain visible.</div>
+            </details>
+        `;
+        messageBlock.appendChild(companionLedger);
+
         const captureEndMarker = document.createElement('div');
         captureEndMarker.style.cssText = 'width:200px;height:12px;background:rgb(255 0 255);';
         messageBlock.appendChild(captureEndMarker);
@@ -183,11 +203,15 @@ async function readScreenshotPixelStats(page, download) {
         let reasoningTitleTop = canvas.height;
         let redPixels = 0;
         let bluePixels = 0;
+        let companionMetaWidth = 0;
+        let companionTitleWidth = 0;
 
         for (let y = 0; y < canvas.height; y++) {
             let hasGradient = false;
             let hasMarker = false;
             let markerRun = 0;
+            let companionMetaRun = 0;
+            let companionTitleRun = 0;
             for (let x = 0; x < canvas.width; x++) {
                 const index = (y * canvas.width + x) * 4;
                 const red = pixels[index];
@@ -227,13 +251,25 @@ async function readScreenshotPixelStats(page, download) {
                 if (alpha > 200 && red > 220 && green < 40 && blue >= 80 && blue <= 190) {
                     reasoningIconPixels++;
                 }
+                if (alpha > 200 && red < 20 && green >= 160 && green <= 200 && blue >= 120 && blue <= 160) {
+                    companionTitleRun++;
+                    companionTitleWidth = Math.max(companionTitleWidth, companionTitleRun);
+                } else {
+                    companionTitleRun = 0;
+                }
+                if (alpha > 200 && red >= 160 && red <= 200 && green >= 60 && green <= 100 && blue >= 160 && blue <= 200) {
+                    companionMetaRun++;
+                    companionMetaWidth = Math.max(companionMetaWidth, companionMetaRun);
+                } else {
+                    companionMetaRun = 0;
+                }
             }
             if (hasGradient && hasMarker) overlappingColorRows++;
         }
 
         const reasoningWidth = reasoningRight >= reasoningLeft ? reasoningRight - reasoningLeft + 1 : 0;
         const reasoningTitleHeight = reasoningTitleBottom >= reasoningTitleTop ? reasoningTitleBottom - reasoningTitleTop + 1 : 0;
-        return { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height };
+        return { bluePixels, companionMetaWidth, companionTitleWidth, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height };
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
@@ -275,7 +311,7 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
-        const { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        const { bluePixels, companionMetaWidth, companionTitleWidth, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
         expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
         expect(redPixels).toBeGreaterThan(10);
         expect(bluePixels).toBeGreaterThan(10);
@@ -287,6 +323,8 @@ test.describe('message screenshots', () => {
         expect(reasoningTitleHeight).toBeGreaterThan(0);
         expect(reasoningTitleHeight).toBeLessThan(20);
         expect(reasoningWidth).toBeGreaterThan(250);
+        expect(companionTitleWidth).toBeGreaterThan(70);
+        expect(companionMetaWidth).toBeGreaterThan(100);
         expect(redPixels).toBeLessThan(totalPixels * 0.01);
         expect(bluePixels).toBeLessThan(totalPixels * 0.01);
 

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -48,6 +48,19 @@ async function installScreenshotMessage(page, messageText) {
         }
 
         messageTextElement.style.color = 'oklch(70% 0.2 140)';
+
+        const gradientSpan = document.createElement('span');
+        gradientSpan.style.backgroundImage = 'linear-gradient(90deg, color(display-p3 1 0 0), color(xyz-d65 0.1 0.4 0.2))';
+        gradientSpan.style.webkitBackgroundClip = 'text';
+        gradientSpan.style.backgroundClip = 'text';
+        gradientSpan.style.webkitTextFillColor = 'transparent';
+        gradientSpan.textContent = text;
+        messageTextElement.appendChild(gradientSpan);
+
+        const assistantTextElement = document.querySelector('#chat .mes[mesid="1"] .mes_text');
+        if (assistantTextElement) {
+            assistantTextElement.style.color = 'lab(60% 20 -30)';
+        }
     }, messageText);
 }
 

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -359,9 +359,17 @@ test.describe('mobile message screenshots', () => {
         await dismissOnboardingIfPresent(page);
         await installScreenshotMessage(page, 'mobile screenshot raster budget regression');
         await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
+            const originalFetch = window.fetch.bind(window);
+            window.fetch = (input, init) => String(input).includes('screenshot-stall.png')
+                ? new Promise((_, reject) => init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true }))
+                : originalFetch(input, init);
+            Object.defineProperty(document.fonts, 'ready', { configurable: true, value: new Promise(() => {}) });
+
             const spacer = document.createElement('div');
             spacer.style.height = '11000px';
-            element.appendChild(spacer);
+            const stalledImage = document.createElement('img');
+            stalledImage.src = '/screenshot-stall.png';
+            element.append(spacer, stalledImage);
         });
 
         const download = await exportScreenshotFromMessage(page, 0, 0, 0);

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -1,5 +1,6 @@
 /* global document, window */
 import { expect, test } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
 
 const APP_URL = process.env.SILLYBUNNY_TEST_BASE_URL || '/';
 
@@ -48,6 +49,7 @@ async function installScreenshotMessage(page, messageText) {
         }
 
         messageTextElement.style.color = 'oklch(70% 0.2 140)';
+        messageTextElement.closest('.mes_block')?.style.setProperty('background-color', 'color(srgb 0.156863 0.164706 0.196078)', 'important');
 
         const gradientSpan = document.createElement('span');
         gradientSpan.style.backgroundImage = 'linear-gradient(90deg, color(display-p3 1 0 0), color(xyz-d65 0.1 0.4 0.2))';
@@ -62,6 +64,42 @@ async function installScreenshotMessage(page, messageText) {
             assistantTextElement.style.color = 'lab(60% 20 -30)';
         }
     }, messageText);
+}
+
+async function readScreenshotPixelStats(page, download) {
+    const downloadPath = await download.path();
+    const imageData = await readFile(downloadPath);
+
+    return await page.evaluate(async (source) => {
+        const image = new window.Image();
+        image.src = source;
+        await image.decode();
+
+        const canvas = document.createElement('canvas');
+        canvas.width = image.naturalWidth;
+        canvas.height = image.naturalHeight;
+        const context = canvas.getContext('2d');
+        context.drawImage(image, 0, 0);
+
+        const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+        let darkPixels = 0;
+        let redPixels = 0;
+
+        for (let index = 0; index < pixels.length; index += 4) {
+            const red = pixels[index];
+            const green = pixels[index + 1];
+            const blue = pixels[index + 2];
+            const alpha = pixels[index + 3];
+            if (alpha > 200 && red >= 25 && red <= 60 && green >= 25 && green <= 65 && blue >= 30 && blue <= 75) {
+                darkPixels++;
+            }
+            if (alpha > 200 && red > 170 && red > green * 1.4 && red > blue * 1.4) {
+                redPixels++;
+            }
+        }
+
+        return { darkPixels, redPixels, totalPixels: canvas.width * canvas.height };
+    }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
 async function completeScreenshotExport(page, startId, endId) {
@@ -87,7 +125,7 @@ async function exportScreenshotFromWand(page, startId, endId) {
 test.describe('message screenshots', () => {
     test.setTimeout(120000);
 
-    test('exports message and wand screenshots with OKLCH message colors', async ({ page }) => {
+    test('exports message and wand screenshots with modern colors', async ({ page }) => {
         const screenshotErrors = [];
         page.on('console', message => {
             if (message.type() === 'error' && /screenshot|html2canvas|unsupported color/i.test(message.text())) {
@@ -102,6 +140,9 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
+        const { darkPixels, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
+        expect(redPixels).toBeLessThan(totalPixels * 0.01);
 
         const rangeDownload = await exportScreenshotFromMessage(page, 0, 0, 1);
         expect(rangeDownload.suggestedFilename()).toContain('messages-0-1.png');

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -68,7 +68,14 @@ async function installScreenshotMessage(page, messageText) {
         const reasoningHeader = document.createElement('div');
         reasoningHeader.className = 'mes_reasoning_header flex-container';
         reasoningHeader.style.backgroundColor = 'rgb(0 255 255)';
-        reasoningHeader.textContent = 'Thought for 3 minutes';
+        const reasoningTitle = document.createElement('span');
+        reasoningTitle.className = 'mes_reasoning_header_title';
+        reasoningTitle.style.color = 'rgb(255 128 0)';
+        reasoningTitle.textContent = 'Thought for 3 minutes';
+        const reasoningArrow = document.createElement('div');
+        reasoningArrow.className = 'mes_reasoning_arrow fa-solid fa-chevron-up';
+        reasoningArrow.style.color = 'rgb(255 0 128)';
+        reasoningHeader.append(reasoningTitle, reasoningArrow);
         reasoningHeaderBlock.appendChild(reasoningHeader);
         reasoningSummary.appendChild(reasoningHeaderBlock);
         const reasoningText = document.createElement('div');
@@ -171,6 +178,9 @@ async function readScreenshotPixelStats(page, download) {
         let overlappingColorRows = 0;
         let reasoningLeft = canvas.width;
         let reasoningRight = -1;
+        let reasoningIconPixels = 0;
+        let reasoningTitleBottom = -1;
+        let reasoningTitleTop = canvas.height;
         let redPixels = 0;
         let bluePixels = 0;
 
@@ -210,12 +220,20 @@ async function readScreenshotPixelStats(page, download) {
                     reasoningLeft = Math.min(reasoningLeft, x);
                     reasoningRight = Math.max(reasoningRight, x);
                 }
+                if (alpha > 200 && red > 220 && green >= 70 && green <= 180 && blue < 40) {
+                    reasoningTitleTop = Math.min(reasoningTitleTop, y);
+                    reasoningTitleBottom = Math.max(reasoningTitleBottom, y);
+                }
+                if (alpha > 200 && red > 220 && green < 40 && blue >= 80 && blue <= 190) {
+                    reasoningIconPixels++;
+                }
             }
             if (hasGradient && hasMarker) overlappingColorRows++;
         }
 
         const reasoningWidth = reasoningRight >= reasoningLeft ? reasoningRight - reasoningLeft + 1 : 0;
-        return { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height };
+        const reasoningTitleHeight = reasoningTitleBottom >= reasoningTitleTop ? reasoningTitleBottom - reasoningTitleTop + 1 : 0;
+        return { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height };
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
@@ -257,7 +275,7 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
-        const { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningWidth, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        const { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
         expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
         expect(redPixels).toBeGreaterThan(10);
         expect(bluePixels).toBeGreaterThan(10);
@@ -265,6 +283,9 @@ test.describe('message screenshots', () => {
         expect(endMarkerWidth).toBeGreaterThan(150);
         expect(markerPixels).toBeGreaterThan(10);
         expect(overlappingColorRows).toBe(0);
+        expect(reasoningIconPixels).toBeGreaterThan(5);
+        expect(reasoningTitleHeight).toBeGreaterThan(0);
+        expect(reasoningTitleHeight).toBeLessThan(20);
         expect(reasoningWidth).toBeGreaterThan(250);
         expect(redPixels).toBeLessThan(totalPixels * 0.01);
         expect(bluePixels).toBeLessThan(totalPixels * 0.01);

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -51,16 +51,26 @@ async function installScreenshotMessage(page, messageText) {
         messageTextElement.style.color = 'oklch(70% 0.2 140)';
         messageTextElement.closest('.mes_block')?.style.setProperty('background-color', 'color(srgb 0.156863 0.164706 0.196078)', 'important');
 
-        const gradientSpan = document.createElement('span');
-        gradientSpan.style.display = 'inline-block';
-        gradientSpan.style.backgroundImage = 'linear-gradient(90deg, color(display-p3 1 0 0), color(display-p3 0 0 1))';
-        gradientSpan.style.backgroundRepeat = 'no-repeat';
-        gradientSpan.style.backgroundSize = '100% 100%';
-        gradientSpan.style.webkitBackgroundClip = 'text';
-        gradientSpan.style.backgroundClip = 'text';
-        gradientSpan.style.webkitTextFillColor = 'transparent';
-        gradientSpan.textContent = text;
-        messageTextElement.appendChild(gradientSpan);
+        const overlapProbe = document.createElement('div');
+        overlapProbe.style.cssText = 'width:270px;font:500 14px/24px sans-serif;';
+
+        const quoteLine = document.createElement('p');
+        quoteLine.style.margin = '0';
+        const gradientQuote = document.createElement('q');
+        gradientQuote.style.backgroundImage = 'linear-gradient(90deg, color(display-p3 1 0 0), color(display-p3 0 0 1))';
+        gradientQuote.style.backgroundRepeat = 'no-repeat';
+        gradientQuote.style.backgroundSize = '100% 100%';
+        gradientQuote.style.webkitBackgroundClip = 'text';
+        gradientQuote.style.backgroundClip = 'text';
+        gradientQuote.style.webkitTextFillColor = 'transparent';
+        gradientQuote.textContent = 'This quote should just fit the source line.';
+        quoteLine.appendChild(gradientQuote);
+
+        const followingLine = document.createElement('p');
+        followingLine.style.cssText = 'margin:0;color:rgb(255 255 0);';
+        followingLine.textContent = 'Following narrow line.';
+        overlapProbe.append(quoteLine, followingLine);
+        messageTextElement.appendChild(overlapProbe);
 
         const assistantTextElement = document.querySelector('#chat .mes[mesid="1"] .mes_text');
         if (assistantTextElement) {
@@ -86,26 +96,40 @@ async function readScreenshotPixelStats(page, download) {
 
         const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
         let darkPixels = 0;
+        let markerPixels = 0;
+        let overlappingColorRows = 0;
         let redPixels = 0;
         let bluePixels = 0;
 
-        for (let index = 0; index < pixels.length; index += 4) {
-            const red = pixels[index];
-            const green = pixels[index + 1];
-            const blue = pixels[index + 2];
-            const alpha = pixels[index + 3];
-            if (alpha > 200 && red >= 25 && red <= 60 && green >= 25 && green <= 65 && blue >= 30 && blue <= 75) {
-                darkPixels++;
+        for (let y = 0; y < canvas.height; y++) {
+            let hasGradient = false;
+            let hasMarker = false;
+            for (let x = 0; x < canvas.width; x++) {
+                const index = (y * canvas.width + x) * 4;
+                const red = pixels[index];
+                const green = pixels[index + 1];
+                const blue = pixels[index + 2];
+                const alpha = pixels[index + 3];
+                if (alpha > 200 && red >= 25 && red <= 60 && green >= 25 && green <= 65 && blue >= 30 && blue <= 75) {
+                    darkPixels++;
+                }
+                if (alpha > 200 && red > 170 && red > green * 1.4 && red > blue * 1.4) {
+                    redPixels++;
+                    hasGradient = true;
+                }
+                if (alpha > 200 && blue > 120 && blue > red * 1.4 && blue > green * 1.4) {
+                    bluePixels++;
+                    hasGradient = true;
+                }
+                if (alpha > 200 && red > 180 && green > 180 && blue < 100) {
+                    markerPixels++;
+                    hasMarker = true;
+                }
             }
-            if (alpha > 200 && red > 170 && red > green * 1.4 && red > blue * 1.4) {
-                redPixels++;
-            }
-            if (alpha > 200 && blue > 120 && blue > red * 1.4 && blue > green * 1.4) {
-                bluePixels++;
-            }
+            if (hasGradient && hasMarker) overlappingColorRows++;
         }
 
-        return { bluePixels, darkPixels, redPixels, totalPixels: canvas.width * canvas.height };
+        return { bluePixels, darkPixels, markerPixels, overlappingColorRows, redPixels, totalPixels: canvas.width * canvas.height };
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
@@ -147,10 +171,12 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
-        const { bluePixels, darkPixels, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        const { bluePixels, darkPixels, markerPixels, overlappingColorRows, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
         expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
         expect(redPixels).toBeGreaterThan(10);
         expect(bluePixels).toBeGreaterThan(10);
+        expect(markerPixels).toBeGreaterThan(10);
+        expect(overlappingColorRows).toBe(0);
         expect(redPixels).toBeLessThan(totalPixels * 0.002);
         expect(bluePixels).toBeLessThan(totalPixels * 0.002);
 

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -49,10 +49,46 @@ async function installScreenshotMessage(page, messageText) {
         }
 
         messageTextElement.style.color = 'oklch(70% 0.2 140)';
-        messageTextElement.closest('.mes_block')?.style.setProperty('background-color', 'color(srgb 0.156863 0.164706 0.196078)', 'important');
+        const messageElement = messageTextElement.closest('.mes');
+        const messageBlock = messageTextElement.closest('.mes_block');
+        if (!messageElement || !messageBlock) {
+            throw new Error('Screenshot message layout not found');
+        }
+
+        messageElement.classList.add('message-screenshot-grid-probe', 'reasoning');
+        messageBlock.style.setProperty('background-color', 'color(srgb 0.156863 0.164706 0.196078)', 'important');
+
+        const reasoningDetails = document.createElement('details');
+        reasoningDetails.className = 'mes_reasoning_details';
+        reasoningDetails.open = true;
+        const reasoningSummary = document.createElement('summary');
+        reasoningSummary.className = 'mes_reasoning_summary flex-container';
+        const reasoningHeaderBlock = document.createElement('div');
+        reasoningHeaderBlock.className = 'mes_reasoning_header_block flex-container';
+        const reasoningHeader = document.createElement('div');
+        reasoningHeader.className = 'mes_reasoning_header flex-container';
+        reasoningHeader.style.backgroundColor = 'rgb(0 255 255)';
+        reasoningHeader.textContent = 'Thought for 3 minutes';
+        reasoningHeaderBlock.appendChild(reasoningHeader);
+        reasoningSummary.appendChild(reasoningHeaderBlock);
+        const reasoningText = document.createElement('div');
+        reasoningText.className = 'mes_reasoning';
+        reasoningText.textContent = 'Reasoning width probe.';
+        reasoningDetails.append(reasoningSummary, reasoningText);
+        messageBlock.prepend(reasoningDetails);
 
         const reflowStyle = document.createElement('style');
-        reflowStyle.textContent = '.message-screenshot-reflow-probe::first-line { font-size: 10px; }';
+        reflowStyle.textContent = `
+            .message-screenshot-grid-probe {
+                contain: content !important;
+                display: grid !important;
+                grid-template-columns: 100px minmax(0, 1fr) !important;
+                grid-template-rows: auto;
+            }
+            .message-screenshot-grid-probe > .mesAvatarWrapper { grid-area: 1 / 1 !important; }
+            .message-screenshot-grid-probe > .mes_block { grid-area: 1 / 2 !important; }
+            .message-screenshot-reflow-probe::first-line { font-size: 4px; }
+        `;
         document.head.appendChild(reflowStyle);
 
         const overlapProbe = document.createElement('div');
@@ -76,7 +112,7 @@ async function installScreenshotMessage(page, messageText) {
         overlapProbe.append(quoteLine, followingLine);
 
         const reflowProbe = document.createElement('div');
-        reflowProbe.style.cssText = 'width:485px;font:500 14px/24px Figtree,sans-serif;';
+        reflowProbe.style.cssText = 'width:485px;font:500 24px/24px Figtree,sans-serif;';
         const reflowLine = document.createElement('p');
         reflowLine.style.margin = '0';
         reflowLine.className = 'message-screenshot-reflow-probe';
@@ -89,12 +125,26 @@ async function installScreenshotMessage(page, messageText) {
         reflowMarker.style.cssText = followingLine.style.cssText;
         reflowMarker.textContent = 'Following reflow line.';
         reflowProbe.append(reflowLine, reflowMarker);
+        for (let index = 0; index < 6; index++) {
+            const extraReflowLine = document.createElement('p');
+            extraReflowLine.className = 'message-screenshot-reflow-probe';
+            extraReflowLine.style.margin = '0';
+            extraReflowLine.textContent = 'This source line fits narrowly but must wrap after foreign-object font reflow.';
+            reflowProbe.appendChild(extraReflowLine);
+        }
         messageTextElement.append(overlapProbe, reflowProbe);
+
+        const captureEndMarker = document.createElement('div');
+        captureEndMarker.style.cssText = 'width:200px;height:12px;background:rgb(255 0 255);';
+        messageBlock.appendChild(captureEndMarker);
 
         const assistantTextElement = document.querySelector('#chat .mes[mesid="1"] .mes_text');
         if (assistantTextElement) {
             assistantTextElement.style.color = 'lab(60% 20 -30)';
         }
+
+        await new Promise(resolve => window.requestAnimationFrame(resolve));
+        messageElement.style.gridTemplateRows = window.getComputedStyle(messageElement).gridTemplateRows;
     }, messageText);
 }
 
@@ -115,14 +165,19 @@ async function readScreenshotPixelStats(page, download) {
 
         const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
         let darkPixels = 0;
+        let endMarkerPixels = 0;
+        let endMarkerWidth = 0;
         let markerPixels = 0;
         let overlappingColorRows = 0;
+        let reasoningLeft = canvas.width;
+        let reasoningRight = -1;
         let redPixels = 0;
         let bluePixels = 0;
 
         for (let y = 0; y < canvas.height; y++) {
             let hasGradient = false;
             let hasMarker = false;
+            let markerRun = 0;
             for (let x = 0; x < canvas.width; x++) {
                 const index = (y * canvas.width + x) * 4;
                 const red = pixels[index];
@@ -144,11 +199,23 @@ async function readScreenshotPixelStats(page, download) {
                     markerPixels++;
                     hasMarker = true;
                 }
+                if (alpha > 200 && red > 220 && green < 30 && blue > 220) {
+                    endMarkerPixels++;
+                    markerRun++;
+                    endMarkerWidth = Math.max(endMarkerWidth, markerRun);
+                } else {
+                    markerRun = 0;
+                }
+                if (alpha > 200 && red < 30 && green > 220 && blue > 220) {
+                    reasoningLeft = Math.min(reasoningLeft, x);
+                    reasoningRight = Math.max(reasoningRight, x);
+                }
             }
             if (hasGradient && hasMarker) overlappingColorRows++;
         }
 
-        return { bluePixels, darkPixels, markerPixels, overlappingColorRows, redPixels, totalPixels: canvas.width * canvas.height };
+        const reasoningWidth = reasoningRight >= reasoningLeft ? reasoningRight - reasoningLeft + 1 : 0;
+        return { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height };
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
@@ -190,12 +257,15 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
-        const { bluePixels, darkPixels, markerPixels, overlappingColorRows, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        const { bluePixels, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningWidth, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
         expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
         expect(redPixels).toBeGreaterThan(10);
         expect(bluePixels).toBeGreaterThan(10);
+        expect(endMarkerPixels).toBeGreaterThan(1000);
+        expect(endMarkerWidth).toBeGreaterThan(150);
         expect(markerPixels).toBeGreaterThan(10);
         expect(overlappingColorRows).toBe(0);
+        expect(reasoningWidth).toBeGreaterThan(250);
         expect(redPixels).toBeLessThan(totalPixels * 0.01);
         expect(bluePixels).toBeLessThan(totalPixels * 0.01);
 

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -52,7 +52,10 @@ async function installScreenshotMessage(page, messageText) {
         messageTextElement.closest('.mes_block')?.style.setProperty('background-color', 'color(srgb 0.156863 0.164706 0.196078)', 'important');
 
         const gradientSpan = document.createElement('span');
-        gradientSpan.style.backgroundImage = 'linear-gradient(90deg, color(display-p3 1 0 0), color(xyz-d65 0.1 0.4 0.2))';
+        gradientSpan.style.display = 'inline-block';
+        gradientSpan.style.backgroundImage = 'linear-gradient(90deg, color(display-p3 1 0 0), color(display-p3 0 0 1))';
+        gradientSpan.style.backgroundRepeat = 'no-repeat';
+        gradientSpan.style.backgroundSize = '100% 100%';
         gradientSpan.style.webkitBackgroundClip = 'text';
         gradientSpan.style.backgroundClip = 'text';
         gradientSpan.style.webkitTextFillColor = 'transparent';
@@ -84,6 +87,7 @@ async function readScreenshotPixelStats(page, download) {
         const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
         let darkPixels = 0;
         let redPixels = 0;
+        let bluePixels = 0;
 
         for (let index = 0; index < pixels.length; index += 4) {
             const red = pixels[index];
@@ -96,9 +100,12 @@ async function readScreenshotPixelStats(page, download) {
             if (alpha > 200 && red > 170 && red > green * 1.4 && red > blue * 1.4) {
                 redPixels++;
             }
+            if (alpha > 200 && blue > 120 && blue > red * 1.4 && blue > green * 1.4) {
+                bluePixels++;
+            }
         }
 
-        return { darkPixels, redPixels, totalPixels: canvas.width * canvas.height };
+        return { bluePixels, darkPixels, redPixels, totalPixels: canvas.width * canvas.height };
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
@@ -140,9 +147,12 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
-        const { darkPixels, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        const { bluePixels, darkPixels, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
         expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
-        expect(redPixels).toBeLessThan(totalPixels * 0.01);
+        expect(redPixels).toBeGreaterThan(10);
+        expect(bluePixels).toBeGreaterThan(10);
+        expect(redPixels).toBeLessThan(totalPixels * 0.002);
+        expect(bluePixels).toBeLessThan(totalPixels * 0.002);
 
         const rangeDownload = await exportScreenshotFromMessage(page, 0, 0, 1);
         expect(rangeDownload.suggestedFilename()).toContain('messages-0-1.png');

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -273,6 +273,14 @@ async function readScreenshotPixelStats(page, download) {
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
+async function readScreenshotDimensions(download) {
+    const bytes = await readFile(await download.path());
+    return {
+        width: bytes.readUInt32BE(16),
+        height: bytes.readUInt32BE(20),
+    };
+}
+
 async function completeScreenshotExport(page, startId, endId) {
     await page.locator('#message_screenshot_start_id').fill(String(startId));
     await page.locator('#message_screenshot_end_id').fill(String(endId));
@@ -335,5 +343,32 @@ test.describe('message screenshots', () => {
         expect(wandDownload.suggestedFilename()).toContain('message-1.png');
 
         expect(screenshotErrors).toEqual([]);
+    });
+});
+
+test.describe('mobile message screenshots', () => {
+    test.use({
+        deviceScaleFactor: 3,
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+        viewport: { width: 390, height: 844 },
+    });
+
+    test('bounds long screenshot raster memory on high-DPR phones', async ({ page }) => {
+        await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+        await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+        await dismissOnboardingIfPresent(page);
+        await installScreenshotMessage(page, 'mobile screenshot raster budget regression');
+        await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
+            const spacer = document.createElement('div');
+            spacer.style.height = '11000px';
+            element.appendChild(spacer);
+        });
+
+        const download = await exportScreenshotFromMessage(page, 0, 0, 0);
+        const { width, height } = await readScreenshotDimensions(download);
+
+        expect(width).toBeLessThanOrEqual(400);
+        expect(width * height).toBeLessThanOrEqual(4_100_000);
+        expect(height).toBeGreaterThan(8000);
     });
 });

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -51,6 +51,10 @@ async function installScreenshotMessage(page, messageText) {
         messageTextElement.style.color = 'oklch(70% 0.2 140)';
         messageTextElement.closest('.mes_block')?.style.setProperty('background-color', 'color(srgb 0.156863 0.164706 0.196078)', 'important');
 
+        const reflowStyle = document.createElement('style');
+        reflowStyle.textContent = '.message-screenshot-reflow-probe::first-line { font-size: 10px; }';
+        document.head.appendChild(reflowStyle);
+
         const overlapProbe = document.createElement('div');
         overlapProbe.style.cssText = 'width:270px;font:500 14px/24px sans-serif;';
 
@@ -70,7 +74,22 @@ async function installScreenshotMessage(page, messageText) {
         followingLine.style.cssText = 'margin:0;color:rgb(255 255 0);';
         followingLine.textContent = 'Following narrow line.';
         overlapProbe.append(quoteLine, followingLine);
-        messageTextElement.appendChild(overlapProbe);
+
+        const reflowProbe = document.createElement('div');
+        reflowProbe.style.cssText = 'width:485px;font:500 14px/24px Figtree,sans-serif;';
+        const reflowLine = document.createElement('p');
+        reflowLine.style.margin = '0';
+        reflowLine.className = 'message-screenshot-reflow-probe';
+        const gradientReflowText = document.createElement('span');
+        gradientReflowText.style.cssText = gradientQuote.style.cssText;
+        gradientReflowText.textContent = 'He fixed my glasses. His hand is warm. Why is his hand warm. Walls. Drainage. Load-bearing things.';
+        reflowLine.appendChild(gradientReflowText);
+
+        const reflowMarker = document.createElement('p');
+        reflowMarker.style.cssText = followingLine.style.cssText;
+        reflowMarker.textContent = 'Following reflow line.';
+        reflowProbe.append(reflowLine, reflowMarker);
+        messageTextElement.append(overlapProbe, reflowProbe);
 
         const assistantTextElement = document.querySelector('#chat .mes[mesid="1"] .mes_text');
         if (assistantTextElement) {
@@ -177,8 +196,8 @@ test.describe('message screenshots', () => {
         expect(bluePixels).toBeGreaterThan(10);
         expect(markerPixels).toBeGreaterThan(10);
         expect(overlappingColorRows).toBe(0);
-        expect(redPixels).toBeLessThan(totalPixels * 0.002);
-        expect(bluePixels).toBeLessThan(totalPixels * 0.002);
+        expect(redPixels).toBeLessThan(totalPixels * 0.01);
+        expect(bluePixels).toBeLessThan(totalPixels * 0.01);
 
         const rangeDownload = await exportScreenshotFromMessage(page, 0, 0, 1);
         expect(rangeDownload.suggestedFilename()).toContain('messages-0-1.png');

--- a/tests/message-screenshot.e2e.js
+++ b/tests/message-screenshot.e2e.js
@@ -269,7 +269,7 @@ async function readScreenshotPixelStats(page, download) {
 
         const reasoningWidth = reasoningRight >= reasoningLeft ? reasoningRight - reasoningLeft + 1 : 0;
         const reasoningTitleHeight = reasoningTitleBottom >= reasoningTitleTop ? reasoningTitleBottom - reasoningTitleTop + 1 : 0;
-        return { bluePixels, companionMetaWidth, companionTitleWidth, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height };
+        return { bluePixels, companionMetaWidth, companionTitleWidth, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels: canvas.width * canvas.height, width: canvas.width };
     }, `data:image/png;base64,${imageData.toString('base64')}`);
 }
 
@@ -301,7 +301,17 @@ async function exportScreenshotFromWand(page, startId, endId) {
     return await completeScreenshotExport(page, startId, endId);
 }
 
-test.describe('message screenshots', () => {
+async function installHangingCloneImage(page) {
+    await page.route('**/screenshot-hang.png', () => new Promise(() => {}));
+    await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
+        const style = document.createElement('style');
+        style.textContent = '.message-screenshot-hanging-image::before { content: url("/screenshot-hang.png"); }';
+        document.head.appendChild(style);
+        element.classList.add('message-screenshot-hanging-image');
+    });
+}
+
+test.describe('desktop message screenshots', () => {
     test.setTimeout(120000);
 
     test('exports message and wand screenshots with modern colors', async ({ page }) => {
@@ -337,20 +347,20 @@ test.describe('message screenshots', () => {
 
         const singleDownload = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(singleDownload.suggestedFilename()).toContain('message-0.png');
-        const { bluePixels, companionMetaWidth, companionTitleWidth, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels } = await readScreenshotPixelStats(page, singleDownload);
+        const { bluePixels, companionMetaWidth, companionTitleWidth, darkPixels, endMarkerPixels, endMarkerWidth, markerPixels, overlappingColorRows, reasoningIconPixels, reasoningTitleHeight, reasoningWidth, redPixels, totalPixels, width } = await readScreenshotPixelStats(page, singleDownload);
         expect(darkPixels).toBeGreaterThan(totalPixels * 0.2);
         expect(redPixels).toBeGreaterThan(10);
         expect(bluePixels).toBeGreaterThan(10);
         expect(endMarkerPixels).toBeGreaterThan(1000);
-        expect(endMarkerWidth).toBeGreaterThan(150);
+        expect(endMarkerWidth).toBeGreaterThan(width * 0.15);
         expect(markerPixels).toBeGreaterThan(10);
         expect(overlappingColorRows).toBe(0);
-        expect(reasoningIconPixels).toBeGreaterThan(5);
+        expect(reasoningIconPixels).toBeGreaterThan(0);
         expect(reasoningTitleHeight).toBeGreaterThan(0);
         expect(reasoningTitleHeight).toBeLessThan(20);
-        expect(reasoningWidth).toBeGreaterThan(250);
-        expect(companionTitleWidth).toBeGreaterThan(70);
-        expect(companionMetaWidth).toBeGreaterThan(100);
+        expect(reasoningWidth).toBeGreaterThan(width * 0.3);
+        expect(companionTitleWidth).toBeGreaterThan(width * 0.06);
+        expect(companionMetaWidth).toBeGreaterThan(width * 0.08);
         expect(redPixels).toBeLessThan(totalPixels * 0.01);
         expect(bluePixels).toBeLessThan(totalPixels * 0.01);
         expect(await page.evaluate(() => window.messageScreenshotSvgDataCount)).toBeGreaterThan(0);
@@ -363,97 +373,147 @@ test.describe('message screenshots', () => {
 
         expect(screenshotErrors).toEqual([]);
     });
-});
 
-test.describe('mobile message screenshots', () => {
-    test.use({
-        deviceScaleFactor: 3,
-        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
-        viewport: { width: 390, height: 844 },
-    });
-
-    test('bounds long screenshot raster memory on high-DPR phones', async ({ page }) => {
+    test('bounds long desktop captures by area and canvas side', async ({ browserName, page }) => {
+        // This limit covers Chromium's larger desktop canvas; WebKit's mobile cap is tested below.
+        // eslint-disable-next-line playwright/no-skipped-test
+        test.skip(browserName !== 'chromium', 'Windows desktop coverage uses Chromium');
         await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
         await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
         await dismissOnboardingIfPresent(page);
-        await installScreenshotMessage(page, 'mobile screenshot raster budget regression');
+        await installScreenshotMessage(page, 'desktop screenshot canvas side regression');
         await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
-            const originalFetch = window.fetch.bind(window);
-            window.fetch = (input, init) => String(input).includes('screenshot-stall.png')
-                ? new Promise((_, reject) => init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true }))
-                : originalFetch(input, init);
-            Object.defineProperty(document.fonts, 'ready', { configurable: true, value: new Promise(() => {}) });
-
             const spacer = document.createElement('div');
-            spacer.style.height = '11000px';
-            const stalledImage = document.createElement('img');
-            stalledImage.src = '/screenshot-stall.png';
-            element.append(spacer, stalledImage);
+            spacer.style.height = '70000px';
+            element.appendChild(spacer);
         });
 
         const download = await exportScreenshotFromMessage(page, 0, 0, 0);
         const { width, height } = await readScreenshotDimensions(download);
 
-        expect(width).toBeLessThanOrEqual(400);
-        expect(width * height).toBeLessThanOrEqual(4_100_000);
-        expect(height).toBeGreaterThan(8000);
+        expect(width * height).toBeLessThanOrEqual(16_100_000);
+        expect(height).toBeLessThanOrEqual(32_767);
+        expect(height).toBeGreaterThan(20_000);
     });
 
     test('completes capture when a cloned image never finishes loading', async ({ page }) => {
-        await page.route('**/screenshot-hang.png', () => new Promise(() => {}));
         await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
         await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
         await dismissOnboardingIfPresent(page);
-        await installScreenshotMessage(page, 'hanging clone image regression');
-        await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
-            const hangingImage = document.createElement('img');
-            hangingImage.src = '/screenshot-hang.png';
-            element.append(hangingImage);
-        });
+        await installScreenshotMessage(page, 'hanging desktop clone image regression');
+        await installHangingCloneImage(page);
 
         const download = await exportScreenshotFromMessage(page, 0, 0, 0);
         expect(download.suggestedFilename()).toContain('message-0.png');
     });
+});
 
-    test('reports a stalled foreign-object render instead of hanging', async ({ page }) => {
-        const screenshotErrors = [];
-        page.on('console', message => {
-            if (message.type() === 'error' && /screenshot/i.test(message.text())) {
-                screenshotErrors.push(message.text());
-            }
+function registerMobileScreenshotTests(profileName, targetBrowserName, useOptions) {
+    test.describe(`${profileName} message screenshots`, () => {
+        test.setTimeout(120000);
+        test.use(useOptions);
+
+        test.beforeEach(({ browserName }) => {
+            // Each emulated mobile profile runs only on its matching Playwright browser engine.
+            // eslint-disable-next-line playwright/no-skipped-test
+            test.skip(browserName !== targetBrowserName, `${profileName} coverage uses ${targetBrowserName}`);
         });
 
-        await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
-        await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
-        await dismissOnboardingIfPresent(page);
-        await installScreenshotMessage(page, 'stalled mobile screenshot regression');
-        await page.evaluate(() => {
-            const imageSource = Object.getOwnPropertyDescriptor(window.HTMLImageElement.prototype, 'src');
-            if (!imageSource?.get || !imageSource.set) {
-                throw new Error('Image source descriptor unavailable');
-            }
+        test('bounds long screenshot raster memory and canvas side', async ({ page }) => {
+            await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+            await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+            await dismissOnboardingIfPresent(page);
+            await installScreenshotMessage(page, 'mobile screenshot raster budget regression');
+            await page.locator('#chat .mes[mesid="0"] .mes_text').evaluate(element => {
+                const originalFetch = window.fetch.bind(window);
+                window.fetch = (input, init) => String(input).includes('screenshot-stall.png')
+                    ? new Promise((_, reject) => init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true }))
+                    : originalFetch(input, init);
+                Object.defineProperty(document.fonts, 'ready', { configurable: true, value: new Promise(() => {}) });
 
-            Object.defineProperty(window.HTMLImageElement.prototype, 'src', {
-                configurable: true,
-                get: imageSource.get,
-                set(value) {
-                    if (!/^data:image\/svg\+xml.*;base64,/.test(String(value))) {
-                        imageSource.set.call(this, value);
-                    }
-                },
+                const spacer = document.createElement('div');
+                spacer.style.height = '100000px';
+                const stalledImage = document.createElement('img');
+                stalledImage.src = '/screenshot-stall.png';
+                element.append(spacer, stalledImage);
             });
 
-            const nativeSetTimeout = window.setTimeout.bind(window);
-            window.setTimeout = (callback, timeout, ...args) => nativeSetTimeout(callback, timeout === 15000 ? 20 : timeout, ...args);
+            const download = await exportScreenshotFromMessage(page, 0, 0, 0);
+            const { width, height } = await readScreenshotDimensions(download);
+
+            expect(width).toBeLessThanOrEqual(400);
+            expect(width * height).toBeLessThanOrEqual(4_100_000);
+            expect(height).toBeGreaterThan(8000);
+            expect(height).toBeLessThanOrEqual(16_384);
         });
 
-        await page.locator('#chat .mes').first().locator('.mes_screenshot').dispatchEvent('click');
-        await page.locator('#message_screenshot_start_id').fill('0');
-        await page.locator('#message_screenshot_end_id').fill('0');
-        await page.locator('.message_screenshot_popup .popup-button-ok').dispatchEvent('click');
+        test('completes capture when a cloned image never finishes loading', async ({ page }) => {
+            await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+            await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+            await dismissOnboardingIfPresent(page);
+            await installScreenshotMessage(page, `hanging ${profileName} clone image regression`);
+            await installHangingCloneImage(page);
 
-        await expect(page.locator('.toast-error').filter({ hasText: 'Screenshot failed' })).toBeVisible({ timeout: 5000 });
-        expect(screenshotErrors).toHaveLength(1);
-        expect(await page.locator('.html2canvas-container').count()).toBe(0);
+            const download = await exportScreenshotFromMessage(page, 0, 0, 0);
+            expect(download.suggestedFilename()).toContain('message-0.png');
+        });
+
+        test('reports a stalled foreign-object render instead of hanging', async ({ page }) => {
+            const screenshotErrors = [];
+            page.on('console', message => {
+                if (message.type() === 'error' && /screenshot/i.test(message.text())) {
+                    screenshotErrors.push(message.text());
+                }
+            });
+
+            await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+            await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+            await dismissOnboardingIfPresent(page);
+            await installScreenshotMessage(page, 'stalled mobile screenshot regression');
+            await page.evaluate(() => {
+                const imageSource = Object.getOwnPropertyDescriptor(window.HTMLImageElement.prototype, 'src');
+                if (!imageSource?.get || !imageSource.set) {
+                    throw new Error('Image source descriptor unavailable');
+                }
+
+                Object.defineProperty(window.HTMLImageElement.prototype, 'src', {
+                    configurable: true,
+                    get: imageSource.get,
+                    set(value) {
+                        if (!/^data:image\/svg\+xml.*;base64,/.test(String(value))) {
+                            imageSource.set.call(this, value);
+                        }
+                    },
+                });
+
+                const nativeSetTimeout = window.setTimeout.bind(window);
+                window.setTimeout = (callback, timeout, ...args) => nativeSetTimeout(callback, timeout === 15000 ? 20 : timeout, ...args);
+            });
+
+            await page.locator('#chat .mes').first().locator('.mes_screenshot').dispatchEvent('click');
+            await page.locator('#message_screenshot_start_id').fill('0');
+            await page.locator('#message_screenshot_end_id').fill('0');
+            await page.locator('.message_screenshot_popup .popup-button-ok').dispatchEvent('click');
+
+            await expect(page.locator('.toast-error').filter({ hasText: 'Screenshot failed' })).toBeVisible({ timeout: 20000 });
+            expect(screenshotErrors).toHaveLength(1);
+            expect(await page.locator('.html2canvas-container').count()).toBe(0);
+        });
     });
+}
+
+registerMobileScreenshotTests('Android', 'chromium', {
+    deviceScaleFactor: 3,
+    hasTouch: true,
+    isMobile: true,
+    userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36',
+    viewport: { width: 412, height: 915 },
+});
+
+registerMobileScreenshotTests('iOS WebKit', 'webkit', {
+    deviceScaleFactor: 3,
+    hasTouch: true,
+    isMobile: true,
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1',
+    viewport: { width: 393, height: 852 },
 });

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -109,6 +109,22 @@ describe('tooling UI hydration wiring', () => {
         expect(scriptSource).not.toContain('normalizeColorFunctionString');
     });
 
+    test('loads foreign-object screenshots through a bounded SVG data URI', () => {
+        const source = getFunctionSource('renderMessageScreenshotWithBoundedSvg');
+        const renderSource = getFunctionSource('renderMessageScreenshotCanvas');
+
+        expect(source).toContain("value.startsWith('<svg') && value.includes('<foreignObject')");
+        expect(source).toContain("new Blob([serializedSvg], { type: 'image/svg+xml;charset=utf-8' })");
+        expect(source).toContain('reader.readAsDataURL(svg)');
+        expect(source).toContain("nativeImageSource.set.call(image, reader.result)");
+        expect(source).toContain('setTimeout(() => fail(new Error(\'Timed out rendering screenshot SVG\')), 15000)');
+        expect(source).toContain('reader.abort()');
+        expect(source).toContain("document.querySelectorAll('.html2canvas-container')");
+        expect(source).toContain('window.Image = NativeImage');
+        expect(source).toContain('window.encodeURIComponent = nativeEncodeURIComponent');
+        expect(renderSource).toContain('renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captureOptions)');
+    });
+
     test('stretches reasoning headers only inside screenshot surfaces', () => {
         expect(styleSource).toContain('.sb-message-screenshot-surface .mes_reasoning_header {\n    flex: 1;\n}');
     });

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -96,6 +96,7 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain("clonedSurface.style.height = 'auto'");
         expect(source).toContain(':is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)');
         expect(source).toContain("element.style.gridTemplateRows = 'auto'");
+        expect(source).toContain('.mes_reasoning_header_title, .ica--companion-title, .ica--companion-title > span, .ica--companion-meta, .ica--companion-summary-spacer');
         expect(source).toContain("element.style.width = 'auto'");
         expect(source).toContain('style.textContent = iconFontStyle');
         expect(source).toContain("clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'))");

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -91,8 +91,38 @@ describe('tooling UI hydration wiring', () => {
 
         expect(source).toContain("backgroundClip.includes('text')");
         expect(source).toContain("computedStyle.backgroundImage !== 'none'");
-        expect(source).toContain("'-webkit-text-fill-color', computedStyle.color");
+        expect(source).toContain("'-webkit-text-fill-color', normalizeColorFunctionString(computedStyle.color)");
         expect(source).toContain("'background-image', 'none'");
+        expect(source.indexOf('for (const propertyName of computedStyle)')).toBeLessThan(source.indexOf('backgroundClip.includes'));
+    });
+
+    test('normalizes every modern color function through the platform color parser', () => {
+        expect(scriptSource).toContain('MODERN_COLOR_FUNCTION_TEST = /(?:\\b(?:color|oklch|oklab|lab|lch)\\s*\\()/i');
+        const source = getFunctionSource('normalizeColorFunctionString');
+
+        expect(source).toContain('MODERN_COLOR_FUNCTION_TEST.test(value)');
+        expect(source).toContain('convertModernColorToken');
+    });
+
+    test('patches pseudo-element colors and re-checks the html2canvas clone', () => {
+        const renderSource = getFunctionSource('renderMessageScreenshotCanvas');
+        const pseudoSource = getFunctionSource('normalizePseudoElementCaptureStyles');
+
+        expect(renderSource).toContain('normalizePseudoElementCaptureStyles(surface)');
+        expect(renderSource).toContain('onclone:');
+        expect(pseudoSource).toContain("'::before'");
+        expect(pseudoSource).toContain("!important");
+        expect(pseudoSource).toContain("contentValue === 'none' || contentValue === 'normal'");
+    });
+
+    test('filters computed style reads through the legacy color proxy during capture', () => {
+        const renderSource = getFunctionSource('renderMessageScreenshotCanvas');
+        const proxySource = getFunctionSource('createLegacyColorComputedStyleProxy');
+
+        expect(renderSource).toContain('createLegacyColorComputedStyleProxy(originalGetComputedStyle.call(window');
+        expect(renderSource).toContain('window.getComputedStyle = originalGetComputedStyle;');
+        expect(proxySource).toContain('normalizeColorFunctionString(value)');
+        expect(proxySource).toContain('Reflect.get(target, property, target)');
     });
 
     test('renders message screenshots inside the chat layout context', () => {

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const scriptSource = readFileSync(path.join(repoRoot, 'public', 'script.js'), 'utf8');
+const styleSource = readFileSync(path.join(repoRoot, 'public', 'style.css'), 'utf8');
 
 function getFunctionSource(name) {
     const markers = [`function ${name}(`, `async function ${name}(`];
@@ -94,6 +95,7 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
         expect(source).toContain("clonedSurface.style.height = 'auto'");
         expect(source).toContain(':is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)');
+        expect(source).toContain("element.style.gridTemplateRows = 'auto'");
         expect(source).toContain("clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'))");
         expect(source).toContain('clonedDocument.body.replaceChildren(clonedSurface)');
         expect(source).not.toContain('getBoundingClientRect()');
@@ -101,6 +103,10 @@ describe('tooling UI hydration wiring', () => {
         expect(source).not.toContain('y:');
         expect(source).not.toContain('normalizeMessageScreenshotStyles');
         expect(scriptSource).not.toContain('normalizeColorFunctionString');
+    });
+
+    test('stretches reasoning headers only inside screenshot surfaces', () => {
+        expect(styleSource).toContain('.sb-message-screenshot-surface .mes_reasoning_header {\n    flex: 1;\n}');
     });
 
     test('inlines screenshot images for foreign-object rendering', () => {

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -91,6 +91,7 @@ describe('tooling UI hydration wiring', () => {
         const source = getFunctionSource('renderMessageScreenshotCanvas');
 
         expect(source).toContain('foreignObjectRendering: true');
+        expect(source).toContain('await Promise.race([document.fonts.ready, delay(2000)])');
         expect(source).toContain('!element.contains(surface) && !surface.contains(element)');
         expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
         expect(source).toContain("clonedSurface.style.height = 'auto'");
@@ -116,9 +117,11 @@ describe('tooling UI hydration wiring', () => {
         const source = getFunctionSource('inlineMessageScreenshotImages');
 
         expect(source).toContain("container.querySelectorAll('img')");
-        expect(source).toContain('await fetch(source)');
+        expect(source).toContain('setTimeout(() => abortController.abort(), 2000)');
+        expect(source).toContain('await fetch(source, { signal: abortController.signal })');
         expect(source).toContain('await getBase64Async(await response.blob())');
         expect(source).toContain("image.srcset = ''");
+        expect(source).toContain('clearTimeout(abortTimer)');
     });
 
     test('embeds the local icon font for foreign-object rendering', () => {

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -96,6 +96,8 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain("clonedSurface.style.height = 'auto'");
         expect(source).toContain(':is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)');
         expect(source).toContain("element.style.gridTemplateRows = 'auto'");
+        expect(source).toContain("element.style.width = 'auto'");
+        expect(source).toContain('style.textContent = iconFontStyle');
         expect(source).toContain("clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'))");
         expect(source).toContain('clonedDocument.body.replaceChildren(clonedSurface)');
         expect(source).not.toContain('getBoundingClientRect()');
@@ -116,6 +118,14 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain('await fetch(source)');
         expect(source).toContain('await getBase64Async(await response.blob())');
         expect(source).toContain("image.srcset = ''");
+    });
+
+    test('embeds the local icon font for foreign-object rendering', () => {
+        const source = getFunctionSource('getMessageScreenshotIconFontStyle');
+
+        expect(source).toContain("fetch('/webfonts/fa-solid-900.woff2')");
+        expect(source).toContain("font-family: 'Font Awesome 6 Free'");
+        expect(source).toContain('getBase64Async');
     });
 
     test('renders message screenshots inside the chat layout context', () => {

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -92,6 +92,8 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain('foreignObjectRendering: true');
         expect(source).toContain('!element.contains(surface) && !surface.contains(element)');
         expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
+        expect(source).toContain("clonedSurface.style.height = 'auto'");
+        expect(source).toContain(':is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)');
         expect(source).toContain("clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'))");
         expect(source).toContain('clonedDocument.body.replaceChildren(clonedSurface)');
         expect(source).not.toContain('getBoundingClientRect()');

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -125,6 +125,17 @@ describe('tooling UI hydration wiring', () => {
         expect(renderSource).toContain('renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captureOptions)');
     });
 
+    test('neutralizes unbounded clone-document waits during capture', () => {
+        const source = getFunctionSource('renderMessageScreenshotWithBoundedSvg');
+
+        expect(source).toContain("Object.defineProperty(cloneDocument, 'fonts', { configurable: true, value: { ready: Promise.resolve() } })");
+        expect(source).toContain("Object.defineProperty(cloneDocument, 'images', { configurable: true, value: [] })");
+        expect(source).toContain('cloneObserver.observe(document.body, { childList: true })');
+        expect(source).toContain("setTimeout(() => reject(new Error('Timed out capturing the screenshot')), 30000)");
+        expect(source).toContain('clearTimeout(watchdog)');
+        expect(source).toContain('cloneObserver.disconnect()');
+    });
+
     test('stretches reasoning headers only inside screenshot surfaces', () => {
         expect(styleSource).toContain('.sb-message-screenshot-surface .mes_reasoning_header {\n    flex: 1;\n}');
     });
@@ -137,13 +148,14 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain('await fetch(source, { signal: abortController.signal })');
         expect(source).toContain('await getBase64Async(await response.blob())');
         expect(source).toContain("image.srcset = ''");
+        expect(source).toContain("image.removeAttribute('src')");
         expect(source).toContain('clearTimeout(abortTimer)');
     });
 
     test('embeds the local icon font for foreign-object rendering', () => {
         const source = getFunctionSource('getMessageScreenshotIconFontStyle');
 
-        expect(source).toContain("fetch('/webfonts/fa-solid-900.woff2')");
+        expect(source).toContain("fetch('/webfonts/fa-solid-900.woff2', { signal: abortController.signal })");
         expect(source).toContain("font-family: 'Font Awesome 6 Free'");
         expect(source).toContain('getBase64Async');
     });

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -92,8 +92,10 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain('foreignObjectRendering: true');
         expect(source).toContain('!element.contains(surface) && !surface.contains(element)');
         expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
-        expect(source).toContain('x: -bounds.left');
-        expect(source).toContain('y: -bounds.top');
+        expect(source).toContain('clonedDocument.body.replaceChildren(clonedSurface)');
+        expect(source).not.toContain('getBoundingClientRect()');
+        expect(source).not.toContain('x:');
+        expect(source).not.toContain('y:');
         expect(source).not.toContain('normalizeMessageScreenshotStyles');
         expect(scriptSource).not.toContain('normalizeColorFunctionString');
     });

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -86,43 +86,25 @@ describe('tooling UI hydration wiring', () => {
         expect(source).not.toContain('if (!messageScreenshotLibraryPromise)');
     });
 
-    test('flattens text-clipped gradient backgrounds before html2canvas capture', () => {
-        const source = getFunctionSource('normalizeMessageScreenshotStyles');
+    test('renders native CSS from only the screenshot subtree', () => {
+        const source = getFunctionSource('renderMessageScreenshotCanvas');
 
-        expect(source).toContain("backgroundClip.includes('text')");
-        expect(source).toContain("computedStyle.backgroundImage !== 'none'");
-        expect(source).toContain("'-webkit-text-fill-color', normalizeColorFunctionString(computedStyle.color)");
-        expect(source).toContain("'background-image', 'none'");
-        expect(source.indexOf('for (const propertyName of computedStyle)')).toBeLessThan(source.indexOf('backgroundClip.includes'));
+        expect(source).toContain('foreignObjectRendering: true');
+        expect(source).toContain('!element.contains(surface) && !surface.contains(element)');
+        expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
+        expect(source).toContain('x: -bounds.left');
+        expect(source).toContain('y: -bounds.top');
+        expect(source).not.toContain('normalizeMessageScreenshotStyles');
+        expect(scriptSource).not.toContain('normalizeColorFunctionString');
     });
 
-    test('normalizes every modern color function through the platform color parser', () => {
-        expect(scriptSource).toContain('MODERN_COLOR_FUNCTION_TEST = /(?:\\b(?:color|oklch|oklab|lab|lch)\\s*\\()/i');
-        const source = getFunctionSource('normalizeColorFunctionString');
+    test('inlines screenshot images for foreign-object rendering', () => {
+        const source = getFunctionSource('inlineMessageScreenshotImages');
 
-        expect(source).toContain('MODERN_COLOR_FUNCTION_TEST.test(value)');
-        expect(source).toContain('convertModernColorToken');
-    });
-
-    test('patches pseudo-element colors and re-checks the html2canvas clone', () => {
-        const renderSource = getFunctionSource('renderMessageScreenshotCanvas');
-        const pseudoSource = getFunctionSource('normalizePseudoElementCaptureStyles');
-
-        expect(renderSource).toContain('normalizePseudoElementCaptureStyles(surface)');
-        expect(renderSource).toContain('onclone:');
-        expect(pseudoSource).toContain("'::before'");
-        expect(pseudoSource).toContain("!important");
-        expect(pseudoSource).toContain("contentValue === 'none' || contentValue === 'normal'");
-    });
-
-    test('filters computed style reads through the legacy color proxy during capture', () => {
-        const renderSource = getFunctionSource('renderMessageScreenshotCanvas');
-        const proxySource = getFunctionSource('createLegacyColorComputedStyleProxy');
-
-        expect(renderSource).toContain('createLegacyColorComputedStyleProxy(originalGetComputedStyle.call(window');
-        expect(renderSource).toContain('window.getComputedStyle = originalGetComputedStyle;');
-        expect(proxySource).toContain('normalizeColorFunctionString(value)');
-        expect(proxySource).toContain('Reflect.get(target, property, target)');
+        expect(source).toContain("container.querySelectorAll('img')");
+        expect(source).toContain('await fetch(source)');
+        expect(source).toContain('await getBase64Async(await response.blob())');
+        expect(source).toContain("image.srcset = ''");
     });
 
     test('renders message screenshots inside the chat layout context', () => {

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -86,6 +86,15 @@ describe('tooling UI hydration wiring', () => {
         expect(source).not.toContain('if (!messageScreenshotLibraryPromise)');
     });
 
+    test('flattens text-clipped gradient backgrounds before html2canvas capture', () => {
+        const source = getFunctionSource('normalizeMessageScreenshotStyles');
+
+        expect(source).toContain("backgroundClip.includes('text')");
+        expect(source).toContain("computedStyle.backgroundImage !== 'none'");
+        expect(source).toContain("'-webkit-text-fill-color', computedStyle.color");
+        expect(source).toContain("'background-image', 'none'");
+    });
+
     test('renders message screenshots inside the chat layout context', () => {
         const source = getFunctionSource('renderMessageScreenshotCanvas');
 

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -92,6 +92,7 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain('foreignObjectRendering: true');
         expect(source).toContain('!element.contains(surface) && !surface.contains(element)');
         expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
+        expect(source).toContain("clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'))");
         expect(source).toContain('clonedDocument.body.replaceChildren(clonedSurface)');
         expect(source).not.toContain('getBoundingClientRect()');
         expect(source).not.toContain('x:');

--- a/tests/tooling-ui-hydration-wiring.test.js
+++ b/tests/tooling-ui-hydration-wiring.test.js
@@ -93,14 +93,17 @@ describe('tooling UI hydration wiring', () => {
         expect(source).toContain('foreignObjectRendering: true');
         expect(source).toContain('await Promise.race([document.fonts.ready, delay(2000)])');
         expect(source).toContain('!element.contains(surface) && !surface.contains(element)');
-        expect(source).toContain("clonedDocument.documentElement.style.backgroundColor = 'transparent'");
-        expect(source).toContain("clonedSurface.style.height = 'auto'");
+        expect(source).toContain('clonedDocument.documentElement.style.backgroundColor = \'transparent\'');
+        expect(source).toContain('clonedSurface.style.height = \'auto\'');
         expect(source).toContain(':is(.mes_text, .mes_reasoning) :is(p, blockquote, li, ul, ol, .dc-gradient-text)');
-        expect(source).toContain("element.style.gridTemplateRows = 'auto'");
+        expect(source).toContain('element.style.gridTemplateRows = \'auto\'');
         expect(source).toContain('.mes_reasoning_header_title, .ica--companion-title, .ica--companion-title > span, .ica--companion-meta, .ica--companion-summary-spacer');
-        expect(source).toContain("element.style.width = 'auto'");
+        expect(source).toContain('element.style.width = \'auto\'');
         expect(source).toContain('style.textContent = iconFontStyle');
-        expect(source).toContain("clonedSurface.prepend(...clonedDocument.body.querySelectorAll(':scope > style'))");
+        expect(source).toContain('const maxCanvasSide = mobileCapture ? 16_384 : 32_767');
+        expect(source).toContain('maxCanvasSide / Math.max(1, clonedSurface.scrollWidth)');
+        expect(source).toContain('maxCanvasSide / Math.max(1, clonedSurface.scrollHeight)');
+        expect(source).toContain('clonedSurface.prepend(...clonedDocument.body.querySelectorAll(\':scope > style\'))');
         expect(source).toContain('clonedDocument.body.replaceChildren(clonedSurface)');
         expect(source).not.toContain('getBoundingClientRect()');
         expect(source).not.toContain('x:');
@@ -113,13 +116,13 @@ describe('tooling UI hydration wiring', () => {
         const source = getFunctionSource('renderMessageScreenshotWithBoundedSvg');
         const renderSource = getFunctionSource('renderMessageScreenshotCanvas');
 
-        expect(source).toContain("value.startsWith('<svg') && value.includes('<foreignObject')");
-        expect(source).toContain("new Blob([serializedSvg], { type: 'image/svg+xml;charset=utf-8' })");
+        expect(source).toContain('value.startsWith(\'<svg\') && value.includes(\'<foreignObject\')');
+        expect(source).toContain('new Blob([serializedSvg], { type: \'image/svg+xml;charset=utf-8\' })');
         expect(source).toContain('reader.readAsDataURL(svg)');
-        expect(source).toContain("nativeImageSource.set.call(image, reader.result)");
+        expect(source).toContain('nativeImageSource.set.call(image, reader.result)');
         expect(source).toContain('setTimeout(() => fail(new Error(\'Timed out rendering screenshot SVG\')), 15000)');
         expect(source).toContain('reader.abort()');
-        expect(source).toContain("document.querySelectorAll('.html2canvas-container')");
+        expect(source).toContain('document.querySelectorAll(\'.html2canvas-container\')');
         expect(source).toContain('window.Image = NativeImage');
         expect(source).toContain('window.encodeURIComponent = nativeEncodeURIComponent');
         expect(renderSource).toContain('renderMessageScreenshotWithBoundedSvg(html2canvas, surface, captureOptions)');
@@ -128,10 +131,10 @@ describe('tooling UI hydration wiring', () => {
     test('neutralizes unbounded clone-document waits during capture', () => {
         const source = getFunctionSource('renderMessageScreenshotWithBoundedSvg');
 
-        expect(source).toContain("Object.defineProperty(cloneDocument, 'fonts', { configurable: true, value: { ready: Promise.resolve() } })");
-        expect(source).toContain("Object.defineProperty(cloneDocument, 'images', { configurable: true, value: [] })");
+        expect(source).toContain('Object.defineProperty(cloneDocument, \'fonts\', { configurable: true, value: { ready: Promise.resolve() } })');
+        expect(source).toContain('Object.defineProperty(cloneDocument, \'images\', { configurable: true, value: [] })');
         expect(source).toContain('cloneObserver.observe(document.body, { childList: true })');
-        expect(source).toContain("setTimeout(() => reject(new Error('Timed out capturing the screenshot')), 30000)");
+        expect(source).toContain('setTimeout(() => reject(new Error(\'Timed out capturing the screenshot\')), 30000)');
         expect(source).toContain('clearTimeout(watchdog)');
         expect(source).toContain('cloneObserver.disconnect()');
     });
@@ -143,20 +146,23 @@ describe('tooling UI hydration wiring', () => {
     test('inlines screenshot images for foreign-object rendering', () => {
         const source = getFunctionSource('inlineMessageScreenshotImages');
 
-        expect(source).toContain("container.querySelectorAll('img')");
+        expect(source).toContain('container.querySelectorAll(\'img\')');
         expect(source).toContain('setTimeout(() => abortController.abort(), 2000)');
         expect(source).toContain('await fetch(source, { signal: abortController.signal })');
         expect(source).toContain('await getBase64Async(await response.blob())');
-        expect(source).toContain("image.srcset = ''");
-        expect(source).toContain("image.removeAttribute('src')");
+        expect(source).toContain('image.srcset = \'\'');
+        expect(source).toContain('image.removeAttribute(\'src\')');
+        expect(source).toContain('pseudoImages.push({ content, element, pseudoElement, sources })');
+        expect(source).toContain('inlineContent = \'none\'');
+        expect(source).toContain('data-sb-screenshot-pseudo-${pseudoName}');
         expect(source).toContain('clearTimeout(abortTimer)');
     });
 
     test('embeds the local icon font for foreign-object rendering', () => {
         const source = getFunctionSource('getMessageScreenshotIconFontStyle');
 
-        expect(source).toContain("fetch('/webfonts/fa-solid-900.woff2', { signal: abortController.signal })");
-        expect(source).toContain("font-family: 'Font Awesome 6 Free'");
+        expect(source).toContain('fetch(\'/webfonts/fa-solid-900.woff2\', { signal: abortController.signal })');
+        expect(source).toContain('font-family: \'Font Awesome 6 Free\'');
         expect(source).toContain('getBase64Async');
     });
 


### PR DESCRIPTION
When using html2canvas to make native screenshot, it preserves CSS Color 4 gradients instead of flattening them.
Some fixes added to prevent text overlap, bottom clipping, transparent captures, and truncated headers.
Preserves pseudo-elements, images, Font Awesome icons, reasoning headers, and companion labels when there is enough space.
Fixes mobile (like iOS) hanging when trying to take a screenshot.