### PR TITLE
fix(reasoning-effort): send 'none' verbatim when the model supports it

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2063,7 +2063,7 @@
                                                 <a href="https://docs.sillytavern.app/usage/prompts/reasoning/#reasoning-effort" target="_blank" class="opacity50p fa-solid fa-circle-question"></a>
                                             </label>
                                             <select id="openai_reasoning_effort">
-                                                <option data-i18n="openai_reasoning_effort_none" value="none">None (don't send)</option>
+                                                <option data-i18n="openai_reasoning_effort_none" value="none">None</option>
                                                 <option data-i18n="openai_reasoning_effort_minimum" value="min">Minimum</option>
                                                 <option data-i18n="openai_reasoning_effort_low" value="low">Low</option>
                                                 <option data-i18n="openai_reasoning_effort_medium" value="medium">Medium</option>
@@ -2071,8 +2071,8 @@
                                                 <option data-i18n="openai_reasoning_effort_xhigh" value="xhigh">Extra High</option>
                                                 <option data-i18n="openai_reasoning_effort_maximum" value="max">Maximum</option>
                                             </select>
-                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None does not send an effort level.">
-                                                OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None does not send an effort level.
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None is sent verbatim to GPT-5.1 and newer; other models get no effort level.">
+                                                OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None is sent verbatim to GPT-5.1 and newer; other models get no effort level.
                                             </div>
                                             <strong class="toggle-description justifyLeft marginBot5" data-source="openrouter">
                                                 Request model reasoning = Off with Reasoning Effort = Minimum disables reasoning entirely on models that support that, but can cause errors with some models.

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5174,7 +5174,12 @@ function getReasoningEffort(settings = null, model = null) {
     function resolveReasoningEffort() {
         switch (settings.reasoning_effort) {
             case reasoning_effort_types.none:
-                return undefined;
+                // GPT-5.1 and newer accept 'none' as a real value that pins thinking off;
+                // omitting the field instead lets the model pick its own default depth.
+                // Everywhere else 'none' stays unsent, since endpoints that do not list it reject it.
+                return [chat_completion_sources.OPENAI, chat_completion_sources.OPENAI_RESPONSES, chat_completion_sources.AZURE_OPENAI, chat_completion_sources.CUSTOM].includes(settings.chat_completion_source) && /^gpt-5\.([1-9]|\d{2,})/.test(model)
+                    ? reasoning_effort_types.none
+                    : undefined;
             case reasoning_effort_types.min:
                 if (chat_completion_sources.OPENROUTER === settings.chat_completion_source && !shouldRequestReasoning(settings)) {
                     return 'none';

--- a/src/constants.js
+++ b/src/constants.js
@@ -516,15 +516,17 @@ export const OPENAI_FIXED_REASONING_EFFORT = {
 };
 
 /**
- * NanoGPT's vocabulary is none < minimal < low < medium < high < xhigh. Four of this fork's
- * six rungs are spelled identically there and are forwarded untouched, so the level the user
- * picks is the level NanoGPT receives.
+ * NanoGPT's vocabulary is none < minimal < low < medium < high < xhigh. Five of this fork's
+ * seven rungs are spelled identically there and are forwarded untouched, so the level the user
+ * picks is the level NanoGPT receives; that includes `none`, which pins thinking off instead
+ * of leaving the model to pick its own default depth.
  * SillyBunny divergence: upstream shifted the whole ladder down one rung, which made "Medium"
  * arrive as `low`. `min` and `max` are the only two names NanoGPT has no equivalent for, so
  * they resolve to its nearest real rungs; that puts `xhigh` and `max` on the same ceiling.
  * Values absent here are omitted entirely by the caller.
  */
 export const NANOGPT_REASONING_EFFORT_MAP = {
+    none: 'none',
     min: 'minimal',
     low: 'low',
     medium: 'medium',

--- a/tests/nanogpt-reasoning-effort.test.js
+++ b/tests/nanogpt-reasoning-effort.test.js
@@ -96,10 +96,12 @@ describe('reasoning effort on outgoing chat completions', () => {
         });
     }
 
-    // NanoGPT documents none < minimal < low < medium < high < xhigh. low, medium, high and
-    // xhigh are spelled the same here, so they go out untouched instead of being shifted a rung
-    // down. min and max are the only names NanoGPT does not have, so they take its nearest rungs.
+    // NanoGPT documents none < minimal < low < medium < high < xhigh. none, low, medium, high
+    // and xhigh are spelled the same here, so they go out untouched instead of being shifted a
+    // rung down. min and max are the only names NanoGPT does not have, so they take its nearest
+    // rungs. none goes out too: omitting it would let the model pick its own reasoning depth.
     test.each([
+        ['none', 'none'],
         ['min', 'minimal'],
         ['low', 'low'],
         ['medium', 'medium'],
@@ -113,7 +115,7 @@ describe('reasoning effort on outgoing chat completions', () => {
         expect(capturedBody.reasoning).toEqual({ effort: expected });
     });
 
-    test.each(['none', 'auto', 'banana', '   '])('NanoGPT omits the reasoning key entirely for %p', async (effort) => {
+    test.each(['auto', 'banana', '   '])('NanoGPT omits the reasoning key entirely for %p', async (effort) => {
         // Upstream emitted a bare `"reasoning": {}` for all of these, because the value is
         // truthy but has no NanoGPT equivalent. hasOwn, not toBeUndefined: an empty object
         // would also read as undefined on the nested effort.
@@ -135,6 +137,7 @@ describe('reasoning effort on outgoing chat completions', () => {
         [' xhigh ', 'xhigh'],
         [' Max ', 'xhigh'],
         ['MAX', 'xhigh'],
+        [' None ', 'none'],
     ])('NanoGPT normalizes %p before the table lookup and sends %s', async (effort, expected) => {
         const response = await makeRequest(CHAT_COMPLETION_SOURCES.NANOGPT, { reasoning_effort: effort });
 
@@ -169,6 +172,19 @@ describe('reasoning effort on outgoing chat completions', () => {
 
         expect(response.status).toBe(200);
         expect(capturedBody.reasoning_effort).toBe('UltraFast');
+    });
+
+    test('\'none\' reaches an OpenAI-compatible endpoint verbatim for a GPT-5.1+ model', async () => {
+        // The client only resolves 'none' for models that document it (GPT-5.1 and newer);
+        // the server's job is to pass it through untouched rather than dropping it.
+        const response = await makeRequest(CHAT_COMPLETION_SOURCES.CUSTOM, {
+            reasoning_effort: 'none',
+            custom_url: 'https://custom.test/v1',
+            model: 'gpt-5.2',
+        });
+
+        expect(response.status).toBe(200);
+        expect(capturedBody.reasoning_effort).toBe('none');
     });
 
     // Two representatives of the branches that assign this key unconditionally (CometAPI and

--- a/tests/reasoning-effort-none.test.js
+++ b/tests/reasoning-effort-none.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { NANOGPT_REASONING_EFFORT_MAP } from '../src/constants.js';
+
+const readSource = (relativePath) => fs.readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const indexSource = readSource('../public/index.html');
+const openAiSource = readSource('../public/scripts/openai.js');
+
+describe('reasoning effort \'none\'', () => {
+    test('the client resolves \'none\' to a literal only for OpenAI-style sources on GPT-5.1+ models', () => {
+        // GPT-5.1 and newer accept 'none' as a value that pins thinking off. Omitting the field
+        // there lets the model pick its own default depth, which defeats picking None. Every
+        // other source keeps omitting it, because endpoints that do not list the value reject it.
+        const noneCase = openAiSource.match(/case reasoning_effort_types\.none:[\s\S]*?(?=case reasoning_effort_types\.min:)/);
+
+        expect(noneCase).not.toBeNull();
+        expect(noneCase[0]).toContain('return [chat_completion_sources.OPENAI, chat_completion_sources.OPENAI_RESPONSES, chat_completion_sources.AZURE_OPENAI, chat_completion_sources.CUSTOM].includes(settings.chat_completion_source) && /^gpt-5\\.([1-9]|\\d{2,})/.test(model)');
+        expect(noneCase[0]).toContain('? reasoning_effort_types.none');
+        expect(noneCase[0]).toContain(': undefined;');
+    });
+
+    test('NanoGPT\'s table forwards \'none\' untouched', () => {
+        // NanoGPT's documented ladder starts at none; leaving it out of the table made the
+        // caller omit the reasoning key entirely, letting the model default to thinking.
+        expect(NANOGPT_REASONING_EFFORT_MAP.none).toBe('none');
+    });
+
+    test('the UI no longer promises that None is never sent', () => {
+        expect(indexSource).not.toContain('None (don\'t send)');
+        expect(indexSource).not.toContain('None does not send an effort level.');
+        expect(indexSource).toContain('None is sent verbatim to GPT-5.1 and newer; other models get no effort level.');
+    });
+});


### PR DESCRIPTION
If nothing is sent, models that support 'none' can end up defaulting to something like high or max - defeating the purpose of turning off thinking. Now 'none' is sent verbatim where it's a documented value: GPT-5.1 and newer (OpenAI, Azure, Responses, and custom endpoints) and NanoGPT. Providers that don't list 'none' (DeepSeek, Kimi, Grok, etc.) still get no effort field, since they'd reject it.