### PR TITLE
fix(ica): ensure every Tracker category agent has the ‘tracker-none’ sentinel

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -52,6 +52,7 @@ import {
     isEmptyOutputSentinel,
     isValidCompanionMessage,
     normalizePlotCompassObjective,
+    TRACKER_EMPTY_OUTPUT_INSTRUCTION,
 } from './companion-shared.js';
 import { resolveCompanionContentMacros } from './companion-macros.js';
 import { findTrackerBlocks, inspectTrackerState, normalizeCompanionTrackerRepairPayload, TRACKER_REPAIR_INSTRUCTION } from '../tracker-state.js';
@@ -1109,7 +1110,7 @@ function getFormatInstruction(format) {
     }
 }
 
-function expandCompanionPrompt(agent, messageIndex, generationType = 'normal') {
+function expandCompanionPrompt(agent, messageIndex, generationType = 'normal', repair = false) {
     const message = chat[messageIndex];
     const messageText = normalizeText(message?.mes ?? '');
     const prompt = substituteParams(agent.prompt, {
@@ -1117,13 +1118,18 @@ function expandCompanionPrompt(agent, messageIndex, generationType = 'normal') {
         original: messageText,
         dynamicMacros: buildPromptDynamicMacros(messageText, message, agent, generationType),
     }).trim();
+    const emptyOutputInstruction = !repair
+        && agent.category === 'tracker'
+        && !prompt.toLowerCase().includes('tracker-none')
+        ? TRACKER_EMPTY_OUTPUT_INSTRUCTION
+        : '';
 
-    return [prompt, getTemplateSettingsPromptBlock(agent, message)].filter(Boolean).join('\n\n').trim();
+    return [prompt, getTemplateSettingsPromptBlock(agent, message), emptyOutputInstruction].filter(Boolean).join('\n\n').trim();
 }
 
 export async function buildCompanionPromptMessages(agent, messageIndex, generationType = 'normal', { repair = false, extraContextSections = [] } = {}) {
     const companion = getCompanionConfig(agent);
-    const expandedPrompt = expandCompanionPrompt(agent, messageIndex, generationType);
+    const expandedPrompt = expandCompanionPrompt(agent, messageIndex, generationType, repair);
     const contextSections = await buildCompanionContextSections(agent, messageIndex, { extraContextSections });
     // rawPrompt sends the agent prompt verbatim: tracker prompts define their own exact output
     // format and break when extra format instructions are appended around them. The guard

--- a/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-shared.js
@@ -39,10 +39,10 @@ export const CHATROOM_STYLE_VALUES = new Set([
 export const CHATROOM_REPLY_MAX_CHARS = 2000;
 
 // SillyBunny: an agent with nothing to report returns one of these instead of prose or an empty
-// string, so "nothing happened" is a deliberate answer rather than a failed run. Suppression keys
-// off the content alone, which means custom agents opt in purely by teaching their prompt a
-// sentinel - no template allowlist to maintain.
+// string, so "nothing happened" is a deliberate answer rather than a failed run. Tracker companions
+// are taught their sentinel automatically; other custom companions can opt in through their prompt.
 export const EMPTY_OUTPUT_SENTINELS = new Set(['phone-none', 'PHONE_NONE', 'tracker-none', 'TRACKER_NONE']);
+export const TRACKER_EMPTY_OUTPUT_INSTRUCTION = 'Empty-turn rule: when your own instructions above produce no block for this turn, reply with exactly the single line tracker-none and nothing else. Apply this only when your instructions genuinely yield no content; when they call for output every turn, always produce that output in full.';
 
 export function isEmptyOutputSentinel(content = '') {
     return EMPTY_OUTPUT_SENTINELS.has(String(content ?? '').trim());

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -3711,6 +3711,25 @@ describe('in-chat agent post-processing runner', () => {
         expect(messages[0].content).not.toContain('Write a markdown companion card body');
     });
 
+    test('teaches every tracker companion the empty-output sentinel', async () => {
+        const tracker = createCompanionAgent({ id: 'custom-tracker', category: 'tracker' });
+        const taughtTracker = createCompanionAgent({ id: 'taught-tracker', category: 'tracker', prompt: 'When nothing changes, reply with tracker-none.' });
+        const custom = createCompanionAgent({ id: 'custom-agent' });
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        chat.push({ mes: 'Assistant reply', name: 'Assistant', is_user: false, is_system: false, extra: {} });
+
+        const trackerPrompt = (await companionRunner.buildCompanionPromptMessages(tracker, 0))[0].content;
+        const taughtPrompt = (await companionRunner.buildCompanionPromptMessages(taughtTracker, 0))[0].content;
+        const customPrompt = (await companionRunner.buildCompanionPromptMessages(custom, 0))[0].content;
+        const repairPrompt = (await companionRunner.buildCompanionPromptMessages(tracker, 0, 'normal', { repair: true }))[0].content;
+
+        expect(trackerPrompt).toContain('reply with exactly the single line tracker-none and nothing else');
+        expect(taughtPrompt.match(/tracker-none/gi)).toHaveLength(1);
+        expect(customPrompt).not.toContain('tracker-none');
+        expect(repairPrompt).not.toContain('tracker-none');
+    });
+
     test('stores readable profile labels instead of raw profile ids', async () => {
         const profiledCompanion = createCompanionAgent({ id: 'profiled-companion' });
         profiledCompanion.connectionProfile = '20345602-939a-44c2-8522-525fb7212b0e';


### PR DESCRIPTION
Previously it only worked on the designated tracker agents from Director, but now it should work on every tracker agent, even custom ones made by users, so if they place it as a Companion, it will have the same behaviour as the default Director trackers turned into Companions.