### PR TITLE
fix: sanitise filenames for linux systems

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -54,6 +54,16 @@ const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0
 const getPngFileName = fileName => path.extname(fileName).toLowerCase() === '.png'
     ? fileName
     : `${fileName}.png`;
+// SillyBunny: allow POSIX-valid character names while keeping avatar access inside the character folder.
+const resolveCharacterAvatarPath = (directory, avatar) => {
+    if (avatar.includes('\0') || path.basename(avatar) !== avatar || path.extname(avatar).toLowerCase() !== '.png') {
+        return null;
+    }
+
+    const charactersDirectory = path.resolve(directory);
+    const avatarPath = path.resolve(charactersDirectory, avatar);
+    return path.dirname(avatarPath) === charactersDirectory ? avatarPath : null;
+};
 const getEntityDateAddedRoot = directories => directories.root || path.dirname(directories.characters);
 const getCharacterDateAddedFallback = stat => [stat.ctimeMs, stat.birthtimeMs, stat.mtimeMs]
     .find(timestamp => Number.isFinite(timestamp) && timestamp > 0) ?? Date.now();
@@ -1617,16 +1627,17 @@ router.post('/last-chat', getFileNameValidationFunction('avatar'), async functio
 });
 
 router.post('/delete', validateAvatarUrlMiddleware, async function (request, response) {
-    if (!request.body || !request.body.avatar_url) {
+    const avatar = request.body?.avatar_url;
+    if (typeof avatar !== 'string' || !avatar) {
         return response.sendStatus(400);
     }
 
-    if (request.body.avatar_url !== sanitize(request.body.avatar_url)) {
+    const avatarPath = resolveCharacterAvatarPath(request.user.directories.characters, avatar);
+    if (!avatarPath) {
         console.error('Malicious filename prevented');
         return response.sendStatus(403);
     }
 
-    const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
     try {
         recoverFileWriteSync(avatarPath);
     } catch (error) {
@@ -1637,9 +1648,11 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
         return response.sendStatus(400);
     }
 
-    let dir_name = request.body.avatar_url.replace('.png', '');
+    const dir_name = avatar.replace('.png', '');
+    const chatsRoot = path.resolve(request.user.directories.chats);
+    const chatsDirectory = path.resolve(chatsRoot, dir_name);
 
-    if (!dir_name.length) {
+    if (!dir_name.length || path.dirname(chatsDirectory) !== chatsRoot) {
         console.error('Malicious dirname prevented');
         return response.sendStatus(403);
     }
@@ -1648,8 +1661,7 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
     let recoveryTargets = [];
     if (request.body.delete_chats == true) {
         try {
-            const owner = sanitize(dir_name);
-            const chatsDirectory = path.join(request.user.directories.chats, owner);
+            const owner = dir_name;
             if (fs.existsSync(chatsDirectory)) {
                 const chatFiles = await fs.promises.readdir(chatsDirectory, { withFileTypes: true });
                 recoveryTargets = chatFiles
@@ -1693,17 +1705,17 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
         removeEntityDateAdded(
             getEntityDateAddedRoot(request.user.directories),
             'characters',
-            request.body.avatar_url,
+            avatar,
         );
     } catch (metadataError) {
         console.error('Could not remove date-added metadata after character deletion.', metadataError);
     }
     try {
-        removeEntityLastChat(getEntityDateAddedRoot(request.user.directories), request.body.avatar_url);
+        removeEntityLastChat(getEntityDateAddedRoot(request.user.directories), avatar);
     } catch (metadataError) {
         console.error('Could not remove last-chat metadata after character deletion.', metadataError);
     }
-    invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
+    invalidateThumbnail(request.user.directories, 'avatar', avatar);
 
     return response.sendStatus(200);
 });
@@ -1717,30 +1729,31 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
  * @param {import("express").Response} response The HTTP response object.
  */
 router.post('/regenerate-thumbnail', validateAvatarUrlMiddleware, async function (request, response) {
-    if (!request.body || !request.body.avatar_url) {
+    const avatar = request.body?.avatar_url;
+    if (typeof avatar !== 'string' || !avatar) {
         return response.sendStatus(400);
     }
 
-    if (request.body.avatar_url !== sanitize(request.body.avatar_url)) {
+    const avatarPath = resolveCharacterAvatarPath(request.user.directories.characters, avatar);
+    if (!avatarPath) {
         console.error('Malicious filename prevented');
         return response.sendStatus(403);
     }
 
-    const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
     if (!fs.existsSync(avatarPath)) {
         return response.status(404).json({ error: 'Character avatar file not found.' });
     }
 
     try {
-        invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
-        const result = await generateThumbnail(request.user.directories, 'avatar', request.body.avatar_url, true);
+        invalidateThumbnail(request.user.directories, 'avatar', avatar);
+        const result = await generateThumbnail(request.user.directories, 'avatar', avatar, true);
         return response.json({
             ok: true,
             regenerated: result.path !== null,
             aspectRatio: result.aspectRatio,
         });
     } catch (error) {
-        console.error('Failed to regenerate thumbnail for', request.body.avatar_url, error);
+        console.error('Failed to regenerate thumbnail for', avatar, error);
         return response.status(500).json({ error: 'Failed to regenerate thumbnail.' });
     }
 });

--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -117,6 +117,17 @@ function getOriginalFolder(directories, type) {
     return originalFolder;
 }
 
+// SillyBunny: path containment permits POSIX-valid names that sanitize-filename rejects.
+function resolveDirectChildPath(folder, file) {
+    if (typeof file !== 'string' || !file || file.includes('\0') || path.basename(file) !== file) {
+        return null;
+    }
+
+    const root = path.resolve(folder);
+    const filePath = path.resolve(root, file);
+    return path.dirname(filePath) === root ? filePath : null;
+}
+
 /**
  * Resolves a requested file name to the name that actually exists in the original images folder.
  * @param {import('../users.js').UserDirectoryList} directories User directories
@@ -164,7 +175,8 @@ export function invalidateThumbnail(directories, type, file) {
         const folder = getThumbnailFolder(directories, type, preset);
         if (folder === undefined) throw new Error('Invalid thumbnail type');
 
-        const pathToThumbnail = path.join(folder, sanitize(file));
+        const pathToThumbnail = resolveDirectChildPath(folder, file);
+        if (!pathToThumbnail) continue;
         if (fs.existsSync(pathToThumbnail)) {
             fs.unlinkSync(pathToThumbnail);
         }
@@ -211,13 +223,18 @@ export async function generateThumbnail(directories, type, file, forceGenerate =
     const thumbnailFolder = getThumbnailFolder(directories, type, preset);
     const originalFolder = getOriginalFolder(directories, type);
     if (thumbnailFolder === undefined || originalFolder === undefined) throw new Error('Invalid thumbnail type');
+    if (!resolveDirectChildPath(originalFolder, file) || !resolveDirectChildPath(thumbnailFolder, file)) {
+        return { path: null, aspectRatio: null, resolution: null };
+    }
     // SillyBunny: tolerate a double percent-encoded name (see resolveOriginalFileName).
     file = resolveOriginalFileName(directories, type, file);
-    const pathToCachedFile = path.join(thumbnailFolder, file);
+    const pathToCachedFile = resolveDirectChildPath(thumbnailFolder, file);
+    const pathToOriginalFile = resolveDirectChildPath(originalFolder, file);
+    if (!pathToCachedFile || !pathToOriginalFile) {
+        return { path: null, aspectRatio: null, resolution: null };
+    }
 
     try {
-        const pathToOriginalFile = path.join(originalFolder, file);
-
         if (type === 'avatar' && path.extname(pathToOriginalFile).toLowerCase() === '.png') {
             recoverFileWriteSync(pathToOriginalFile);
         }
@@ -366,17 +383,17 @@ publicRouter.get('/', async function (request, response) {
             return response.sendStatus(400);
         }
 
-        const sanitizedFile = sanitize(rawFile);
-        if (sanitizedFile !== rawFile) return response.sendStatus(403);
+        const originalFolder = getOriginalFolder(request.user.directories, type);
+        if (!resolveDirectChildPath(originalFolder, rawFile)) return response.sendStatus(403);
 
         // SillyBunny: tolerate a double percent-encoded `file` param (see resolveOriginalFileName).
-        const file = resolveOriginalFileName(request.user.directories, type, sanitizedFile);
+        const file = resolveOriginalFileName(request.user.directories, type, rawFile);
+        const pathToOriginalFile = resolveDirectChildPath(originalFolder, file);
+        if (!pathToOriginalFile) return response.sendStatus(403);
 
         const requestedPreset = rawPreset === 'mobile' ? 'mobile' : 'desktop';
 
         const serveOriginal = () => {
-            const folder = getOriginalFolder(request.user.directories, type);
-            const pathToOriginalFile = path.resolve(path.join(folder, file));
             if (!fs.existsSync(pathToOriginalFile)) return response.sendStatus(404);
             invalidateFirefoxCache(pathToOriginalFile, request, response);
             return response.sendFile(pathToOriginalFile);
@@ -402,7 +419,8 @@ publicRouter.get('/', async function (request, response) {
         // If the mobile preset is disabled, fall back to the desktop thumbnail.
         const effectivePreset = (requestedPreset === 'mobile' && thumbnailMobileRuntimeSettings.enabled) ? 'mobile' : 'desktop';
         const thumbnailFolder = getThumbnailFolder(request.user.directories, type, effectivePreset);
-        const pathToCachedFile = path.join(thumbnailFolder, file);
+        const pathToCachedFile = resolveDirectChildPath(thumbnailFolder, file);
+        if (!pathToCachedFile) return response.sendStatus(403);
 
         // Try to generate thumbnail if it doesn't exist
         if (!fs.existsSync(pathToCachedFile)) {

--- a/tests/character-card-metadata-preservation.test.js
+++ b/tests/character-card-metadata-preservation.test.js
@@ -21,6 +21,7 @@ const diskCacheEnvironmentKey = 'SILLYTAVERN_PERFORMANCE_USEDISKCACHE';
 const originalDiskCacheSetting = process.env[diskCacheEnvironmentKey];
 const describeWindows = process.platform === 'win32' ? describe : describe.skip;
 const describeCaseSensitive = process.platform === 'win32' ? describe.skip : describe;
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
 process.env[diskCacheEnvironmentKey] = 'false';
 process.chdir(repoRoot);
 setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
@@ -330,6 +331,45 @@ describe('character card metadata preservation', () => {
         expect(response.status).toBe(200);
         expect(fs.existsSync(path.join(directories.characters, avatar))).toBe(false);
         expect(fs.existsSync(chatDirectory)).toBe(false);
+    });
+
+    describePosix('POSIX character filenames', () => {
+        test('deletes a character and its chats when the filename contains a pipe', async () => {
+            const owner = 'Alice | Test';
+            const avatar = `${owner}.png`;
+            const avatarPath = path.join(directories.characters, avatar);
+            const chatDirectory = path.join(directories.chats, owner);
+            fs.writeFileSync(avatarPath, 'avatar');
+            fs.mkdirSync(chatDirectory, { recursive: true });
+            fs.writeFileSync(path.join(chatDirectory, 'chat.jsonl'), '{}\n');
+
+            const response = await postJson('/api/characters/delete', {
+                avatar_url: avatar,
+                delete_chats: true,
+            });
+
+            expect(response.status).toBe(200);
+            expect(fs.existsSync(avatarPath)).toBe(false);
+            expect(fs.existsSync(chatDirectory)).toBe(false);
+        });
+    });
+
+    test('does not delete the chats root for an unsafe character owner', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const avatar = '..png';
+        const avatarPath = path.join(directories.characters, avatar);
+        const sentinelPath = path.join(directories.chats, 'keep.jsonl');
+        fs.writeFileSync(avatarPath, 'avatar');
+        fs.writeFileSync(sentinelPath, '{}\n');
+
+        const response = await postJson('/api/characters/delete', {
+            avatar_url: avatar,
+            delete_chats: true,
+        });
+
+        expect(response.status).toBe(403);
+        expect(fs.existsSync(avatarPath)).toBe(true);
+        expect(fs.existsSync(sentinelPath)).toBe(true);
     });
 
     function saveCharacter(character, avatarUrl = 'Alice.png') {

--- a/tests/thumbnails-endpoint.test.js
+++ b/tests/thumbnails-endpoint.test.js
@@ -34,6 +34,7 @@ const originalMobileThumbnailSettings = getThumbnailMobileRuntimeSettings();
 const originalThumbnailDimensions = getThumbnailDimensions();
 const originalMobileThumbnailDimensions = getThumbnailMobileDimensions();
 const nativeFetch = global.fetch;
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
 
 // Node's fetch cannot load the file: WASM URLs used by the Jimp codecs in Jest.
 async function fetchWithFileSupport(input, init) {
@@ -83,6 +84,7 @@ describe('thumbnail file name resolution', () => {
             backgrounds: path.join(tempRoot, 'backgrounds'),
             characters: path.join(tempRoot, 'characters'),
             thumbnailsAvatar: path.join(tempRoot, 'thumbnails', 'avatar'),
+            thumbnailsAvatarMobile: path.join(tempRoot, 'thumbnails', 'avatar', 'mobile'),
             thumbnailsBg: path.join(tempRoot, 'thumbnails', 'bg'),
             thumbnailsBgMobile: path.join(tempRoot, 'thumbnails', 'bg', 'mobile'),
             thumbnailsPersona: path.join(tempRoot, 'thumbnails', 'persona'),
@@ -212,6 +214,22 @@ describe('thumbnail file name resolution', () => {
         expect(await response.text()).toBe(THUMBNAIL_MARKER);
     });
 
+    describePosix('POSIX file names', () => {
+        test('serves and invalidates a thumbnail whose file name contains a pipe', async () => {
+            const file = 'Alice | Test.png';
+            writeCharacter(file);
+            writeCachedThumbnail(file);
+
+            const response = await requestThumbnail(`type=avatar&file=${encodeURIComponent(file)}`);
+
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe(THUMBNAIL_MARKER);
+
+            invalidateThumbnail(directories, 'avatar', file);
+            expect(fs.existsSync(path.join(directories.thumbnailsAvatar, file))).toBe(false);
+        });
+    });
+
     test('rejects a traversal hidden behind double percent-encoding', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -287,6 +305,6 @@ describe('thumbnail file name resolution', () => {
         const result = await generateThumbnail(directories, 'avatar', '%2E%2E%2Fsecret.png');
 
         expect(result.path).toBeNull();
-        expect(fs.readdirSync(directories.thumbnailsAvatar)).toEqual([]);
+        expect(fs.readdirSync(directories.thumbnailsAvatar, { withFileTypes: true }).filter(entry => entry.isFile())).toEqual([]);
     });
 });


### PR DESCRIPTION
Allows character names with | to render properly and be deleted without a 403 error.