### PR TITLE
fix: fixes 'Char is typing' not stopping on group chats, and allow opening of Definitions/Greetings

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2177,8 +2177,10 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
         border-radius: 10px;
     }
 
+    /* Must beat the generic 34px !important band height above: the parked mode toggle
+       (top 8px + 44px) otherwise hangs over the top of the editor sub-tab pills. */
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > #CharListButtonAndHotSwaps {
-        min-height: 54px;
+        min-height: 54px !important;
         padding-block: 5px;
     }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5915,10 +5915,9 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     background: color-mix(in srgb, var(--sb-shell-main-bg) 54%, transparent);
 }
 
-/* Spoiler-free mode reroutes Definitions/Greetings to Metadata; dim them so the tap is not mistaken for a dead button. */
-#right-nav-panel .sb-character-editor-subtab[aria-disabled="true"] {
+/* Spoiler-free mode hides Definitions/Greetings; dim them, but keep them tappable so a tap can reveal the fields. */
+#right-nav-panel .sb-character-editor-subtab.is-spoiler-hidden {
     opacity: 0.45;
-    cursor: not-allowed;
 }
 
 #right-nav-panel .sb-character-editor-subtabs::before {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5915,6 +5915,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     background: color-mix(in srgb, var(--sb-shell-main-bg) 54%, transparent);
 }
 
+/* Spoiler-free mode reroutes Definitions/Greetings to Metadata; dim them so the tap is not mistaken for a dead button. */
+#right-nav-panel .sb-character-editor-subtab[aria-disabled="true"] {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
 #right-nav-panel .sb-character-editor-subtabs::before {
     display: none;
 }

--- a/public/script.js
+++ b/public/script.js
@@ -5892,9 +5892,13 @@ function showStopButton() {
 }
 
 function hideStopButton({ emitGenerationEnded = true } = {}) {
-    $('#send_form').removeClass('sb-generating-controls');
     // prevent NOOP, because hideStopButton() gets called multiple times
-    if ($('#mes_stop').css('display') !== 'none') {
+    // SillyBunny: read visibility before dropping the class. On mobile, mobile-styles.css forces
+    // `#send_form:not(.sb-generating-controls) #mes_stop` to display:none !important, so checking
+    // after removeClass always reads 'none' and GENERATION_ENDED would never be emitted.
+    const wasVisible = $('#mes_stop').css('display') !== 'none';
+    $('#send_form').removeClass('sb-generating-controls');
+    if (wasVisible) {
         $('#mes_stop').css({ 'display': 'none' });
         if (emitGenerationEnded) {
             eventSource.emit(event_types.GENERATION_ENDED, chat.length);

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1287,15 +1287,16 @@ function setCharacterSpoilerFreeFieldsHidden(hidden) {
             panel.hidden = true;
             panel.setAttribute('aria-hidden', 'true');
         });
-    } else {
-        syncActiveCharacterEditorPanel();
     }
 
     $('#spoiler_free_desc').toggleClass('flex1', hidden);
     $('#creators_note_desc_hidden').toggle(hidden);
 
+    // Always re-click a tab so the sub-tab buttons pick up their aria-disabled state.
     if (hidden && !activePanelCanRemainVisible) {
         showCharacterEditorMetadataPanel();
+    } else {
+        syncActiveCharacterEditorPanel();
     }
 }
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1268,7 +1268,8 @@ function syncActiveCharacterEditorPanel() {
     }
 }
 
-function setCharacterSpoilerFreeFieldsHidden(hidden) {
+// Exported so the editor sub-tabs (sillybunny-tabs.js) can reveal the hidden fields when a dimmed tab is tapped.
+export function setCharacterSpoilerFreeFieldsHidden(hidden) {
     const form = document.getElementById('form_create');
     const activePanel = form?.querySelector('[data-sb-character-editor-panel]:not([hidden])');
     const activePanelCanRemainVisible = activePanel instanceof HTMLElement
@@ -1291,8 +1292,10 @@ function setCharacterSpoilerFreeFieldsHidden(hidden) {
 
     $('#spoiler_free_desc').toggleClass('flex1', hidden);
     $('#creators_note_desc_hidden').toggle(hidden);
+    // The eye mirrors the actual state, so it stays correct when the fields are revealed from a sub-tab or at load.
+    $('#spoiler_free_desc_button').toggleClass('fa-eye', !hidden).toggleClass('fa-eye-slash', hidden);
 
-    // Always re-click a tab so the sub-tab buttons pick up their aria-disabled state.
+    // Always re-click a tab so the sub-tab buttons pick up their spoiler-hidden state.
     if (hidden && !activePanelCanRemainVisible) {
         showCharacterEditorMetadataPanel();
     } else {
@@ -4882,7 +4885,6 @@ jQuery(async () => {
     $('#spoiler_free_desc_button').on('click', function (e) {
         e.stopPropagation();
         peekSpoilerMode();
-        $(this).toggleClass('fa-eye fa-eye-slash');
     });
 
     $('#custom_stopping_strings').on('input', function () {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -22,6 +22,7 @@ import {
     TOPBAR_ADOPTION_ATTRIBUTE,
     TOPBAR_EXTENSION_SLOT_ID,
 } from './topbar-extension-slot/index.js';
+import { setCharacterSpoilerFreeFieldsHidden } from './power-user.js';
 import { escapeRegex } from './util/escape-regex.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
 import { characters, flushCharacterSaveDebounced, getOneCharacter, getThumbnailUrl, parseAvatarSource, refreshCsrfToken, saveSettingsDebounced, this_chid } from '../script.js';
@@ -2171,13 +2172,14 @@ function isCharacterSpoilerFreeFieldsHidden() {
     return form instanceof HTMLElement && form.dataset.sbSpoilerFreeFieldsHidden === 'true';
 }
 
+function isCharacterEditorSubTabSpoilerHidden(tabId) {
+    return isCharacterSpoilerFreeFieldsHidden()
+        && !SB_CHARACTER_EDITOR_SPOILER_FREE_VISIBLE_TABS.includes(normalizeCharacterEditorSubTab(tabId));
+}
+
 function resolveCharacterEditorSubTab(tabId) {
     const normalizedTabId = normalizeCharacterEditorSubTab(tabId);
-    if (!isCharacterSpoilerFreeFieldsHidden() || SB_CHARACTER_EDITOR_SPOILER_FREE_VISIBLE_TABS.includes(normalizedTabId)) {
-        return normalizedTabId;
-    }
-
-    return 'metadata';
+    return isCharacterEditorSubTabSpoilerHidden(normalizedTabId) ? 'metadata' : normalizedTabId;
 }
 
 function isCharacterEditorMenuType(menuType) {
@@ -8174,7 +8176,6 @@ function saveCharacterEditorSubTab(tabId) {
 
 function updateCharacterEditorSubTabButtons(activeTabId) {
     const activeSubTab = resolveCharacterEditorSubTab(activeTabId);
-    const spoilerFreeFieldsHidden = isCharacterSpoilerFreeFieldsHidden();
 
     for (const tabButton of document.querySelectorAll('#sb_character_editor_subtabs [data-sb-character-editor-tab]')) {
         if (!(tabButton instanceof HTMLElement)) {
@@ -8182,16 +8183,11 @@ function updateCharacterEditorSubTabButtons(activeTabId) {
         }
 
         const isActive = tabButton.dataset.sbCharacterEditorTab === activeSubTab;
-        // Spoiler-free mode reroutes these tabs to Metadata; surface that instead of leaving them looking clickable.
-        const isDisabled = spoilerFreeFieldsHidden && !SB_CHARACTER_EDITOR_SPOILER_FREE_VISIBLE_TABS.includes(tabButton.dataset.sbCharacterEditorTab ?? '');
         tabButton.classList.toggle('is-active', isActive);
         tabButton.setAttribute('aria-selected', String(isActive));
         tabButton.setAttribute('tabindex', isActive ? '0' : '-1');
-        if (isDisabled) {
-            tabButton.setAttribute('aria-disabled', 'true');
-        } else {
-            tabButton.removeAttribute('aria-disabled');
-        }
+        // Dimmed, not disabled: tapping a spoiler-hidden tab reveals the fields (see bindCharacterEditorSubTabs).
+        tabButton.classList.toggle('is-spoiler-hidden', isCharacterEditorSubTabSpoilerHidden(tabButton.dataset.sbCharacterEditorTab));
     }
 }
 
@@ -8393,7 +8389,14 @@ function bindCharacterEditorSubTabs() {
             return;
         }
 
-        setCharacterEditorSubTab(target.dataset.sbCharacterEditorTab, { focusButton: false });
+        const tabId = target.dataset.sbCharacterEditorTab;
+        // Spoiler-free mode hides Definitions/Greetings; a deliberate tap on one of them is the same request as the eye
+        // button's peek, so reveal the fields first instead of silently landing on Metadata.
+        if (isCharacterEditorSubTabSpoilerHidden(tabId)) {
+            setCharacterSpoilerFreeFieldsHidden(false);
+        }
+
+        setCharacterEditorSubTab(tabId, { focusButton: false });
     });
 
     tablist.addEventListener('keydown', (event) => {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -8174,6 +8174,7 @@ function saveCharacterEditorSubTab(tabId) {
 
 function updateCharacterEditorSubTabButtons(activeTabId) {
     const activeSubTab = resolveCharacterEditorSubTab(activeTabId);
+    const spoilerFreeFieldsHidden = isCharacterSpoilerFreeFieldsHidden();
 
     for (const tabButton of document.querySelectorAll('#sb_character_editor_subtabs [data-sb-character-editor-tab]')) {
         if (!(tabButton instanceof HTMLElement)) {
@@ -8181,9 +8182,16 @@ function updateCharacterEditorSubTabButtons(activeTabId) {
         }
 
         const isActive = tabButton.dataset.sbCharacterEditorTab === activeSubTab;
+        // Spoiler-free mode reroutes these tabs to Metadata; surface that instead of leaving them looking clickable.
+        const isDisabled = spoilerFreeFieldsHidden && !SB_CHARACTER_EDITOR_SPOILER_FREE_VISIBLE_TABS.includes(tabButton.dataset.sbCharacterEditorTab ?? '');
         tabButton.classList.toggle('is-active', isActive);
         tabButton.setAttribute('aria-selected', String(isActive));
         tabButton.setAttribute('tabindex', isActive ? '0' : '-1');
+        if (isDisabled) {
+            tabButton.setAttribute('aria-disabled', 'true');
+        } else {
+            tabButton.removeAttribute('aria-disabled');
+        }
     }
 }
 

--- a/tests/generation-lifecycle-wiring.test.js
+++ b/tests/generation-lifecycle-wiring.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from '@jest/globals';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import vm from 'node:vm';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const scriptSource = readFileSync(path.join(repoRoot, 'public', 'script.js'), 'utf8');
@@ -32,6 +33,27 @@ function getFunctionSource(name, { exported = false } = {}) {
     }
 
     throw new Error(`Unable to find function source for ${name}`);
+}
+
+// Minimal jQuery stand-in that mirrors mobile-styles.css:
+// `#send_form:not(.sb-generating-controls) #mes_stop { display: none !important; }`
+function createMobileStopButtonDom() {
+    const state = { generatingClass: true, inlineDisplay: 'flex' };
+    const elements = {
+        '#send_form': {
+            removeClass: () => { state.generatingClass = false; },
+        },
+        '#mes_stop': {
+            css: value => {
+                if (typeof value === 'string') {
+                    return state.generatingClass ? state.inlineDisplay : 'none';
+                }
+                state.inlineDisplay = value.display;
+            },
+        },
+    };
+
+    return { $: selector => elements[selector], state };
 }
 
 function getSourceBetween(startMarker, endMarker) {
@@ -98,6 +120,22 @@ describe('generation lifecycle wiring', () => {
         expect(unblockSource).toContain('unblockState.shouldResetProgress');
         expect(unblockSource).toContain('unblockState.shouldFlushEphemeralState');
         expect(unblockSource).not.toContain('type === \'quiet\' && streamingProcessor && !streamingProcessor.isFinished');
+    });
+
+    test('emits GENERATION_ENDED once even when the mobile stylesheet hides the stop button on class removal', () => {
+        const hideSource = getFunctionSource('hideStopButton');
+        const emitted = [];
+        const { $, state } = createMobileStopButtonDom();
+
+        vm.runInNewContext(`${hideSource}\nhideStopButton();\nhideStopButton();`, {
+            $,
+            eventSource: { emit: (...args) => emitted.push(args) },
+            event_types: { GENERATION_ENDED: 'generation_ended' },
+            chat: { length: 3 },
+        });
+
+        expect(emitted).toEqual([['generation_ended', 3]]);
+        expect(state).toEqual({ generatingClass: false, inlineDisplay: 'none' });
     });
 
     test('routes provider-error cleanup through stopped lifecycle semantics', () => {

--- a/tests/mobile-character-editor-css.test.js
+++ b/tests/mobile-character-editor-css.test.js
@@ -55,9 +55,24 @@ describe('mobile character editor css', () => {
         expect(flattenedActionWrappersRule).toContain('display: contents !important;');
     });
 
+    test('keeps the parked mode toggle and close button clear of the editor sub-tabs on mobile', () => {
+        const editorBandRule = getRuleBody(mobileShellCss, '#right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > #CharListButtonAndHotSwaps');
+
+        // The generic band rule is `min-height: 34px !important`; the toggle sits at top 8px with a 44px touch target.
+        expect(editorBandRule).toContain('min-height: 54px !important;');
+    });
+
+    test('dims the editor sub-tabs that spoiler-free mode reroutes to Metadata', () => {
+        const disabledTabRule = getRuleBody(tabsCss, '#right-nav-panel .sb-character-editor-subtab[aria-disabled="true"]');
+
+        expect(disabledTabRule).toContain('opacity: 0.45;');
+        expect(disabledTabRule).toContain('cursor: not-allowed;');
+        expect(disabledTabRule).not.toContain('pointer-events');
+    });
+
     test('keeps the desktop editor shell from reintroducing refactor padding and wrapper collapse', () => {
         const desktopActionWrappersRule = getRuleBody(tabsCss, '#right-nav-panel .sb-character-editor-controls-row #character-editor-pinned-actions,\n#right-nav-panel .sb-character-editor-controls-row #avatar_controls,\n#right-nav-panel .sb-character-editor-controls-row #avatar_controls > .form_create_bottom_buttons_block,\n#right-nav-panel .sb-character-editor-controls-row #avatar_controls .char-button-toolbar');
-        const desktopNavPaddingRule = getRuleBody(tabsCss, ":root:not([data-sb-desktop-nav-layout='vertical']) #right-nav-panel.openDrawer .sb-character-shell-nav");
+        const desktopNavPaddingRule = getRuleBody(tabsCss, ':root:not([data-sb-desktop-nav-layout=\'vertical\']) #right-nav-panel.openDrawer .sb-character-shell-nav');
         const desktopCreateButtonSelector = '#right-nav-panel .sb-character-create-bar #rm_button_create,\n#right-nav-panel .sb-character-create-bar #rm_button_group_chats';
         const desktopCreateButtonRule = getRuleBody(tabsCss, desktopCreateButtonSelector);
         const unlayeredGuardIndex = tabsCss.indexOf('/* Unlayered fork cascade guards');

--- a/tests/mobile-character-editor-css.test.js
+++ b/tests/mobile-character-editor-css.test.js
@@ -62,12 +62,14 @@ describe('mobile character editor css', () => {
         expect(editorBandRule).toContain('min-height: 54px !important;');
     });
 
-    test('dims the editor sub-tabs that spoiler-free mode reroutes to Metadata', () => {
-        const disabledTabRule = getRuleBody(tabsCss, '#right-nav-panel .sb-character-editor-subtab[aria-disabled="true"]');
+    test('dims the spoiler-hidden editor sub-tabs without making them untappable', () => {
+        const hiddenTabRule = getRuleBody(tabsCss, '#right-nav-panel .sb-character-editor-subtab.is-spoiler-hidden');
 
-        expect(disabledTabRule).toContain('opacity: 0.45;');
-        expect(disabledTabRule).toContain('cursor: not-allowed;');
-        expect(disabledTabRule).not.toContain('pointer-events');
+        expect(hiddenTabRule).toContain('opacity: 0.45;');
+        // A tap on a dimmed tab reveals the fields, so nothing here may swallow the click or advertise a dead button.
+        expect(hiddenTabRule).not.toContain('pointer-events');
+        expect(hiddenTabRule).not.toContain('not-allowed');
+        expect(tabsCss).not.toContain('.sb-character-editor-subtab[aria-disabled');
     });
 
     test('keeps the desktop editor shell from reintroducing refactor padding and wrapper collapse', () => {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -3,6 +3,7 @@ import { parse } from '@adobe/css-tools';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import vm from 'node:vm';
 
 import {
     MOBILE_SHELL_VIEWPORT_SYNC_STEP,
@@ -921,5 +922,67 @@ describe('mobile shell lifecycle wiring', () => {
         expect(syncBoundsSource).not.toContain('style.setProperty(\'top\'');
         expect(syncBoundsSource).not.toContain('style.setProperty(\'height\'');
         expect(syncBoundsSource).not.toContain('style.removeProperty(');
+    });
+
+    test('reveals spoiler-hidden character fields when a dimmed editor sub-tab is tapped', () => {
+        class HTMLElement {}
+        class HTMLButtonElement extends HTMLElement {}
+
+        const calls = [];
+        const listeners = {};
+        const form = Object.assign(new HTMLElement(), { dataset: { sbSpoilerFreeFieldsHidden: 'true' } });
+        const tablist = Object.assign(new HTMLElement(), {
+            dataset: {},
+            addEventListener: (type, handler) => { listeners[type] = handler; },
+        });
+        const tapTab = (tabId) => {
+            const button = Object.assign(new HTMLButtonElement(), { dataset: { sbCharacterEditorTab: tabId } });
+            button.closest = () => button;
+            listeners.click({ target: button });
+        };
+        const context = {
+            HTMLElement,
+            HTMLButtonElement,
+            document: {
+                getElementById: (id) => ({ sb_character_editor_subtabs: tablist, form_create: form })[id],
+            },
+            normalizeText: (value) => String(value ?? '').trim(),
+            SB_CHARACTER_EDITOR_SUB_TABS: ['char-info', 'definitions', 'greetings', 'metadata'],
+            SB_CHARACTER_EDITOR_DEFAULT_SUB_TAB: 'char-info',
+            SB_CHARACTER_EDITOR_SPOILER_FREE_VISIBLE_TABS: ['char-info', 'metadata'],
+            setCharacterSpoilerFreeFieldsHidden: (hidden) => {
+                calls.push(['reveal', hidden]);
+                form.dataset.sbSpoilerFreeFieldsHidden = String(hidden);
+            },
+            setCharacterEditorSubTab: (tabId) => calls.push(['open', tabId]),
+            syncCharacterEditorSubTabs: () => {},
+        };
+
+        const resolveTab = vm.runInNewContext([
+            getFunctionSource('normalizeCharacterEditorSubTab'),
+            getFunctionSource('isCharacterSpoilerFreeFieldsHidden'),
+            getFunctionSource('isCharacterEditorSubTabSpoilerHidden'),
+            getFunctionSource('resolveCharacterEditorSubTab'),
+            getFunctionSource('bindCharacterEditorSubTabs'),
+            'bindCharacterEditorSubTabs();',
+            'resolveCharacterEditorSubTab;',
+        ].join('\n'), context);
+
+        // While hidden, Definitions is rerouted to Metadata; that is exactly what the reporter saw.
+        expect(resolveTab('definitions')).toBe('metadata');
+
+        // Tapping an always-visible tab must not touch the spoiler state.
+        tapTab('char-info');
+        expect(calls).toEqual([['open', 'char-info']]);
+
+        // Tapping a dimmed tab reveals the fields first, then opens that tab for real.
+        tapTab('definitions');
+        expect(calls).toEqual([['open', 'char-info'], ['reveal', false], ['open', 'definitions']]);
+        expect(resolveTab('definitions')).toBe('definitions');
+
+        // Once revealed, further taps are plain tab switches.
+        tapTab('greetings');
+        expect(calls.at(-1)).toEqual(['open', 'greetings']);
+        expect(calls.filter(([kind]) => kind === 'reveal')).toHaveLength(1);
     });
 });


### PR DESCRIPTION
The first bug is due to the extension 'Typing Indicator', which ends when GENERATION_ENDED is sent, which SB never did. Now it does.
The second bug is due to the 'Spoiler Free mode'. When activated, Definitions and Greetings is rerouted to the Metadata button, so neither works. It will now show as hidden in Spoiler Free Mode. To make it unhidden, turn the mode off.
Secondly, the mode toggle for RP and Conversation overlaps the top of Greetings/Metadata on mobile. CSS fix to 54px.
