### PR TITLE
feat(prompt-manager): show token counts even when a prompt is injected or a variable

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -13,7 +13,7 @@ import { Popup } from './popup.js';
 import { t } from './i18n.js';
 import { isMobile } from './RossAscends-mods.js';
 import { accountStorage } from './util/AccountStorage.js';
-import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts, mergePromptTokenCounts } from './prompt-token-counts.js';
+import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts, isCommentOnlyPromptContent, mergePromptTokenCounts } from './prompt-token-counts.js';
 import { getRenderedMarkerPrompt } from './prompt-manager-marker-preview.js';
 import { clearPromptSetVariables } from './prompt-variable-cleanup.js';
 import { RUNTIME_AGENTS_IDENTIFIER, resolveInChatAgentTokenUsage } from './in-chat-agent-inspection.js';
@@ -2126,7 +2126,8 @@ class PromptManager {
         // identifier: in-chat injections are squashed into the chat history, and prompts
         // whose content substitutes to an empty string (e.g. variable setters) count as
         // zero. Estimate those from their source content; for the latter, count the raw
-        // content so the entry's size is visible at all.
+        // content so the entry's size is visible at all — except pure comments, which
+        // send nothing anywhere and keep showing '-'.
         const runtimeCounts = this.hasRuntimePromptTokenCounts() ? this.promptTokenCounts : {};
         const rawContentFallbacks = new Set();
         const prompts = this.getPromptsForCharacter(this.activeCharacter, true)
@@ -2134,7 +2135,7 @@ class PromptManager {
             .filter(prompt => !(Number(runtimeCounts[prompt.identifier]) > 0))
             .map(prompt => {
                 const prepared = this.preparePrompt(prompt);
-                if (!prepared.content && typeof prompt.content === 'string' && prompt.content) {
+                if (!prepared.content && typeof prompt.content === 'string' && prompt.content && !isCommentOnlyPromptContent(prompt.content)) {
                     prepared.content = prompt.content;
                     rawContentFallbacks.add(prompt.identifier);
                 }

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -13,7 +13,7 @@ import { Popup } from './popup.js';
 import { t } from './i18n.js';
 import { isMobile } from './RossAscends-mods.js';
 import { accountStorage } from './util/AccountStorage.js';
-import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts } from './prompt-token-counts.js';
+import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts, mergePromptTokenCounts } from './prompt-token-counts.js';
 import { getRenderedMarkerPrompt } from './prompt-manager-marker-preview.js';
 import { clearPromptSetVariables } from './prompt-variable-cleanup.js';
 import { RUNTIME_AGENTS_IDENTIFIER, resolveInChatAgentTokenUsage } from './in-chat-agent-inspection.js';
@@ -2100,7 +2100,11 @@ class PromptManager {
     }
 
     getActivePromptTokenCounts() {
-        return this.hasRuntimePromptTokenCounts() ? this.promptTokenCounts : this.sourcePromptTokenCounts;
+        if (!this.hasRuntimePromptTokenCounts()) {
+            return this.sourcePromptTokenCounts;
+        }
+
+        return mergePromptTokenCounts(this.sourcePromptTokenCounts, this.promptTokenCounts);
     }
 
     getDisplayTokenUsage() {
@@ -2112,18 +2116,39 @@ class PromptManager {
     }
 
     async populateSourcePromptTokenCounts() {
-        if (this.hasRuntimePromptTokenCounts() || !this.activeCharacter || !this.tokenHandler) {
+        if (!this.activeCharacter || !this.tokenHandler) {
             this.sourcePromptTokenCounts = {};
             this.sourcePromptTokenUsage = 0;
             return;
         }
 
+        // Runtime counts miss prompts that never join the message tree under their own
+        // identifier: in-chat injections are squashed into the chat history, and prompts
+        // whose content substitutes to an empty string (e.g. variable setters) count as
+        // zero. Estimate those from their source content; for the latter, count the raw
+        // content so the entry's size is visible at all.
+        const runtimeCounts = this.hasRuntimePromptTokenCounts() ? this.promptTokenCounts : {};
+        const rawContentFallbacks = new Set();
         const prompts = this.getPromptsForCharacter(this.activeCharacter, true)
             .filter(prompt => this.shouldTrigger(prompt))
-            .map(prompt => this.preparePrompt(prompt));
+            .filter(prompt => !(Number(runtimeCounts[prompt.identifier]) > 0))
+            .map(prompt => {
+                const prepared = this.preparePrompt(prompt);
+                if (!prepared.content && typeof prompt.content === 'string' && prompt.content) {
+                    prepared.content = prompt.content;
+                    rawContentFallbacks.add(prompt.identifier);
+                }
+                return prepared;
+            });
 
         this.sourcePromptTokenCounts = await getPromptSourceTokenCounts(prompts, message => this.tokenHandler.countUntrackedAsync(message));
-        this.sourcePromptTokenUsage = Object.values(this.sourcePromptTokenCounts).reduce((total, tokens) => {
+        // Raw-content fallbacks are display-only: their text reaches the request through
+        // whichever prompt reads the variable, and is counted there.
+        this.sourcePromptTokenUsage = Object.entries(this.sourcePromptTokenCounts).reduce((total, [identifier, tokens]) => {
+            if (rawContentFallbacks.has(identifier)) {
+                return total;
+            }
+
             const tokenCount = Number(tokens);
             return total + (Number.isFinite(tokenCount) ? tokenCount : 0);
         }, 0);

--- a/public/scripts/prompt-token-counts.js
+++ b/public/scripts/prompt-token-counts.js
@@ -52,6 +52,21 @@ export function getPromptDisplayTokenCounts(messages) {
     return { ...aggregateCounts, ...directCounts };
 }
 
+export function mergePromptTokenCounts(sourceCounts, runtimeCounts) {
+    const counts = { ...(sourceCounts ?? {}) };
+
+    for (const [identifier, tokens] of Object.entries(runtimeCounts ?? {})) {
+        const tokenCount = Number(tokens);
+        // A runtime zero means the prompt never made it into the message tree under
+        // its own identifier; keep the source estimate instead of clobbering it.
+        if (Number.isFinite(tokenCount) && tokenCount > 0) {
+            counts[identifier] = tokenCount;
+        }
+    }
+
+    return counts;
+}
+
 export async function getPromptSourceTokenCounts(prompts, countPromptTokens) {
     const counts = {};
 

--- a/public/scripts/prompt-token-counts.js
+++ b/public/scripts/prompt-token-counts.js
@@ -52,6 +52,59 @@ export function getPromptDisplayTokenCounts(messages) {
     return { ...aggregateCounts, ...directCounts };
 }
 
+// Scoped {{//}}...{{///}} blocks must go first: their opener also reads as the start
+// of an inline comment, which would strip the delimiters but keep the body.
+const SCOPED_COMMENT_PATTERN = /{{\/\/}}[\s\S]*?{{\/\/\/}}/g;
+// Zero-output utility macros commonly appended to comments, e.g. {{// ...}}{{trim}}.
+const NO_OUTPUT_MACRO_PATTERN = /{{(?:trim|noop)}}/gi;
+
+// The macro lexer allows nested macros inside args, so a comment body can contain
+// balanced {{...}} pairs; a non-greedy regex would stop at the first '}}'. Walk the
+// braces instead, dropping each comment up to its matching close.
+function stripInlineComments(text) {
+    let result = '';
+    let i = 0;
+    while (i < text.length) {
+        const isComment = text.startsWith('{{//', i) || /^{{comment[\s:}]/i.test(text.slice(i, i + 10));
+        if (!isComment) {
+            result += text[i];
+            i++;
+            continue;
+        }
+
+        let depth = 0;
+        let j = i;
+        while (j < text.length) {
+            if (text.startsWith('{{', j)) {
+                depth++;
+                j += 2;
+            } else if (text.startsWith('}}', j)) {
+                depth--;
+                j += 2;
+                if (depth === 0) break;
+            } else {
+                j++;
+            }
+        }
+
+        if (depth !== 0) {
+            // Unterminated macro; keep the character and move on.
+            result += text[i];
+            i++;
+            continue;
+        }
+
+        i = j;
+    }
+
+    return result;
+}
+
+export function isCommentOnlyPromptContent(content) {
+    const withoutScoped = String(content ?? '').replace(SCOPED_COMMENT_PATTERN, '');
+    return !stripInlineComments(withoutScoped).replace(NO_OUTPUT_MACRO_PATTERN, '').trim();
+}
+
 export function mergePromptTokenCounts(sourceCounts, runtimeCounts) {
     const counts = { ...(sourceCounts ?? {}) };
 

--- a/tests/prompt-token-counts.test.js
+++ b/tests/prompt-token-counts.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts } from '../public/scripts/prompt-token-counts.js';
+import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts, mergePromptTokenCounts } from '../public/scripts/prompt-token-counts.js';
 
 function makeMessage(identifier, tokens) {
     return {
@@ -69,5 +69,26 @@ describe('prompt token display counts', () => {
             { role: 'system', content: 'Main prompt text' },
             { role: 'user', content: 'Post-history instruction' },
         ]);
+    });
+
+    test('merges source estimates under runtime counts', () => {
+        const merged = mergePromptTokenCounts(
+            { main: 500, injection: 120, variable: 80 },
+            { main: 550, chatHistory: 900, variable: 0 },
+        );
+
+        expect(merged).toEqual({
+            main: 550,
+            chatHistory: 900,
+            injection: 120,
+            variable: 80,
+        });
+    });
+
+    test('merge tolerates missing count maps', () => {
+        expect(mergePromptTokenCounts(null, null)).toEqual({});
+        expect(mergePromptTokenCounts(undefined, { main: 3 })).toEqual({ main: 3 });
+        expect(mergePromptTokenCounts({ main: 4 }, undefined)).toEqual({ main: 4 });
+        expect(mergePromptTokenCounts({ main: 4 }, { main: 'NaN-ish' })).toEqual({ main: 4 });
     });
 });

--- a/tests/prompt-token-counts.test.js
+++ b/tests/prompt-token-counts.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts, mergePromptTokenCounts } from '../public/scripts/prompt-token-counts.js';
+import { getPromptDisplayTokenCounts, getPromptSourceTokenCounts, isCommentOnlyPromptContent, mergePromptTokenCounts } from '../public/scripts/prompt-token-counts.js';
 
 function makeMessage(identifier, tokens) {
     return {
@@ -90,5 +90,19 @@ describe('prompt token display counts', () => {
         expect(mergePromptTokenCounts(undefined, { main: 3 })).toEqual({ main: 3 });
         expect(mergePromptTokenCounts({ main: 4 }, undefined)).toEqual({ main: 4 });
         expect(mergePromptTokenCounts({ main: 4 }, { main: 'NaN-ish' })).toEqual({ main: 4 });
+    });
+
+    test('detects comment-only prompt content', () => {
+        expect(isCommentOnlyPromptContent('{{// A note to the user}}')).toBe(true);
+        expect(isCommentOnlyPromptContent('{{comment same via alias}}')).toBe(true);
+        expect(isCommentOnlyPromptContent('{{//}}First line\nSecond line{{///}}')).toBe(true);
+        expect(isCommentOnlyPromptContent(' {{// one}} \n {{// two}} ')).toBe(true);
+        expect(isCommentOnlyPromptContent('{{// preset readme text}}{{trim}}')).toBe(true);
+        expect(isCommentOnlyPromptContent('{{// docs can mention {{char}} or {{getvar::mode}} inline}}{{trim}}')).toBe(true);
+        expect(isCommentOnlyPromptContent('')).toBe(true);
+
+        expect(isCommentOnlyPromptContent('{{// a note}}{{setvar::mode::on}}')).toBe(false);
+        expect(isCommentOnlyPromptContent('plain instruction text')).toBe(false);
+        expect(isCommentOnlyPromptContent('{{commentary}}')).toBe(false);
     });
 });


### PR DESCRIPTION
It always showed as - for in-chat injections and variable prompts because neither gets counted under its own identifier: injections get squashed into the chat history, and variables substitute to an empty string before counting. It was just withholding info for no reason.

Now those rows fall back to an estimate from the prompt's own content: injections count their substituted text, and variable/setvar prompts count their raw content so you can at least see the entry's size. Real runtime counts still win when they exist, disabled and genuinely empty prompts still show -, and the estimates aren't added to the header total. Comment-only entries ({{// ...}} readmes and the like) also still show -, since they send nothing.