### PR TITLE
fix(mobile): re-clicking the top bar icons when the window is open closes them

### DIFF
--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -695,21 +695,21 @@ export function shouldAutoCloseMobileNav({
 
 /**
  * Resolves page inert policy from active mobile modal roots.
+ * Every mobile surface docks below the top bar rather than covering it, so the bar
+ * stays interactive: its proxy buttons are how an open panel is closed again.
  * @param {object} options Options.
  * @param {string[]} [options.activeRootIds=[]] Active modal root ids.
- * @returns {{hasActiveMobileModal: boolean, shouldInertShell: boolean, shouldInertTopBar: boolean}}
+ * @returns {{hasActiveMobileModal: boolean, shouldInertShell: boolean}}
  */
 export function resolveMobileModalA11yState({
     activeRootIds = [],
 } = {}) {
     const ids = Array.isArray(activeRootIds) ? activeRootIds : [];
     const hasActiveMobileModal = ids.length > 0;
-    const shouldInertTopBar = ids.some(id => id !== 'sb-mobile-nav');
 
     return {
         hasActiveMobileModal,
         shouldInertShell: hasActiveMobileModal,
-        shouldInertTopBar,
     };
 }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -7784,8 +7784,10 @@ function syncMobileModalState() {
         setMobileModalRootA11y(root, activeRootSet.has(root));
     }
 
+    // SillyBunny: only the chat is inerted. Mobile panels dock below the top bar instead of
+    // covering it, so its proxy buttons stay reachable and re-tapping one closes the panel,
+    // same as on desktop.
     setElementInertForMobileModal(document.getElementById('sheld'), modalState.shouldInertShell);
-    setElementInertForMobileModal(document.getElementById('top-bar'), modalState.shouldInertTopBar);
 }
 
 function queueMobileModalStateSync() {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -544,8 +544,9 @@ describe('mobile shell lifecycle wiring', () => {
         expect(syncMobileModalStateSource).toContain('activeRootIds: activeRoots.map(root => root.id)');
         expect(syncMobileModalStateSource).toContain('modalState.hasActiveMobileModal');
         expect(syncMobileModalStateSource).toContain('modalState.shouldInertShell');
-        expect(syncMobileModalStateSource).toContain('modalState.shouldInertTopBar');
         expect(syncMobileModalStateSource).not.toContain('activeRoots.some(root => root.id !== \'sb-mobile-nav\')');
+        // Re-tapping a top bar proxy button has to close the panel it opened, so the bar is never inerted.
+        expect(syncMobileModalStateSource).not.toContain('getElementById(\'top-bar\')');
     });
 
     test('routes mobile nav outside-click auto-close through the lifecycle seam', () => {

--- a/tests/mobile-shell-lifecycle.test.js
+++ b/tests/mobile-shell-lifecycle.test.js
@@ -283,13 +283,12 @@ describe('mobile shell lifecycle helper', () => {
         })).toBe(false);
     });
 
-    test('inerts shell for any active mobile modal and top bar for non-nav modals', () => {
+    test('inerts the shell for any active mobile modal and never the top bar', () => {
         expect(resolveMobileModalA11yState({
             activeRootIds: [],
         })).toEqual({
             hasActiveMobileModal: false,
             shouldInertShell: false,
-            shouldInertTopBar: false,
         });
 
         expect(resolveMobileModalA11yState({
@@ -297,7 +296,6 @@ describe('mobile shell lifecycle helper', () => {
         })).toEqual({
             hasActiveMobileModal: true,
             shouldInertShell: true,
-            shouldInertTopBar: false,
         });
 
         expect(resolveMobileModalA11yState({
@@ -305,7 +303,6 @@ describe('mobile shell lifecycle helper', () => {
         })).toEqual({
             hasActiveMobileModal: true,
             shouldInertShell: true,
-            shouldInertTopBar: true,
         });
     });
 


### PR DESCRIPTION
Same behaviour as desktop.