### PR TITLE
fix(chats): suppress redundant pre-write backups during deferred save runs to prevent ring eviction (#373)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -40,6 +40,7 @@ import {
 import { shouldRestoreTextGenStatusOnStartup } from './scripts/textgen-startup-status.js';
 import { normalizeCharacterChatName, resolveCharacterChatNameForLoad } from './scripts/character-chat-resolver.js';
 import { getDebouncedChatSaveAbortReason } from './scripts/chat-save-guard.js';
+import { getChatBackupSaveOptions } from './scripts/chat-backup-sequence.js';
 import { getCharacterDefinitionFormValues, getSuspiciousEmptyCharacterDefinitionSave } from './scripts/character-save-guard.js';
 // SillyBunny: keep model-produced chat filenames behind a strict, independently tested parser.
 import { CHAT_LABEL_TITLE_LIMIT, extractGeneratedChatLabel, normalizeGeneratedChatLabel, truncateChatLabelText } from './scripts/chat-label.js';
@@ -212,6 +213,7 @@ import {
     loadFileToDocument,
     getSanitizedFilename,
     getStringHash,
+    uuidv4,
 } from './scripts/utils.js';
 import {
     TOOLING_UI_HYDRATION_STATUS,
@@ -10665,7 +10667,7 @@ export async function flushPendingChatSaves({ silent = false } = {}) {
  */
 export function saveChat(...saveChatArguments) {
     const [firstArgument] = saveChatArguments;
-    const options = firstArgument && typeof firstArgument === 'object'
+    let options = firstArgument && typeof firstArgument === 'object'
         ? firstArgument
         : saveChatArguments.length === 0
             ? {}
@@ -10673,6 +10675,7 @@ export function saveChat(...saveChatArguments) {
     let queuedSaveArguments = saveChatArguments;
 
     if (options) {
+        options = getChatBackupSaveOptions(options, JSON.stringify([characters[this_chid]?.avatar, getCurrentChatId(), chatGeneration]), uuidv4);
         const mesId = options.mesId;
         const sourceChatData = Array.isArray(options.chatData)
             ? options.chatData
@@ -10703,7 +10706,7 @@ export function saveChat(...saveChatArguments) {
     return saveTask;
 }
 
-async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, deferBackup = false, allowShrink = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
+async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, deferBackup = false, deferSequenceId, allowShrink = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
     if (wasGroupChat || (selected_group && !activeChatName)) {
         toastr.error(t`Operation was aborted to prevent data corruption.`, t`saveChat called for a group chat`);
         throw new Error('saveChat called for a group chat');
@@ -10764,6 +10767,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
                 avatar_url: resolvedAvatarUrl,
                 force: force,
                 deferBackup: Boolean(deferBackup),
+                deferSequenceId,
                 allowShrink: Boolean(allowShrink),
             }),
         });
@@ -10811,7 +10815,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
             return false;
         }
 
-        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, allowShrink, activeChatName, characterName, avatarUrl, wasGroupChat });
+        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, deferSequenceId, allowShrink, activeChatName, characterName, avatarUrl, wasGroupChat });
     } catch (error) {
         console.error(error);
         toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Chat could not be saved`);

--- a/public/scripts/chat-backup-sequence.js
+++ b/public/scripts/chat-backup-sequence.js
@@ -1,0 +1,25 @@
+let activeSequence = null;
+
+export function resetChatBackupSequence() {
+    activeSequence = null;
+}
+
+export function getChatBackupSaveOptions(options, contextKey, createId) {
+    if (typeof options.deferSequenceId === 'string' && options.deferSequenceId.trim()) {
+        return options;
+    }
+
+    if (options.deferBackup === true) {
+        if (activeSequence?.contextKey !== contextKey) {
+            activeSequence = { contextKey, id: createId() };
+        }
+        return { ...options, deferSequenceId: activeSequence.id };
+    }
+
+    // Only an explicit closing save belongs to the agent run. Ordinary edits keep their own backup.
+    const deferSequenceId = options.deferBackup === false && options.completeDeferredBackup === true && activeSequence?.contextKey === contextKey
+        ? activeSequence.id
+        : undefined;
+    resetChatBackupSequence();
+    return deferSequenceId ? { ...options, deferSequenceId } : options;
+}

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -41,6 +41,7 @@ import {
     resolveConnectionProfile,
 } from './agent-store.js';
 import { regexFromString } from '../../utils.js';
+import { resetChatBackupSequence } from '../../chat-backup-sequence.js';
 import { isKimiK3Model } from '../../openai-model-capabilities.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
 import { getConnectionProfileDisplayName, getConnectionProfileModelName } from './profile-utils.js';
@@ -202,7 +203,7 @@ function companionTriggerMatches(keyword, messageText) {
 }
 
 function saveChatDebouncedForAgent({ deferBackup = shouldDeferAgentRegularBackup() } = {}) {
-    saveChatDebounced({ deferBackup: Boolean(deferBackup) });
+    saveChatDebounced({ deferBackup: Boolean(deferBackup), completeDeferredBackup: !deferBackup });
 }
 
 async function saveChatForAgent(context, { deferBackup = shouldDeferAgentRegularBackup() } = {}) {
@@ -210,7 +211,7 @@ async function saveChatForAgent(context, { deferBackup = shouldDeferAgentRegular
         return;
     }
 
-    await context.saveChat({ deferBackup: Boolean(deferBackup) });
+    await context.saveChat({ deferBackup: Boolean(deferBackup), completeDeferredBackup: !deferBackup });
 }
 
 function migrateLegacyRegexSnapshotsForCurrentChat(chatId = getCurrentChatId()) {
@@ -3634,6 +3635,7 @@ function onGenerationStarted(generationType, _options, dryRun) {
     }
 
     currentMainGenerationType = normalizeGenerationType(generationType);
+    resetChatBackupSequence();
     isGenerationInProgress = true;
     generationStartChatId = getCurrentSnapshotChatId();
     postProcessingInvalidatedByChatChange = false;
@@ -3714,6 +3716,8 @@ function onGenerationStopped() {
     if (internalPromptTransformDepth > 0) {
         return;
     }
+
+    resetChatBackupSequence();
 
     generationStopRequested = true;
     stoppedGenerationRunId = postProcessingGenerationRunId;
@@ -5371,6 +5375,7 @@ export async function runAgentOnTarget(agentId, target) {
 }
 
 export async function runTrackerFixOnMessage(messageIndex, { cancelRevision = agentGenerationCancelRevision } = {}) {
+    resetChatBackupSequence();
     if (!areAgentsGloballyEnabled()) {
         toastr.warning('In-Chat Agents are disabled.');
         return;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -78,7 +78,9 @@ import {
     ensureMessageMediaIsArray,
     syncCharacterMenuActiveEntity,
     incrementChatGeneration,
+    getChatGeneration,
 } from '../script.js';
+import { getChatBackupSaveOptions } from './chat-backup-sequence.js';
 import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect, printTagFilters, tag_filter_type } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
 import { isExternalMediaAllowed } from './chats.js';
@@ -1120,6 +1122,7 @@ function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = f
     const chatSnapshot = cloneGroupChatSavePayload(chat);
     const metadataSnapshot = structuredClone(chat_metadata);
     const chatIdSnapshot = group.chat_id;
+    options = getChatBackupSaveOptions(options, JSON.stringify([groupId, chatIdSnapshot, getChatGeneration()]), uuidv4);
     const saveTask = groupChatSaveQueue
         .catch(error => console.warn('Previous group chat save failed before queued save.', error))
         .then(() => saveGroupChatImmediately({
@@ -1131,6 +1134,7 @@ function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = f
             chatData: chatSnapshot,
             metadata: metadataSnapshot,
             deferBackup: Boolean(options.deferBackup),
+            deferSequenceId: options.deferSequenceId,
             allowShrink: Boolean(options.allowShrink),
         }));
 
@@ -1153,7 +1157,7 @@ export async function waitForQueuedGroupChatSaves() {
     }
 }
 
-async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata, deferBackup = false, allowShrink = false }) {
+async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata, deferBackup = false, deferSequenceId, allowShrink = false }) {
     const group = groups.find(x => x.id == groupId);
     if (!group) {
         console.warn('Group not found', groupId);
@@ -1175,7 +1179,7 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
         character_name: 'unused',
     };
     const chatMessages = Array.isArray(chatData) ? chatData : cloneGroupChatSavePayload(chat);
-    const savePayload = JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup), allowShrink: Boolean(allowShrink) });
+    const savePayload = JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup), deferSequenceId, allowShrink: Boolean(allowShrink) });
     const buildSaveGroupChatRequest = () => compressRequest({
         method: 'POST',
         headers: getRequestHeaders(),
@@ -1212,7 +1216,7 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
             return false;
         }
 
-        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup, allowShrink });
+        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup, deferSequenceId, allowShrink });
     }
 
     const responseData = await response.json().catch(() => ({}));

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -488,6 +488,97 @@ function getDestructiveChatSaveReason(newData, existingSerializedChat) {
  */
 const backupFunctions = new Map();
 
+// SillyBunny: track active deferred save sequences (e.g. multi-step in-chat agent runs).
+// A deferred run captures one pre-write snapshot of the pre-run on-disk state before the first
+// intermediate mutation, and suppresses redundant pre-write churn during subsequent in-flight passes (#373).
+const deferredPreWriteBackupSequences = new Map();
+
+function normalizeDeferredBackupPath(filePath) {
+    return path.resolve(filePath);
+}
+
+function hasDeferredSequenceId(deferSequenceId) {
+    return deferSequenceId !== undefined && deferSequenceId !== null && String(deferSequenceId).trim().length > 0;
+}
+
+export function clearActiveDeferredChatPreWrites() {
+    deferredPreWriteBackupSequences.clear();
+}
+
+function getDeferredPreWriteBackupDecision({
+    filePath,
+    deferBackup,
+    deferSequenceId,
+}) {
+    const normalizedPath = normalizeDeferredBackupPath(filePath);
+    const hasSequence = hasDeferredSequenceId(deferSequenceId);
+    const activeSequence = deferredPreWriteBackupSequences.get(normalizedPath);
+
+    // No token means this is an unrelated ordinary save. It must always retain
+    // normal pre-write backup behavior and clear any stale abandoned sequence.
+    if (!hasSequence) {
+        return {
+            normalizedPath,
+            shouldCreateBackup: true,
+            closeSequence: false,
+            clearActiveSequenceAfterSuccess: Boolean(activeSequence),
+        };
+    }
+
+    if (deferBackup === true) {
+        if (activeSequence === deferSequenceId) {
+            return {
+                normalizedPath,
+                shouldCreateBackup: false,
+                closeSequence: false,
+            };
+        }
+
+        // First save of this sequence: preserve the pre-turn baseline.
+        return {
+            normalizedPath,
+            shouldCreateBackup: true,
+            beginSequence: true,
+            closeSequence: false,
+        };
+    }
+
+    // Closing save. Only the matching sequence may skip the redundant backup.
+    if (activeSequence === deferSequenceId) {
+        return {
+            normalizedPath,
+            shouldCreateBackup: false,
+            closeSequence: true,
+        };
+    }
+
+    // A closing save with no matching active sequence is an ordinary save.
+    return {
+        normalizedPath,
+        shouldCreateBackup: true,
+        closeSequence: false,
+    };
+}
+
+function commitDeferredPreWriteBackupDecision(decision, deferSequenceId) {
+    if (decision.beginSequence) {
+        deferredPreWriteBackupSequences.set(
+            decision.normalizedPath,
+            deferSequenceId,
+        );
+    }
+
+    if (decision.closeSequence || decision.clearActiveSequenceAfterSuccess) {
+        deferredPreWriteBackupSequences.delete(decision.normalizedPath);
+    }
+}
+
+function clearDeferredPreWriteBackupSequence(filePath) {
+    deferredPreWriteBackupSequences.delete(
+        normalizeDeferredBackupPath(filePath),
+    );
+}
+
 /**
  * Gets a backup function for a user.
  * @param {string} handle User handle
@@ -1070,7 +1161,7 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
     }
 }
 
-function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory, { deferBackup = false, recoveryTarget = null, allowShrink = false, persistDerivedMetadata = false } = {}) {
+function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory, { deferBackup = false, deferSequenceId = undefined, recoveryTarget = null, allowShrink = false, persistDerivedMetadata = false } = {}) {
     const doIntegrityCheck = (checkIntegrity && !skipIntegrityCheck);
     const incomingIntegrity = chatData?.[0]?.chat_metadata?.integrity;
     const chatIntegritySlug = doIntegrityCheck && typeof incomingIntegrity === 'string' ? incomingIntegrity : '';
@@ -1097,6 +1188,7 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
     // already on disk, so the recovery snapshot and regular backup mirror the authoritative file.
     let unchangedChatData = null;
     let unchangedIntegrity;
+    let backupDecision = null;
     let preserveFileIdentity = false;
     let replaceFileOnly = false;
     let expectedFileIdentity;
@@ -1170,11 +1262,29 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
             // SillyBunny: compare parsed records because loading canonicalizes legacy JSONL formatting.
             // Replacing equivalent content through atomic temp-and-rename would swap the file identity
             // for no gain. Legacy chats remain slugless until their first genuine content change.
+            backupDecision = getDeferredPreWriteBackupDecision({
+                filePath,
+                deferBackup,
+                deferSequenceId,
+            });
+
             if (isSameChatSaveContent(jsonlData, currentChatData, { ignoreDerivedMetadata: !persistDerivedMetadata })) {
                 unchangedChatData = currentChatData;
                 unchangedIntegrity = existingIntegrity;
+                if (backupDecision.closeSequence || backupDecision.clearActiveSequenceAfterSuccess) {
+                    commitDeferredPreWriteBackupDecision(backupDecision, deferSequenceId);
+                }
             } else {
-                backupChatPreWrite(backupDirectory, cardName, currentChatData, handle);
+                if (backupDecision.shouldCreateBackup) {
+                    backupChatPreWrite(backupDirectory, cardName, currentChatData, handle);
+                } else {
+                    logBackupEvent('chat-backup-skipped', {
+                        type: 'pre-write',
+                        handle,
+                        chat: cardName,
+                        reason: backupDecision.closeSequence ? 'deferred-closed' : 'deferred-intermediate',
+                    });
+                }
 
                 if (destructiveReason) {
                     console.warn(`Forced destructive chat save for "${cardName}" (${destructiveReason}): incoming payload has ${savedChatData.length} JSONL rows, existing file has ${existingLines} rows.`);
@@ -1185,6 +1295,11 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
                 }
             }
         }
+    }
+
+    // SillyBunny: commit deferred sequence state changes only after backup/content decisions succeed.
+    if (backupDecision) {
+        commitDeferredPreWriteBackupDecision(backupDecision, deferSequenceId);
     }
 
     // SillyBunny: the regular backup still runs for an unchanged save. An agent run defers every
@@ -1267,6 +1382,7 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
             const recoveryTarget = createChatRecoveryTarget(request, false, sanitizedChatFileName);
             const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, cardName, request.user.directories.backups, {
                 deferBackup: request.body.deferBackup === true,
+                deferSequenceId: typeof request.body.deferSequenceId === 'string' ? request.body.deferSequenceId : undefined,
                 allowShrink: request.body.allowShrink === true,
                 recoveryTarget,
             });
@@ -1395,6 +1511,7 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
 
             // SillyBunny: atomic renames prevent interrupted chat renames from leaving cloned files behind.
             const renameResult = renameChatFile(pathToOriginalFile, pathToRenamedFile);
+            clearDeferredPreWriteBackupSequence(pathToOriginalFile);
             if (isBackupEnabled) {
                 const rekeyResult = runChatRecoveryBestEffort(
                     () => rekeyChatRecoveryState(sourceRecoveryTarget, destinationRecoveryTarget),
@@ -1458,6 +1575,7 @@ router.post('/delete', validateAvatarUrlMiddleware, function (request, response)
         }
 
         if (chatFileDeleted) {
+            clearDeferredPreWriteBackupSequence(chatFilePath);
             runChatRecoveryBestEffort(
                 () => clearChatRecoveryState(recoveryTarget),
                 'Failed to clear chat recovery state after deletion.',
@@ -1742,6 +1860,7 @@ router.post('/group/delete', (request, response) => {
         }
 
         if (chatFileDeleted) {
+            clearDeferredPreWriteBackupSequence(chatFilePath);
             runChatRecoveryBestEffort(
                 () => clearChatRecoveryState(recoveryTarget),
                 'Failed to clear chat recovery state after deletion.',
@@ -1773,6 +1892,7 @@ router.post('/group/save', async function (request, response) {
             const recoveryTarget = createChatRecoveryTarget(request, true, chatFileName);
             const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, String(id), request.user.directories.backups, {
                 deferBackup: request.body.deferBackup === true,
+                deferSequenceId: typeof request.body.deferSequenceId === 'string' ? request.body.deferSequenceId : undefined,
                 allowShrink: request.body.allowShrink === true,
                 recoveryTarget,
             });

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -443,6 +443,7 @@ function backupChatPreWrite(directory, name, data, handle = '') {
         removeOldBackups(directory, CHAT_PRE_WRITE_BACKUPS_PREFIX, maxTotalChatBackups);
     } catch (err) {
         console.error(`Could not create pre-write chat backup for ${name}`, err);
+        throw err;
     }
 }
 
@@ -1271,9 +1272,6 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
             if (isSameChatSaveContent(jsonlData, currentChatData, { ignoreDerivedMetadata: !persistDerivedMetadata })) {
                 unchangedChatData = currentChatData;
                 unchangedIntegrity = existingIntegrity;
-                if (backupDecision.closeSequence || backupDecision.clearActiveSequenceAfterSuccess) {
-                    commitDeferredPreWriteBackupDecision(backupDecision, deferSequenceId);
-                }
             } else {
                 if (backupDecision.shouldCreateBackup) {
                     backupChatPreWrite(backupDirectory, cardName, currentChatData, handle);
@@ -1295,11 +1293,6 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
                 }
             }
         }
-    }
-
-    // SillyBunny: commit deferred sequence state changes only after backup/content decisions succeed.
-    if (backupDecision) {
-        commitDeferredPreWriteBackupDecision(backupDecision, deferSequenceId);
     }
 
     // SillyBunny: the regular backup still runs for an unchanged save. An agent run defers every
@@ -1357,6 +1350,10 @@ function trySaveChatLocked(chatData, filePath, skipIntegrityCheck = false, handl
         });
     } else {
         logBackupEvent('chat-save-skipped', { handle, chat: cardName, reason: 'unchanged', force: Boolean(skipIntegrityCheck), ...savedChatSizeDetails });
+    }
+    // A no-op cannot open a sequence: it has not captured a pre-write snapshot yet.
+    if (backupDecision && (!backupDecision.beginSequence || unchangedChatData === null)) {
+        commitDeferredPreWriteBackupDecision(backupDecision, deferSequenceId);
     }
     if (!deferBackup) {
         getBackupFunction(handle)(backupDirectory, cardName, persistedChatData, CHAT_BACKUPS_PREFIX, handle);

--- a/tests/chat-backup-sequence.test.js
+++ b/tests/chat-backup-sequence.test.js
@@ -1,0 +1,177 @@
+/* eslint-disable playwright/no-standalone-expect -- These parameterized cases run under Jest. */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import vm from 'node:vm';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'acorn';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { getChatBackupSaveOptions, resetChatBackupSequence } from '../public/scripts/chat-backup-sequence.js';
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+const { trySaveChat, clearActiveDeferredChatPreWrites } = await import('../src/endpoints/chats.js');
+const sources = Object.fromEntries(['script.js', 'scripts/group-chats.js', 'scripts/extensions/in-chat-agents/agent-runner.js'].map(file => {
+    const source = fs.readFileSync(new URL(`../public/${file}`, import.meta.url), 'utf8');
+    return [file, { source, ast: parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) }];
+}));
+
+function records(integrity, text) {
+    return [{ chat_metadata: { integrity } }, { name: 'Bunny', is_user: false, mes: text }];
+}
+
+let directory;
+let chatFile;
+let backups;
+let handle;
+beforeEach(() => {
+    jest.useFakeTimers();
+    resetChatBackupSequence();
+    clearActiveDeferredChatPreWrites();
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-backup-sequence-'));
+    chatFile = path.join(directory, 'chat.jsonl');
+    backups = path.join(directory, 'backups');
+    handle = randomUUID();
+    fs.mkdirSync(backups);
+    fs.writeFileSync(chatFile, records('original', 'before the turn').map(JSON.stringify).join('\n'));
+});
+afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function preWriteFiles() {
+    return fs.readdirSync(backups).filter(name => name.startsWith('chat_pre_write_'));
+}
+
+function createClient(group) {
+    const sent = [];
+    async function send(_url, request) {
+        const payload = JSON.parse(request.body);
+        sent.push(payload);
+        const result = await trySaveChat(payload.chat, chatFile, payload.force, handle, 'Bunny', backups, payload);
+        return { ok: true, json: async () => result };
+    }
+    const runtime = vm.createContext({
+        console, structuredClone, getChatBackupSaveOptions, uuidv4: randomUUID,
+        chatSaveQueue: Promise.resolve(), groupChatSaveQueue: Promise.resolve(),
+        chat: records('original', 'first pass').slice(1), chat_metadata: { integrity: 'original' },
+        chatGeneration: 1, getChatGeneration: () => 1,
+        this_chid: 0, selected_group: group ? 'group' : null,
+        groups: [{ id: 'group', chat_id: 'chat', chats: ['chat'] }],
+        characters: [{ name: 'Bunny', avatar: 'bunny.png', chat: 'chat' }],
+        getCurrentChatId: () => 'chat', name2: 'Bunny', neutralCharacterName: 'Assistant',
+        cloneChatSavePayload: structuredClone, cloneGroupChatSavePayload: structuredClone,
+        setChatSaveActive: jest.fn(), getQueuedChatIntegrityKey: () => 'key',
+        applyQueuedChatIntegrity: (metadata) => { metadata.integrity = runtime.chat_metadata.integrity; },
+        applyQueuedGroupChatIntegrity: (metadata) => { metadata.integrity = runtime.chat_metadata.integrity; },
+        rememberQueuedChatIntegrity: jest.fn(), rememberQueuedGroupChatIntegrity: jest.fn(),
+        compressRequest: async request => request, getRequestHeaders: () => ({}),
+        fetch: send, fetchWithCsrfRetry: async (url, build) => send(url, await build()),
+        refreshCsrfToken: jest.fn(), editGroup: jest.fn(),
+        toastr: { error: jest.fn() }, t: strings => strings.join(''),
+    });
+    const { source, ast } = sources[group ? 'scripts/group-chats.js' : 'script.js'];
+    for (const name of group ? ['saveGroupChat', 'saveGroupChatImmediately'] : ['saveChat', 'saveChatImmediately']) {
+        const node = ast.body.map(node => node.declaration ?? node).find(node => node.id?.name === name);
+        vm.runInContext(source.slice(node.start, node.end), runtime);
+    }
+    const save = options => group ? runtime.saveGroupChat('group', false, false, true, options) : runtime.saveChat(options);
+    const runner = sources['scripts/extensions/in-chat-agents/agent-runner.js'];
+    const helper = runner.ast.body.find(node => node.id?.name === 'saveChatForAgent');
+    vm.runInContext(runner.source.slice(helper.start, helper.end), runtime);
+    return { runtime, sent, save, saveForAgent: options => runtime.saveChatForAgent({ saveChat: save }, options) };
+}
+
+describe('deferred backups through the real save queues', () => {
+    test.each([false, true])('keeps one baseline and one final backup across four passes (group: %s)', async group => {
+        const { runtime, save, saveForAgent, sent } = createClient(group);
+        for (let pass = 1; pass <= 4; pass++) {
+            runtime.chat[0].mes = `pass ${pass}`;
+            await expect(save({ deferBackup: true })).resolves.toBe(true);
+        }
+        runtime.chat[0].mes = 'final reply';
+        await saveForAgent({ deferBackup: false });
+        expect(new Set(sent.map(payload => payload.deferSequenceId)).size).toBe(1);
+        expect(sent[0].deferSequenceId).toEqual(expect.any(String));
+        expect(preWriteFiles()).toHaveLength(1);
+        expect(fs.readFileSync(path.join(backups, preWriteFiles()[0]), 'utf8')).toContain('before the turn');
+        const completed = fs.readdirSync(backups).filter(name => name.startsWith('chat_bunny_'));
+        expect(completed).toHaveLength(1);
+        expect(fs.readFileSync(path.join(backups, completed[0]), 'utf8')).toContain('final reply');
+    });
+
+    test('ordinary edits do not inherit an abandoned sequence', async () => {
+        const { runtime, save, sent } = createClient(false);
+        await save({ deferBackup: true });
+        runtime.chat[0].mes = 'manual edit';
+        await save({});
+        expect(sent[1].deferSequenceId).toBeUndefined();
+        expect(preWriteFiles()).toHaveLength(2);
+        runtime.chat[0].mes = 'new agent run';
+        await save({ deferBackup: true });
+        expect(sent[2].deferSequenceId).not.toBe(sent[0].deferSequenceId);
+    });
+
+    test('a new generation gets its own baseline after an abandoned run', async () => {
+        const { runtime, save, sent } = createClient(false);
+        await save({ deferBackup: true });
+        resetChatBackupSequence();
+        runtime.chat[0].mes = 'new generation';
+        await save({ deferBackup: true });
+        expect(sent[1].deferSequenceId).not.toBe(sent[0].deferSequenceId);
+        expect(preWriteFiles()).toHaveLength(2);
+    });
+
+    test('an unrelated explicit regular save does not close an abandoned agent run', async () => {
+        const { runtime, save, sent } = createClient(false);
+        await save({ deferBackup: true });
+        runtime.chat[0].mes = 'manual companion edit';
+        await save({ deferBackup: false });
+        expect(sent[1].deferSequenceId).toBeUndefined();
+        expect(preWriteFiles()).toHaveLength(2);
+    });
+});
+
+describe('deferred recovery anchor failures', () => {
+    test('an unchanged opening save cannot suppress the first actual backup', async () => {
+        const options = { deferBackup: true, deferSequenceId: 'no-op-first' };
+        await trySaveChat(records('original', 'before the turn'), chatFile, false, handle, 'Bunny', backups, options);
+        expect(preWriteFiles()).toHaveLength(0);
+        await trySaveChat(records('original', 'changed'), chatFile, false, handle, 'Bunny', backups, options);
+        expect(preWriteFiles()).toHaveLength(1);
+        expect(fs.readFileSync(path.join(backups, preWriteFiles()[0]), 'utf8')).toContain('before the turn');
+    });
+
+    test('a failed baseline backup rejects the save and allows a protected retry', async () => {
+        const options = { deferBackup: true, deferSequenceId: 'failed-backup' };
+        const open = fs.openSync.bind(fs);
+        const failure = jest.spyOn(fs, 'openSync').mockImplementation((target, ...args) => {
+            if (String(target).startsWith(backups + path.sep)) throw new Error('backup disk unavailable');
+            return open(target, ...args);
+        });
+        await expect(trySaveChat(records('original', 'must not be written'), chatFile, false, handle, 'Bunny', backups, options)).rejects.toThrow('backup disk unavailable');
+        expect(fs.readFileSync(chatFile, 'utf8')).toContain('before the turn');
+        failure.mockRestore();
+        await trySaveChat(records('original', 'safe retry'), chatFile, false, handle, 'Bunny', backups, options);
+        expect(preWriteFiles()).toHaveLength(1);
+    });
+
+    test('a failed authoritative write does not open a suppression sequence', async () => {
+        const options = { deferBackup: true, deferSequenceId: 'failed-write' };
+        const open = fs.openSync.bind(fs);
+        const failure = jest.spyOn(fs, 'openSync').mockImplementation((target, flags, ...args) => {
+            if (target === chatFile && flags === 'r+') throw new Error('chat disk unavailable');
+            return open(target, flags, ...args);
+        });
+        await expect(trySaveChat(records('original', 'failed write'), chatFile, false, handle, 'Bunny', backups, options)).rejects.toThrow('chat disk unavailable');
+        failure.mockRestore();
+        fs.writeFileSync(chatFile, records('other', 'another writer').map(JSON.stringify).join('\n'));
+        await trySaveChat(records('other', 'safe retry'), chatFile, false, handle, 'Bunny', backups, options);
+        expect(preWriteFiles()).toHaveLength(2);
+        expect(preWriteFiles().some(name => fs.readFileSync(path.join(backups, name), 'utf8').includes('another writer'))).toBe(true);
+    });
+});

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -302,6 +302,98 @@ describe('chat integrity rotation', () => {
         await expect(fs.readFile(path.join(backupDir, postSaveBackups[0]), 'utf8')).resolves.toContain('final post-processed chat');
     });
 
+    test('preserves pre-turn baseline and avoids ring eviction across multi-pass agent sequences (#373)', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-agent-ring-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('initial-integrity', 'pristine pre-turn baseline').map(JSON.stringify).join('\n'));
+
+        // Simulate 4 intermediate agent passes (e.g. tracker 1, tracker 2, prose polisher, companion)
+        let previousIntegrity = 'initial-integrity';
+        for (let pass = 1; pass <= 4; pass++) {
+            const passResult = await trySaveChat(
+                chatWithIntegrity(previousIntegrity, `agent pass ${pass} intermediate`),
+                chatFile,
+                false,
+                'agent-ring-user',
+                'Test Card',
+                backupDir,
+                { deferBackup: true, deferSequenceId: 'agent-run-seq-1' },
+            );
+            previousIntegrity = passResult.integrity;
+        }
+
+        // Final closing save
+        const finalResult = await trySaveChat(
+            chatWithIntegrity(previousIntegrity, 'final generated reply'),
+            chatFile,
+            false,
+            'agent-ring-user',
+            'Test Card',
+            backupDir,
+            { deferBackup: false, deferSequenceId: 'agent-run-seq-1' },
+        );
+        expect(finalResult?.integrity).toEqual(expect.any(String));
+        jest.runOnlyPendingTimers();
+
+        const backupFiles = await fs.readdir(backupDir);
+        const postSaveBackups = backupFiles.filter(fileName => fileName.startsWith('chat_test_card_'));
+        const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        // Exactly 1 post-save backup (final reply) and 1 pre-write backup (pristine pre-turn baseline)
+        expect(postSaveBackups).toHaveLength(1);
+        expect(preWriteBackups).toHaveLength(1);
+        await expect(fs.readFile(path.join(backupDir, postSaveBackups[0]), 'utf8')).resolves.toContain('final generated reply');
+        await expect(fs.readFile(path.join(backupDir, preWriteBackups[0]), 'utf8')).resolves.toContain('pristine pre-turn baseline');
+    });
+
+    test('abandoned deferred sequence does not suppress pre-write backup for subsequent user edits (#373)', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-abandoned-seq-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('initial-integrity', 'baseline before agent').map(JSON.stringify).join('\n'));
+
+        // Agent starts deferred sequence and crashes/abandons after step 1
+        const pass1 = await trySaveChat(
+            chatWithIntegrity('initial-integrity', 'agent crashed intermediate'),
+            chatFile,
+            false,
+            'abandon-user',
+            'Test Card',
+            backupDir,
+            { deferBackup: true, deferSequenceId: 'crashed-sequence' },
+        );
+
+        // User makes an independent manual edit 10s later (no deferSequenceId)
+        jest.advanceTimersByTime(10_000);
+        await trySaveChat(
+            chatWithIntegrity(pass1.integrity, 'user manual edit after crash'),
+            chatFile,
+            false,
+            'abandon-user',
+            'Test Card',
+            backupDir,
+        );
+        jest.runOnlyPendingTimers();
+
+        const backupFiles = await fs.readdir(backupDir);
+        const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        // Must have TWO pre-write backups: 1 for baseline before agent, and 1 for intermediate state before user edit!
+        expect(preWriteBackups).toHaveLength(2);
+        const backupContents = await Promise.all(preWriteBackups.map(f => fs.readFile(path.join(backupDir, f), 'utf8')));
+        expect(backupContents.some(c => c.includes('baseline before agent'))).toBe(true);
+        expect(backupContents.some(c => c.includes('agent crashed intermediate'))).toBe(true);
+    });
+
     test('leaves a semantically unchanged noncanonical chat untouched and returns its disk integrity', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-unchanged-save-'));

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -1364,7 +1364,7 @@ describe('chat integrity rotation', () => {
         expect(scriptSource).toContain('applyQueuedChatIntegrity(metadata, integrityKey, isActiveChatSave);');
         expect(scriptSource).toContain('rememberQueuedChatIntegrity(integrityKey, responseData?.integrity);');
         expect(scriptSource).toContain('deferBackup: Boolean(deferBackup)');
-        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, allowShrink, activeChatName, characterName, avatarUrl, wasGroupChat });');
+        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, deferSequenceId, allowShrink, activeChatName, characterName, avatarUrl, wasGroupChat });');
     });
 
     test('debounced chat saves abort after the active chat generation changes', async () => {
@@ -1405,7 +1405,7 @@ describe('chat integrity rotation', () => {
         expect(groupChatSource).toContain('applyQueuedGroupChatIntegrity(metadataForSave, chatId, isActiveGroupChatSave);');
         expect(groupChatSource).toContain('rememberQueuedGroupChatIntegrity(chatId, responseData?.integrity);');
         expect(groupChatSource).toContain('deferBackup: Boolean(options.deferBackup)');
-        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup, allowShrink });');
+        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup, deferSequenceId, allowShrink });');
         expect(groupChatSource).toContain('const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;');
         expect(groupChatSource).toContain('if (isActiveGroupChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });


### PR DESCRIPTION
### What broke?
When running in-chat agents (like Trackers, Prose Polisher, or Companions) or generating messages, SillyBunny performs multiple intermediate saves in the background before the turn completes. 

Although regular post-save backups are deferred until the turn finishes, SillyBunny was creating an unthrottled `chat_pre_write_` backup on every single intermediate save. For a chat with 3 or 4 agent steps, this generated **4 to 6 full-sized `.jsonl` files in `backups/` on every single message turn**.

Even worse: because the pre-write backup ring buffer only keeps the 3 most recent files, a 4-step agent turn would push out and delete the true pre-turn backup from before the message was generated, leaving only intermediate half-baked agent drafts in the recovery ring.

### Why did it break?
In `src/endpoints/chats.js` (`trySaveChatLocked`), `backupChatPreWrite()` was called unconditionally whenever incoming content differed from the on-disk file, completely ignoring the `deferBackup` option sent by the client.

### How is it fixed?
1. The server now tracks active deferred save sequences (`activeDeferredChatPreWrites`) by file path.
2. On the first write of a deferred run, `backupChatPreWrite()` captures the pristine pre-turn baseline on disk as the recovery anchor.
3. Subsequent intermediate saves within the same deferred sequence skip writing redundant pre-write snapshots to disk.
4. When the sequence finishes with its final non-deferred save, the deferred tracker is cleared, intermediate pre-write churn is skipped, and the standard post-save backup captures the final completed reply.
5. Standard, non-deferred chat saves continue to capture pre-write snapshots exactly as before.

### How was it tested?
- Tested on both Linux Node.js and Windows Canary (`C:\Users\badiy\SillyBunny-Canary`, port 4445).
- All 43 tests in `tests/chat-integrity-rotation.test.js` pass cleanly.
- Added a permanent regression test `preserves pre-turn baseline and avoids ring eviction across multi-pass agent sequences (#373)` that exercises 4 consecutive deferred agent passes followed by a final save and verifies that:
  1. Exactly 1 pre-write backup is created (preserving the pristine pre-turn baseline).
  2. Exactly 1 post-save backup is created (preserving the final reply).
  3. Intermediate disk-thrash snapshots are eliminated and zero eviction occurs.
- ESLint passed with 0 errors and 0 warnings.
