### PR TITLE
fix(ui): debugger inherits theme for dropdown + is the same button as the others in the wand menu + scroll feature when there are too many extensions in wand menu

### DIFF
--- a/public/scripts/extensions/sillybunny-debugger/src/ui.js
+++ b/public/scripts/extensions/sillybunny-debugger/src/ui.js
@@ -466,17 +466,10 @@ function ensureDrawer() {
     // Strongest key for the fork's settings-drawer dedupe guard.
     drawer.dataset.extensionName = 'SillyBunny-Debugger';
 
-    const toggle = el('button', 'inline-drawer-toggle inline-drawer-header');
-    toggle.type = 'button';
-    toggle.setAttribute('aria-controls', DRAWER_CONTENT_ID);
-    toggle.setAttribute('aria-expanded', 'false');
-    toggle.addEventListener('click', () => {
-        toggle.setAttribute('aria-expanded', String(toggle.getAttribute('aria-expanded') !== 'true'));
-    });
+    // Same markup as every other extension drawer, so theme rules for headers reach it too.
+    const toggle = el('div', 'inline-drawer-toggle inline-drawer-header');
     toggle.appendChild(el('b', undefined, 'Bunny Debugger'));
-    const toggleIcon = el('span', 'inline-drawer-icon fa-solid fa-circle-chevron-down down');
-    toggleIcon.setAttribute('aria-hidden', 'true');
-    toggle.appendChild(toggleIcon);
+    toggle.appendChild(el('div', 'inline-drawer-icon fa-solid fa-circle-chevron-down down'));
     drawer.appendChild(toggle);
 
     const content = el('div', 'inline-drawer-content');
@@ -522,13 +515,11 @@ function ensureMenuItem() {
         return;
     }
 
-    const item = el('button', 'list-group-item flex-container flexGap5 interactable');
+    // Same markup as the other wand entries; a <button> shrinks when the menu overflows the screen.
+    const item = el('div', 'list-group-item flex-container flexGap5 interactable');
     item.id = MENU_ITEM_ID;
-    item.type = 'button';
     item.title = 'Open the in-app debugger console';
-    const icon = el('span', 'fa-solid fa-bug extensionsMenuExtensionButton');
-    icon.setAttribute('aria-hidden', 'true');
-    item.append(icon, el('span', undefined, 'Debugger'));
+    item.append(el('div', 'fa-solid fa-bug extensionsMenuExtensionButton'), el('span', undefined, 'Debugger'));
     item.addEventListener('click', () => openDebugger());
     host.appendChild(item);
 }

--- a/public/scripts/extensions/sillybunny-debugger/style.css
+++ b/public/scripts/extensions/sillybunny-debugger/style.css
@@ -1,37 +1,5 @@
 /* Bunny Debugger — drawer and report popup. */
 
-#sbdbg-menu-item {
-    width: 100%;
-    border: 0;
-    background: none;
-    color: var(--SmartThemeBodyColor);
-    padding: 5px;
-    font: inherit;
-    text-align: left;
-    column-gap: 10px;
-    cursor: pointer;
-    align-items: baseline;
-}
-
-#sbdbg-settings > .inline-drawer-toggle {
-    width: 100%;
-    -webkit-appearance: none;
-    appearance: none;
-    color: inherit;
-    font: inherit;
-    text-align: inherit;
-}
-
-#sbdbg-settings > .inline-drawer-toggle.inline-drawer-header {
-    min-height: 44px;
-}
-
-#sbdbg-settings > .inline-drawer-toggle:focus,
-#sbdbg-settings > .inline-drawer-toggle:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px var(--sb-focus-ring, var(--SmartThemeQuoteColor, currentColor));
-}
-
 #sbdbg-settings .sbdbg-actions,
 .sbdbg-report .sbdbg-actions {
     display: flex;

--- a/tests/sillybunny-debugger.e2e.js
+++ b/tests/sillybunny-debugger.e2e.js
@@ -244,11 +244,13 @@ test('cleans tools that fail during initialization', async ({ page }) => {
     });
 });
 
-test('mounts an accessible drawer and tears the extension down cleanly', async ({ page }) => {
+test('uses the host drawer and wand markup and tears the extension down cleanly', async ({ page }) => {
     await page.addStyleTag({
-        content: ':root{--sb-focus-ring:#7cacf8;--SmartThemeQuoteColor:#7cacf8}'
+        content: '.inline-drawer-header{font-family:cursive}'
             + '#extensions_settings2 .inline-drawer-toggle.inline-drawer-header{min-height:42px}'
-            + '.inline-drawer-content{display:none}',
+            + '.inline-drawer-content{display:none}'
+            + '#extensionsMenu{display:flex;flex-flow:column;max-height:40px;overflow-y:auto}'
+            + '#extensionsMenu>div{padding:5px}',
     });
     await page.addStyleTag({ path: stylePath });
     await page.evaluate(() => {
@@ -259,23 +261,31 @@ test('mounts an accessible drawer and tears the extension down cleanly', async (
         });
     });
     await initializeExtensionFixture(page);
+    await page.evaluate(() => {
+        document.getElementById('extensionsMenu').insertAdjacentHTML('afterbegin', '<div>Filler</div><div>Filler</div>');
+    });
 
-    const toggle = page.locator('#sbdbg-settings > .inline-drawer-toggle');
-    await expect(toggle).toHaveRole('button', { name: 'Bunny Debugger' });
-    await expect(toggle).toHaveAttribute('aria-controls', 'sbdbg-settings-content');
-    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    await expect(toggle).toHaveCSS('min-height', '44px');
+    // Theme rules written for the shared header markup must reach the debugger header too.
+    const toggle = page.locator('#sbdbg-settings > .inline-drawer-toggle.inline-drawer-header');
+    await expect(toggle).toHaveJSProperty('tagName', 'DIV');
+    await expect(toggle.locator(':scope > b')).toHaveText('Bunny Debugger');
+    await expect(toggle.locator(':scope > div.inline-drawer-icon.fa-circle-chevron-down.down')).toHaveCount(1);
+    await expect(toggle).toHaveCSS('font-family', 'cursive');
+    await expect(toggle).toHaveCSS('min-height', '42px');
     await expect(page.locator('#sbdbg-settings-content')).toBeHidden();
-    await page.evaluate(() => document.activeElement?.blur());
-    await page.keyboard.press('Tab');
-    await expect(toggle).toBeFocused();
-    await expect(toggle).toHaveCSS('box-shadow', /inset/);
-    await toggle.press('Enter');
-    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await toggle.click();
     await expect(page.locator('#sbdbg-settings-content')).toBeVisible();
-    await toggle.press('Enter');
-    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await toggle.click();
     await expect(page.locator('#sbdbg-settings-content')).toBeHidden();
+
+    // The wand entry is a plain div like its siblings, so it keeps its height when the menu overflows.
+    const menuItem = page.locator('#sbdbg-menu-item');
+    await expect(menuItem).toHaveJSProperty('tagName', 'DIV');
+    await expect(menuItem).toHaveClass(/\blist-group-item\b/);
+    await expect(menuItem.locator(':scope > div.fa-bug.extensionsMenuExtensionButton + span')).toHaveText('Debugger');
+    const [boxHeight, contentHeight] = await menuItem.evaluate(node => [node.getBoundingClientRect().height, node.scrollHeight]);
+    expect(boxHeight).toBeGreaterThan(0);
+    expect(boxHeight).toBeGreaterThanOrEqual(contentHeight);
 
     await page.locator('#sbdbg-menu-item').click();
     await expect.poll(() => page.evaluate(() => globalThis.eruda?._isInit)).toBe(true);


### PR DESCRIPTION
Bunny Debugger has its own style, which clashes against the user's current theme. In mobile, the Debugger is also squished when there are too many buttons, so this adds a scroll feature as well.