### PR TITLE
fix(ui): Creator Notes actually show the rendered text as is

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -6049,6 +6049,15 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     padding-inline-end: 4px;
 }
 
+.sb-creator-notes-fullscreen {
+    width: 100%;
+    height: 100%;
+    /* The popup centres its text; the preview does not, and notes carry their own alignment. */
+    text-align: start;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
 #right-nav-panel :is(#creator_notes_textarea, #tags_textarea) {
     min-height: 5.5rem;
     max-height: 7.5rem;

--- a/public/index.html
+++ b/public/index.html
@@ -6673,7 +6673,8 @@
                             <div id="spoiler_free_desc" class="flex-container flexFlowColumn flexNoGap sb-creator-notes-compact sb-character-creator-notes-preview">
                                 <div id="creators_notes_div" class="title_restorable flexGap5 wide100p sb-character-creator-notes-preview-title">
                                     <span class="flex1" data-i18n="Creator's Notes">Creator's Notes</span>
-                                    <button type="button" class="menu_button menu_button_icon editor_maximize margin0" data-for="creator_notes_textarea" title="Expand the editor" aria-label="Expand the editor" data-i18n="[title]Expand the editor;[aria-label]Expand the editor">
+                                    <!-- SillyBunny: this sits beside the rendered preview, so it opens the formatted notes rather than the raw textarea value; the editor's own .editor_maximize in Char Info still expands the source. -->
+                                    <button type="button" id="sb_creator_notes_maximize" class="menu_button menu_button_icon margin0" title="Expand the editor" aria-label="Expand the editor" data-i18n="[title]Expand the editor;[aria-label]Expand the editor">
                                         <i class="fa-solid fa-maximize" aria-hidden="true"></i>
                                     </button>
                                 </div>

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -8332,6 +8332,45 @@ function bindCharacterEditorFullscreenToggle() {
     syncCharacterEditorFullscreenAvailability();
 }
 
+async function openCreatorNotesFullscreen() {
+    const context = getSillyTavernContext();
+    const spoiler = document.getElementById('creator_notes_spoiler');
+
+    if (!context?.callGenericPopup || !spoiler) {
+        return;
+    }
+
+    // Move the rendered node instead of re-rendering it: formatCreatorNotes() scopes embedded
+    // <custom-style> rules to '#creator_notes_spoiler ', and the live textarea sync keeps writing
+    // to this same element while the popup is open.
+    const anchor = document.createComment('sb-creator-notes-fullscreen');
+    spoiler.replaceWith(anchor);
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'sb-creator-notes-fullscreen';
+    wrapper.append(spoiler);
+
+    try {
+        await context.callGenericPopup(wrapper, context.POPUP_TYPE.TEXT, '', { wide: true, large: true });
+    } finally {
+        if (anchor.isConnected) {
+            anchor.replaceWith(spoiler);
+        } else {
+            document.querySelector('.sb-character-creator-notes-preview-body')?.prepend(spoiler);
+        }
+    }
+}
+
+function bindCreatorNotesFullscreen() {
+    const button = document.getElementById('sb_creator_notes_maximize');
+    if (!(button instanceof HTMLButtonElement) || button.dataset.sbBound === 'true') {
+        return;
+    }
+
+    button.dataset.sbBound = 'true';
+    button.addEventListener('click', () => openCreatorNotesFullscreen());
+}
+
 function focusCharacterPanelTab(tabId) {
     const normalizedTabId = normalizeCharacterPanelTab(tabId);
     const button = getCharacterPanel()?.querySelector(`[data-sb-character-tab="${CSS.escape(normalizedTabId)}"]`);
@@ -16044,6 +16083,7 @@ function injectCharacterDrawerControls() {
     getCharacterPanel()?.classList.add('sb-character-drawer-root');
     ensureCharacterListToolbarLayout();
     bindCharacterEditorFullscreenToggle();
+    bindCreatorNotesFullscreen();
 
     const shellCloseButton = document.getElementById('sb_character_shell_close');
     if (shellCloseButton instanceof HTMLButtonElement && shellCloseButton.dataset.sbBound !== 'true') {


### PR DESCRIPTION
Some Creator Notes include HTML and such and are not rendered exactly when viewing them on full screen. Now they are. The expand button next to the Creator's Notes editor still opens the raw text, since that one is for editing.