### PR TITLE
fix(connection-profile): send the reasoning effort saved in a profile's preset

### DIFF
--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -2,6 +2,7 @@ import { CONNECT_API_MAP, createModelIcon, getRequestHeaders } from '../../scrip
 import { extension_settings, openThirdPartyExtensionMenu } from '../extensions.js';
 import { t } from '../i18n.js';
 import { oai_settings, proxies, ZAI_ENDPOINT } from '../openai.js';
+import { getPresetManager } from '../preset-manager.js';
 import { SECRET_KEYS, secret_state } from '../secrets.js';
 import { textgen_types, textgenerationwebui_settings } from '../textgen-settings.js';
 import { getTokenCountAsync } from '../tokenizers.js';
@@ -25,6 +26,36 @@ const CHAT_COMPLETION_PROFILE_REQUEST_FIELDS = {
     'custom-include-headers': ['custom_include_headers', value => String(value ?? '')],
 };
 
+/**
+ * Reasoning settings a completion preset owns, keyed by the connection profile field that would
+ * override them. A profile can only capture what was set when it was saved, and profiles saved
+ * before these fields existed carry none of them, so the preset a profile points at is the
+ * fallback: that is where the setting is usually made.
+ * @type {Record<string, string>}
+ */
+const PRESET_BACKED_REASONING_FIELDS = Object.freeze({
+    'reasoning-effort': 'reasoning_effort',
+    'verbosity': 'verbosity',
+});
+
+/**
+ * Loads the completion preset a connection profile points at.
+ * @param {object} profile Connection profile
+ * @returns {object|null} Preset, if it can be read
+ */
+function getProfileCompletionPreset(profile) {
+    if (!profile?.preset) {
+        return null;
+    }
+
+    try {
+        return getPresetManager('openai')?.getCompletionPresetByName(profile.preset) ?? null;
+    } catch (error) {
+        console.warn('Could not read the completion preset of the connection profile', error);
+        return null;
+    }
+}
+
 export function getChatCompletionProfileRequestOverrides(profile, overridePayload) {
     const overrides = {};
     const profileFieldNames = [];
@@ -35,6 +66,25 @@ export function getChatCompletionProfileRequestOverrides(profile, overridePayloa
         }
 
         overrides[requestKey] = coerceValue(profile[profileKey]);
+        profileFieldNames.push(requestKey);
+    }
+
+    // SillyBunny: a profile that states no reasoning preference of its own inherits the one its
+    // preset carries, which is where the setting is usually made. An explicit value on the
+    // profile, and anything the caller passes, still wins.
+    const preset = getProfileCompletionPreset(profile);
+    for (const [profileKey, requestKey] of Object.entries(PRESET_BACKED_REASONING_FIELDS)) {
+        if (Object.hasOwn(profile, profileKey) || Object.hasOwn(overridePayload, requestKey)) {
+            continue;
+        }
+
+        const value = preset?.[requestKey];
+        if (value === undefined || value === null || value === '') {
+            continue;
+        }
+
+        const [, coerceValue] = CHAT_COMPLETION_PROFILE_REQUEST_FIELDS[profileKey];
+        overrides[requestKey] = coerceValue(value);
         profileFieldNames.push(requestKey);
     }
 

--- a/tests/connection-profile-request-fields.test.js
+++ b/tests/connection-profile-request-fields.test.js
@@ -28,6 +28,14 @@ await jest.unstable_mockModule('../public/scripts/openai.js', () => ({
     },
 }));
 
+const mockPresets = new Map();
+
+await jest.unstable_mockModule('../public/scripts/preset-manager.js', () => ({
+    getPresetManager: jest.fn(() => ({
+        getCompletionPresetByName: (name) => mockPresets.get(name),
+    })),
+}));
+
 await jest.unstable_mockModule('../public/scripts/secrets.js', () => ({
     SECRET_KEYS: {},
     secret_state: {},
@@ -242,3 +250,57 @@ describe('Connection Profile reverse proxy request mapping', () => {
         expect(getChatCompletionProfileReverseProxy({}, 'openai')).toEqual({});
     });
 });
+
+describe('reasoning settings from the profile preset', () => {
+    beforeEach(() => {
+        mockPresets.clear();
+        mockPresets.set('Thinking Preset', { reasoning_effort: 'high', verbosity: 'low', temperature: 0.9, stop: ['\\n\\n'] });
+    });
+
+    test('a profile that captured no reasoning settings inherits the ones its preset carries', () => {
+        const profile = { id: 'profile-preset', mode: 'cc', name: 'Preset Profile', api: 'openai', model: 'gpt-5.2', preset: 'Thinking Preset' };
+
+        const { overrides, profileFieldNames } = getChatCompletionProfileRequestOverrides(profile, {});
+
+        expect(overrides.reasoning_effort).toBe('high');
+        expect(overrides.verbosity).toBe('low');
+        expect(profileFieldNames).toEqual(expect.arrayContaining(['reasoning_effort', 'verbosity']));
+    });
+
+    test('settings the preset does not own are never taken from it', () => {
+        const profile = { id: 'profile-preset', mode: 'cc', name: 'Preset Profile', api: 'openai', model: 'gpt-5.2', preset: 'Thinking Preset' };
+
+        const { overrides } = getChatCompletionProfileRequestOverrides(profile, {});
+
+        expect(overrides.temperature).toBeUndefined();
+        expect(overrides.stop).toBeUndefined();
+    });
+
+    test('a setting stated on the profile wins over the preset', () => {
+        const profile = { id: 'profile-preset', mode: 'cc', name: 'Preset Profile', api: 'openai', model: 'gpt-5.2', preset: 'Thinking Preset', 'reasoning-effort': 'min' };
+
+        const { overrides } = getChatCompletionProfileRequestOverrides(profile, {});
+
+        expect(overrides.reasoning_effort).toBe('min');
+        expect(overrides.verbosity).toBe('low');
+    });
+
+    test('a value the caller is already sending is left alone', () => {
+        const profile = { id: 'profile-preset', mode: 'cc', name: 'Preset Profile', api: 'openai', model: 'gpt-5.2', preset: 'Thinking Preset' };
+
+        const { overrides, profileFieldNames } = getChatCompletionProfileRequestOverrides(profile, { reasoning_effort: 'medium' });
+
+        expect(overrides.reasoning_effort).toBeUndefined();
+        expect(profileFieldNames).not.toContain('reasoning_effort');
+    });
+
+    test('an empty preset value, a missing preset and a profile without one send nothing extra', () => {
+        mockPresets.set('Empty Preset', { reasoning_effort: '', verbosity: undefined });
+        const base = { id: 'profile-preset', mode: 'cc', name: 'Preset Profile', api: 'openai', model: 'gpt-5.2' };
+
+        expect(getChatCompletionProfileRequestOverrides({ ...base, preset: 'Empty Preset' }, {}).overrides).toEqual({});
+        expect(getChatCompletionProfileRequestOverrides({ ...base, preset: 'Missing Preset' }, {}).overrides).toEqual({});
+        expect(getChatCompletionProfileRequestOverrides(base, {}).overrides).toEqual({});
+    });
+});
+


### PR DESCRIPTION
People will usually assume that a reasoning effort set in a preset, and saved to the connection profile that points at it, is sent as-is.