### PR TITLE
fix(ui): render newlines in scenario notes in persona, add full screen button, and fix button spacing

### DIFF
--- a/public/css/personas.css
+++ b/public/css/personas.css
@@ -333,6 +333,15 @@
     }
 }
 
+/* SillyBunny: mobile icon-only mode caps every shell tab at the 44px touch target, so the three
+   equal grid tracks leave each icon stranded at the start of its own third. Fall back to the shared
+   .sb-shell-nav flex row, which centres them next to each other. */
+@media screen and (max-width: 768px) {
+    :root[data-sb-mobile-nav-mode='icon-only'] #PersonaManagement .persona-editor-tabs {
+        display: flex;
+    }
+}
+
 #PersonaManagement .persona-editor-tabs .sb-shell-tab {
     width: 100%;
     padding-inline: 10px;
@@ -730,7 +739,15 @@
     grid-area: description;
     margin: 0;
     line-height: 1.38;
+    white-space: pre-wrap;
     overflow-wrap: anywhere;
+}
+
+.persona-appendix-editor-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
 }
 
 .persona-appendix-actions {

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1251,6 +1251,25 @@ async function showPersonaAppendixEditor(appendixId = '') {
         },
     );
 
+    // Popup custom inputs are built without an expand affordance, so wire the shared
+    // .editor_maximize handler to the note body the way the Persona Description field does.
+    const noteField = popup.dlg.querySelector('#persona_appendix_description_input');
+    const noteLabel = noteField?.previousElementSibling;
+    if (noteLabel) {
+        noteLabel.classList.add('persona-appendix-editor-label');
+        const maximize = document.createElement('button');
+        maximize.type = 'button';
+        maximize.className = 'menu_button menu_button_icon editor_maximize margin0';
+        maximize.dataset.for = 'persona_appendix_description_input';
+        maximize.title = t`Expand the editor`;
+        maximize.setAttribute('aria-label', t`Expand the editor`);
+        const maximizeIcon = document.createElement('i');
+        maximizeIcon.className = 'fa-solid fa-maximize';
+        maximizeIcon.setAttribute('aria-hidden', 'true');
+        maximize.append(maximizeIcon);
+        noteLabel.append(maximize);
+    }
+
     const result = await popup.show();
     if (result !== POPUP_RESULT.AFFIRMATIVE) {
         return;


### PR DESCRIPTION
Ensures newlines are rendered as such and you can view the scenario notes textbox in full screen. Also makes the buttons next to each other for the Scenario Notes, Connections, and Settings tabs on mobile when the nav is set to icons only.