### PR TITLE
fix: exclude partial prefill from post-gen ICA rewrites

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -10,6 +10,7 @@ import {
     substituteParamsExtended,
     generateQuietPrompt,
     getCurrentChatId,
+    itemizedPrompts,
     normalizeContentText,
     saveChatDebounced,
     stopGeneration,
@@ -40,6 +41,7 @@ import {
     resolveConnectionProfile,
 } from './agent-store.js';
 import { regexFromString } from '../../utils.js';
+import { isKimiK3Model } from '../../openai-model-capabilities.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
 import { getConnectionProfileDisplayName, getConnectionProfileModelName } from './profile-utils.js';
 import {
@@ -3181,18 +3183,34 @@ export async function requestPromptTransform(agent, promptMessages, maxTokens, o
     }
 }
 
+function getProtectedKimiPartialPrefill(message, messageIndex, messageText) {
+    if (message?.is_user !== false || message?.is_system !== false || !Number.isInteger(messageIndex)) {
+        return '';
+    }
+
+    const api = String(message.extra?.api ?? '').trim().toLowerCase();
+    if (!['custom', 'moonshot', 'nanogpt', 'openrouter'].includes(api) || !isKimiK3Model(message.extra?.model)) {
+        return '';
+    }
+
+    const promptBias = itemizedPrompts.find(item => Number(item?.mesId) === messageIndex)?.promptBias;
+    return typeof promptBias === 'string' && promptBias && messageText.startsWith(promptBias) ? promptBias : '';
+}
+
 async function runPromptTransformAgent(agent, message, generationType, messageTextOverride = null, messageIndex = null, options = {}) {
     const applyToMessage = options.applyToMessage !== false;
     const currentMessageText = unwrapAssistantResponseWrapper(
         messageTextOverride !== null ? messageTextOverride : message?.mes,
     );
+    const protectedPartialPrefill = getProtectedKimiPartialPrefill(message, messageIndex, currentMessageText);
+    const transformMessageText = currentMessageText.slice(protectedPartialPrefill.length);
     const normalizedGenerationType = normalizeGenerationType(generationType);
     const promptTransformMode = getPromptTransformMode(agent);
     const profileId = resolveAgentConnectionProfile(agent);
     const runMetadata = getPromptTransformRunMetadata(agent, profileId);
     const showNotifications = shouldShowPromptTransformNotifications(agent);
 
-    if (!currentMessageText.trim()) {
+    if (!transformMessageText.trim()) {
         const result = {
             agentId: agent.id,
             agentName: agent.name,
@@ -3213,8 +3231,8 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
 
     const expandedPrompt = substituteParams(agent.prompt, {
         name2Override: String(message?.name ?? '').trim(),
-        original: currentMessageText,
-        dynamicMacros: buildPromptDynamicMacros(currentMessageText, message, agent, normalizedGenerationType),
+        original: transformMessageText,
+        dynamicMacros: buildPromptDynamicMacros(transformMessageText, message, agent, normalizedGenerationType),
     }).trim();
 
     if (!expandedPrompt) {
@@ -3238,7 +3256,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
 
     const helperRequest = appendConfiguredHelperPrefillMessages(buildPromptTransformMessages(
         expandedPrompt,
-        currentMessageText,
+        transformMessageText,
         String(message?.name ?? '').trim(),
         normalizedGenerationType,
         promptTransformMode,
@@ -3282,9 +3300,10 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             return result;
         }
 
-        const nextMessageText = promptTransformMode === 'append'
-            ? appendPromptTransformOutput(currentMessageText, promptOutputText)
+        const transformedMessageText = promptTransformMode === 'append'
+            ? appendPromptTransformOutput(transformMessageText, promptOutputText)
             : promptOutputText;
+        const nextMessageText = protectedPartialPrefill + transformedMessageText;
         if (agentGenerationCancelRevision !== cancelRevision) {
             return {
                 agentId: agent.id,

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -60,6 +60,7 @@ describe('in-chat agent post-processing runner', () => {
     let replacePathfinderSettings;
     let getToolAction;
     let getForcedToolChoice;
+    let itemizedPrompts;
 
     beforeEach(async () => {
         jest.resetModules();
@@ -152,6 +153,7 @@ describe('in-chat agent post-processing runner', () => {
         });
         getToolAction = jest.fn(() => null);
         getForcedToolChoice = jest.fn(() => null);
+        itemizedPrompts = [];
 
         const addListener = (listeners, event, handler) => {
             const eventListeners = listeners.get(event) ?? [];
@@ -232,6 +234,7 @@ describe('in-chat agent post-processing runner', () => {
             substituteParamsExtended: jest.fn(value => String(value ?? '')),
             generateQuietPrompt,
             getCurrentChatId: jest.fn(() => currentChatId),
+            itemizedPrompts,
             normalizeContentText: jest.fn(value => String(value ?? '')),
             main_api: mainApi,
             saveChatDebounced,
@@ -5345,6 +5348,38 @@ describe('in-chat agent post-processing runner', () => {
         expect(chat[0].extra.inChatAgentTransformHistory).toHaveLength(1);
         expect(chat[0].swipe_info[0].extra.inChatAgentTransformHistory).toEqual(chat[0].extra.inChatAgentTransformHistory);
         expect(saveChatDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    test('excludes Kimi K3 partial prefill from prompt-transform rewrites', async () => {
+        usePromptTransformPostAgent();
+        generateQuietPrompt.mockResolvedValue('Rewritten continuation');
+        itemizedPrompts.push({ mesId: 0, promptBias: 'Protected prefix: ' });
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        chat.push({
+            name: 'Assistant',
+            mes: 'Protected prefix: Original continuation',
+            is_user: false,
+            is_system: false,
+            extra: {
+                api: 'moonshot',
+                model: 'kimi-k3',
+            },
+        });
+
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        await waitFor(() => saveChat.mock.calls.length === 1);
+
+        const quietPrompt = generateQuietPrompt.mock.calls[0][0].quietPrompt;
+        expect(quietPrompt).toContain('<assistant_response>\nOriginal continuation\n</assistant_response>');
+        expect(quietPrompt).not.toContain('Protected prefix: ');
+        expect(chat[0].mes).toBe('Protected prefix: Rewritten continuation');
+        expect(chat[0].extra.inChatAgentTransformHistory).toEqual([expect.objectContaining({
+            beforeText: 'Protected prefix: Original continuation',
+            afterText: 'Protected prefix: Rewritten continuation',
+        })]);
     });
 
     test('shows the resolved profile model in prompt-transform running toasts', async () => {


### PR DESCRIPTION
Kimi K3 has a partial prefill function, but when a post-gen agent like Prose Polisher rewrites it, it considers the partial prefill as part of the output to modify, which messes up the LLM being used to do a post-gen agent rewrite.