### PR TITLE
feat(group_chat): add a hide and unhide button/option for the group chat-specific bottom bar

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1930,8 +1930,8 @@
 
     .group_speaker_controls {
         display: grid !important;
-        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) !important;
-        grid-template-areas: "avatars greeting speak" !important;
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) !important;
+        grid-template-areas: "avatars greeting speak hide" !important;
         gap: 5px !important;
         align-items: center !important;
         min-height: calc(var(--sb-mobile-touch-target, 44px) + 8px) !important;
@@ -2010,12 +2010,14 @@
 
     .group_speaker_avatar span,
     #group_add_greeting span,
-    #group_speaker_now span {
+    #group_speaker_now span,
+    #group_speaker_hide span {
         display: none !important;
     }
 
     #group_add_greeting,
-    #group_speaker_now {
+    #group_speaker_now,
+    #group_speaker_hide {
         width: var(--sb-mobile-touch-target, 44px) !important;
         min-width: var(--sb-mobile-touch-target, 44px) !important;
         max-width: var(--sb-mobile-touch-target, 44px) !important;
@@ -2039,6 +2041,10 @@
 
     #group_speaker_now {
         grid-area: speak !important;
+    }
+
+    #group_speaker_hide {
+        grid-area: hide !important;
     }
 
     /* SillyBunny: Mobile-specific group member touch targets for Add Members screen */

--- a/public/index.html
+++ b/public/index.html
@@ -8839,6 +8839,10 @@
                     <i class="fa-solid fa-comment-dots"></i>
                     <span data-i18n="Speak Now">Speak Now</span>
                 </button>
+                <button type="button" id="group_speaker_hide" class="menu_button menu_button_icon" title="Hide this bar (restore it from the wand menu)" data-i18n="[title]Hide this bar (restore it from the wand menu)">
+                    <i class="fa-solid fa-eye-slash"></i>
+                    <span data-i18n="Hide Bar">Hide Bar</span>
+                </button>
             </div>
             <div id="dialogue_del_mes">
                 <div id="dialogue_del_mes_ok" data-i18n="Delete" class="menu_button">Delete</div>

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -243,6 +243,7 @@ async function runWithGroupMemberModelOverride(group, avatarId, callback) {
     }
 }
 
+const GROUP_SPEAKER_CONTROLS_HIDDEN_KEY = 'GroupSpeakerControlsHidden';
 let selectedGroupSpeakerAvatar = '';
 let groupSpeakerControlsInitialized = false;
 let activeGroupTypingName = '';
@@ -441,6 +442,15 @@ function setGroupTypingIndicator(characterName = '') {
     $('#group_speaker_controls').toggleClass('is-typing', Boolean(activeGroupTypingName));
 }
 
+function isGroupSpeakerControlsHidden() {
+    return accountStorage.getItem(GROUP_SPEAKER_CONTROLS_HIDDEN_KEY) === 'true';
+}
+
+function setGroupSpeakerControlsHidden(hidden) {
+    accountStorage.setItem(GROUP_SPEAKER_CONTROLS_HIDDEN_KEY, String(Boolean(hidden)));
+    updateGroupSpeakerControls();
+}
+
 function updateGroupSpeakerControls() {
     const container = $('#group_speaker_controls');
     if (!container.length) {
@@ -449,8 +459,13 @@ function updateGroupSpeakerControls() {
 
     const group = selected_group ? groups.find(x => x.id === selected_group) : null;
     const members = getGroupEnabledMembers(group);
-    container.toggleClass('displayNone', !group || members.length === 0);
-    if (!group || members.length === 0) {
+    const isAvailable = Boolean(group) && members.length > 0;
+    const isHidden = isGroupSpeakerControlsHidden();
+    container.toggleClass('displayNone', !isAvailable || isHidden);
+    // The wand entry is injected later than this runs, so gate it with a body class instead of a direct toggle.
+    // Keyed on the hidden flag alone: the way back must exist whenever the bar is hidden.
+    document.body.classList.toggle('groupSpeakerControlsHidden', isHidden);
+    if (!isAvailable) {
         clearSelectedGroupSpeaker();
         setGroupTypingIndicator('');
         groupSpeakerAvatarRenderKey = '';
@@ -524,6 +539,8 @@ function initGroupSpeakerControls() {
     });
 
     container.on('click', '#group_add_greeting', addSelectedGroupGreeting);
+    container.on('click', '#group_speaker_hide', () => setGroupSpeakerControlsHidden(true));
+    $(document).on('click', '#wand_group_speaker_controls', () => setGroupSpeakerControlsHidden(false));
 }
 
 export const group_activation_strategy = {

--- a/public/scripts/templates/wandMenu.html
+++ b/public/scripts/templates/wandMenu.html
@@ -3,6 +3,10 @@
         <div class="fa-solid fa-camera extensionsMenuExtensionButton"></div>
         <span data-i18n="Screenshot message(s)">Screenshot message(s)</span>
     </div>
+    <div id="wand_group_speaker_controls" class="list-group-item flex-container flexGap5" title="Show the group bar" data-i18n="[title]Show the group bar">
+        <div class="fa-solid fa-eye extensionsMenuExtensionButton"></div>
+        <span data-i18n="Show Group Bar">Show Group Bar</span>
+    </div>
     <div id="data_bank_wand_container" class="extension_container"></div>
     <div id="attach_file_wand_container" class="extension_container"></div>
     <div id="sd_wand_container" class="extension_container"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -7558,6 +7558,15 @@ body:not(.movingUI) .drawer-content.maximized {
     display: none !important;
 }
 
+/* Beats the #extensionsMenu>div:not(.extension_container) display rule without !important. */
+#extensionsMenu>#wand_group_speaker_controls {
+    display: none;
+}
+
+body.groupSpeakerControlsHidden #extensionsMenu>#wand_group_speaker_controls {
+    display: flex;
+}
+
 .group_typing_indicator {
     flex: 0 0 100%;
     width: 100%;
@@ -7615,8 +7624,8 @@ body:not(.movingUI) .drawer-content.maximized {
 @media screen and (max-width: 600px) {
     .group_speaker_controls {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) 34px 34px;
-        grid-template-areas: "typing typing typing" "avatars greeting speak";
+        grid-template-columns: minmax(0, 1fr) 34px 34px 34px;
+        grid-template-areas: "typing typing typing typing" "avatars greeting speak hide";
         align-items: center;
         gap: 4px;
         padding: 4px 6px;
@@ -7660,7 +7669,8 @@ body:not(.movingUI) .drawer-content.maximized {
 
     .group_speaker_avatar span,
     #group_add_greeting span,
-    #group_speaker_now span {
+    #group_speaker_now span,
+    #group_speaker_hide span {
         display: none;
     }
 
@@ -7670,7 +7680,8 @@ body:not(.movingUI) .drawer-content.maximized {
     }
 
     #group_add_greeting,
-    #group_speaker_now {
+    #group_speaker_now,
+    #group_speaker_hide {
         width: 34px;
         min-width: 34px;
         max-width: 34px;
@@ -7691,15 +7702,20 @@ body:not(.movingUI) .drawer-content.maximized {
         grid-area: speak;
     }
 
+    #group_speaker_hide {
+        grid-area: hide;
+    }
+
 }
 
 @media screen and (max-width: 420px) {
     .group_speaker_controls {
-        grid-template-columns: minmax(0, 1fr) 30px 30px;
+        grid-template-columns: minmax(0, 1fr) 30px 30px 30px;
     }
 
     #group_add_greeting,
-    #group_speaker_now {
+    #group_speaker_now,
+    #group_speaker_hide {
         width: 30px;
         min-width: 30px;
         max-width: 30px;

--- a/tests/group-chat-greetings-qol.test.js
+++ b/tests/group-chat-greetings-qol.test.js
@@ -46,11 +46,39 @@ describe('group chat greetings QoL', () => {
         expect(indexSource).toContain('class="fa-solid fa-hand-sparkles"');
         expect(indexSource).toContain('Add New Greeting');
         expect(groupChatSource).toContain('container.on(\'click\', \'#group_add_greeting\', addSelectedGroupGreeting);');
-        expect(styleSource).toContain('grid-template-areas: "typing typing typing" "avatars greeting speak";');
+        expect(styleSource).toContain('grid-template-areas: "typing typing typing typing" "avatars greeting speak hide";');
         expect(styleSource).toContain('#group_add_greeting span,');
         expect(styleSource).toMatch(/#group_add_greeting\s*\{[\s\S]*?grid-area:\s*greeting;\s*}/);
-        expect(mobileStyleSource).toContain('grid-template-areas: "avatars greeting speak" !important;');
+        expect(mobileStyleSource).toContain('grid-template-areas: "avatars greeting speak hide" !important;');
         expect(mobileStyleSource).toContain('#group_add_greeting span,');
         expect(mobileStyleSource).toMatch(/#group_add_greeting\s*\{[\s\S]*?grid-area:\s*greeting\s*!important;\s*}/);
+    });
+
+    test('hides the speaker controls from the bar and restores them from the wand menu', async () => {
+        const indexSource = await fs.readFile(fileURLToPath(new URL('../public/index.html', import.meta.url)), 'utf8');
+        const wandMenuSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/templates/wandMenu.html', import.meta.url)), 'utf8');
+        const styleSource = await fs.readFile(fileURLToPath(new URL('../public/style.css', import.meta.url)), 'utf8');
+        const mobileStyleSource = await fs.readFile(fileURLToPath(new URL('../public/css/mobile-styles.css', import.meta.url)), 'utf8');
+        const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
+
+        expect(indexSource).toContain('id="group_speaker_hide"');
+        expect(wandMenuSource).toContain('id="wand_group_speaker_controls"');
+
+        // Hiding persists per account, and both directions run through the same setter.
+        expect(groupChatSource).toContain('const GROUP_SPEAKER_CONTROLS_HIDDEN_KEY = \'GroupSpeakerControlsHidden\';');
+        expect(groupChatSource).toContain('container.on(\'click\', \'#group_speaker_hide\', () => setGroupSpeakerControlsHidden(true));');
+        expect(groupChatSource).toContain('$(document).on(\'click\', \'#wand_group_speaker_controls\', () => setGroupSpeakerControlsHidden(false));');
+        expect(groupChatSource).toContain('container.toggleClass(\'displayNone\', !isAvailable || isHidden);');
+        expect(groupChatSource).toContain('document.body.classList.toggle(\'groupSpeakerControlsHidden\', isHidden);');
+
+        // The wand entry only exists while a hidden bar is waiting to come back.
+        expect(styleSource).toMatch(/#extensionsMenu>#wand_group_speaker_controls\s*\{\s*display:\s*none;\s*}/);
+        expect(styleSource).toMatch(/body\.groupSpeakerControlsHidden\s+#extensionsMenu>#wand_group_speaker_controls\s*\{\s*display:\s*flex;\s*}/);
+
+        // The mobile grids reserve a column for the new button instead of overlapping the avatars.
+        expect(styleSource).toContain('grid-template-columns: minmax(0, 1fr) 34px 34px 34px;');
+        expect(styleSource).toContain('grid-template-columns: minmax(0, 1fr) 30px 30px 30px;');
+        expect(styleSource).toMatch(/#group_speaker_hide\s*\{[\s\S]*?grid-area:\s*hide;\s*}/);
+        expect(mobileStyleSource).toMatch(/#group_speaker_hide\s*\{[\s\S]*?grid-area:\s*hide\s*!important;\s*}/);
     });
 });


### PR DESCRIPTION
Allows the user to hide the group chat-specific bottom bar and unhide it using the wand menu.