### PR TITLE
chore: add Fable 5.1 on Claude backend and add support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3145,6 +3145,7 @@
                                     <optgroup label="Versions">
                                         <option value="claude-opus-5">claude-opus-5</option>
                                         <option value="claude-sonnet-5">claude-sonnet-5</option>
+                                        <option value="claude-fable-5-1">claude-fable-5-1</option><!-- SillyBunny: claude-fable-5.1 support -->
                                         <option value="claude-fable-5">claude-fable-5</option><!-- SillyBunny: claude-fable-5 support -->
                                         <option value="claude-opus-4-8">claude-opus-4-8</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -3320,6 +3320,13 @@ export async function handleChatCompletionsGenerate(request, response) {
             applyKimiK3ModelParameterConstraints(requestBody);
         }
 
+        // SillyBunny: Fable 5.1 rejects legacy thinking types supplied by Custom endpoint settings.
+        if (!isTextCompletion
+            && request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM
+            && /claude-fable-5(?:-1|\.1)(?:[-/:]|$)/i.test(String(requestBody.model))) {
+            requestBody.thinking = { type: 'adaptive' };
+        }
+
         if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
             excludeKeysByYaml(requestBody, request.body.custom_exclude_body);
         }

--- a/tests/claude-sonnet5.test.js
+++ b/tests/claude-sonnet5.test.js
@@ -192,6 +192,24 @@ describe('Claude 5 backend request handling', () => {
         expect(body.top_k).toBeUndefined();
     });
 
+    test.each([
+        { label: 'canonical ID', model: 'claude-fable-5-1', customExcludeBody: undefined, expectedThinking: { type: 'adaptive' } },
+        { label: 'OpenRouter-style ID', model: 'anthropic/claude-fable-5.1', customExcludeBody: undefined, expectedThinking: { type: 'adaptive' } },
+        { label: 'explicit thinking exclusion', model: 'claude-fable-5-1', customExcludeBody: 'thinking', expectedThinking: undefined },
+    ])('Custom Fable 5.1 with $label handles thinking correctly', async ({ model, customExcludeBody, expectedThinking }) => {
+        const getBody = captureClaudePayload();
+        const res = await makeRequest({
+            chat_completion_source: CHAT_COMPLETION_SOURCES.CUSTOM,
+            custom_url: 'https://example.com/v1/chat/completions',
+            custom_include_body: 'thinking:\n  type: enabled',
+            custom_exclude_body: customExcludeBody,
+            model,
+        });
+
+        expect(res.status).toBe(200);
+        expect(getBody().thinking).toEqual(expectedThinking);
+    });
+
     test.each(currentClaude5Models)('%s with web search enabled includes the web_search tool', async (model) => {
         const getBody = captureClaudePayload();
         const res = await makeRequest({ model, reasoning_effort: 'high', enable_web_search: true });

--- a/tests/openai-static-models.test.js
+++ b/tests/openai-static-models.test.js
@@ -144,6 +144,7 @@ test('Claude pickers include current Claude 5 models and omit all retired Claude
     const visionModels = openAiScript.match(/const visionSupportedModels = \[([\s\S]*?)\];/)[1];
 
     expect(mainPicker).toEqual(expect.arrayContaining(currentClaudeModels));
+    expect(mainPicker).toContain('claude-fable-5-1');
     expect(captionPicker).toEqual(expect.arrayContaining(currentClaudeModels));
     expect(mainPicker).toEqual(expect.not.arrayContaining(retiredClaudeModels));
     expect(captionPicker).toEqual(expect.not.arrayContaining(retiredClaudeModels));


### PR DESCRIPTION
Adds support for Claude Fable 5.1 by adding it to the list in the Claude backend and having the thinking type adaptive be passed on custom openAI chat completions backend.