### PR TITLE
feat(ica): lorebook scout now directly sends to lorebook

### DIFF
--- a/docs/in-chat-agents-glossary.md
+++ b/docs/in-chat-agents-glossary.md
@@ -277,6 +277,8 @@ The token information pills describe the Companion request itself. Input tokens 
 
 ### Special Panel Controls
 
+Lorebook Scout - Creates a lorebook keyword after manually running it, then has an option to send it directly to the lorebook attached to the chat, or creates a Lorebook Scout that it places the entries to.
+
 Plot Compass can display a **Plot Objective** field. Entering an objective and pressing the compass button saves it and reruns Plot Compass on the applicable message. Submitting an empty field clears the objective, though if it runs anyway, the LLM could still make up its own objective to follow.
 
 Chat Only can display a **Private side chat** field. Sending an aside adds it to the Chat Only side transcript and reruns that Companion. It is not part of the main chat context unless you modify it to be.

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -24,6 +24,7 @@ import {
     runCompanionAgentOnMessage,
     runCompanionsOnMessage,
 } from './companion-runner.js';
+import { isLorebookAgent, sendCompanionResultToLorebook } from './lorebook-sender.js';
 import {
     cleanCompanionAgentName,
     editCompanionResult,
@@ -618,6 +619,7 @@ function buildPanelAgentSection(state) {
     const name = getStateDisplayName(state);
     const icon = getStateIcon(state);
     const isHidden = isAgentHidden(agentId);
+    const canSendToLorebook = isLorebookAgent(state.agent);
 
     const settingsButton = state.agent
         ? '<button type="button" class="ica--cdash-action" data-action="panel-edit" title="Open this companion\'s agent settings" aria-label="Agent settings"><i class="fa-solid fa-gear"></i></button>'
@@ -657,6 +659,7 @@ function buildPanelAgentSection(state) {
                             <span>Message #${entry.messageIndex}</span>
                             ${buildAbsorbedPillHtml(entry)}
                             ${buildCompanionTokenUsagePillsHtml(entry.result)}
+                            ${canSendToLorebook && String(entry.result?.status ?? 'done') === 'done' ? '<button type="button" class="ica--cdash-action" data-action="panel-send-to-lorebook" title="Send this state to the attached lorebook" aria-label="Send history entry to lorebook"><i class="fa-solid fa-book-medical"></i></button>' : ''}
                             <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text" aria-label="Edit history entry"><i class="fa-solid fa-pen-to-square"></i></button>
                         </div>
                         <div class="ica--tpanel-agent-body">${buildPanelEntryBody(agentId, entry)}</div>
@@ -685,6 +688,7 @@ function buildPanelAgentSection(state) {
                     ${dragHandleButton}
                     ${hiddenButton}
                     ${runLatestButton}${rerunButtons}
+                    ${canSendToLorebook && String(latest.result?.status ?? 'done') === 'done' ? '<button type="button" class="ica--cdash-action" data-action="panel-send-to-lorebook" title="Send this state to the attached lorebook" aria-label="Send state to lorebook"><i class="fa-solid fa-book-medical"></i></button>' : ''}
                     <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text by hand (e.g. type your Plot Compass objective)" aria-label="Edit state text"><i class="fa-solid fa-pen-to-square"></i></button>
                     ${settingsButton}
                     <button type="button" class="ica--cdash-action" data-action="panel-jump" title="Scroll to the source message" aria-label="Scroll to source message"><i class="fa-solid fa-comment-dots"></i></button>
@@ -1099,6 +1103,22 @@ async function handlePanelAction(event) {
         await editCompanionResult(messageIndex, agentId, message, result);
         if (panelOpen) {
             renderPanel();
+        }
+        return;
+    }
+
+    if (action === 'panel-send-to-lorebook' && agentId && Number.isInteger(messageIndex)) {
+        const result = getCompanionResults(chat[messageIndex])[agentId];
+        if (!result) {
+            toastr.warning('No stored state to send.');
+            return;
+        }
+
+        button.prop('disabled', true);
+        try {
+            await sendCompanionResultToLorebook(result.content);
+        } finally {
+            button.prop('disabled', false);
         }
         return;
     }

--- a/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-ui.js
@@ -16,6 +16,7 @@ import {
 } from '../agent-store.js';
 import { AGENT_REGEX_PLACEMENT, applyRegexScriptList } from '../regex-scripts.js';
 import { resolveCompanionContentMacros } from './companion-macros.js';
+import { isLorebookAgent, sendCompanionResultToLorebook } from './lorebook-sender.js';
 import {
     COMPANION_RESULTS_UPDATED_EVENT,
     deleteCompanionResult,
@@ -516,6 +517,9 @@ function buildCompanionCard(agentId, result, message) {
     // Results saved before profile labels were resolved to names may carry raw profile ids.
     const meta = [profileLabel, modelLabel].filter(isReadableLabel).join(' / ');
     const openAttribute = result.collapsed ? '' : ' open';
+    const lorebookButton = isLorebookAgent(getAgentById(agentId)) && status === 'done'
+        ? '<button type="button" class="ica--companion-action" data-action="send-to-lorebook" title="Send companion note to lorebook" aria-label="Send companion note to lorebook"><i class="fa-solid fa-book-medical"></i></button>'
+        : '';
 
     return `
         <details class="ica--companion-card ica--companion-card--${escapeHtml(status)}" data-agent-id="${escapeHtml(agentId)}"${openAttribute}>
@@ -530,6 +534,7 @@ function buildCompanionCard(agentId, result, message) {
                 <span class="ica--companion-actions">
                     <button type="button" class="ica--companion-action" data-action="regenerate" title="Regenerate companion note" aria-label="Regenerate companion note"><i class="fa-solid fa-rotate-right"></i></button>
                     <button type="button" class="ica--companion-action" data-action="edit" title="Edit companion note" aria-label="Edit companion note"><i class="fa-solid fa-pen-to-square"></i></button>
+                    ${lorebookButton}
                     <button type="button" class="ica--companion-action" data-action="copy" title="Copy companion note" aria-label="Copy companion note"><i class="fa-solid fa-copy"></i></button>
                     <button type="button" class="ica--companion-action caution" data-action="delete" title="Delete companion note" aria-label="Delete companion note"><i class="fa-solid fa-trash"></i></button>
                 </span>
@@ -853,6 +858,17 @@ async function handleCompanionAction(event) {
     if (action === 'copy') {
         await copyText(String(result?.content ?? ''));
         toastr.success('Companion note copied.');
+        return;
+    }
+
+    if (action === 'send-to-lorebook') {
+        const button = $(event.currentTarget);
+        button.prop('disabled', true);
+        try {
+            await sendCompanionResultToLorebook(result?.content);
+        } finally {
+            button.prop('disabled', false);
+        }
         return;
     }
 

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -82,6 +82,57 @@ function normalizeTitle(value) {
     return String(value ?? '').normalize().trim().replaceAll(/\s+/g, ' ').toLowerCase();
 }
 
+function getCurrentCharacters(context) {
+    const characters = Array.isArray(context.characters) ? context.characters : [];
+    const hasGroup = context.groupId !== null
+        && context.groupId !== undefined
+        && String(context.groupId).trim() !== '';
+    if (hasGroup) {
+        const group = context.groups?.find(group => String(group?.id ?? '') === String(context.groupId));
+        const members = new Set(Array.isArray(group?.members) ? group.members : []);
+        return characters.filter(character => members.has(character?.avatar));
+    }
+
+    const characterId = Number(context.characterId);
+    return Number.isInteger(characterId) && characters[characterId] ? [characters[characterId]] : [];
+}
+
+async function offerAuxiliaryLorebook(context, bookName) {
+    if (normalizeTitle(bookName) !== normalizeTitle(FALLBACK_BOOK_NAME)) {
+        return;
+    }
+
+    const charLore = Array.isArray(context.worldInfoSettings?.charLore) ? context.worldInfoSettings.charLore : [];
+    const missingCharacters = getCurrentCharacters(context).filter(character => {
+        const fileName = String(character?.avatar ?? '').replace(/\.[^/.]+$/, '');
+        const extraBooks = charLore.find(entry => entry?.name === fileName)?.extraBooks;
+        return !Array.isArray(extraBooks)
+            || !extraBooks.some(name => normalizeTitle(name) === normalizeTitle(bookName));
+    });
+    if (missingCharacters.length === 0) {
+        return;
+    }
+
+    if (typeof context.callGenericPopup !== 'function'
+        || !context.POPUP_TYPE
+        || typeof context.charUpdateAddAuxWorld !== 'function') {
+        console.warn('[In-Chat Agents] Auxiliary lorebook confirmation is unavailable.');
+        return;
+    }
+
+    const confirmed = await context.callGenericPopup(
+        'Add Lorebook Scout as an Auxiliary Lorebook to the current chat automatically?',
+        context.POPUP_TYPE.CONFIRM,
+    );
+    if (confirmed !== (context.POPUP_RESULT?.AFFIRMATIVE ?? 1)) {
+        return;
+    }
+
+    for (const character of missingCharacters) {
+        await context.charUpdateAddAuxWorld(character.avatar, bookName);
+    }
+}
+
 async function getTargetBook(context) {
     const attachedBook = String(context.chatMetadata?.world_info ?? '').trim();
     if (attachedBook) {
@@ -139,6 +190,7 @@ async function sendLorebookEntries(content, context, notifier) {
         }
 
         const bookName = await getTargetBook(context);
+        await offerAuxiliaryLorebook(context, bookName);
         const bookData = await context.loadWorldInfo(bookName);
         if (!bookData?.entries || typeof bookData.entries !== 'object') {
             throw new Error(`Lorebook "${bookName}" could not be loaded.`);

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -225,6 +225,12 @@ async function sendLorebookEntries(content, context, notifier) {
             entry.selective = false;
             entry.constant = false;
             entry.disable = false;
+            if (bookData.originalData && Array.isArray(bookData.originalData.entries)) {
+                if (typeof context.syncWIOriginalDataEntry !== 'function') {
+                    throw new Error('Imported lorebook synchronization is unavailable.');
+                }
+                context.syncWIOriginalDataEntry(bookData, entry.uid);
+            }
             knownTitles.add(normalizedTitle);
             created++;
         }

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -102,7 +102,7 @@ function getCurrentCharacters(context) {
     return Number.isInteger(characterId) && characters[characterId] ? [characters[characterId]] : [];
 }
 
-async function offerAuxiliaryLorebook(context, bookName) {
+async function offerFallbackLorebookAttachment(context, bookName, attachToChat) {
     if (normalizeTitle(bookName) !== normalizeTitle(FALLBACK_BOOK_NAME)) {
         return;
     }
@@ -114,13 +114,19 @@ async function offerAuxiliaryLorebook(context, bookName) {
         return !Array.isArray(extraBooks)
             || !extraBooks.some(name => normalizeTitle(name) === normalizeTitle(bookName));
     });
-    if (missingCharacters.length === 0) {
+    if (missingCharacters.length === 0 && !attachToChat) {
         return;
     }
 
+    const canAttachToChat = !attachToChat
+        || ((typeof context.updateChatMetadata === 'function' || context.chatMetadata)
+            && typeof context.saveMetadata === 'function');
+    const canAttachToCharacters = missingCharacters.length === 0
+        || typeof context.charUpdateAddAuxWorld === 'function';
     if (typeof context.callGenericPopup !== 'function'
         || !context.POPUP_TYPE
-        || typeof context.charUpdateAddAuxWorld !== 'function') {
+        || !canAttachToChat
+        || !canAttachToCharacters) {
         console.warn('[In-Chat Agents] Auxiliary lorebook confirmation is unavailable.');
         return;
     }
@@ -133,6 +139,15 @@ async function offerAuxiliaryLorebook(context, bookName) {
         return;
     }
 
+    if (attachToChat) {
+        if (typeof context.updateChatMetadata === 'function') {
+            context.updateChatMetadata({ world_info: bookName });
+        } else {
+            context.chatMetadata.world_info = bookName;
+        }
+        await context.saveMetadata();
+    }
+
     for (const character of missingCharacters) {
         await context.charUpdateAddAuxWorld(character.avatar, bookName);
     }
@@ -141,7 +156,7 @@ async function offerAuxiliaryLorebook(context, bookName) {
 async function getTargetBook(context) {
     const attachedBook = String(context.chatMetadata?.world_info ?? '').trim();
     if (attachedBook) {
-        return attachedBook;
+        return { bookName: attachedBook, attachToChat: false };
     }
 
     const findFallback = () => context.getWorldInfoNames?.()
@@ -159,19 +174,7 @@ async function getTargetBook(context) {
         }
     }
 
-    if (typeof context.updateChatMetadata === 'function') {
-        context.updateChatMetadata({ world_info: bookName });
-    } else if (context.chatMetadata) {
-        context.chatMetadata.world_info = bookName;
-    } else {
-        throw new Error('Chat metadata is unavailable.');
-    }
-
-    if (typeof context.saveMetadata !== 'function') {
-        throw new Error('Chat metadata saving is unavailable.');
-    }
-    await context.saveMetadata();
-    return bookName;
+    return { bookName, attachToChat: true };
 }
 
 async function sendLorebookEntries(content, context, notifier) {
@@ -194,8 +197,7 @@ async function sendLorebookEntries(content, context, notifier) {
             throw new Error('Lorebook APIs are unavailable.');
         }
 
-        const bookName = await getTargetBook(context);
-        await offerAuxiliaryLorebook(context, bookName);
+        const { bookName, attachToChat } = await getTargetBook(context);
         const bookData = await context.loadWorldInfo(bookName);
         if (!bookData?.entries || typeof bookData.entries !== 'object') {
             throw new Error(`Lorebook "${bookName}" could not be loaded.`);
@@ -237,6 +239,10 @@ async function sendLorebookEntries(content, context, notifier) {
 
         if (created > 0) {
             await context.saveWorldInfo(bookName, bookData, true);
+        }
+
+        await offerFallbackLorebookAttachment(context, bookName, attachToChat);
+        if (created > 0) {
             const duplicateNote = duplicates > 0 ? ` Skipped ${duplicates} duplicate${duplicates === 1 ? '' : 's'}.` : '';
             notifier?.success?.(`Added ${created} lorebook entr${created === 1 ? 'y' : 'ies'} to "${bookName}".${duplicateNote}`);
         } else {

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -4,6 +4,7 @@ const TITLE_PATTERN = /^\s*\*\*(?!keys\b)(.+?)\*\*\s*$/i;
 const KEYS_PATTERN = /^\s*(?:\*\*Keys:\*\*|\*\*Keys\*\*:|Keys:)\s*(.*?)\s*$/i;
 
 let writeChain = Promise.resolve();
+const booksNeedingSaveRetry = new Set();
 
 export function isLorebookAgent(agent) {
     return Array.isArray(agent?.tags)
@@ -237,8 +238,10 @@ async function sendLorebookEntries(content, context, notifier) {
             created++;
         }
 
-        if (created > 0) {
+        if (created > 0 || booksNeedingSaveRetry.has(bookName)) {
+            booksNeedingSaveRetry.add(bookName);
             await context.saveWorldInfo(bookName, bookData, true);
+            booksNeedingSaveRetry.delete(bookName);
         }
 
         await offerFallbackLorebookAttachment(context, bookName, attachToChat);

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -1,0 +1,195 @@
+const EMPTY_RESULT = 'lorebook has nothing durable this turn.';
+const FALLBACK_BOOK_NAME = 'Lorebook Scout';
+const TITLE_PATTERN = /^\s*\*\*(?!keys\b)(.+?)\*\*\s*$/i;
+const KEYS_PATTERN = /^\s*(?:\*\*Keys:\*\*|\*\*Keys\*\*:|Keys:)\s*(.+?)\s*$/i;
+
+let writeChain = Promise.resolve();
+
+export function isLorebookAgent(agent) {
+    return Array.isArray(agent?.tags)
+        && agent.tags.some(tag => String(tag ?? '').trim().toLowerCase() === 'lorebook');
+}
+
+export function parseLorebookEntries(value) {
+    const text = String(value ?? '').replaceAll(/\r\n?/g, '\n').trim();
+    if (!text || text.toLowerCase() === EMPTY_RESULT) {
+        return [];
+    }
+
+    const entries = [];
+    let current = null;
+
+    const finishEntry = () => {
+        if (!current) {
+            return;
+        }
+
+        const content = current.body.join('\n').trim();
+        if (!content) {
+            throw new Error('Lorebook entry body is missing.');
+        }
+
+        entries.push({
+            title: current.title,
+            keys: current.keys ?? [current.title],
+            content,
+        });
+    };
+
+    for (const line of text.split('\n')) {
+        const titleMatch = line.match(TITLE_PATTERN);
+        if (titleMatch) {
+            finishEntry();
+            const title = titleMatch[1].trim().replace(/:\s*$/, '');
+            if (!title) {
+                throw new Error('Lorebook entry title is missing.');
+            }
+            current = { title, keys: null, body: [] };
+            continue;
+        }
+
+        if (!current) {
+            if (line.trim()) {
+                throw new Error('Lorebook entry title is missing.');
+            }
+            continue;
+        }
+
+        const keysMatch = line.match(KEYS_PATTERN);
+        if (keysMatch) {
+            if (current.keys || current.body.some(value => value.trim())) {
+                throw new Error('Lorebook Keys line is misplaced.');
+            }
+
+            current.keys = [...new Set(keysMatch[1].split(',').map(key => key.trim()).filter(Boolean))];
+            if (current.keys.length < 2 || current.keys.length > 5) {
+                throw new Error('Lorebook Keys line must contain 2 to 5 keys.');
+            }
+            continue;
+        }
+
+        current.body.push(line);
+    }
+
+    finishEntry();
+    if (entries.length === 0) {
+        throw new Error('No lorebook entries found.');
+    }
+    return entries;
+}
+
+function normalizeTitle(value) {
+    return String(value ?? '').normalize().trim().replaceAll(/\s+/g, ' ').toLowerCase();
+}
+
+async function getTargetBook(context) {
+    const attachedBook = String(context.chatMetadata?.world_info ?? '').trim();
+    if (attachedBook) {
+        return attachedBook;
+    }
+
+    const findFallback = () => context.getWorldInfoNames?.()
+        ?.find(name => normalizeTitle(name) === normalizeTitle(FALLBACK_BOOK_NAME));
+    let bookName = findFallback();
+    if (!bookName) {
+        if (typeof context.createNewWorldInfo !== 'function') {
+            throw new Error('Lorebook creation is unavailable.');
+        }
+
+        const created = await context.createNewWorldInfo(FALLBACK_BOOK_NAME);
+        bookName = findFallback() ?? (created ? FALLBACK_BOOK_NAME : '');
+        if (!bookName) {
+            throw new Error('Could not create the fallback lorebook.');
+        }
+    }
+
+    if (typeof context.updateChatMetadata === 'function') {
+        context.updateChatMetadata({ world_info: bookName });
+    } else if (context.chatMetadata) {
+        context.chatMetadata.world_info = bookName;
+    } else {
+        throw new Error('Chat metadata is unavailable.');
+    }
+
+    if (typeof context.saveMetadata !== 'function') {
+        throw new Error('Chat metadata saving is unavailable.');
+    }
+    await context.saveMetadata();
+    return bookName;
+}
+
+async function sendLorebookEntries(content, context, notifier) {
+    let entries;
+    try {
+        entries = parseLorebookEntries(content);
+    } catch (error) {
+        console.warn('[In-Chat Agents] Could not parse lorebook companion result.', error);
+        notifier?.warning?.('Could not read lorebook entries. Use a bold title, an optional Keys line, and a body for each entry.');
+        return null;
+    }
+
+    if (entries.length === 0) {
+        notifier?.info?.('No durable lorebook entries to send.');
+        return { bookName: null, created: 0, duplicates: 0 };
+    }
+
+    try {
+        if (!context?.loadWorldInfo || !context?.createWorldInfoEntry || !context?.saveWorldInfo) {
+            throw new Error('Lorebook APIs are unavailable.');
+        }
+
+        const bookName = await getTargetBook(context);
+        const bookData = await context.loadWorldInfo(bookName);
+        if (!bookData?.entries || typeof bookData.entries !== 'object') {
+            throw new Error(`Lorebook "${bookName}" could not be loaded.`);
+        }
+
+        const knownTitles = new Set(Object.values(bookData.entries)
+            .map(entry => normalizeTitle(entry?.comment))
+            .filter(Boolean));
+        let duplicates = 0;
+        let created = 0;
+
+        for (const draft of entries) {
+            const normalizedTitle = normalizeTitle(draft.title);
+            if (knownTitles.has(normalizedTitle)) {
+                duplicates++;
+                continue;
+            }
+
+            const entry = context.createWorldInfoEntry(bookName, bookData);
+            if (!entry || entry.uid === undefined) {
+                throw new Error(`Could not create an entry in "${bookName}".`);
+            }
+
+            entry.comment = draft.title;
+            entry.key = draft.keys;
+            entry.content = draft.content;
+            entry.selective = false;
+            entry.constant = false;
+            entry.disable = false;
+            knownTitles.add(normalizedTitle);
+            created++;
+        }
+
+        if (created > 0) {
+            await context.saveWorldInfo(bookName, bookData, true);
+            const duplicateNote = duplicates > 0 ? ` Skipped ${duplicates} duplicate${duplicates === 1 ? '' : 's'}.` : '';
+            notifier?.success?.(`Added ${created} lorebook entr${created === 1 ? 'y' : 'ies'} to "${bookName}".${duplicateNote}`);
+        } else {
+            notifier?.info?.(`No new entries added to "${bookName}"; ${duplicates} already exist${duplicates === 1 ? 's' : ''}.`);
+        }
+
+        return { bookName, created, duplicates };
+    } catch (error) {
+        console.error('[In-Chat Agents] Could not send companion result to lorebook.', error);
+        notifier?.error?.('Could not send entries to the lorebook.');
+        return null;
+    }
+}
+
+export function sendCompanionResultToLorebook(content, context = globalThis.SillyTavern?.getContext?.(), notifier = globalThis.toastr) {
+    const run = writeChain.then(() => sendLorebookEntries(content, context, notifier));
+    writeChain = run.then(() => undefined, () => undefined);
+    return run;
+}

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -61,10 +61,11 @@ export function parseLorebookEntries(value) {
                 throw new Error('Lorebook Keys line is misplaced.');
             }
 
-            current.keys = [...new Set(keysMatch[1].split(',').map(key => key.trim()).filter(Boolean))];
-            if (current.keys.length < 2 || current.keys.length > 5) {
-                throw new Error('Lorebook Keys line must contain 2 to 5 keys.');
+            const keys = [...new Set(keysMatch[1].split(',').map(key => key.trim()).filter(Boolean))];
+            if (keys.length < 2) {
+                throw new Error('Lorebook Keys line must contain at least 2 keys.');
             }
+            current.keys = keys.slice(0, 5);
             continue;
         }
 

--- a/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
+++ b/public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js
@@ -1,7 +1,7 @@
 const EMPTY_RESULT = 'lorebook has nothing durable this turn.';
 const FALLBACK_BOOK_NAME = 'Lorebook Scout';
 const TITLE_PATTERN = /^\s*\*\*(?!keys\b)(.+?)\*\*\s*$/i;
-const KEYS_PATTERN = /^\s*(?:\*\*Keys:\*\*|\*\*Keys\*\*:|Keys:)\s*(.+?)\s*$/i;
+const KEYS_PATTERN = /^\s*(?:\*\*Keys:\*\*|\*\*Keys\*\*:|Keys:)\s*(.*?)\s*$/i;
 
 let writeChain = Promise.resolve();
 
@@ -24,6 +24,10 @@ export function parseLorebookEntries(value) {
             return;
         }
 
+        if (!current.keys) {
+            throw new Error('Lorebook Keys line is missing.');
+        }
+
         const content = current.body.join('\n').trim();
         if (!content) {
             throw new Error('Lorebook entry body is missing.');
@@ -31,7 +35,7 @@ export function parseLorebookEntries(value) {
 
         entries.push({
             title: current.title,
-            keys: current.keys ?? [current.title],
+            keys: current.keys,
             content,
         });
     };
@@ -176,7 +180,7 @@ async function sendLorebookEntries(content, context, notifier) {
         entries = parseLorebookEntries(content);
     } catch (error) {
         console.warn('[In-Chat Agents] Could not parse lorebook companion result.', error);
-        notifier?.warning?.('Could not read lorebook entries. Use a bold title, an optional Keys line, and a body for each entry.');
+        notifier?.warning?.('Could not read lorebook entries. Use a bold title, a Keys line with 2-5 comma-separated trigger keywords, and a body for each entry.');
         return null;
     }
 

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -112,7 +112,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
 import { addGlobalVariable, addLocalVariable, decrementGlobalVariable, decrementLocalVariable, deleteGlobalVariable, deleteLocalVariable, existsGlobalVariable, existsLocalVariable, getGlobalVariable, getLocalVariable, incrementGlobalVariable, incrementLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
-import { convertCharacterBook, createNewWorldInfo, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
+import { charUpdateAddAuxWorld, convertCharacterBook, createNewWorldInfo, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
@@ -298,6 +298,7 @@ export function getContext() {
         },
         // SillyBunny: Pathfinder and Companion lorebook writes use the core APIs through extension context.
         loadWorldInfo,
+        charUpdateAddAuxWorld,
         createNewWorldInfo,
         createWorldInfoEntry,
         saveWorldInfo,

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -112,7 +112,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
 import { addGlobalVariable, addLocalVariable, decrementGlobalVariable, decrementLocalVariable, deleteGlobalVariable, deleteLocalVariable, existsGlobalVariable, existsLocalVariable, getGlobalVariable, getLocalVariable, incrementGlobalVariable, incrementLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
-import { charUpdateAddAuxWorld, convertCharacterBook, createNewWorldInfo, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
+import { charUpdateAddAuxWorld, convertCharacterBook, createNewWorldInfo, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, syncWIOriginalDataEntry, updateWorldInfoList, world_info, world_names } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
@@ -302,6 +302,7 @@ export function getContext() {
         createNewWorldInfo,
         createWorldInfoEntry,
         saveWorldInfo,
+        syncWIOriginalDataEntry,
         reloadWorldInfoEditor: reloadEditor,
         updateWorldInfoList,
         convertCharacterBook,

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -112,7 +112,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
 import { addGlobalVariable, addLocalVariable, decrementGlobalVariable, decrementLocalVariable, deleteGlobalVariable, deleteLocalVariable, existsGlobalVariable, existsLocalVariable, getGlobalVariable, getLocalVariable, incrementGlobalVariable, incrementLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
-import { convertCharacterBook, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
+import { convertCharacterBook, createNewWorldInfo, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
@@ -296,8 +296,9 @@ export function getContext() {
                 has: existsGlobalVariable,
             },
         },
-        // SillyBunny: Pathfinder write tools need the lorebook entry factory in extension context.
+        // SillyBunny: Pathfinder and Companion lorebook writes use the core APIs through extension context.
         loadWorldInfo,
+        createNewWorldInfo,
         createWorldInfoEntry,
         saveWorldInfo,
         reloadWorldInfoEditor: reloadEditor,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2986,6 +2986,18 @@ function getWIOriginalDataIndex(data, uid) {
     return data.originalData?.entries?.findIndex(x => String(x.id ?? x.uid) === String(uid)) ?? -1;
 }
 
+// SillyBunny: built-in extension writers need one atomic resync after populating a new imported-book entry.
+export function syncWIOriginalDataEntry(data, uid) {
+    const entry = data.entries?.[uid];
+    const originalIndex = getWIOriginalDataIndex(data, uid);
+    if (!entry || originalIndex < 0) {
+        return;
+    }
+
+    const originalEntry = data.originalData.entries[originalIndex];
+    data.originalData.entries[originalIndex] = structuredClone(serializeWorldInfoEntry(entry, world_info_position, originalEntry));
+}
+
 function syncWIOriginalDataKeys(data, uid) {
     const entry = data.entries?.[uid];
     if (!entry) {

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -443,6 +443,25 @@ describe('companion tracker panel', () => {
         expect(editNoteMatches).toHaveLength(3);
     });
 
+    test('shows lorebook actions on every stored state only for tagged agents', async () => {
+        const scout = { id: 'scout', name: 'Lorebook Scout', execution: 'companion', enabled: true, tags: ['LoreBook'] };
+        agents = [scout];
+        const panel = await importPanel();
+
+        for (let index = 0; index < 3; index++) {
+            const message = { is_user: false, is_system: false, mes: `reply ${index}` };
+            chat.push(message);
+            companionResultsByMessage.set(message, {
+                scout: { status: 'done', content: `state ${index}`, agentName: 'Lorebook Scout' },
+            });
+        }
+
+        expect(panel.buildPanelHtml().match(/data-action="panel-send-to-lorebook"/g)).toHaveLength(3);
+
+        scout.tags = ['notes'];
+        expect(panel.buildPanelHtml()).not.toContain('data-action="panel-send-to-lorebook"');
+    });
+
     test('shows enabled memory shard before threshold and offers shard compaction after a run', async () => {
         agents = [
             { id: 'memory-shard', name: 'Memory Shard', sourceTemplateId: 'tpl-memory-shard-companion', execution: 'companion', enabled: true, companion: { minContextTokens: 30000 } },

--- a/tests/in-chat-agents-companion.test.js
+++ b/tests/in-chat-agents-companion.test.js
@@ -35,6 +35,7 @@ describe('companion card ui', () => {
     let sanitize;
     let encodeStyleTags;
     let decodeStyleTags;
+    let jqueryObject;
 
     async function importCompanionUi() {
         jest.resetModules();
@@ -158,7 +159,7 @@ describe('companion card ui', () => {
             addEventListener: jest.fn(),
             querySelector: jest.fn(() => null),
         };
-        const jqueryObject = {};
+        jqueryObject = {};
         Object.assign(jqueryObject, {
             on: jest.fn(() => jqueryObject),
             each: jest.fn(),
@@ -188,7 +189,7 @@ describe('companion card ui', () => {
         expect(sanitize).toHaveBeenCalled();
     });
 
-    // DESIGN.md limits inline companion cards to regenerate, edit, copy, delete, and manual-run.
+    // Inline companion cards keep general actions small; tagged agents may add one purpose-built action.
     // Hiding an agent lives in the companion panel; agent settings live behind Workspace.
     test('keeps inline card actions within the documented vocabulary', () => {
         const source = fs.readFileSync(new URL('../public/scripts/extensions/in-chat-agents/companion/companion-ui.js', import.meta.url), 'utf8');
@@ -196,6 +197,35 @@ describe('companion card ui', () => {
         expect(source).not.toContain('data-action="hide"');
         expect(source).not.toContain('data-action="settings"');
         expect(source).not.toContain('configureCompanionCardUi');
+    });
+
+    test('shows the lorebook action only on tagged inline cards', async () => {
+        agents[0].tags = ['LoreBook'];
+        const message = {
+            is_user: false,
+            is_system: false,
+            name: 'Aria',
+            extra: {
+                inChatAgentCompanionResults: {
+                    'companion-tracker': {
+                        status: 'done',
+                        content: '**Moon Well**\nThe well reflects tomorrow\'s sky.',
+                        agentName: 'Lorebook Scout',
+                        displayMode: 'card',
+                    },
+                },
+            },
+        };
+        chat.push(message);
+        const ui = await importCompanionUi();
+        jqueryObject.length = 1;
+
+        ui.renderCompanionResultsForMessage(0);
+        expect(jqueryObject.html).toHaveBeenLastCalledWith(expect.stringContaining('data-action="send-to-lorebook"'));
+
+        agents[0].tags = ['notes'];
+        ui.renderCompanionResultsForMessage(0);
+        expect(jqueryObject.html).toHaveBeenLastCalledWith(expect.not.stringContaining('data-action="send-to-lorebook"'));
     });
 
     test('beautifies Chat Only transcript speaker turns before markdown conversion', async () => {

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -5,7 +5,7 @@ import {
     sendCompanionResultToLorebook,
 } from '../public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js';
 
-function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks = [], confirmResult = 1 } = {}) {
+function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks = [], confirmResult = 1, importedBook = false } = {}) {
     const names = attachedBook ? [attachedBook] : [];
     const books = {};
     const worldInfoSettings = auxiliaryBooks.length > 0
@@ -15,6 +15,12 @@ function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks 
         books[attachedBook] = {
             entries: Object.fromEntries(existingTitles.map((comment, uid) => [uid, { uid, comment }])),
         };
+        if (importedBook) {
+            books[attachedBook].originalData = {
+                entries: existingTitles.map((comment, id) => ({ id, comment })),
+            };
+            books[attachedBook].originalDataUidMap = Object.fromEntries(existingTitles.map((_, uid) => [uid, uid]));
+        }
     }
 
     const context = {
@@ -38,9 +44,50 @@ function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks 
         loadWorldInfo: jest.fn(async name => books[name] ?? null),
         createWorldInfoEntry: jest.fn((_name, data) => {
             const uid = Object.keys(data.entries).length;
-            const entry = { uid };
+            const entry = {
+                uid,
+                key: [],
+                keysecondary: [],
+                comment: '',
+                content: '',
+                constant: false,
+                selective: true,
+                disable: false,
+            };
             data.entries[uid] = entry;
+            if (data.originalData && Array.isArray(data.originalData.entries)) {
+                data.originalDataUidMap ??= {};
+                data.originalDataUidMap[uid] = data.originalData.entries.length;
+                data.originalData.entries.push({
+                    id: uid,
+                    keys: [],
+                    secondary_keys: [],
+                    comment: '',
+                    content: '',
+                    constant: false,
+                    selective: true,
+                    enabled: true,
+                });
+            }
             return entry;
+        }),
+        syncWIOriginalDataEntry: jest.fn((data, uid) => {
+            const index = data.originalDataUidMap?.[uid];
+            const entry = data.entries[uid];
+            if (!Number.isInteger(index) || !entry) {
+                return;
+            }
+            data.originalData.entries[index] = {
+                ...data.originalData.entries[index],
+                id: uid,
+                keys: [...entry.key],
+                secondary_keys: [...entry.keysecondary],
+                comment: entry.comment,
+                content: entry.content,
+                constant: entry.constant,
+                selective: entry.selective,
+                enabled: !entry.disable,
+            };
         }),
         saveWorldInfo: jest.fn(async () => {}),
         charUpdateAddAuxWorld: jest.fn(async (avatar, name) => {
@@ -147,6 +194,30 @@ describe('Lorebook Scout sender', () => {
         expect(context.callGenericPopup).not.toHaveBeenCalled();
         expect(notifier.success).toHaveBeenCalledWith('Added 1 lorebook entry to "Campaign Lore". Skipped 1 duplicate.');
         expect(notifier.info).toHaveBeenCalledWith('No new entries added to "Campaign Lore"; 2 already exist.');
+    });
+
+    test('synchronizes new entries into imported character-book data', async () => {
+        const { books, context } = createContext({
+            attachedBook: 'Imported Lore',
+            importedBook: true,
+        });
+
+        await sendCompanionResultToLorebook(
+            '**Moon Well**\nKeys: Moon Well, silver water\nThe Moon Well reflects tomorrow night\'s sky.',
+            context,
+            notifier,
+        );
+
+        expect(books['Imported Lore'].originalData.entries[0]).toEqual(expect.objectContaining({
+            id: 0,
+            keys: ['Moon Well', 'silver water'],
+            secondary_keys: [],
+            comment: 'Moon Well',
+            content: 'The Moon Well reflects tomorrow night\'s sky.',
+            constant: false,
+            selective: false,
+            enabled: true,
+        }));
     });
 
     test('creates and attaches the fallback book when the chat has none', async () => {

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -232,6 +232,8 @@ describe('Lorebook Scout sender', () => {
         expect(context.createNewWorldInfo).toHaveBeenCalledWith('Lorebook Scout');
         expect(context.updateChatMetadata).toHaveBeenCalledWith({ world_info: 'Lorebook Scout' });
         expect(context.saveMetadata).toHaveBeenCalledTimes(1);
+        expect(context.saveWorldInfo.mock.invocationCallOrder[0])
+            .toBeLessThan(context.updateChatMetadata.mock.invocationCallOrder[0]);
         expect(books['Lorebook Scout'].entries[0].key).toEqual(['Sun Dial', 'rain omen']);
         expect(context.callGenericPopup).toHaveBeenCalledWith(
             'Add Lorebook Scout as an Auxiliary Lorebook to the current chat automatically?',
@@ -246,6 +248,22 @@ describe('Lorebook Scout sender', () => {
         );
         expect(context.callGenericPopup).toHaveBeenCalledTimes(1);
         expect(context.charUpdateAddAuxWorld).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps a declined fallback book detached from the current chat', async () => {
+        const { books, context } = createContext({ confirmResult: 0 });
+
+        await sendCompanionResultToLorebook(
+            '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.',
+            context,
+            notifier,
+        );
+
+        expect(books['Lorebook Scout'].entries[0].comment).toBe('Sun Dial');
+        expect(context.callGenericPopup).toHaveBeenCalledTimes(1);
+        expect(context.updateChatMetadata).not.toHaveBeenCalled();
+        expect(context.saveMetadata).not.toHaveBeenCalled();
+        expect(context.charUpdateAddAuxWorld).not.toHaveBeenCalled();
     });
 
     test('skips the confirmation when Lorebook Scout is already an auxiliary lorebook', async () => {

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import {
+    isLorebookAgent,
+    parseLorebookEntries,
+    sendCompanionResultToLorebook,
+} from '../public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js';
+
+function createContext({ attachedBook = '', existingTitles = [] } = {}) {
+    const names = attachedBook ? [attachedBook] : [];
+    const books = {};
+    if (attachedBook) {
+        books[attachedBook] = {
+            entries: Object.fromEntries(existingTitles.map((comment, uid) => [uid, { uid, comment }])),
+        };
+    }
+
+    const context = {
+        chatMetadata: attachedBook ? { world_info: attachedBook } : {},
+        getWorldInfoNames: jest.fn(() => [...names]),
+        createNewWorldInfo: jest.fn(async name => {
+            names.push(name);
+            books[name] = { entries: {} };
+            return true;
+        }),
+        updateChatMetadata: jest.fn(values => Object.assign(context.chatMetadata, values)),
+        saveMetadata: jest.fn(async () => {}),
+        loadWorldInfo: jest.fn(async name => books[name] ?? null),
+        createWorldInfoEntry: jest.fn((_name, data) => {
+            const uid = Object.keys(data.entries).length;
+            const entry = { uid };
+            data.entries[uid] = entry;
+            return entry;
+        }),
+        saveWorldInfo: jest.fn(async () => {}),
+    };
+
+    return { books, context };
+}
+
+describe('Lorebook Scout sender', () => {
+    let notifier;
+
+    beforeEach(() => {
+        notifier = {
+            info: jest.fn(),
+            success: jest.fn(),
+            warning: jest.fn(),
+            error: jest.fn(),
+        };
+    });
+
+    test('recognises the opt-in tag case-insensitively', () => {
+        expect(isLorebookAgent({ tags: ['notes', 'LoreBook'] })).toBe(true);
+        expect(isLorebookAgent({ tags: ['notes', 'world info'] })).toBe(false);
+    });
+
+    test('parses multiple drafts, bold Keys labels, and title key fallbacks', () => {
+        const entries = parseLorebookEntries([
+            '**The Ember Gate**',
+            '**Keys:** Ember Gate, ash gate, Cinder Road',
+            'The Ember Gate seals the Cinder Road whenever its braziers go dark.',
+            '',
+            '**Moon Well:**',
+            'The Moon Well reflects the sky of the next clear night.',
+        ].join('\n'));
+
+        expect(entries).toEqual([
+            {
+                title: 'The Ember Gate',
+                keys: ['Ember Gate', 'ash gate', 'Cinder Road'],
+                content: 'The Ember Gate seals the Cinder Road whenever its braziers go dark.',
+            },
+            {
+                title: 'Moon Well',
+                keys: ['Moon Well'],
+                content: 'The Moon Well reflects the sky of the next clear night.',
+            },
+        ]);
+        expect(parseLorebookEntries('Lorebook has nothing durable this turn.')).toEqual([]);
+        expect(() => parseLorebookEntries('A plain paragraph without a title.')).toThrow('title');
+        expect(() => parseLorebookEntries('**Gate**\nKeys: gate\nA gate.')).toThrow('2 to 5');
+    });
+
+    test('writes new entries once and skips normalized duplicate titles on repeat sends', async () => {
+        const { books, context } = createContext({
+            attachedBook: 'Campaign Lore',
+            existingTitles: ['  the   ember gate  '],
+        });
+        const content = [
+            '**The Ember Gate**',
+            'Keys: Ember Gate, Cinder Road',
+            'The Ember Gate seals the Cinder Road.',
+            '',
+            '**Moon Well**',
+            'Keys: Moon Well, silver water',
+            'The Moon Well reflects tomorrow night\'s sky.',
+        ].join('\n');
+
+        await expect(sendCompanionResultToLorebook(content, context, notifier)).resolves.toEqual({
+            bookName: 'Campaign Lore',
+            created: 1,
+            duplicates: 1,
+        });
+        expect(books['Campaign Lore'].entries[1]).toEqual(expect.objectContaining({
+            comment: 'Moon Well',
+            key: ['Moon Well', 'silver water'],
+            content: 'The Moon Well reflects tomorrow night\'s sky.',
+            selective: false,
+            constant: false,
+            disable: false,
+        }));
+        expect(context.saveWorldInfo).toHaveBeenCalledWith('Campaign Lore', books['Campaign Lore'], true);
+
+        await expect(sendCompanionResultToLorebook(content, context, notifier)).resolves.toEqual({
+            bookName: 'Campaign Lore',
+            created: 0,
+            duplicates: 2,
+        });
+        expect(context.saveWorldInfo).toHaveBeenCalledTimes(1);
+        expect(context.createNewWorldInfo).not.toHaveBeenCalled();
+        expect(notifier.success).toHaveBeenCalledWith('Added 1 lorebook entry to "Campaign Lore". Skipped 1 duplicate.');
+        expect(notifier.info).toHaveBeenCalledWith('No new entries added to "Campaign Lore"; 2 already exist.');
+    });
+
+    test('creates and attaches the fallback book when the chat has none', async () => {
+        const { books, context } = createContext();
+
+        await expect(sendCompanionResultToLorebook(
+            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            context,
+            notifier,
+        )).resolves.toEqual({ bookName: 'Lorebook Scout', created: 1, duplicates: 0 });
+
+        expect(context.createNewWorldInfo).toHaveBeenCalledWith('Lorebook Scout');
+        expect(context.updateChatMetadata).toHaveBeenCalledWith({ world_info: 'Lorebook Scout' });
+        expect(context.saveMetadata).toHaveBeenCalledTimes(1);
+        expect(books['Lorebook Scout'].entries[0].key).toEqual(['Sun Dial']);
+    });
+});

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -99,7 +99,9 @@ describe('Lorebook Scout sender', () => {
         ]);
         expect(parseLorebookEntries('Lorebook has nothing durable this turn.')).toEqual([]);
         expect(() => parseLorebookEntries('A plain paragraph without a title.')).toThrow('title');
-        expect(() => parseLorebookEntries('**Gate**\nKeys: gate\nA gate.')).toThrow('2 to 5');
+        expect(() => parseLorebookEntries('**Gate**\nKeys: gate\nA gate.')).toThrow('at least 2');
+        expect(parseLorebookEntries('**Gate**\nKeys: one, two, three, four, five, six\nA gate.')[0].keys)
+            .toEqual(['one', 'two', 'three', 'four', 'five']);
     });
 
     test('writes new entries once and skips normalized duplicate titles on repeat sends', async () => {

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -75,13 +75,14 @@ describe('Lorebook Scout sender', () => {
         expect(isLorebookAgent({ tags: ['notes', 'world info'] })).toBe(false);
     });
 
-    test('parses multiple drafts, bold Keys labels, and title key fallbacks', () => {
+    test('parses multiple drafts and bold Keys labels', () => {
         const entries = parseLorebookEntries([
             '**The Ember Gate**',
             '**Keys:** Ember Gate, ash gate, Cinder Road',
             'The Ember Gate seals the Cinder Road whenever its braziers go dark.',
             '',
             '**Moon Well:**',
+            'Keys: Moon Well, silver water',
             'The Moon Well reflects the sky of the next clear night.',
         ].join('\n'));
 
@@ -93,12 +94,14 @@ describe('Lorebook Scout sender', () => {
             },
             {
                 title: 'Moon Well',
-                keys: ['Moon Well'],
+                keys: ['Moon Well', 'silver water'],
                 content: 'The Moon Well reflects the sky of the next clear night.',
             },
         ]);
         expect(parseLorebookEntries('Lorebook has nothing durable this turn.')).toEqual([]);
         expect(() => parseLorebookEntries('A plain paragraph without a title.')).toThrow('title');
+        expect(() => parseLorebookEntries('**Gate**\nA gate.')).toThrow('Keys');
+        expect(() => parseLorebookEntries('**Gate**\nKeys:\nA gate.')).toThrow('at least 2');
         expect(() => parseLorebookEntries('**Gate**\nKeys: gate\nA gate.')).toThrow('at least 2');
         expect(parseLorebookEntries('**Gate**\nKeys: one, two, three, four, five, six\nA gate.')[0].keys)
             .toEqual(['one', 'two', 'three', 'four', 'five']);
@@ -150,7 +153,7 @@ describe('Lorebook Scout sender', () => {
         const { books, context } = createContext();
 
         await expect(sendCompanionResultToLorebook(
-            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.',
             context,
             notifier,
         )).resolves.toEqual({ bookName: 'Lorebook Scout', created: 1, duplicates: 0 });
@@ -158,7 +161,7 @@ describe('Lorebook Scout sender', () => {
         expect(context.createNewWorldInfo).toHaveBeenCalledWith('Lorebook Scout');
         expect(context.updateChatMetadata).toHaveBeenCalledWith({ world_info: 'Lorebook Scout' });
         expect(context.saveMetadata).toHaveBeenCalledTimes(1);
-        expect(books['Lorebook Scout'].entries[0].key).toEqual(['Sun Dial']);
+        expect(books['Lorebook Scout'].entries[0].key).toEqual(['Sun Dial', 'rain omen']);
         expect(context.callGenericPopup).toHaveBeenCalledWith(
             'Add Lorebook Scout as an Auxiliary Lorebook to the current chat automatically?',
             'confirm',
@@ -166,7 +169,7 @@ describe('Lorebook Scout sender', () => {
         expect(context.charUpdateAddAuxWorld).toHaveBeenCalledWith('Scout.png', 'Lorebook Scout');
 
         await sendCompanionResultToLorebook(
-            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.',
             context,
             notifier,
         );
@@ -181,7 +184,7 @@ describe('Lorebook Scout sender', () => {
         });
 
         await sendCompanionResultToLorebook(
-            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.',
             context,
             notifier,
         );
@@ -200,7 +203,7 @@ describe('Lorebook Scout sender', () => {
         context.groups = [{ id: 'group-1', members: ['Scout.png', 'Other.png'] }];
 
         await sendCompanionResultToLorebook(
-            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.',
             context,
             notifier,
         );
@@ -217,7 +220,7 @@ describe('Lorebook Scout sender', () => {
         });
 
         await sendCompanionResultToLorebook(
-            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.',
             context,
             notifier,
         );

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -5,9 +5,10 @@ import {
     sendCompanionResultToLorebook,
 } from '../public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js';
 
-function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks = [], confirmResult = 1, importedBook = false } = {}) {
+function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks = [], confirmResult = 1, importedBook = false, saveFailures = 0 } = {}) {
     const names = attachedBook ? [attachedBook] : [];
     const books = {};
+    let remainingSaveFailures = saveFailures;
     const worldInfoSettings = auxiliaryBooks.length > 0
         ? { charLore: [{ name: 'Scout', extraBooks: [...auxiliaryBooks] }] }
         : {};
@@ -89,7 +90,12 @@ function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks 
                 enabled: !entry.disable,
             };
         }),
-        saveWorldInfo: jest.fn(async () => {}),
+        saveWorldInfo: jest.fn(async () => {
+            if (remainingSaveFailures > 0) {
+                remainingSaveFailures--;
+                throw new Error('Simulated lorebook save failure.');
+            }
+        }),
         charUpdateAddAuxWorld: jest.fn(async (avatar, name) => {
             const fileName = avatar.replace(/\.[^/.]+$/, '');
             worldInfoSettings.charLore ??= [];
@@ -264,6 +270,28 @@ describe('Lorebook Scout sender', () => {
         expect(context.updateChatMetadata).not.toHaveBeenCalled();
         expect(context.saveMetadata).not.toHaveBeenCalled();
         expect(context.charUpdateAddAuxWorld).not.toHaveBeenCalled();
+    });
+
+    test('retries a failed fallback save before attaching its cached entry', async () => {
+        const { context } = createContext({ saveFailures: 1 });
+        const content = '**Sun Dial**\nKeys: Sun Dial, rain omen\nThe Sun Dial rings at noon when rain is coming.';
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await expect(sendCompanionResultToLorebook(content, context, notifier)).resolves.toBeNull();
+        expect(consoleError).toHaveBeenCalled();
+        expect(context.saveWorldInfo).toHaveBeenCalledTimes(1);
+        expect(context.callGenericPopup).not.toHaveBeenCalled();
+        expect(context.updateChatMetadata).not.toHaveBeenCalled();
+
+        await expect(sendCompanionResultToLorebook(content, context, notifier)).resolves.toEqual({
+            bookName: 'Lorebook Scout',
+            created: 0,
+            duplicates: 1,
+        });
+        expect(context.saveWorldInfo).toHaveBeenCalledTimes(2);
+        expect(context.callGenericPopup).toHaveBeenCalledTimes(1);
+        expect(context.updateChatMetadata).toHaveBeenCalledWith({ world_info: 'Lorebook Scout' });
+        consoleError.mockRestore();
     });
 
     test('skips the confirmation when Lorebook Scout is already an auxiliary lorebook', async () => {

--- a/tests/in-chat-agents-lorebook-sender.test.js
+++ b/tests/in-chat-agents-lorebook-sender.test.js
@@ -5,9 +5,12 @@ import {
     sendCompanionResultToLorebook,
 } from '../public/scripts/extensions/in-chat-agents/companion/lorebook-sender.js';
 
-function createContext({ attachedBook = '', existingTitles = [] } = {}) {
+function createContext({ attachedBook = '', existingTitles = [], auxiliaryBooks = [], confirmResult = 1 } = {}) {
     const names = attachedBook ? [attachedBook] : [];
     const books = {};
+    const worldInfoSettings = auxiliaryBooks.length > 0
+        ? { charLore: [{ name: 'Scout', extraBooks: [...auxiliaryBooks] }] }
+        : {};
     if (attachedBook) {
         books[attachedBook] = {
             entries: Object.fromEntries(existingTitles.map((comment, uid) => [uid, { uid, comment }])),
@@ -16,6 +19,14 @@ function createContext({ attachedBook = '', existingTitles = [] } = {}) {
 
     const context = {
         chatMetadata: attachedBook ? { world_info: attachedBook } : {},
+        characters: [{ avatar: 'Scout.png' }],
+        characterId: 0,
+        groupId: null,
+        groups: [],
+        worldInfoSettings,
+        POPUP_TYPE: { CONFIRM: 'confirm' },
+        POPUP_RESULT: { AFFIRMATIVE: 1 },
+        callGenericPopup: jest.fn(async () => confirmResult),
         getWorldInfoNames: jest.fn(() => [...names]),
         createNewWorldInfo: jest.fn(async name => {
             names.push(name);
@@ -32,6 +43,16 @@ function createContext({ attachedBook = '', existingTitles = [] } = {}) {
             return entry;
         }),
         saveWorldInfo: jest.fn(async () => {}),
+        charUpdateAddAuxWorld: jest.fn(async (avatar, name) => {
+            const fileName = avatar.replace(/\.[^/.]+$/, '');
+            worldInfoSettings.charLore ??= [];
+            let characterLore = worldInfoSettings.charLore.find(entry => entry.name === fileName);
+            if (!characterLore) {
+                characterLore = { name: fileName, extraBooks: [] };
+                worldInfoSettings.charLore.push(characterLore);
+            }
+            characterLore.extraBooks.push(name);
+        }),
     };
 
     return { books, context };
@@ -118,6 +139,7 @@ describe('Lorebook Scout sender', () => {
         });
         expect(context.saveWorldInfo).toHaveBeenCalledTimes(1);
         expect(context.createNewWorldInfo).not.toHaveBeenCalled();
+        expect(context.callGenericPopup).not.toHaveBeenCalled();
         expect(notifier.success).toHaveBeenCalledWith('Added 1 lorebook entry to "Campaign Lore". Skipped 1 duplicate.');
         expect(notifier.info).toHaveBeenCalledWith('No new entries added to "Campaign Lore"; 2 already exist.');
     });
@@ -135,5 +157,71 @@ describe('Lorebook Scout sender', () => {
         expect(context.updateChatMetadata).toHaveBeenCalledWith({ world_info: 'Lorebook Scout' });
         expect(context.saveMetadata).toHaveBeenCalledTimes(1);
         expect(books['Lorebook Scout'].entries[0].key).toEqual(['Sun Dial']);
+        expect(context.callGenericPopup).toHaveBeenCalledWith(
+            'Add Lorebook Scout as an Auxiliary Lorebook to the current chat automatically?',
+            'confirm',
+        );
+        expect(context.charUpdateAddAuxWorld).toHaveBeenCalledWith('Scout.png', 'Lorebook Scout');
+
+        await sendCompanionResultToLorebook(
+            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            context,
+            notifier,
+        );
+        expect(context.callGenericPopup).toHaveBeenCalledTimes(1);
+        expect(context.charUpdateAddAuxWorld).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips the confirmation when Lorebook Scout is already an auxiliary lorebook', async () => {
+        const { context } = createContext({
+            attachedBook: 'Lorebook Scout',
+            auxiliaryBooks: ['Lorebook Scout'],
+        });
+
+        await sendCompanionResultToLorebook(
+            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            context,
+            notifier,
+        );
+
+        expect(context.callGenericPopup).not.toHaveBeenCalled();
+        expect(context.charUpdateAddAuxWorld).not.toHaveBeenCalled();
+    });
+
+    test('adds Lorebook Scout only to group members that do not already use it', async () => {
+        const { context } = createContext({
+            attachedBook: 'Lorebook Scout',
+            auxiliaryBooks: ['Lorebook Scout'],
+        });
+        context.characters.push({ avatar: 'Other.png' });
+        context.groupId = 'group-1';
+        context.groups = [{ id: 'group-1', members: ['Scout.png', 'Other.png'] }];
+
+        await sendCompanionResultToLorebook(
+            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            context,
+            notifier,
+        );
+
+        expect(context.callGenericPopup).toHaveBeenCalledTimes(1);
+        expect(context.charUpdateAddAuxWorld).toHaveBeenCalledTimes(1);
+        expect(context.charUpdateAddAuxWorld).toHaveBeenCalledWith('Other.png', 'Lorebook Scout');
+    });
+
+    test('keeps the entry when auxiliary lorebook confirmation is declined', async () => {
+        const { books, context } = createContext({
+            attachedBook: 'Lorebook Scout',
+            confirmResult: 0,
+        });
+
+        await sendCompanionResultToLorebook(
+            '**Sun Dial**\nThe Sun Dial rings at noon when rain is coming.',
+            context,
+            notifier,
+        );
+
+        expect(books['Lorebook Scout'].entries[0].comment).toBe('Sun Dial');
+        expect(context.callGenericPopup).toHaveBeenCalledTimes(1);
+        expect(context.charUpdateAddAuxWorld).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Before, Lorebook Scout was display only - now it actually can send to the lorebook if any keys are created.

Also has a dialogue box that confirms if you want to attach the Lorebook Scout as an auxiliary lorebook to the current chat/card.