### PR TITLE
fix: prevent the frontend from using so many resources to reduce GPU usage

### DIFF
--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -95,7 +95,7 @@
         "user_prompt_bias": "",
         "show_user_prompt_bias": true,
         "markdown_escape_strings": "",
-        "fast_ui_mode": false,
+        "fast_ui_mode": true,
         "avatar_style": 0,
         "chat_display": 0,
         "chat_width": 55,

--- a/default/content/themes/Dark V 1.0.json
+++ b/default/content/themes/Dark V 1.0.json
@@ -13,7 +13,7 @@
     "shadow_width": 2,
     "border_color": "rgba(0, 0, 0, 1)",
     "font_scale": 1,
-    "fast_ui_mode": false,
+    "fast_ui_mode": true,
     "waifuMode": false,
     "avatar_style": 0,
     "chat_display": 0,

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -7,13 +7,18 @@
     width: 100%;
     height: 100%;
     opacity: var(--customCSS-bg-opacity, 1);
-    filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));
     transition: background-image var(--sb-transition-slow), opacity var(--sb-transition-slow), filter var(--sb-transition-slow);
     z-index: -1;
 }
 
 #bg_custom {
     opacity: var(--customCSS-bg-opacity, 1);
+}
+
+/* SillyBunny: a zero-strength filter still gives the full-screen background its own compositing layer,
+   so the blur rule is attached only while the Background Blur slider is above 0 (body class from applyThemeEffects). */
+body.sb-bg-blur #bg1,
+body.sb-bg-blur #bg_custom {
     filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));
 }
 

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -7,7 +7,7 @@
     width: 100%;
     height: 100%;
     opacity: var(--customCSS-bg-opacity, 1);
-    transition: background-image var(--sb-transition-slow), opacity var(--sb-transition-slow), filter var(--sb-transition-slow);
+    transition: background-image var(--sb-transition-slow), opacity var(--sb-transition-slow);
     z-index: -1;
 }
 

--- a/public/css/character-group-overlay.css
+++ b/public/css/character-group-overlay.css
@@ -83,8 +83,8 @@
 }
 
 #bulk_tag_shadow_popup {
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
+    backdrop-filter: var(--SmartThemeBackdropFilter2x);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
     background-color: var(--black30a);
     position: absolute;
     width: 100%;

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1244,8 +1244,8 @@
         border-radius: 0 0 20px 20px;
         top: var(--topBarBlockSize) !important;
         left: 0 !important;
-        -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
-        backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
+        -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
+        backdrop-filter: var(--SmartThemeBackdropFilter2x);
 
         @starting-style {
             height: 0;
@@ -1478,8 +1478,8 @@
         max-width: unset;
         min-height: unset;
         max-height: unset;
-        -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
-        backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
+        -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
+        backdrop-filter: var(--SmartThemeBackdropFilter2x);
         left: 0;
         right: 0;
         top: 0;

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -24,8 +24,8 @@ dialog {
     /* Overflow visible so elements (like toasts) can appear outside of the dialog. '.popup-body' is hiding overflow for the real content. */
     overflow: visible;
 
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
 
     /* Fix weird animation issue with font-scaling during popup open */
     backface-visibility: hidden;

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -15,8 +15,8 @@
     border-radius: 10px;
     box-shadow: 0 0 5px black;
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
+    backdrop-filter: var(--SmartThemeBackdropFilter2x);
     color: var(--SmartThemeBodyColor);
     z-index: var(--sb-z-critical);
     -webkit-user-select: none;

--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -83,11 +83,6 @@ body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ri
     }
 }
 
-/* Fast UI Mode: body.no-blur * cannot reach a pseudo-element, so switch the chat column layer off explicitly. */
-body.no-blur #sheld::before {
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-}
 body.hideChatAvatars.echostyle #chat,
 body.hideChatAvatars.whisperstyle #chat,
 body.hideChatAvatars.hushstyle #chat,
@@ -157,8 +152,8 @@ body.echostyle #chat {
             overflow: hidden;
             margin-top: calc(var(--custom-ChatAvatar) * 0.35);
             border-radius: 10px;
-            backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
-            -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
+            backdrop-filter: var(--SmartThemeBackdropFilter);
+            -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
             box-shadow: 3px 3px 8px rgba(0, 0, 0, 3%);
         }
 

--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -57,10 +57,15 @@
     position: absolute;
     inset: 0;
     background: var(--sheldBackgroundColor, transparent);
-    backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));
-    -webkit-backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));
     z-index: -1 !important;
     pointer-events: none;
+}
+
+/* SillyBunny: a zero-strength backdrop-filter still creates a compositing layer over the whole chat column,
+   so the blur rule is attached only while the Sheld Blur slider is above 0 (body class from applyThemeEffects). */
+body.sb-sheld-blur #sheld::before {
+    backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));
+    -webkit-backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));
 }
 
 body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ripplestyle):not(.tidestyle) #chat .mes:not(.smallSysMes) .mes_block {
@@ -72,10 +77,16 @@ body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ri
 }
 
 @media screen and (max-width: 1000px) {
-    #sheld::before {
+    body.sb-sheld-blur #sheld::before {
         backdrop-filter: blur(calc(var(--mobileSheldBlurStrength, 0) * 1px));
         -webkit-backdrop-filter: blur(calc(var(--mobileSheldBlurStrength, 0) * 1px));
     }
+}
+
+/* Fast UI Mode: body.no-blur * cannot reach a pseudo-element, so switch the chat column layer off explicitly. */
+body.no-blur #sheld::before {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
 }
 body.hideChatAvatars.echostyle #chat,
 body.hideChatAvatars.whisperstyle #chat,

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -489,8 +489,8 @@ body::before {
         var(--sb-topbar-surface-bg);
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
     box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
 }
 
 #top-bar::before {
@@ -1913,16 +1913,16 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     :root:not([data-sb-theme]) #top-bar,
     :root[data-sb-theme='clean-minimal'] #top-bar {
         background: var(--sb-topbar-surface-bg) !important;
-        backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
-        -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
+        backdrop-filter: var(--SmartThemeBackdropFilterSaturated);
+        -webkit-backdrop-filter: var(--SmartThemeBackdropFilterSaturated);
     }
 
     :root:not([data-sb-theme]) #send_form,
     :root[data-sb-theme='clean-minimal'] #send_form {
         background: var(--sb-composer-surface-bg) !important;
         border-color: color-mix(in srgb, var(--SmartThemeBorderColor) 86%, transparent) !important;
-        backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
-        -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
+        backdrop-filter: var(--SmartThemeBackdropFilterSaturated);
+        -webkit-backdrop-filter: var(--SmartThemeBackdropFilterSaturated);
     }
 
     :root:not([data-sb-theme]) #send_textarea,

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -489,8 +489,8 @@ body::before {
         var(--sb-topbar-surface-bg);
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
     box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
+    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
 }
 
 #top-bar::before {
@@ -1913,16 +1913,16 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     :root:not([data-sb-theme]) #top-bar,
     :root[data-sb-theme='clean-minimal'] #top-bar {
         background: var(--sb-topbar-surface-bg) !important;
-        backdrop-filter: blur(12px) saturate(110%);
-        -webkit-backdrop-filter: blur(12px) saturate(110%);
+        backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
+        -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
     }
 
     :root:not([data-sb-theme]) #send_form,
     :root[data-sb-theme='clean-minimal'] #send_form {
         background: var(--sb-composer-surface-bg) !important;
         border-color: color-mix(in srgb, var(--SmartThemeBorderColor) 86%, transparent) !important;
-        backdrop-filter: blur(12px) saturate(110%);
-        -webkit-backdrop-filter: blur(12px) saturate(110%);
+        backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
+        -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength)) saturate(110%);
     }
 
     :root:not([data-sb-theme]) #send_textarea,

--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -371,7 +371,12 @@ body.documentstyle #chat .mes_block .ch_name {
 
 /*FastUI blur removal*/
 
-body.no-blur * {
+body.no-blur *,
+body.no-blur::before,
+body.no-blur::after,
+body.no-blur *::before,
+body.no-blur *::after,
+body.no-blur *::backdrop {
     -webkit-backdrop-filter: unset !important;
     backdrop-filter: unset !important;
 }

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -680,8 +680,8 @@
 .popup:has(#qr--modalEditor) .popup-content > #qr--modalEditor > #qr--main > .qr--labels > .label .qr--modal-switcherList {
   background-color: var(--stcdx--bgColor);
   border: 1px solid var(--SmartThemeBorderColor);
-  -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
-  backdrop-filter: blur(var(--SmartThemeBlurStrength));
+  -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
+  backdrop-filter: var(--SmartThemeBackdropFilter);
   border-radius: 10px;
   font-size: smaller;
   position: absolute;

--- a/public/scripts/extensions/stable-diffusion/style.css
+++ b/public/scripts/extensions/stable-diffusion/style.css
@@ -1,7 +1,7 @@
 #sd_dropdown {
     z-index: 30000;
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
+    backdrop-filter: var(--SmartThemeBackdropFilter);
 }
 
 #sd_comfy_open_workflow_editor {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -216,9 +216,9 @@ const THEME_COLOR_PROPERTIES = Object.freeze([
 ]);
 
 const THEME_EFFECT_PROPERTIES = Object.freeze([
-    { key: 'customCSS-bg-blur', selector: '#background_blur', counterSelector: '#background_blur_counter', cssVar: '--customCSS-bg-blur', defaultValue: 0, min: 0, max: 10 },
+    { key: 'customCSS-bg-blur', selector: '#background_blur', counterSelector: '#background_blur_counter', cssVar: '--customCSS-bg-blur', defaultValue: 0, min: 0, max: 10, activeClass: 'sb-bg-blur' },
     { key: 'customCSS-bg-opacity', selector: '#background_opacity', counterSelector: '#background_opacity_counter', cssVar: '--customCSS-bg-opacity', defaultValue: 1, min: 0, max: 1 },
-    { key: 'sheldBlurStrength', selector: '#sheld_blur_strength', counterSelector: '#sheld_blur_strength_counter', cssVar: '--sheldBlurStrength', linkedCssVars: ['--mobileSheldBlurStrength'], defaultValue: 0, min: 0, max: 10 },
+    { key: 'sheldBlurStrength', selector: '#sheld_blur_strength', counterSelector: '#sheld_blur_strength_counter', cssVar: '--sheldBlurStrength', linkedCssVars: ['--mobileSheldBlurStrength'], defaultValue: 0, min: 0, max: 10, activeClass: 'sb-sheld-blur' },
     { key: 'sheldBackgroundColor', cssVar: '--sheldBackgroundColor', defaultValue: 'transparent' },
 ]);
 
@@ -2072,6 +2072,11 @@ function applyThemeEffects() {
         document.documentElement.style.setProperty(property.cssVar, String(value));
         for (const cssVar of property.linkedCssVars || []) {
             document.documentElement.style.setProperty(cssVar, String(value));
+        }
+
+        // SillyBunny: a zero-strength blur still forces its own compositing layer, so the CSS only attaches the filter while the slider is above 0.
+        if (property.activeClass) {
+            document.body.classList.toggle(property.activeClass, Number(value) > 0);
         }
 
         if (property.selector) {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2039,6 +2039,7 @@ function applyCustomThemeStyleEntries() {
 }
 
 function applyBlurStrength() {
+    document.body.classList.toggle('sb-theme-blur', Number(power_user.blur_strength) > 0);
     document.documentElement.style.setProperty('--blurStrength', String(power_user.blur_strength));
     $('#blur_strength_counter').val(power_user.blur_strength);
     $('#blur_strength').val(power_user.blur_strength);

--- a/public/style.css
+++ b/public/style.css
@@ -78,6 +78,9 @@
     --SmartThemeUserMesBlurTintColor: rgba(29, 33, 40, 0.9);
     --SmartThemeBotMesBlurTintColor: rgba(29, 33, 40, 0.9);
     --SmartThemeBlurStrength: calc(var(--blurStrength) * 1px);
+    --SmartThemeBackdropFilter: none;
+    --SmartThemeBackdropFilter2x: none;
+    --SmartThemeBackdropFilterSaturated: none;
     --SmartThemeShadowColor: rgba(0, 0, 0, 0.9);
     --SmartThemeBorderColor: rgba(0, 0, 0, 1);
     --SmartThemeCheckboxBgColorR: 207;
@@ -242,6 +245,13 @@ body {
     color-scheme: only light;
     /* SillyBunny: paired with html; stops scroll chaining off the document. */
     overscroll-behavior: none;
+}
+
+/* SillyBunny: `blur(0px)` still creates compositor layers, so only expose blur filters above zero. */
+body.sb-theme-blur {
+    --SmartThemeBackdropFilter: blur(var(--SmartThemeBlurStrength));
+    --SmartThemeBackdropFilter2x: blur(calc(var(--SmartThemeBlurStrength) * 2));
+    --SmartThemeBackdropFilterSaturated: blur(var(--SmartThemeBlurStrength)) saturate(110%);
 }
 
 /* SillyBunny: Firefox ignores WebKit scrollbar pseudo-elements. */
@@ -906,9 +916,9 @@ hr {
     position: absolute;
     border-bottom: 1px solid var(--color-border, var(--SmartThemeBorderColor));
     box-shadow: 0 4px 24px rgba(2, 8, 5, 0.25);
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
     background-color: color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, transparent);
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
     z-index: 3005;
     gap: 2px;
 }
@@ -998,9 +1008,9 @@ body .panelControlBar {
     overflow-y: scroll;
     display: flex;
     bottom: 10px;
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
     background-color: var(--SmartThemeChatTintColor);
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
     flex-direction: column;
     z-index: 30;
@@ -1035,8 +1045,8 @@ body .panelControlBar {
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 0 0 1.65rem 1.65rem;
     background-color: var(--SmartThemeBlurTintColor);
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
+    backdrop-filter: var(--SmartThemeBackdropFilter);
 }
 
 #nonQRFormItems {
@@ -1271,8 +1281,8 @@ body .panelControlBar {
        keeps these menus above zoomed avatars/MovingUI panels (9999) like before. */
     z-index: var(--sb-z-critical, 10000);
     background-color: var(--SmartThemeBlurTintColor);
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
+    backdrop-filter: var(--SmartThemeBackdropFilter);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     flex-flow: column;
     border-radius: 10px;
@@ -2137,8 +2147,8 @@ body {
 
     --bottom: 50vh;
     background: var(--ac-color-background);
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
+    backdrop-filter: var(--SmartThemeBackdropFilter);
     border: 1px solid var(--ac-color-border);
     border-radius: 3px;
     color: var(--ac-color-text);
@@ -4288,8 +4298,8 @@ grammarly-extension {
 }
 
 #shadow_popup {
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
+    backdrop-filter: var(--SmartThemeBackdropFilter2x);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
     background-color: var(--black30a);
     display: none;
     opacity: 0.0;
@@ -5204,8 +5214,8 @@ body:is([data-generating="true"], [data-swiping="true"]) :is(
     z-index: 4100;
     top: 0;
     background-color: var(--black70a);
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
 }
 
 #select_chat_popup {
@@ -5598,8 +5608,8 @@ body .ui-widget-content {
     border-radius: 10px;
     box-shadow: 0 0 3px var(--black50a);
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
+    backdrop-filter: var(--SmartThemeBackdropFilter2x);
     color: var(--SmartThemeBodyColor);
 }
 
@@ -5779,8 +5789,8 @@ a:hover {
     margin-top: 0;
     overflow: hidden;
     background-color: var(--SmartThemeBlurTintColor);
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter2x);
+    backdrop-filter: var(--SmartThemeBackdropFilter2x);
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 10px;
     box-shadow: 0 0 5px black;
@@ -6270,8 +6280,8 @@ body:has(.drawer-content.open) #top-settings-holder:has(.drawer-content.openDraw
     right: 0;
     margin: 0 auto;
     height: 0;
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
     box-shadow: 0 18px 80px rgba(2, 8, 5, 0.35);
     transition-property: height, display;
     transition-duration: 200ms;
@@ -6587,8 +6597,8 @@ body:not(.movingUI) .drawer-content.maximized {
     border-radius: 10px;
     border: 1px solid var(--SmartThemeBorderColor);
     aspect-ratio: unset;
-    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
-    backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
+    backdrop-filter: var(--SmartThemeBackdropFilter);
     background-color: var(--SmartThemeBlurTintColor);
     padding: 5px;
 }
@@ -7273,8 +7283,8 @@ body:not(.movingUI) .drawer-content.maximized {
     border: 1px solid;
     background-color: var(--SmartThemeBlurTintColor);
     color: var(--SmartThemeBodyColor);
-    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
-    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
+    backdrop-filter: var(--SmartThemeBackdropFilter);
+    -webkit-backdrop-filter: var(--SmartThemeBackdropFilter);
 }
 
 .info-block.hint {

--- a/public/style.css
+++ b/public/style.css
@@ -906,9 +906,9 @@ hr {
     position: absolute;
     border-bottom: 1px solid var(--color-border, var(--SmartThemeBorderColor));
     box-shadow: 0 4px 24px rgba(2, 8, 5, 0.25);
-    backdrop-filter: blur(20px);
+    backdrop-filter: blur(var(--SmartThemeBlurStrength));
     background-color: color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, transparent);
-    -webkit-backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
     z-index: 3005;
     gap: 2px;
 }
@@ -1035,8 +1035,8 @@ body .panelControlBar {
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 0 0 1.65rem 1.65rem;
     background-color: var(--SmartThemeBlurTintColor);
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
+    backdrop-filter: blur(var(--SmartThemeBlurStrength));
 }
 
 #nonQRFormItems {

--- a/tests/core-message-transparency.test.js
+++ b/tests/core-message-transparency.test.js
@@ -11,6 +11,18 @@ describe('core message transparency wiring', () => {
     const styleSource = readSource('public', 'style.css');
     const powerUserSource = readSource('public', 'scripts', 'power-user.js');
     const indexSource = readSource('public', 'index.html');
+    const toggleDependentSource = readSource('public', 'css', 'toggle-dependent.css');
+    const themeBlurSources = [
+        styleSource,
+        readSource('public', 'css', 'character-group-overlay.css'),
+        readSource('public', 'css', 'mobile-styles.css'),
+        readSource('public', 'css', 'popup.css'),
+        readSource('public', 'css', 'select2-overrides.css'),
+        readSource('public', 'css', 'sillybunny-chat-styles.css'),
+        readSource('public', 'css', 'sillybunny-theme.css'),
+        readSource('public', 'scripts', 'extensions', 'quick-reply', 'style.css'),
+        readSource('public', 'scripts', 'extensions', 'stable-diffusion', 'style.css'),
+    ].join('\n');
 
     test('loads the native chat stylesheet during chat-display setup so default chat styles get core transparency', () => {
         expect(indexSource).not.toContain('id="sillybunny-native-chat-styles"');
@@ -36,6 +48,16 @@ describe('core message transparency wiring', () => {
         expect(backgroundsSource).toContain('opacity: var(--customCSS-bg-opacity, 1);');
         expect(backgroundsSource).toContain('filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));');
         expect(styleSource).toContain('@import url(css/backgrounds.css?v=20260606a);');
+    });
+
+    test('keeps zero-strength theme blur and Fast UI free of backdrop-filter layers', () => {
+        expect(powerUserSource).toContain('document.body.classList.toggle(\'sb-theme-blur\', Number(power_user.blur_strength) > 0);');
+        expect(styleSource).toContain('--SmartThemeBackdropFilter: none;');
+        expect(styleSource).toContain('body.sb-theme-blur {');
+        expect(themeBlurSources).not.toMatch(/backdrop-filter:\s*blur\((?:calc\()?var\(--SmartThemeBlurStrength\)/);
+        expect(toggleDependentSource).toContain('body.no-blur *::before,');
+        expect(toggleDependentSource).toContain('body.no-blur *::backdrop {');
+        expect(backgroundsSource).not.toContain('filter var(--sb-transition-slow)');
     });
 
     test('persists and applies the three core visual sliders', () => {


### PR DESCRIPTION
Mitigates GPU usage spikes: 
- UI blur is now off by default for new installs, the top bar and composer follow the Blur Strength slider instead of fixed blurs, and zero-strength blur layers are no longer created. 
- Fast UI Mode now also switches off the chat-area blur layer. (No Blur Effect in Visual Toggles)
- Added active-only theme blur tokens so `0px` blur creates no GPU compositor layer.
- Extended Fast UI blur removal to pseudo-elements and dialog backdrops.
- Stopped animating the full-screen background filter.