### PR TITLE
fix(ui): make lorebooks more easily accessible for mobile iOS

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -1478,3 +1478,14 @@ select.keyselect+span.select2-container .select2-selection--multiple {
         min-width: 96px;
     }
 }
+
+@media screen and (max-width: 960px) {
+    /* SillyBunny: let the Characters shell own scrolling for embedded mobile lorebooks. */
+    #WorldInfo.sb-shell-embedded-content :is(#world_popup, #world_popup_entries_list) {
+        width: 100%;
+        height: auto;
+        max-width: 100%;
+        max-height: none;
+        overflow: visible;
+    }
+}

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -130,7 +130,7 @@ const SB_SHORTCUT_LABELS = Object.freeze({
 });
 const SB_PANEL_STYLESHEETS = Object.freeze({
     'characters:world-info': [
-        { href: 'css/world-info.css?v=20260425b', id: 'deferred-world-info-css' },
+        { href: 'css/world-info.css?v=20260829a', id: 'deferred-world-info-css' },
     ],
     'characters:persona': [
         { href: 'css/personas.css?v=20260609a', id: 'deferred-personas-css' },

--- a/tests/mobile-character-drawer-row-css.test.js
+++ b/tests/mobile-character-drawer-row-css.test.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const mobileStylesCss = readFileSync(path.join(repoRoot, 'public', 'css', 'mobile-styles.css'), 'utf8').replace(/\r\n/g, '\n');
 const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8').replace(/\r\n/g, '\n');
+const worldInfoCss = readFileSync(path.join(repoRoot, 'public', 'css', 'world-info.css'), 'utf8').replace(/\r\n/g, '\n');
 
 function getRuleBodies(cssSource, selector) {
     const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -64,5 +65,24 @@ describe('mobile character drawer entity row css', () => {
         const bulkEntityRowRule = getRuleBody(mobileStylesCss, '#rm_print_characters_block.bulk_select > :is(.character_select, .group_select)');
 
         expect(bulkEntityRowRule).toContain('flex: 0 0 auto;');
+    });
+});
+
+describe('mobile embedded lorebook css', () => {
+    test('lets the character drawer own scrolling after narrower container rules', () => {
+        const selector = '#WorldInfo.sb-shell-embedded-content :is(#world_popup, #world_popup_entries_list)';
+        const rule = getRuleBody(worldInfoCss, selector);
+        const listHeightCap = worldInfoCss.indexOf('max-height: clamp(280px, 40vh, 420px);');
+        const mobileBreakpoint = worldInfoCss.indexOf('@media screen and (max-width: 960px)', listHeightCap);
+        const mobileReset = worldInfoCss.indexOf(selector);
+
+        expect(rule).toContain('width: 100%;');
+        expect(rule).toContain('height: auto;');
+        expect(rule).toContain('max-width: 100%;');
+        expect(rule).toContain('max-height: none;');
+        expect(rule).toContain('overflow: visible;');
+        expect(listHeightCap).toBeGreaterThan(-1);
+        expect(mobileBreakpoint).toBeGreaterThan(listHeightCap);
+        expect(mobileReset).toBeGreaterThan(mobileBreakpoint);
     });
 });


### PR DESCRIPTION
It is near impossible to access lorebooks on mobile, this fixes that.

Legacy iOS sizing causes lorebook to not be visible. Mobile lorebooks now use the Characters panel’s scrollbar instead of clipped legacy iOS sizing.