### PR TITLE
fix: protect drafts and saved settings when using Story Mode

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -331,6 +331,7 @@ import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker
 import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-send-button.js';
 import { formatMobileStreamingPreview, getMobileStreamingBottomPinBehavior, getStreamingUpdateInterval, isAndroidStreamingPlatform, shouldReduceStreamingDomWork, shouldUsePlainTextStreamingPreview } from './scripts/mobile-streaming.js';
 import { fetchResumable } from './scripts/resumable-generation.js';
+import { applyGenerationRequestControls, isGenerationLengthFinish, limitGenerationProse } from './scripts/generation-request-controls.js';
 import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_RENDER_LIFECYCLE_ROUTE,
@@ -5380,6 +5381,7 @@ export function getStoppingStrings(isImpersonate, isContinue, api = main_api) {
  * @prop {string} [quietImage] Image to use for the quiet prompt
  * @prop {string} [quietName] Name to use for the quiet prompt (defaults to "System:")
  * @prop {number} [responseLength] Maximum response length. If unset, the global default value is used.
+ * @prop {boolean} [preserveReasoningBudget=false] Keep the preset's total allowance for reasoning requests
  * @prop {number} [forceChId] Character ID to use for this generation run. Works in groups only.
  * @prop {object} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
  * @prop {boolean} [removeReasoning] Parses and removes the reasoning block according to reasoning format preferences
@@ -5389,13 +5391,13 @@ export function getStoppingStrings(isImpersonate, isContinue, api = main_api) {
  * @param {GenerateQuietPromptParams} params Parameters for the quiet prompt generation
  * @returns {Promise<string>} Generated text. If using structured output, will contain a serialized JSON object.
  */
-export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, jsonSchema = null, removeReasoning = true, trimToSentence = false, signal = null, cacheScope = 'auxiliary' } = {}) {
+export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, jsonSchema = null, removeReasoning = true, trimToSentence = false, signal = null, cacheScope = 'auxiliary', preserveReasoningBudget = false } = {}) {
     if (arguments.length > 0 && typeof arguments[0] !== 'object') {
         console.trace('generateQuietPrompt called with positional arguments. Please use an object instead.');
         [quietPrompt, quietToLoud, skipWIAN, quietImage, quietName, responseLength, forceChId, jsonSchema] = arguments;
     }
 
-    const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
+    const responseLengthCustomized = !preserveReasoningBudget && typeof responseLength === 'number' && responseLength > 0;
     const externalSignal = signal instanceof AbortSignal ? signal : null;
     const quietAbortController = externalSignal ? new AbortController() : null;
     const abortFromExternalSignal = quietAbortController
@@ -5424,6 +5426,8 @@ export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = fals
             jsonSchema: jsonSchema ?? null,
             signal: quietAbortController?.signal ?? null,
             cacheScope,
+            responseLength: preserveReasoningBudget ? responseLength : null,
+            preserveReasoningBudget,
         };
         if (responseLengthCustomized) {
             TempResponseLength.save(main_api, responseLength);
@@ -5954,8 +5958,9 @@ class StreamingProcessor {
      * @param {Date} timeStarted Date when generation was started
      * @param {string} continueMessage Previous message if the type is 'continue'
      * @param {PromptReasoning} promptReasoning Prompt reasoning instance
+     * @param {GenerateOptions} [requestControls] Controls for this request and its owned successors
      */
-    constructor(type, forceName2, timeStarted, continueMessage, promptReasoning) {
+    constructor(type, forceName2, timeStarted, continueMessage, promptReasoning, requestControls = {}) {
         this.result = '';
         this.messageId = -1;
         /** @type {HTMLElement} */
@@ -5975,6 +5980,15 @@ class StreamingProcessor {
         this.isFinished = false;
         this.generator = this.nullStreamingGeneration;
         this.abortController = new AbortController();
+        // SillyBunny: a prose limit closes the transport, not the generation lifecycle.
+        this.requestAbortController = new AbortController();
+        this.abortController.signal.addEventListener('abort', () => this.requestAbortController.abort(this.abortController.signal.reason), { once: true });
+        this.requestControls = requestControls;
+        this.maxOutputTokens = Number.isFinite(requestControls.maxOutputTokens) && requestControls.maxOutputTokens > 0 ? requestControls.maxOutputTokens : 0;
+        this.finishReason = null;
+        this.lastRawText = null;
+        this.lastReasoningPrefix = null;
+        this.limitedOutput = null;
         this.firstMessageText = '...';
         this.timeStarted = timeStarted;
         /** @type {number?} */
@@ -6005,6 +6019,29 @@ class StreamingProcessor {
         }
     }
 
+    #applyProseLimit(state, isFinal = false) {
+        if (!this.maxOutputTokens || (isFinal && this.lastRawText === null)) {
+            return false;
+        }
+        if (state?.finishReason === 'length') {
+            this.finishReason = 'length';
+        }
+        const rawText = isFinal ? this.lastRawText : this.result;
+        const prefix = isFinal ? this.lastReasoningPrefix : this.promptReasoning?.prefixIncomplete && !this.pendingReasoning ? this.promptReasoning.prefixReasoningFormatted : '';
+        if (isFinal || rawText !== this.lastRawText || prefix !== this.lastReasoningPrefix) {
+            this.lastRawText = rawText;
+            this.lastReasoningPrefix = prefix;
+            this.limitedOutput = limitGenerationProse(rawText, this.maxOutputTokens, power_user.reasoning, prefix, !isFinal);
+        }
+        this.result = this.limitedOutput.text;
+        if (!isFinal) {
+            this.pendingReasoning = [this.pendingReasoning, this.limitedOutput.reasoning].filter(Boolean).join('\n\n');
+        } else if (this.limitedOutput.limited) {
+            this.finishReason = 'length';
+        }
+        return this.limitedOutput.limited;
+    }
+
     /**
      * Initializes DOM elements for the current message.
      * @param {number} messageId Current message ID
@@ -6030,7 +6067,8 @@ class StreamingProcessor {
             this.messageTokenCounterDom = this.messageDom?.querySelector('.tokenCounterDisplay');
         }
         if (continueOnReasoning) {
-            await this.reasoningHandler.process(messageId, false, this.promptReasoning);
+            // Controlled streams parse inline reasoning once in #applyProseLimit.
+            await this.reasoningHandler.process(messageId, false, this.maxOutputTokens ? null : this.promptReasoning);
         }
         if (this.reasoningHandler.hasReasoningContent()) {
             this.reasoningHandler.updateDom(messageId);
@@ -6120,7 +6158,7 @@ class StreamingProcessor {
             getMessage: text,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
-            displayIncompleteSentences: !isFinal,
+            displayIncompleteSentences: !isFinal || this.finishReason === 'length',
             stoppingStrings: this.stoppingStrings,
         });
 
@@ -6146,7 +6184,7 @@ class StreamingProcessor {
 
             // Update reasoning
             this.#applyPendingReasoning();
-            await this.reasoningHandler.process(messageId, mesChanged, this.promptReasoning);
+            await this.reasoningHandler.process(messageId, mesChanged, this.maxOutputTokens ? null : this.promptReasoning);
             processedText = chat[messageId].mes;
 
             // Token count update.
@@ -6331,7 +6369,7 @@ class StreamingProcessor {
 
         const isAborted = this.abortController.signal.aborted;
         if (!isAborted && power_user.auto_swipe && generatedTextFiltered(text)) {
-            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
+            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1, generationOptions: this.requestControls });
         }
         await saveChatConditional();
 
@@ -6413,16 +6451,26 @@ class StreamingProcessor {
                     this.messageLogprobs.push(...(Array.isArray(logprobs) ? logprobs : [logprobs]));
                 }
                 this.pendingReasoning = typeof state?.reasoning === 'string' ? state.reasoning : null;
+                const reachedLimit = this.#applyProseLimit(state);
                 if (this.pendingReasoning !== null) {
                     this.reasoningHandler.reasoning = getRegexedString(this.pendingReasoning, regex_placement.REASONING);
                 }
                 this.images = state?.images ?? [];
                 this.reasoningSignature = state?.signature ?? null;
                 this.reasoningTokens = state?.reasoning_tokens ?? 0;
+                if (reachedLimit) {
+                    this.finishReason = 'length';
+                    this.requestAbortController.abort();
+                    break;
+                }
             }
             const seconds = (timestamps[timestamps.length - 1] - timestamps[0]) / 1000;
             console.warn(`Stream stats: ${timestamps.length} tokens, ${seconds.toFixed(2)} seconds, rate: ${Number(timestamps.length / seconds).toFixed(2)} TPS`);
         } catch (err) {
+            if (this.finishReason === 'length' && err === this.requestAbortController.signal.reason && !this.abortController.signal.aborted) {
+                this.isFinished = true;
+                return this.result;
+            }
             const isCancelled = this.isCancelled || this.abortController.signal.aborted;
             if (!this.isFinished && isCancelled) {
                 this.isStopped = true;
@@ -6439,6 +6487,7 @@ class StreamingProcessor {
             return this.result;
         }
 
+        this.#applyProseLimit(null, true);
         this.isFinished = true;
         return this.result;
     }
@@ -6483,15 +6532,25 @@ class StreamingProcessor {
                 // SillyBunny: keep full reasoning regex/DOM work on UI ticks. Reasoning-heavy
                 // streams like DeepSeek and GLM can otherwise overwhelm iOS WebKit.
                 this.pendingReasoning = typeof state?.reasoning === 'string' ? state.reasoning : null;
+                const reachedLimit = this.#applyProseLimit(state);
                 this.images = state?.images ?? [];
                 this.reasoningSignature = state?.signature ?? null;
                 this.reasoningTokens = state?.reasoning_tokens ?? 0;
-                await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, text);
-                await sw.tick(async () => await this.onProgressStreaming(this.messageId, this.continueMessage + text));
+                await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, this.result);
+                await sw.tick(async () => await this.onProgressStreaming(this.messageId, this.continueMessage + this.result));
+                if (reachedLimit && !this.isCancelled && !this.abortController.signal.aborted) {
+                    this.finishReason = 'length';
+                    this.requestAbortController.abort();
+                    break;
+                }
             }
             const seconds = (timestamps[timestamps.length - 1] - timestamps[0]) / 1000;
             console.warn(`Stream stats: ${timestamps.length} tokens, ${seconds.toFixed(2)} seconds, rate: ${Number(timestamps.length / seconds).toFixed(2)} TPS`);
         } catch (err) {
+            if (this.finishReason === 'length' && err === this.requestAbortController.signal.reason && !this.abortController.signal.aborted) {
+                this.isFinished = true;
+                return this.result;
+            }
             const isCancelled = this.isCancelled || this.abortController.signal.aborted;
             if (!this.isFinished && isCancelled) {
                 this.setFirstSwipe(this.messageId);
@@ -6507,6 +6566,7 @@ class StreamingProcessor {
             return this.result;
         }
 
+        this.#applyProseLimit(null, true);
         this.isFinished = true;
         return this.result;
     }
@@ -6609,6 +6669,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @prop {boolean} [quietToLoud] true to generate a message in system mode, false to generate a message in character mode
  * @prop {string} [systemPrompt] System prompt to use.
  * @prop {number} [responseLength] Maximum response length. If unset, the global default value is used.
+ * @prop {boolean} [preserveReasoningBudget=false] Keep the preset's total allowance for reasoning requests
  * @prop {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
  * @prop {string} [prefill] An optional prefill for the prompt.
  * @prop {JsonSchema} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
@@ -6622,7 +6683,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {GenerateRawParams} params Parameters for generating a message
  * @returns {Promise<object | string>} Raw API response data, or a JSON string extracted from the response when `jsonSchema` is provided.
  */
-export async function generateRawData({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, prefill = '', jsonSchema = null, signal = null, cacheScope = 'auxiliary' } = {}) {
+export async function generateRawData({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, prefill = '', jsonSchema = null, signal = null, cacheScope = 'auxiliary', preserveReasoningBudget = false } = {}) {
     if (!api) {
         api = main_api;
     }
@@ -6637,7 +6698,9 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
             externalSignal.addEventListener('abort', abortFromExternalSignal, { once: true });
         }
     }
-    const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
+    // SillyBunny: route preserved budgets before TempResponseLength can overwrite the preset.
+    const responseLengthCustomized = !preserveReasoningBudget && typeof responseLength === 'number' && responseLength > 0;
+    const requestControls = preserveReasoningBudget ? { responseLength, preserveReasoningBudget } : {};
     let eventHook = () => { };
 
     // construct final prompt from the input. Can either be a string or an array of chat-style messages.
@@ -6685,30 +6748,37 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
                     const koboldSettings = koboldai_settings[koboldai_setting_names[kai_settings.preset_settings]];
                     generateData = getKoboldGenerationData(prompt.toString(), koboldSettings, amount_gen, max_context, isHorde, 'quiet');
                 }
-                TempResponseLength.restore(api);
+                responseLengthCustomized && TempResponseLength.restore(api);
                 break;
             case 'novel': {
                 const novelSettings = novelai_settings[novelai_setting_names[nai_settings.preset_settings_novel]];
-                generateData = getNovelGenerationData(prompt, novelSettings, amount_gen, false, false, null, 'quiet');
-                TempResponseLength.restore(api);
+                const maxLength = applyGenerationRequestControls({ max_length: amount_gen, model: nai_settings.model_novel }, requestControls).max_length;
+                generateData = getNovelGenerationData(prompt, novelSettings, maxLength, false, false, null, 'quiet');
+                requestControls.responseLength = null;
+                responseLengthCustomized && TempResponseLength.restore(api);
                 break;
             }
             case 'textgenerationwebui':
                 generateData = await getTextGenGenerationData(prompt, amount_gen, false, false, null, 'quiet', { cacheScope });
-                TempResponseLength.restore(api);
+                responseLengthCustomized && TempResponseLength.restore(api);
                 break;
             case 'openai': {
                 generateData = prompt;  // generateData is just the chat message object
-                eventHook = TempResponseLength.setupEventHook(api);
+                if (responseLengthCustomized) {
+                    eventHook = TempResponseLength.setupEventHook(api);
+                }
             } break;
         }
 
+        if (api !== 'openai') {
+            generateData = applyGenerationRequestControls(generateData, { model: api === 'koboldhorde' ? horde_settings.models : api === main_api ? getGeneratingModel() : undefined, ...requestControls });
+        }
         let data = {};
 
         if (api === 'koboldhorde') {
             data = await generateHorde(prompt.toString(), generateData, abortController.signal, false);
         } else if (api === 'openai') {
-            data = await sendOpenAIRequest('quiet', generateData, abortController.signal, { jsonSchema, cacheScope });
+            data = await sendOpenAIRequest('quiet', generateData, abortController.signal, { jsonSchema, cacheScope, ...requestControls });
         } else {
             const generateUrl = getGenerateUrl(api);
             const response = await fetchResumable(generateUrl, {
@@ -6756,13 +6826,13 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
  * @param {GenerateRawParams} params Parameters for generating a message
  * @returns {Promise<string>} Generated output: a cleaned-up message string when `jsonSchema` is not provided, or an extracted JSON string conforming to `jsonSchema` when it is.
  */
-export async function generateRaw({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, trimNames = true, prefill = '', jsonSchema = null, signal = null, cacheScope = 'auxiliary' } = {}) {
+export async function generateRaw({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, trimNames = true, prefill = '', jsonSchema = null, signal = null, cacheScope = 'auxiliary', preserveReasoningBudget = false } = {}) {
     if (arguments.length > 0 && typeof arguments[0] !== 'object') {
         console.trace('generateRaw called with positional arguments. Please use an object instead.');
         [prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames, prefill, jsonSchema] = arguments;
     }
 
-    const data = await generateRawData({ prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, prefill, jsonSchema, signal, cacheScope });
+    const data = await generateRawData({ prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, prefill, jsonSchema, signal, cacheScope, preserveReasoningBudget });
 
     // JSON string (matching the provided schema) will already be extracted.
     if (jsonSchema) {
@@ -6920,7 +6990,11 @@ function removeLastMessage(messageId = null) {
  * @property {string} [quietName] Name to use for the quiet prompt (defaults to "System:")
  * @property {number} [depth] Recursion depth for the generation. Used to prevent infinite loops in tool calls.
  * @property {JsonSchema} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
- * @property {boolean} [suppressUserMessage] Whether the visible user message was already rendered by a caller.
+ * @property {boolean} [suppressUserMessage] Ignore composer input, including commands and pending attachments.
+ * @property {boolean} [suppressAutoContinue=false] Skip automatic continuation for this request
+ * @property {number} [maxOutputTokens] Limit generated prose without reducing the reasoning allowance
+ * @property {number} [responseLength] Request-local response length override
+ * @property {boolean} [preserveReasoningBudget=false] Ignore responseLength for reasoning requests
  * @property {'main'|'auxiliary'|'none'} [cacheScope] Prompt cache lane for local backends.
  * @property {boolean} [preserveLastMessage] Whether regeneration should retain the last assistant message as context.
  * @property {ChatMessage} [companionHistoryTarget] Rewrite target whose Companion output must stay excluded during recursive tool calls.
@@ -6968,16 +7042,17 @@ function consumePendingUserMessageExtra(message) {
     pendingUserMessageExtra = null;
 }
 
-export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, jsonSchema = null, depth = 0, suppressUserMessage = false, cacheScope = null, preserveLastMessage = false, companionHistoryTarget = null } = {}, dryRun = false) {
+export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, jsonSchema = null, depth = 0, suppressUserMessage = false, cacheScope = null, preserveLastMessage = false, companionHistoryTarget = null, suppressAutoContinue = false, maxOutputTokens = 0, responseLength = null, preserveReasoningBudget = false } = {}, dryRun = false) {
     console.log('Generate entered');
     setGenerationProgress(0);
     generation_started = new Date();
+    const requestControls = { suppressUserMessage, suppressAutoContinue, maxOutputTokens, responseLength, preserveReasoningBudget };
 
     // Prevent generation from shallow characters
     await unshallowCharacter(this_chid);
 
     // Occurs every time, even if the generation is aborted due to slash commands execution
-    await eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope, preserveLastMessage }, dryRun);
+    await eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope, preserveLastMessage, suppressUserMessage, ...requestControls }, dryRun);
 
     // Don't recreate abort controller if signal is passed
     if (!(abortController && signal)) {
@@ -6992,7 +7067,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     let textareaText = '';
     let renderedUserMessage = false;
 
-    if (!(dryRun || depth || type == 'regenerate' || type == 'swipe' || type == 'quiet')) {
+    if (!(dryRun || depth || suppressUserMessage || type == 'regenerate' || type == 'swipe' || type == 'quiet')) {
         const interruptedByCommand = await processCommands(String($('#send_textarea').val()));
 
         if (interruptedByCommand) {
@@ -7013,8 +7088,8 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             textareaText = '';
             if (chat.length && lastMessage.is_user) {
                 //do nothing? why does this check exist?
-            // SillyBunny: Guided Correction regenerates against the existing assistant reply.
-            } else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && !depth && chat.length && !(type === 'regenerate' && preserveLastMessage)) {
+            // SillyBunny: retain continuation targets and Guided Correction regeneration context.
+            } else if (type !== 'quiet' && type !== 'swipe' && type !== 'continue' && !isImpersonate && !dryRun && !depth && chat.length && !(type === 'regenerate' && preserveLastMessage) && (!suppressUserMessage || type === 'regenerate')) {
                 if (type === 'regenerate') {
                     requestMobileChatBottomPin();
                 }
@@ -7042,7 +7117,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         'continue',
     ];
 
-    if ((textareaText != '' || (hasPendingFileAttachment() && !noAttachTypes.includes(type))) && !automatic_trigger && type !== 'quiet' && !dryRun && !depth && !selected_group) {
+    if ((textareaText != '' || (hasPendingFileAttachment() && !noAttachTypes.includes(type))) && !automatic_trigger && type !== 'quiet' && !dryRun && !depth && !suppressUserMessage && !selected_group) {
         // If user message contains no text other than bias - send as a system message
         if (messageBias && !removeMacros(textareaText)) {
             sendSystemMessage(system_message_types.GENERIC, ' ', { bias: messageBias });
@@ -7063,7 +7138,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // Occurs only if the generation is not aborted due to slash commands execution
     const companionFeedbackTarget = companionHistoryTarget
         ?? (type === 'continue' || type === 'swipe' || type === 'regenerate' ? lastMessage : null);
-    await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget }, dryRun);
+    await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget, suppressUserMessage, ...requestControls }, dryRun);
 
     if (main_api == 'kobold' && kai_settings.streaming_kobold && !kai_flags.can_use_streaming) {
         toastr.error(t`Streaming is enabled, but the version of Kobold used does not support token streaming.`, undefined, { timeOut: 10000, preventDuplicates: true });
@@ -7086,7 +7161,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     if (selected_group && !is_group_generating) {
         if (!dryRun) {
             // Returns the promise that generateGroupWrapper returns; resolves when generation is done
-            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget });
+            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget, suppressUserMessage, ...requestControls });
         }
 
         const characterIndexMap = new Map(characters.map((char, index) => [char.avatar, index]));
@@ -7415,7 +7490,11 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     }
 
     // Determine token limit
-    let this_max_context = getMaxPromptTokens();
+    // Reserve enough context for either the preset reasoning allowance or the requested reply.
+    const requestResponseLength = Number.isFinite(responseLength) && responseLength > 0
+        ? Math.max(Number(getMaxResponseTokens()), responseLength)
+        : null;
+    let this_max_context = getMaxPromptTokens(requestResponseLength);
 
     if (!dryRun) {
         console.debug('Running extension interceptors');
@@ -8152,7 +8231,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         case 'novel': {
             const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale } : null;
             const presetSettings = novelai_settings[novelai_setting_names[nai_settings.preset_settings_novel]];
-            generate_data = getNovelGenerationData(finalPrompt, presetSettings, maxLength, isImpersonate, isContinue, cfgValues, type);
+            const responseTokens = applyGenerationRequestControls({ max_length: maxLength, model: nai_settings.model_novel }, requestControls).max_length;
+            generate_data = getNovelGenerationData(finalPrompt, presetSettings, responseTokens, isImpersonate, isContinue, cfgValues, type);
+            requestControls.responseLength = null;
             break;
         }
         case 'openai': {
@@ -8173,6 +8254,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 jailbreakPromptOverride: jailbreak,
                 messages: oaiMessages,
                 messageExamples: oaiMessageExamples,
+                responseLength: requestResponseLength,
             }, dryRun);
             generate_data = { prompt: prompt, cacheScope: resolvedCacheScope };
 
@@ -8260,14 +8342,14 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             let startedSuccessorGeneration = false;
             try {
                 continue_mag = promptReasoning.removePrefix(continue_mag);
-                const activeStreamingProcessor = streamingProcessor = new StreamingProcessor(type, force_name2, generation_started, continue_mag, promptReasoning);
+                const activeStreamingProcessor = streamingProcessor = new StreamingProcessor(type, force_name2, generation_started, continue_mag, promptReasoning, requestControls);
                 if (isContinue) {
                     // Save reply does add cycle text to the prompt, so it's not needed here
                     activeStreamingProcessor.firstMessageText = '';
                 }
 
                 const shouldBufferOutput = await shouldBufferMainGenerationOutput({ type, isStreaming: true });
-                activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
+                activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope, ...requestControls });
 
                 hideSwipeButtons();
                 let getMessage = shouldBufferOutput
@@ -8277,7 +8359,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                     getMessage: getMessage,
                     isImpersonate: isImpersonate,
                     isContinue: isContinue,
-                    displayIncompleteSentences: false,
+                    displayIncompleteSentences: activeStreamingProcessor.finishReason === 'length',
                 });
 
                 const isReasoningOnlyStream = !getMessage.trim() && !!(activeStreamingProcessor.reasoningHandler.reasoning || activeStreamingProcessor.pendingReasoning);
@@ -8321,7 +8403,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                         depth = depth + 1;
                         await ToolManager.saveFunctionToolInvocations(invocationResult.invocations);
                         startedSuccessorGeneration = true;
-                        return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, companionHistoryTarget: companionRewriteTarget }, dryRun);
+                        return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, cacheScope: resolvedCacheScope, companionHistoryTarget: companionRewriteTarget, ...requestControls }, dryRun);
                     }
                 }
 
@@ -8344,7 +8426,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                             getMessage: getMessage,
                             isImpersonate: isImpersonate,
                             isContinue: isContinue,
-                            displayIncompleteSentences: false,
+                            displayIncompleteSentences: activeStreamingProcessor.finishReason === 'length',
                         });
 
                         const saveReplyType = originalType !== 'continue' ? type : 'appendFinal';
@@ -8352,7 +8434,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                             type: saveReplyType,
                             getMessage,
                             swipes: activeStreamingProcessor.swipes,
-                            reasoning: activeStreamingProcessor.reasoningHandler.reasoning,
+                            reasoning: activeStreamingProcessor.lastReasoningPrefix
+                                ? activeStreamingProcessor.reasoningHandler.reasoning.slice(promptReasoning.prefixReasoning.length)
+                                : activeStreamingProcessor.reasoningHandler.reasoning,
                             imageUrls: activeStreamingProcessor.images,
                             reasoningSignature: activeStreamingProcessor.reasoningSignature,
                             reasoningTokens: activeStreamingProcessor.reasoningTokens,
@@ -8363,24 +8447,26 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
                         const isAborted = activeStreamingProcessor.abortController.signal.aborted;
                         if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
-                            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
+                            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1, generationOptions: requestControls });
                         }
 
                         await saveChatConditional();
                         playMessageSound();
-                        triggerAutoContinue(messageChunk, isImpersonate);
+                        triggerAutoContinue(messageChunk, isImpersonate, requestControls);
                         return Object.defineProperties(new String(getMessage), {
                             'messageChunk': { value: messageChunk },
                             'fromStream': { value: true },
+                            'finishReason': { value: activeStreamingProcessor.finishReason },
                         });
                     }
 
                     await activeStreamingProcessor.onFinishStreaming(activeStreamingProcessor.messageId, getMessage);
                     clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-                    triggerAutoContinue(messageChunk, isImpersonate);
+                    triggerAutoContinue(messageChunk, isImpersonate, requestControls);
                     return Object.defineProperties(new String(getMessage), {
                         'messageChunk': { value: messageChunk },
                         'fromStream': { value: true },
+                        'finishReason': { value: activeStreamingProcessor.finishReason },
                     });
                 }
 
@@ -8394,7 +8480,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 }
             }
         } else {
-            return await sendGenerationRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
+            return await sendGenerationRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope, ...requestControls });
         }
     }
 
@@ -8445,11 +8531,21 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
         const swipes = extractMultiSwipes(data, type);
 
+        // SillyBunny: non-streaming reasoners keep their preset allowance; only separated prose is capped locally.
+        const reasoningPrefix = promptReasoning.prefixIncomplete && !reasoning ? promptReasoning.prefixReasoningFormatted : '';
+        const limitedOutput = limitGenerationProse(getMessage, maxOutputTokens, power_user.reasoning, reasoningPrefix);
+        limitedOutput.limited ||= Number.isFinite(maxOutputTokens) && maxOutputTokens > 0 && isGenerationLengthFinish(data);
+        getMessage = limitedOutput.text;
+        const inlineReasoning = reasoningPrefix && limitedOutput.reasoning.startsWith(promptReasoning.prefixReasoning)
+            ? limitedOutput.reasoning.slice(promptReasoning.prefixReasoning.length)
+            : limitedOutput.reasoning;
+        reasoning = [reasoning, inlineReasoning].filter(Boolean).join('\n\n');
+
         messageChunk = cleanUpMessage({
             getMessage: getMessage,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
-            displayIncompleteSentences: false,
+            displayIncompleteSentences: limitedOutput.limited,
         });
 
 
@@ -8474,7 +8570,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             getMessage: getMessage,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
-            displayIncompleteSentences: displayIncomplete,
+            displayIncompleteSentences: displayIncomplete || limitedOutput.limited,
         });
 
         const interceptResult = await applyMainGenerationOutputInterceptors({
@@ -8494,7 +8590,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             getMessage: getMessage,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
-            displayIncompleteSentences: false,
+            displayIncompleteSentences: limitedOutput.limited,
         });
 
         if (isImpersonate) {
@@ -8532,7 +8628,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
                 depth = depth + 1;
                 await ToolManager.saveFunctionToolInvocations(invocationResult.invocations);
-                return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, companionHistoryTarget: companionRewriteTarget }, dryRun);
+                return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, cacheScope: resolvedCacheScope, companionHistoryTarget: companionRewriteTarget, ...requestControls }, dryRun);
             }
         }
 
@@ -8543,7 +8639,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         const isAborted = abortController && abortController.signal.aborted;
         if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
             is_send_press = false;
-            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
+            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1, generationOptions: requestControls });
         }
 
         console.debug('/api/chats/save called by /Generate');
@@ -8552,11 +8648,14 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         streamingProcessor = null;
 
         if (type !== 'quiet') {
-            triggerAutoContinue(messageChunk, isImpersonate);
+            triggerAutoContinue(messageChunk, isImpersonate, requestControls);
         }
 
         // Don't break the API chain that expects a single string in return
-        return Object.defineProperty(new String(getMessage), 'messageChunk', { value: messageChunk });
+        return Object.defineProperties(new String(getMessage), {
+            'messageChunk': { value: messageChunk },
+            'finishReason': { value: limitedOutput.limited ? 'length' : null },
+        });
     }
 
     /**
@@ -8722,9 +8821,13 @@ export function getNextMessageId(type, preserveLastMessage = false) {
  * Determines if the message should be auto-continued.
  * @param {string} messageChunk Current message chunk
  * @param {boolean} isImpersonate Is the user impersonation
+ * @param {GenerateOptions} [options] Request-local auto-continue controls
  * @returns {boolean} Whether the message should be auto-continued
  */
-export function shouldAutoContinue(messageChunk, isImpersonate) {
+export function shouldAutoContinue(messageChunk, isImpersonate, { suppressAutoContinue = false } = {}) {
+    if (suppressAutoContinue) {
+        return false;
+    }
     if (!power_user.auto_continue.enabled) {
         console.debug('Auto-continue is disabled by user.');
         return false;
@@ -8790,8 +8893,9 @@ export function shouldAutoContinue(messageChunk, isImpersonate) {
  * Triggers auto-continue if the message meets the criteria.
  * @param {string} messageChunk Current message chunk
  * @param {boolean} isImpersonate Is the user impersonation
+ * @param {GenerateOptions} [options] Controls forwarded to automatic continuations
  */
-export function triggerAutoContinue(messageChunk, isImpersonate) {
+export function triggerAutoContinue(messageChunk, isImpersonate, options = {}) {
     if (selected_group) {
         console.debug('Auto-continue is disabled for group chat');
         return;
@@ -8803,8 +8907,8 @@ export function triggerAutoContinue(messageChunk, isImpersonate) {
         return;
     }
 
-    if (shouldAutoContinue(messageChunk, isImpersonate)) {
-        $('#option_continue').trigger('click');
+    if (shouldAutoContinue(messageChunk, isImpersonate, options)) {
+        $('#option_continue').trigger('click', { generationOptions: options });
     }
 }
 
@@ -9127,6 +9231,9 @@ function setInContextMessages(msgInContextCount, type, preserveLastMessage = fal
  * @typedef {object} AdditionalRequestOptions
  * @property {JsonSchema} [jsonSchema]
  * @property {'main'|'auxiliary'|'none'} [cacheScope]
+ * @property {number} [maxOutputTokens]
+ * @property {number} [responseLength]
+ * @property {boolean} [preserveReasoningBudget]
  */
 
 /**
@@ -9142,6 +9249,7 @@ export async function sendGenerationRequest(type, data, options = {}) {
         return await sendOpenAIRequest(type, data.prompt, abortController.signal, options);
     }
 
+    data = applyGenerationRequestControls(data, { model: main_api === 'koboldhorde' ? horde_settings.models : getGeneratingModel(), ...options });
     if (main_api === 'koboldhorde') {
         return await generateHorde(data.prompt, data, abortController.signal, true);
     }
@@ -9173,15 +9281,18 @@ export async function sendStreamingRequest(type, data, options = {}) {
         throw new Error('Generation was aborted.');
     }
 
+    if (main_api !== 'openai') {
+        data = applyGenerationRequestControls(data, { model: getGeneratingModel(), ...options });
+    }
     switch (main_api) {
         case 'openai':
-            return await sendOpenAIRequest(type, data.prompt, streamingProcessor.abortController.signal, options);
+            return await sendOpenAIRequest(type, data.prompt, streamingProcessor.requestAbortController.signal, options);
         case 'textgenerationwebui':
-            return await generateTextGenWithStreaming(data, streamingProcessor.abortController.signal);
+            return await generateTextGenWithStreaming(data, streamingProcessor.requestAbortController.signal);
         case 'novel':
-            return await generateNovelWithStreaming(data, streamingProcessor.abortController.signal);
+            return await generateNovelWithStreaming(data, streamingProcessor.requestAbortController.signal);
         case 'kobold':
-            return await generateKoboldWithStreaming(data, streamingProcessor.abortController.signal);
+            return await generateKoboldWithStreaming(data, streamingProcessor.requestAbortController.signal);
         default:
             throw new Error('Streaming is enabled, but the current API does not support streaming.');
     }
@@ -9413,8 +9524,13 @@ export function extractMessageFromData(data, activeApi = null) {
                     || normalizeContentText(data?.text)
                     || normalizeContentText(data?.message?.content)
                     || normalizeContentText(data?.message?.tool_plan)
-                    || normalizeContentText(data?.responseContent?.parts)
-                    || normalizeContentText(data?.candidates?.[0]?.content?.parts)
+                    // SillyBunny: an empty reply must not fall back to Gemini's thinking parts.
+                    || normalizeContentText(Array.isArray(data?.responseContent?.parts)
+                        ? data.responseContent.parts.filter(part => !part?.thought)
+                        : data?.responseContent?.parts)
+                    || normalizeContentText(Array.isArray(data?.candidates?.[0]?.content?.parts)
+                        ? data.candidates[0].content.parts.filter(part => !part?.thought)
+                        : data?.candidates?.[0]?.content?.parts)
                     || stringifyUnknown(data?.message?.content);
             default:
                 return '';
@@ -14738,8 +14854,8 @@ export async function deleteSwipe(swipeId = null, messageId = chat.length - 1) {
     return newSwipeId;
 }
 
-export async function saveMetadata() {
-    return await saveChatConditional();
+export async function saveMetadata(options = {}) {
+    return await saveChatConditional(options);
 }
 
 export async function saveChatConditional(options = {}) {
@@ -14748,17 +14864,28 @@ export async function saveChatConditional(options = {}) {
 
         setChatSaveActive(true);
 
-        if (selected_group) {
-            await saveGroupChat(selected_group, true, false, false, options);
-        } else {
-            await saveChat(options);
+        const saved = selected_group
+            ? await saveGroupChat(selected_group, true, false, options.throwOnError ?? false, options)
+            : await saveChat(options);
+
+        // SillyBunny: strict callers must also see saves declined without an exception.
+        if (saved !== true) {
+            if (options.throwOnError) {
+                throw new Error('Chat was not saved');
+            }
+            return false;
         }
 
         // Save token and prompts cache to IndexedDB storage
-        saveTokenCache();
-        saveItemizedPrompts(getCurrentChatId());
+        await saveTokenCache();
+        await saveItemizedPrompts(getCurrentChatId());
+        return true;
     } catch (error) {
         console.error('Error saving chat', error);
+        if (options.throwOnError) {
+            throw error;
+        }
+        return false;
     } finally {
         setChatSaveActive(false);
     }
@@ -15201,8 +15328,9 @@ function formatSwipeCounter(current, total) {
  * @param {number} [params.forceMesId] The message id to swipe.
  * @param {number} [params.forceSwipeId] The target swipe_id. When out of range, it will be looped or clamped.
  * @param {number} [params.forceDuration] Overwrites the default swipe duration.
+ * @param {GenerateOptions} [params.generationOptions] Controls for an owned successor generation.
  */
-export async function swipe(event, direction, { source, repeated, message = chat[chat.length - 1], forceMesId, forceSwipeId, forceDuration } = {}) {
+export async function swipe(event, direction, { source, repeated, message = chat[chat.length - 1], forceMesId, forceSwipeId, forceDuration, generationOptions } = {}) {
     if (chat.length === 0) {
         console.warn('Swipe was called on an empty chat.');
         return;
@@ -15580,7 +15708,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
 
         if (run_generate && !is_send_press) {
             is_send_press = true;
-            generation = Generate('swipe');
+            generation = Generate('swipe', generationOptions);
         }
 
         //Swipe in from the opposite side.
@@ -17021,6 +17149,7 @@ jQuery(async function () {
         // Check whether a custom prompt was provided via custom data (for example through a slash command)
         const additionalPrompt = customData?.additionalPrompt?.trim() || undefined;
         const buildOrFillAdditionalArgs = (args = {}) => ({
+            ...customData?.generationOptions,
             ...args,
             ...(additionalPrompt !== undefined && { quiet_prompt: additionalPrompt, quietToLoud: true }),
         });

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -2562,18 +2562,64 @@ export async function runGenerationInterceptors(chat, contextSize, type) {
  * @param {number|string} characterId Index in the character array
  * @param {string} key Field name
  * @param {any} value Field value
- * @returns {Promise<void>} When the field is written
+ * @param {object} [options] Write options
+ * @param {boolean} [options.throwOnError=false] Commit local data only after a successful save
+ * @returns {Promise<void|boolean>} True on strict success
  */
-export async function writeExtensionField(characterId, key, value) {
-    const context = getContext();
-    const character = context.characters[characterId];
+export async function writeExtensionField(characterId, key, value, { throwOnError = false } = {}) {
+    let context = getContext();
+    let character = context.characters[characterId];
     if (!character) {
+        if (throwOnError) {
+            throw new Error('Character not found');
+        }
         console.warn('Character not found', characterId);
         return;
+    }
+    const avatar = character.avatar;
+    if (throwOnError && (typeof avatar !== 'string' || !avatar || avatar === 'none')) {
+        throw new Error('Character has no saved identity');
     }
     const extensionPath = `data.extensions.${key}`;
     const isUnset = value === UNSET_VALUE;
 
+    const saveDataRequest = {
+        avatar,
+        data: {
+            extensions: {
+                [key]: value,
+            },
+        },
+    };
+    const requestBody = JSON.stringify(saveDataRequest);
+    async function persist() {
+        const mergeResponse = await fetch('/api/characters/merge-attributes', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: requestBody,
+        });
+
+        if (!mergeResponse.ok) {
+            console.error('Failed to save extension field', mergeResponse.statusText);
+            if (throwOnError) {
+                throw new Error('Failed to save extension field');
+            }
+        }
+    }
+
+    if (throwOnError) {
+        // SillyBunny: bind the request to the card, then merge into its latest local state.
+        value = JSON.parse(requestBody).data.extensions[key];
+        await persist();
+        context = getContext();
+        characterId = context.characters.findIndex(candidate => candidate?.avatar === avatar);
+        character = context.characters[characterId];
+        if (!character) {
+            throw new Error('Saved character is no longer available');
+        }
+    }
+
+    const jsonData = character.json_data ? JSON.parse(character.json_data) : null;
     if (isUnset) {
         deleteValueByPath(character, extensionPath);
     } else {
@@ -2581,8 +2627,7 @@ export async function writeExtensionField(characterId, key, value) {
     }
 
     // Process JSON data
-    if (character.json_data) {
-        const jsonData = JSON.parse(character.json_data);
+    if (jsonData) {
         if (isUnset) {
             deleteValueByPath(jsonData, extensionPath);
         } else {
@@ -2596,24 +2641,11 @@ export async function writeExtensionField(characterId, key, value) {
         }
     }
 
-    // Save data to the server
-    const saveDataRequest = {
-        avatar: character.avatar,
-        data: {
-            extensions: {
-                [key]: value,
-            },
-        },
-    };
-    const mergeResponse = await fetch('/api/characters/merge-attributes', {
-        method: 'POST',
-        headers: getRequestHeaders(),
-        body: JSON.stringify(saveDataRequest),
-    });
-
-    if (!mergeResponse.ok) {
-        console.error('Failed to save extension field', mergeResponse.statusText);
+    if (!throwOnError) {
+        await persist();
+        return;
     }
+    return true;
 }
 
 /**

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -30,6 +30,7 @@ import {
     getEnabledToolAgents,
     getGlobalSettings,
     getPromptTransformMode,
+    isAgentRuntimeAllowed,
     isCompanionAgent,
     isTrackerFixAgent,
     isPathfinderSubmoduleEnabled,
@@ -530,7 +531,7 @@ export function getPathfinderRuntimeAgent(agents = getEnabledToolAgents()) {
         return null;
     }
 
-    return agents.find(isPathfinderToolAgent) ?? null;
+    return agents.find(agent => isPathfinderToolAgent(agent) && isAgentRuntimeAllowed(agent)) ?? null;
 }
 
 function getAgentToolByName(agent, toolName) {
@@ -629,7 +630,7 @@ export async function syncPathfinderAgentLorebooksForCurrentChat(agent = getPath
         return false;
     }
 
-    if (!agent || !isPathfinderToolAgent(agent)) {
+    if (!agent || !isPathfinderToolAgent(agent) || !isAgentRuntimeAllowed(agent)) {
         return false;
     }
 
@@ -715,16 +716,19 @@ export function syncToolAgentRegistrations() {
                 description: toolDef.description,
                 parameters: toolDef.parameters,
                 action: async (args) => {
+                    if (!isAgentRuntimeAllowed(agent)) {
+                        return '';
+                    }
                     if (shouldConfirmToolCall(toolDef.name)) {
                         const approved = await confirmToolCall(toolDef.displayName ?? toolDef.name, args);
                         if (!approved) {
                             return 'The user declined this tool call. Continue the response without it and do not retry.';
                         }
                     }
-                    return action(args);
+                    return isAgentRuntimeAllowed(agent) ? action(args) : '';
                 },
                 formatMessage,
-                shouldRegister: async () => true,
+                shouldRegister: async () => isAgentRuntimeAllowed(agent),
                 stealth: toolDef.stealth ?? false,
             });
 
@@ -1929,7 +1933,7 @@ function getSnapshotAgents(snapshot) {
 
     return snapshot.activeAgentIds
         .map(id => getAgentById(id))
-        .filter(Boolean);
+        .filter(agent => agent && isAgentRuntimeAllowed(agent));
 }
 
 function getActiveAgentsForMessage(generationType, activationSnapshot = null) {
@@ -1958,7 +1962,7 @@ export function buildPromptDynamicMacros(messageText = '', message = null, agent
 
 function updateMessageRegexSnapshot(message, activeAgents, generationType) {
     message.extra ??= {};
-    const inlineAgents = activeAgents.filter(agent => !isCompanionAgent(agent));
+    const inlineAgents = activeAgents.filter(agent => !isCompanionAgent(agent) && isAgentRuntimeAllowed(agent));
     const regexScriptRefs = inlineAgents.flatMap(agent => {
         const scripts = getAgentRegexScripts(agent);
         cacheAgentRegexScripts(agent?.id, scripts);
@@ -2044,7 +2048,7 @@ function ensureMessageRegexSnapshot(messageIndex, generationType, activationSnap
 }
 
 function isRegexRefreshAgentCandidate(agent, generationType, { respectGenerationTypes = true } = {}) {
-    if (!agent || isCompanionAgent(agent) || getAgentRegexScripts(agent).length === 0) {
+    if (!agent || !isAgentRuntimeAllowed(agent) || isCompanionAgent(agent) || getAgentRegexScripts(agent).length === 0) {
         return false;
     }
 
@@ -2224,6 +2228,9 @@ function applyAgentRegexScriptsToText(agents, text, { characterOverride = '' } =
     };
 
     for (const agent of agents) {
+        if (!isAgentRuntimeAllowed(agent)) {
+            continue;
+        }
         const scripts = getAgentRegexScripts(agent);
         if (scripts.length === 0) {
             continue;
@@ -2950,6 +2957,9 @@ function consolidateAppendPromptTransformOutputs(baseText, agents, results) {
         }
 
         const agent = agentMap.get(result.agentId);
+        if (!isAgentRuntimeAllowed(agent)) {
+            continue;
+        }
         const shouldPrepend = shouldPrependPromptTransformOutput(agent, outputText);
         const dedupeKey = `${shouldPrepend ? 'prepend' : 'append'}:${outputText}`;
         if (seenSegments.has(dedupeKey)) {
@@ -3048,7 +3058,7 @@ async function requestMainChatCompletionPromptTransform(context, promptMessages,
     };
 }
 
-async function requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride = '', signal = null) {
+async function requestProfilePromptTransform(isRuntimeAllowed, CMRS, profileId, promptMessages, maxTokens, modelOverride = '', signal = null) {
     const requestOptions = {
         extractData: true,
         includePreset: true,
@@ -3104,6 +3114,9 @@ async function requestProfilePromptTransform(CMRS, profileId, promptMessages, ma
         fallbackOptions.modelOverride = modelOverride.trim();
     }
 
+    if (!isRuntimeAllowed()) {
+        throw new DOMException('', 'AbortError');
+    }
     const fallbackResponse = await CMRS.sendRequest(profileId, fallbackRequestPrompt, maxTokens, fallbackOptions);
 
     return {
@@ -3114,6 +3127,10 @@ async function requestProfilePromptTransform(CMRS, profileId, promptMessages, ma
 }
 
 export async function requestPromptTransform(agent, promptMessages, maxTokens, options = {}) {
+    const isRuntimeAllowed = () => isAgentRuntimeAllowed(agent) && (options.runtimeAgents ?? []).every(isAgentRuntimeAllowed);
+    if (!isRuntimeAllowed()) {
+        throw new DOMException('', 'AbortError');
+    }
     const profileId = resolveAgentConnectionProfile(agent);
     const modelOverride = typeof agent.modelOverride === 'string' ? agent.modelOverride.trim() : '';
     const context = getContext();
@@ -3123,6 +3140,9 @@ export async function requestPromptTransform(agent, promptMessages, maxTokens, o
         internalPromptTransformDepth++;
         notifyAgentGenerationStateChanged();
         try {
+            if (!isRuntimeAllowed()) {
+                throw new DOMException('', 'AbortError');
+            }
             return await requestFn();
         } finally {
             internalPromptTransformDepth = Math.max(0, internalPromptTransformDepth - 1);
@@ -3140,7 +3160,7 @@ export async function requestPromptTransform(agent, promptMessages, maxTokens, o
             }
 
             return await runAsInternalPromptTransform(async () =>
-                await requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride, requestAbortController.signal),
+                await requestProfilePromptTransform(isRuntimeAllowed, CMRS, profileId, promptMessages, maxTokens, modelOverride, requestAbortController.signal),
             );
         }
 
@@ -3210,12 +3230,14 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
     const runMetadata = getPromptTransformRunMetadata(agent, profileId);
     const showNotifications = shouldShowPromptTransformNotifications(agent);
 
-    if (!transformMessageText.trim()) {
+    const isRuntimeAllowed = () => isAgentRuntimeAllowed(agent) && (options.runtimeAgents ?? []).every(isAgentRuntimeAllowed);
+    const runtimeAllowed = isRuntimeAllowed();
+    if (!runtimeAllowed || !transformMessageText.trim()) {
         const result = {
             agentId: agent.id,
             agentName: agent.name,
             changed: false,
-            status: 'skipped-empty-message',
+            status: runtimeAllowed ? 'skipped-empty-message' : 'skipped-runtime-filter',
             mode: promptTransformMode,
             profileId,
             ...runMetadata,
@@ -3272,7 +3294,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             agent,
             helperRequest.promptMessages,
             maxTokens,
-            { allowAssistantPrefillTail: helperRequest.allowAssistantPrefillTail },
+            { allowAssistantPrefillTail: helperRequest.allowAssistantPrefillTail, runtimeAgents: options.runtimeAgents },
         );
         const promptOutputText = unwrapAssistantResponseWrapper(response.output).trim();
 
@@ -3304,12 +3326,12 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             ? appendPromptTransformOutput(transformMessageText, promptOutputText)
             : promptOutputText;
         const nextMessageText = protectedPartialPrefill + transformedMessageText;
-        if (agentGenerationCancelRevision !== cancelRevision) {
+        if (agentGenerationCancelRevision !== cancelRevision || !isRuntimeAllowed()) {
             return {
                 agentId: agent.id,
                 agentName: agent.name,
                 changed: false,
-                status: 'cancelled',
+                status: agentGenerationCancelRevision !== cancelRevision ? 'cancelled' : 'skipped-runtime-filter',
                 mode: promptTransformMode,
                 profileId: response.profileId,
                 ...getPromptTransformRunMetadata(agent, response.profileId),
@@ -3394,11 +3416,11 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
     }
 }
 
-async function runPromptTransformAppendBatch(agents, message, generationType, messageTextOverride = null, messageIndex = null, { applyToMessage = true, cancelRevision = null } = {}) {
+async function runPromptTransformAppendBatch(agents, message, generationType, messageTextOverride = null, messageIndex = null, { applyToMessage = true, cancelRevision = null, runtimeAgents = [] } = {}) {
     const currentMessageText = unwrapAssistantResponseWrapper(
         messageTextOverride !== null ? messageTextOverride : message?.mes,
     );
-    const isCancelled = () => cancelRevision !== null && agentGenerationCancelRevision !== cancelRevision;
+    const isCancelled = () => (cancelRevision !== null && agentGenerationCancelRevision !== cancelRevision) || !runtimeAgents.every(isAgentRuntimeAllowed);
     const globalSettings = getGlobalSettings();
     const executionMode = globalSettings.appendAgentsExecutionMode === 'sequential' ? 'sequential' : 'parallel';
 
@@ -3423,6 +3445,7 @@ async function runPromptTransformAppendBatch(agents, message, generationType, me
             try {
                 const result = await runPromptTransformAgent(agent, message, generationType, currentMessageText, messageIndex, {
                     applyToMessage: false,
+                    runtimeAgents,
                 });
                 results.push(result);
                 if (isCancelled() || result.status === 'cancelled') {
@@ -3450,6 +3473,7 @@ async function runPromptTransformAppendBatch(agents, message, generationType, me
                 try {
                     return await runPromptTransformAgent(agent, message, generationType, currentMessageText, messageIndex, {
                         applyToMessage: false,
+                        runtimeAgents,
                     });
                 } catch (error) {
                     return {
@@ -3592,6 +3616,7 @@ export function deactivatePathfinderRuntime() {
 
 function injectPreGenerationAgentPrompts(activeAgents, generationType) {
     const promptAgents = activeAgents.filter(agent =>
+        isAgentRuntimeAllowed(agent) &&
         !isCompanionAgent(agent) &&
         (agent.phase === 'pre' || agent.phase === 'both') &&
         agent.preProcess?.mode !== 'intercept',
@@ -3796,7 +3821,7 @@ async function onGenerationAfterCommands(generationType, options, dryRun) {
                 activePathfinderRetrievalAbortControllers.delete(retrievalAbortController);
             }
 
-            if (!generationStopRequested && agentGenerationCancelRevision === retrievalCancelRevision && !retrievalAbortController.signal.aborted) {
+            if (!generationStopRequested && agentGenerationCancelRevision === retrievalCancelRevision && !retrievalAbortController.signal.aborted && isAgentRuntimeAllowed(pathfinderAgent)) {
                 storePathfinderRetrievalCache(retrievalCacheTarget?.message, retrievalCacheSignature);
             }
         }
@@ -3805,7 +3830,9 @@ async function onGenerationAfterCommands(generationType, options, dryRun) {
             return;
         }
 
-        if (shouldAutoSummarize() && isPathfinderSummarizeToolEnabled(pathfinderAgent)) {
+        if (!isAgentRuntimeAllowed(pathfinderAgent)) {
+            clearPathfinderExtensionPrompts();
+        } else if (shouldAutoSummarize() && isPathfinderSummarizeToolEnabled(pathfinderAgent)) {
             setExtensionPrompt(
                 PATHFINDER_AUTO_SUMMARY_PROMPT_KEY,
                 'Pathfinder memory summary is due. If the recent conversation contains a meaningful scene, event, state change, or resolved arc, call Pathfinder_Summarize with a concise title, useful content, significance, and arc when applicable. If nothing important happened, do not call it.',
@@ -3823,7 +3850,7 @@ async function onGenerationAfterCommands(generationType, options, dryRun) {
     }
 
     injectPreGenerationAgentPrompts(activeAgents, generationType);
-    companionRuntime?.injectCompanionFeedbackPrompts?.(activeAgents, {
+    companionRuntime?.injectCompanionFeedbackPrompts?.(activeAgents.filter(isAgentRuntimeAllowed), {
         excludeMessage: options?.companionHistoryTarget ?? null,
     });
 
@@ -3882,9 +3909,9 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
 
         // Companions normally run last so they see the post-transform reply; the concurrent
         // option trades that for speed and runs them against the current reply alongside the passes.
-        const companionStageArgs = { messageIndex, message, generationType, activeAgents };
+        const companionStageArgs = { messageIndex, message, generationType };
         const concurrentCompanionStage = getGlobalSettings().companionConcurrentWithPostGen && companionRuntime?.runCompanionStage
-            ? companionRuntime.runCompanionStage(companionStageArgs).catch(error => {
+            ? companionRuntime.runCompanionStage({ ...companionStageArgs, activeAgents: activeAgents.filter(isAgentRuntimeAllowed) }).catch(error => {
                 console.warn('[InChatAgents] Companion stage failed:', error);
             })
             : null;
@@ -3987,6 +4014,9 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
         }
 
         for (const agent of utilityAgents) {
+            if (!isAgentRuntimeAllowed(agent)) {
+                continue;
+            }
             const postProcess = agent.postProcess;
 
             switch (postProcess.type) {
@@ -4042,7 +4072,7 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
             await concurrentCompanionStage;
         } else if (companionRuntime?.runCompanionStage) {
             try {
-                await companionRuntime.runCompanionStage(companionStageArgs);
+                await companionRuntime.runCompanionStage({ ...companionStageArgs, activeAgents: activeAgents.filter(isAgentRuntimeAllowed) });
             } catch (error) {
                 console.warn('[InChatAgents] Companion stage failed:', error);
             }
@@ -4176,7 +4206,7 @@ function onMessageEdited(messageIndex) {
     saveChatDebouncedForAgent();
 }
 
-async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType, { messageContext = {}, cancelRevision = null, stopOnFailure = false } = {}) {
+async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType, { messageContext = {}, cancelRevision = null, stopOnFailure = false, runtimeAgents = [] } = {}) {
     const message = {
         mes: initialText,
         name: getUserMessageName(),
@@ -4187,7 +4217,7 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
     };
     const promptRuns = [];
     const initialPromptTransformText = unwrapAssistantResponseWrapper(initialText);
-    const isCancelled = () => cancelRevision !== null && agentGenerationCancelRevision !== cancelRevision;
+    const isCancelled = () => (cancelRevision !== null && agentGenerationCancelRevision !== cancelRevision) || !runtimeAgents.every(isAgentRuntimeAllowed);
     const cancelledResult = () => ({
         promptRuns,
         text: initialPromptTransformText,
@@ -4221,7 +4251,7 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
             generationType,
             currentPromptTransformText,
             null,
-            { cancelRevision },
+            { cancelRevision, runtimeAgents },
         );
         promptRuns.push(...batchResult.results);
 
@@ -4258,6 +4288,7 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
         try {
             const result = await runPromptTransformAgent(agent, message, generationType, currentPromptTransformText, null, {
                 applyToMessage: false,
+                runtimeAgents,
             });
             promptRuns.push(result);
 
@@ -4322,7 +4353,7 @@ export async function runCompanionOutputPostPasses(companionAgent, initialText, 
         return { text: baseText, changed: false };
     }
 
-    const isCancelled = () => agentGenerationCancelRevision !== cancelRevision;
+    const isCancelled = () => agentGenerationCancelRevision !== cancelRevision || !isAgentRuntimeAllowed(companionAgent);
     if (isCancelled()) {
         return { text: baseText, changed: false, cancelled: true };
     }
@@ -4347,6 +4378,7 @@ export async function runCompanionOutputPostPasses(companionAgent, initialText, 
                 messageContext: characterName ? { name: characterName } : {},
                 cancelRevision,
                 stopOnFailure: true,
+                runtimeAgents: [companionAgent],
             },
         );
         if (promptResult.cancelled || isCancelled()) {
@@ -4405,10 +4437,11 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
         dynamicMacros: buildPromptDynamicMacros(currentContextText, null, agent, generationType),
     }).trim();
 
-    if (!expandedPrompt || !currentContextText.trim()) {
+    const runtimeAllowed = isAgentRuntimeAllowed(agent);
+    if (!runtimeAllowed || !expandedPrompt || !currentContextText.trim()) {
         return {
             ...baseResult,
-            status: 'skipped-empty-prompt',
+            status: runtimeAllowed ? 'skipped-empty-prompt' : 'skipped-runtime-filter',
         };
     }
 
@@ -4435,10 +4468,10 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
             { allowAssistantPrefillTail: helperRequest.allowAssistantPrefillTail },
         );
 
-        if (agentGenerationCancelRevision !== cancelRevision) {
+        if (agentGenerationCancelRevision !== cancelRevision || !isAgentRuntimeAllowed(agent)) {
             return {
                 ...baseResult,
-                status: 'cancelled',
+                status: agentGenerationCancelRevision !== cancelRevision ? 'cancelled' : 'skipped-runtime-filter',
                 profileId: response.profileId,
                 runner: response.runner,
             };
@@ -4996,7 +5029,7 @@ function onChatCompletionSettingsReady(data) {
     // "Require tool use on every response": force only the first pass of a
     // turn. Forcing recursive passes too would make every turn consume the
     // whole recursion budget before the model may write its reply.
-    if (toolRecursionDepth === 0) {
+    if (toolRecursionDepth === 0 && getPathfinderRuntimeAgent()) {
         const forcedToolChoice = getForcedToolChoice(data.chat_completion_source, data.model);
         if (forcedToolChoice) {
             data.tool_choice = forcedToolChoice;
@@ -5201,16 +5234,19 @@ export function initAgentRunner() {
  * @param {{ characterOverride?: string, messageContext?: object }} [options]
  * @returns {Promise<{ text: string, changed: boolean }>}
  */
-export async function runSingleAgentPostPassesOnText(agent, text, generationType, { characterOverride = '', messageContext = {} } = {}) {
+export async function runSingleAgentPostPassesOnText(agent, text, generationType, { characterOverride = '', messageContext = {}, runtimeAgents = [] } = {}) {
     let currentText = String(text ?? '');
     let changed = false;
 
     if (String(agent?.prompt ?? '').trim()) {
-        const promptResult = await runPromptTransformAgentsForText([agent], currentText, generationType, { messageContext });
+        const promptResult = await runPromptTransformAgentsForText([agent], currentText, generationType, { messageContext, runtimeAgents });
         currentText = promptResult.text;
         changed = changed || promptResult.changed;
     }
 
+    if (!isAgentRuntimeAllowed(agent) || !runtimeAgents.every(isAgentRuntimeAllowed)) {
+        return { text: String(text ?? ''), changed: false };
+    }
     if (getAgentRegexScripts(agent).length > 0) {
         const regexText = applyAgentRegexScriptsToText([agent], currentText, { characterOverride });
         if (regexText !== currentText) {
@@ -5270,6 +5306,9 @@ async function executeManualAgentRun(agentId, target, cancelRevision = agentGene
         toastr.error('Agent not found.');
         return null;
     }
+    if (!isAgentRuntimeAllowed(agent)) {
+        return null;
+    }
 
     if (runTarget.kind === 'composer') {
         return await executeManualComposerAgentRun(agent, cancelRevision);
@@ -5292,6 +5331,9 @@ async function executeManualAgentRun(agentId, target, cancelRevision = agentGene
     const messageIndex = runTarget.messageIndex;
     await commitOpenEditorForMessage(messageIndex);
 
+    if (!isAgentRuntimeAllowed(agent)) {
+        return null;
+    }
     const message = chat[messageIndex];
     if (!message || message.is_user || message.is_system) {
         return null;
@@ -5512,6 +5554,7 @@ export async function runTrackerFixOnMessage(messageIndex, { cancelRevision = ag
     // derives metadata from that validated text instead of discarding model output.
     for (const agent of trackerExtractAgents) {
         if (isFixCancelled()) break;
+        if (!isAgentRuntimeAllowed(agent)) continue;
 
         const inspection = inspectTrackerState(agent, message.mes);
         if (inspection.status === 'valid') {
@@ -5577,6 +5620,7 @@ export async function runTrackerFixOnMessage(messageIndex, { cancelRevision = ag
     }
 
     for (const agent of trackerExtractAgents) {
+        if (!isAgentRuntimeAllowed(agent)) continue;
         const metadataKey = getTrackerMetadataKey(agent);
         if (!metadataKey) continue;
 
@@ -5606,6 +5650,7 @@ export async function runTrackerFixOnMessage(messageIndex, { cancelRevision = ag
     }
 
     const utilityAgents = trackerAgents.filter(agent =>
+        isAgentRuntimeAllowed(agent) &&
         agent.postProcess?.enabled &&
         agent.postProcess.type !== 'regex' &&
         agent.postProcess.type !== 'extract',

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -140,6 +140,9 @@ import {
 /** @type {InChatAgent[]} */
 let agents = [];
 
+/** @type {Map<string, (agent: InChatAgent) => boolean>} */
+const runtimeAgentFilters = new Map();
+
 /** @type {AgentGroup[]} */
 let builtinGroups = [];
 
@@ -1414,6 +1417,44 @@ export function getAgents() {
     return [...agents];
 }
 
+export function setRuntimeAgentFilter(owner, predicateOrNull) {
+    if (typeof owner !== 'string' || !owner.trim()) {
+        throw new TypeError('Runtime agent filter owner must be a non-empty string.');
+    }
+    if (predicateOrNull !== null && typeof predicateOrNull !== 'function') {
+        throw new TypeError('Runtime agent filter must be a function or null.');
+    }
+
+    if (predicateOrNull === null) {
+        runtimeAgentFilters.delete(owner);
+    } else {
+        runtimeAgentFilters.set(owner, predicateOrNull);
+    }
+}
+
+export function isAgentRuntimeAllowed(agent) {
+    if (runtimeAgentFilters.size === 0) {
+        return true;
+    }
+
+    // Saves replace agent objects; queued runs must evaluate the current record.
+    const currentAgent = getAgentById(agent?.id);
+    if (!currentAgent) {
+        return false;
+    }
+    for (const predicate of runtimeAgentFilters.values()) {
+        try {
+            if (predicate(currentAgent) !== true) {
+                return false;
+            }
+        } catch {
+            // Fail closed without flooding the console from automatic retries.
+            return false;
+        }
+    }
+    return true;
+}
+
 /**
  * Returns enabled agents, sorted by injection order.
  * @returns {InChatAgent[]}
@@ -1426,7 +1467,7 @@ export function getEnabledAgents() {
     const activeScope = getActiveAgentChatScope();
 
     return agents
-        .filter(agent => isAgentEnabledForScope(agent, activeScope))
+        .filter(agent => isAgentEnabledForScope(agent, activeScope) && isAgentRuntimeAllowed(agent))
         .sort((a, b) => a.injection.order - b.injection.order);
 }
 
@@ -1457,7 +1498,7 @@ export function getEnabledToolAgents() {
     }
 
     const activeScope = getActiveAgentChatScope();
-    return agents.filter(agent => isAgentEnabledForScope(agent, activeScope) && agent.category === 'tool');
+    return agents.filter(agent => isAgentEnabledForScope(agent, activeScope) && agent.category === 'tool' && isAgentRuntimeAllowed(agent));
 }
 
 /**

--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -23,6 +23,7 @@ import {
     getGlobalSettings,
     MAX_AGENT_MAX_TOKENS,
     isAgentHidden,
+    isAgentRuntimeAllowed,
     isCompanionAgent,
     isTrackerFixAgent,
     resolveCompanionConnectionProfile,
@@ -598,6 +599,17 @@ export function deleteCompanionResult(message, agentId) {
     }
 
     return true;
+}
+
+function restoreCompanionResult(message, agentId, previousResult) {
+    if (previousResult) {
+        setAgentExtraValue(message, COMPANION_RESULTS_EXTRA_KEY, {
+            ...getCompanionResults(message),
+            [agentId]: previousResult,
+        });
+    } else {
+        deleteCompanionResult(message, agentId);
+    }
 }
 
 async function emitCompanionResultsUpdated(messageIndex, agentId = '') {
@@ -1494,7 +1506,7 @@ function getCompanionResultContent(message, agentId) {
  * is never lost to a post-pass problem.
  */
 async function applyCompanionOutputPostPassesToContent(agent, content, messageIndex, cancelRevision) {
-    if (!normalizeText(content)) {
+    if (!isAgentRuntimeAllowed(agent) || !normalizeText(content)) {
         return content;
     }
 
@@ -1523,28 +1535,28 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
     const isTargetCurrent = () => getCurrentChatId() === targetChatId && chat[messageIndex] === message;
 
     try {
-        if (getAgentGenerationCancelRevision() !== cancelRevision) {
+        if (getAgentGenerationCancelRevision() !== cancelRevision || !isAgentRuntimeAllowed(agent)) {
             throw new DOMException('Companion run cancelled.', 'AbortError');
         }
 
         const promptMessages = await buildCompanionPromptMessages(agent, messageIndex, generationType, { repair, extraContextSections });
-        if (!isTargetCurrent()) {
+        if (!isTargetCurrent() || !isAgentRuntimeAllowed(agent)) {
             throw new DOMException('Companion target changed.', 'AbortError');
         }
         const response = await requestPromptTransform(agent, promptMessages, companion.maxTokens);
 
-        if (!isTargetCurrent() || getAgentGenerationCancelRevision() !== cancelRevision) {
+        if (!isTargetCurrent() || getAgentGenerationCancelRevision() !== cancelRevision || !isAgentRuntimeAllowed(agent)) {
             throw new DOMException('Companion run cancelled.', 'AbortError');
         }
 
         const rawContent = capResultContent(response.output);
         // Token usage reflects the companion's own generation; post passes run after counting.
         const tokenUsage = await buildCompanionTokenUsage(promptMessages, rawContent);
-        if (!isTargetCurrent()) {
+        if (!isTargetCurrent() || !isAgentRuntimeAllowed(agent)) {
             throw new DOMException('Companion target changed.', 'AbortError');
         }
         let content = await applyCompanionOutputPostPassesToContent(agent, rawContent, messageIndex, cancelRevision);
-        if (!isTargetCurrent() || getAgentGenerationCancelRevision() !== cancelRevision) {
+        if (!isTargetCurrent() || getAgentGenerationCancelRevision() !== cancelRevision || !isAgentRuntimeAllowed(agent)) {
             throw new DOMException('Companion run cancelled.', 'AbortError');
         }
         // An empty-output sentinel yields no payload here, which is deliberate: repair is the manual
@@ -1567,18 +1579,13 @@ async function runSingleCompanionAgent(agent, messageIndex, generationType, canc
             modelLabel: getModelLabel(agent),
         });
     } catch (error) {
+        if (!isAgentRuntimeAllowed(agent)) {
+            return { agentId: agent.id, changed: false, result: null };
+        }
         const targetChanged = !isTargetCurrent();
         const cancelled = targetChanged || getAgentGenerationCancelRevision() !== cancelRevision || error?.name === 'AbortError';
         if (repair) {
-            if (previousResult) {
-                const results = getCompanionResults(message);
-                setAgentExtraValue(message, COMPANION_RESULTS_EXTRA_KEY, {
-                    ...results,
-                    [agent.id]: previousResult,
-                });
-            } else {
-                deleteCompanionResult(message, agent.id);
-            }
+            restoreCompanionResult(message, agent.id, previousResult);
         } else {
             setCompanionResult(message, agent, {
                 status: cancelled ? 'cancelled' : 'error',
@@ -1657,6 +1664,7 @@ async function buildBatchPromptPayload(agents, messageIndex, generationType, { e
 
 async function cancelCompanionAgentResults(message, agents, messageIndex, profileId = '') {
     for (const agent of agents) {
+        if (!isAgentRuntimeAllowed(agent)) continue;
         setCompanionResult(message, agent, {
             status: 'cancelled',
             content: '',
@@ -1671,6 +1679,8 @@ async function cancelCompanionAgentResults(message, agents, messageIndex, profil
 }
 
 async function runBatchCompanionAgents(agents, messageIndex, generationType, cancelRevision, { allowUserMessage = false, previousContents = null, extraContextSectionsByAgentId = null } = {}) {
+    agents = agents.filter(isAgentRuntimeAllowed);
+    if (!agents.length) return [];
     const message = chat[messageIndex];
     if (!isValidCompanionTargetMessage(message, { allowUserMessage })) {
         return agents.map(agent => ({ agentId: agent.id, changed: false, result: null }));
@@ -1692,7 +1702,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
         const extraContextSections = getUnitExtraContextSections(agents, extraContextSectionsByAgentId);
         const { promptMessages, taskPayloads } = await buildBatchPromptPayload(agents, messageIndex, generationType, { extraContextSections });
         const maxTokens = Math.min(MAX_AGENT_MAX_TOKENS, agents.reduce((sum, agent) => sum + getCompanionConfig(agent).maxTokens, 0));
-        const response = await requestPromptTransform(agents[0], promptMessages, maxTokens);
+        const response = await requestPromptTransform(agents[0], promptMessages, maxTokens, { runtimeAgents: agents });
 
         if (getAgentGenerationCancelRevision() !== cancelRevision) {
             await cancelCompanionAgentResults(message, agents, messageIndex, response.profileId);
@@ -1703,6 +1713,7 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
         const parsed = parseBatchResponse(response.output);
         const missingAgents = [];
         for (const agent of agents) {
+            if (!isAgentRuntimeAllowed(agent)) continue;
             if (!parsed.has(agent.id)) {
                 missingAgents.push(agent);
                 continue;
@@ -1710,11 +1721,13 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
 
             const rawContent = capResultContent(parsed.get(agent.id));
             const outputTokens = await countCompanionTokens({ role: 'assistant', content: rawContent });
+            if (!isAgentRuntimeAllowed(agent)) continue;
             const content = await applyCompanionOutputPostPassesToContent(agent, rawContent, messageIndex, cancelRevision);
             if (getAgentGenerationCancelRevision() !== cancelRevision) {
                 await cancelCompanionAgentResults(message, agents, messageIndex, response.profileId);
                 return getResults();
             }
+            if (!isAgentRuntimeAllowed(agent)) continue;
             setCompanionResult(message, agent, {
                 status: 'done',
                 content,
@@ -1748,7 +1761,9 @@ async function runBatchCompanionAgents(agents, messageIndex, generationType, can
             return getResults();
         }
 
-        console.warn('[InChatAgents] Companion batch failed, falling back to individual runs:', error);
+        if (error?.name !== 'AbortError') {
+            console.warn('[InChatAgents] Companion batch failed, falling back to individual runs:', error);
+        }
         for (const agent of agents) {
             if (getAgentGenerationCancelRevision() !== cancelRevision) {
                 await cancelCompanionAgentResults(message, agents, messageIndex);
@@ -1808,6 +1823,7 @@ export function meetsCompanionContextThreshold(agent, messageIndex = chat.length
 
 function getRunnableCompanionAgents(activeAgents = [], { manual = false, messageIndex = chat.length - 1, includeHidden = manual } = {}) {
     return activeAgents.filter(agent => {
+        if (!isAgentRuntimeAllowed(agent)) return false;
         const companion = getCompanionConfig(agent);
         if (!isCompanionAgent(agent) || !String(agent.prompt ?? '').trim()) {
             return false;
@@ -1838,6 +1854,7 @@ async function runCompanionUnits(units, messageIndex, generationType, cancelRevi
 }
 
 async function runCompanionAgentSet(agents, messageIndex, generationType, cancelRevision, { allowUserMessage = false, contextSourceAgents = agents } = {}) {
+    agents = agents.filter(isAgentRuntimeAllowed);
     if (!agents.length) {
         return [];
     }
@@ -1848,19 +1865,32 @@ async function runCompanionAgentSet(agents, messageIndex, generationType, cancel
     }
 
     const previousContents = new Map(agents.map(agent => [agent.id, getCompanionResultContent(message, agent.id)]));
-    const extraContextSectionsByAgentId = buildCompanionExtraContextSectionsByAgentId(agents, messageIndex, contextSourceAgents);
-    for (const agent of agents) {
-        setCompanionResult(message, agent, {
-            status: 'pending',
-            content: '',
-            error: '',
-            tokenUsage: null,
-        });
-        await emitCompanionResultsUpdated(messageIndex, agent.id);
-    }
+    const previousResults = new Map(agents.map(agent => [agent.id, getCompanionResults(message)[agent.id]]));
+    const pendingAgentIds = new Set();
+    const extraContextSectionsByAgentId = buildCompanionExtraContextSectionsByAgentId(agents, messageIndex, contextSourceAgents.filter(isAgentRuntimeAllowed));
+    try {
+        for (const agent of agents) {
+            if (!isAgentRuntimeAllowed(agent)) continue;
+            setCompanionResult(message, agent, {
+                status: 'pending',
+                content: '',
+                error: '',
+                tokenUsage: null,
+            });
+            pendingAgentIds.add(agent.id);
+            await emitCompanionResultsUpdated(messageIndex, agent.id);
+        }
 
-    const units = partitionCompanionRuns(agents, messageIndex, extraContextSectionsByAgentId);
-    return await runCompanionUnits(units, messageIndex, generationType, cancelRevision, { allowUserMessage, previousContents, extraContextSectionsByAgentId });
+        const units = partitionCompanionRuns(agents, messageIndex, extraContextSectionsByAgentId);
+        return await runCompanionUnits(units, messageIndex, generationType, cancelRevision, { allowUserMessage, previousContents, extraContextSectionsByAgentId });
+    } finally {
+        // Skipped runs leave only a pending placeholder; keep the previous note intact.
+        for (const agentId of pendingAgentIds) {
+            if (getCompanionResults(message)[agentId]?.status !== 'pending') continue;
+            restoreCompanionResult(message, agentId, previousResults.get(agentId));
+            await emitCompanionResultsUpdated(messageIndex, agentId);
+        }
+    }
 }
 
 async function runCompanionAgentsWithDependencyDelay(agents, messageIndex, generationType, cancelRevision, { allowUserMessage = false, contextSourceAgents = agents } = {}) {
@@ -1898,13 +1928,14 @@ async function runCompanionDependencyCascade(messageIndex, changedAgentIds, gene
 
     const allEnabled = getEnabledAgents();
     const runnable = Array.isArray(contextSourceAgents)
-        ? contextSourceAgents
+        ? contextSourceAgents.filter(isAgentRuntimeAllowed)
         : getRunnableCompanionAgents(allEnabled, { manual: true, messageIndex });
     const agentByReferenceId = buildCompanionReferenceMap(runnable);
     const dependents = [];
 
     for (const changedId of changedAgentIds) {
         const changedAgent = agentByReferenceId.get(changedId) ?? { id: changedId };
+        if (!isAgentRuntimeAllowed(changedAgent)) continue;
         for (const dependent of findCompanionDependents(changedAgent, runnable)) {
             if (!visited.has(dependent.id) && !isAgentHidden(dependent.id)) {
                 dependents.push(dependent);
@@ -1946,6 +1977,7 @@ export async function runCompanionStage({ messageIndex, message, generationType 
 }
 
 export function injectCompanionFeedbackPrompts(activeAgents = [], { excludeMessage = null } = {}) {
+    activeAgents = activeAgents.filter(isAgentRuntimeAllowed);
     const excludedIndex = excludeMessage ? chat.indexOf(excludeMessage) : -1;
     const beforeMessageIndex = excludedIndex >= 0 ? excludedIndex : chat.length;
     const inlineTrackerTags = getActiveInlineTrackerTags(activeAgents);
@@ -2041,7 +2073,7 @@ export async function runCompanionAgentOnMessage(agentId, messageIndex, { cancel
     const message = chat[messageIndex];
     const targetChatId = getCurrentChatId();
     const isTargetCurrent = () => getCurrentChatId() === targetChatId && chat[messageIndex] === message;
-    if (!agent || !isCompanionAgent(agent) || !isValidCompanionTargetMessage(message, { allowUserMessage })) {
+    if (!agent || !isAgentRuntimeAllowed(agent) || !isCompanionAgent(agent) || !isValidCompanionTargetMessage(message, { allowUserMessage })) {
         return null;
     }
 
@@ -2054,6 +2086,11 @@ export async function runCompanionAgentOnMessage(agentId, messageIndex, { cancel
             if (existingPayload !== previousContent || storedResult?.status !== 'done') {
                 updateCompanionResult(message, agent.id, { status: 'done', content: existingPayload, error: '' });
                 await emitCompanionResultsUpdated(messageIndex, agent.id);
+                if (!isAgentRuntimeAllowed(agent)) {
+                    restoreCompanionResult(message, agent.id, previousResult);
+                    if (isTargetCurrent()) await emitCompanionResultsUpdated(messageIndex, agent.id);
+                    return previousResult;
+                }
                 if (!isTargetCurrent()) return getCompanionResults(message)[agent.id];
                 saveChatDebounced({ deferBackup: false });
             }
@@ -2070,13 +2107,9 @@ export async function runCompanionAgentOnMessage(agentId, messageIndex, { cancel
         tokenUsage: null,
     });
     await emitCompanionResultsUpdated(messageIndex, agent.id);
-    if (!isTargetCurrent()) {
-        if (previousResult) {
-            const results = getCompanionResults(message);
-            setAgentExtraValue(message, COMPANION_RESULTS_EXTRA_KEY, { ...results, [agent.id]: previousResult });
-        } else {
-            deleteCompanionResult(message, agent.id);
-        }
+    if (!isTargetCurrent() || !isAgentRuntimeAllowed(agent)) {
+        restoreCompanionResult(message, agent.id, previousResult);
+        if (isTargetCurrent()) await emitCompanionResultsUpdated(messageIndex, agent.id);
         return previousResult;
     }
     const { changed, result } = await runSingleCompanionAgent(agent, messageIndex, 'normal', cancelRevision, {
@@ -2091,6 +2124,11 @@ export async function runCompanionAgentOnMessage(agentId, messageIndex, { cancel
         previousResult,
     });
 
+    if (result === null && getCompanionResults(message)[agent.id]?.status === 'pending') {
+        restoreCompanionResult(message, agent.id, previousResult);
+        if (isTargetCurrent()) await emitCompanionResultsUpdated(messageIndex, agent.id);
+        return previousResult;
+    }
     if (!isTargetCurrent()) return result;
 
     if (changed) {
@@ -2142,6 +2180,8 @@ export async function applyAgentPostPassesToCompanionResult(transformerAgentId, 
         toastr.warning('This agent cannot be applied to that companion note.');
         return null;
     }
+    const isRuntimeAllowed = () => isAgentRuntimeAllowed(transformer) && isAgentRuntimeAllowed(getAgentById(companionAgentId));
+    if (!isRuntimeAllowed()) return null;
 
     const result = getCompanionResults(message)[companionAgentId];
     if (result?.status !== 'done' || !normalizeText(result?.content)) {
@@ -2153,9 +2193,10 @@ export async function applyAgentPostPassesToCompanionResult(transformerAgentId, 
     const passResult = await runSingleAgentPostPassesOnText(transformer, result.content, COMPANION_OUTPUT_GENERATION_TYPE, {
         characterOverride: characterName,
         messageContext: characterName ? { name: characterName } : {},
+        runtimeAgents: [getAgentById(companionAgentId)],
     });
 
-    if (getAgentGenerationCancelRevision() !== cancelRevision) {
+    if (getAgentGenerationCancelRevision() !== cancelRevision || !isRuntimeAllowed()) {
         return null;
     }
 

--- a/public/scripts/generation-request-controls.js
+++ b/public/scripts/generation-request-controls.js
@@ -1,0 +1,147 @@
+import { isKimiK3Model } from './openai-model-capabilities.js';
+
+function positiveLimit(value) {
+    return Number.isFinite(value) && value > 0 ? Math.max(1, Math.floor(value)) : 0;
+}
+
+export function requestUsesReasoning(data) {
+    if (Array.isArray(data.model)) {
+        return data.model.some(model => typeof model === 'string' && requestUsesReasoning({ ...data, model }));
+    }
+    const model = String(data.model ?? '').toLowerCase();
+    const effort = String(data.reasoning?.effort ?? data.reasoning_effort ?? '').toLowerCase();
+    const thinking = data.thinking;
+    const thinkingConfig = data.thinkingConfig ?? data.generationConfig?.thinkingConfig;
+
+    if (thinking === false || thinking?.type === 'disabled' || data.reasoning === false || data.reasoning?.enabled === false || data.think === false
+        || thinkingConfig?.thinkingBudget === 0 || data.enable_thinking === false) {
+        return false;
+    }
+    if (thinking === true || data.think === true || data.reasoning === true || ['enabled', 'adaptive'].includes(thinking?.type)
+        || positiveLimit(thinking?.budget_tokens) || data.reasoning?.enabled === true
+        || positiveLimit(data.reasoning?.max_tokens) || data.enable_thinking === true
+        || thinkingConfig?.thinkingBudget > 0 || thinkingConfig?.thinkingBudget === -1 || thinkingConfig?.thinkingLevel) {
+        return true;
+    }
+    if (/non[-_ ]?(?:reasoning|thinking)|gpt-5(?:\.\d+)?-chat/.test(model)) {
+        return false;
+    }
+
+    // These models reason even when the host's default effort is 'none' (unsent).
+    if (isKimiK3Model(model) || /(?:^|[/:])o[134](?:[-/:]|$)|gpt-6-astra|gpt-oss|grok-(?:3-mini|4|code)|deepseek[-_](?:r1|reasoner|v4)|qwq|qvq|magistral|(?:^|[-_/:])(?:reasoner|reasoning|thinking)(?:[-_/:]|$)/.test(model)) {
+        return true;
+    }
+    if (/gemini-(?:2\.5|3)/.test(model)) {
+        return !(effort === 'min' && /gemini-2\.5-flash/.test(model));
+    }
+    if (data.chat_completion_source === 'moonshot' && /kimi-k2\.5/.test(model)) {
+        return Boolean(data.include_reasoning);
+    }
+    if (data.chat_completion_source === 'zai' && /glm-(?:4\.[5-9]|5)/.test(model)) {
+        return /glm-5\.3/.test(model) || Boolean(data.include_reasoning);
+    }
+    if (effort === 'none' || effort === 'disabled') {
+        return false;
+    }
+    if (/(?:^|[/:])gpt-5|(?:reasoner|reasoning|thinking)|qwen3(?!.*instruct)|glm-(?:4\.[5-9]|5)|kimi-k2\.5/.test(model)) {
+        return true;
+    }
+
+    // include_reasoning alone only controls visibility, not a model's thinking budget.
+    const ordinaryModel = /(?:^|[/:])gpt-[34]|deepseek-chat|claude-(?:3-[0-5]|instant|2)/.test(model);
+    return !ordinaryModel && ['min', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].includes(effort);
+}
+
+export function applyGenerationRequestControls(data, { maxOutputTokens, responseLength, preserveReasoningBudget = false, model = data.model, reasoning } = {}) {
+    const cap = positiveLimit(maxOutputTokens);
+    const response = positiveLimit(responseLength);
+    if (!cap && !response) {
+        return data;
+    }
+    reasoning ??= requestUsesReasoning({ ...data, model: data.model || model });
+    const override = !preserveReasoningBudget || !reasoning ? response : 0;
+    const limit = reasoning ? 0 : cap;
+    if (!override && !limit) {
+        return data;
+    }
+
+    const result = { ...data };
+    const fields = ['max_tokens', 'max_completion_tokens', 'max_new_tokens', 'max_length', 'n_predict', 'num_predict', 'max_output_tokens'];
+    const present = fields.filter(key => Object.hasOwn(data, key) && data[key] !== undefined);
+    if (!present.length) {
+        present.push('max_tokens');
+    }
+    for (const key of present) {
+        const budget = override || positiveLimit(Number(data[key]));
+        result[key] = limit ? Math.min(budget || limit, limit) : budget;
+    }
+    if (data.options && Object.hasOwn(data.options, 'num_predict')) {
+        const budget = override || positiveLimit(Number(data.options.num_predict));
+        result.options = { ...data.options, num_predict: limit ? Math.min(budget || limit, limit) : budget };
+    }
+    const max = Math.min(...present.map(key => result[key]));
+    for (const key of ['min_tokens', 'min_length', 'minimum_message_content_tokens']) {
+        if (Number(data[key]) > max) {
+            result[key] = max;
+        }
+    }
+    return result;
+}
+
+export function isGenerationLengthFinish(data) {
+    const choice = Array.isArray(data?.choices) ? data.choices.find(choice => choice && !choice.index) : null;
+    const reason = choice?.finish_reason
+        ?? data?.delta?.stop_reason ?? data?.stop_reason
+        ?? data?.candidates?.[0]?.finishReason ?? data?.done_reason;
+    return ['length', 'max_tokens', 'MAX_TOKENS'].includes(reason) || data?.stopped_limit === true;
+}
+
+export function limitGenerationProse(text, maxOutputTokens, template, reasoningPrefix = '', isStreaming = false) {
+    const cap = positiveLimit(maxOutputTokens);
+    if (!cap) {
+        return { text, reasoning: '', limited: false };
+    }
+
+    const templates = [template, ...['think', 'thinking', 'thought'].map(tag => ({ prefix: `<${tag}>`, suffix: `</${tag}>` }))]
+        .filter(item => item?.prefix && item?.suffix);
+    let content = reasoningPrefix + text;
+    const reasoning = [];
+    while (content) {
+        const next = templates.map(item => ({ ...item, index: content.indexOf(item.prefix) }))
+            .filter(item => item.index >= 0).sort((a, b) => a.index - b.index)[0];
+        if (!next) {
+            break;
+        }
+        const end = content.indexOf(next.suffix, next.index + next.prefix.length);
+        if (end < 0) {
+            // Match ReasoningHandler's incomplete-block handling without regexing every thinking token.
+            reasoning.push(content.slice(next.index + next.prefix.length));
+            content = content.slice(0, next.index);
+            break;
+        }
+        // Keep whitespace until continuation prefixes have been removed by the caller.
+        reasoning.push(content.slice(next.index + next.prefix.length, end));
+        content = content.slice(0, next.index) + content.slice(end + next.suffix.length);
+    }
+    // A partially received opening tag is not prose yet.
+    let partialTagLength = 0;
+    for (const { prefix } of templates) {
+        for (let length = isStreaming ? Math.min(prefix.length - 1, content.length) : 0; length > 0; length--) {
+            if (content.endsWith(prefix.slice(0, length))) {
+                partialTagLength = Math.max(partialTagLength, length);
+                break;
+            }
+        }
+    }
+    if (partialTagLength) {
+        content = content.slice(0, -partialTagLength);
+    }
+
+    // SillyBunny/ponytail: four characters per prose token; use a local tokenizer if exact accounting is needed.
+    const maxCharacters = cap * 4;
+    let accepted = content.slice(0, maxCharacters);
+    if (accepted.length < content.length && /[\uD800-\uDBFF]$/.test(accepted)) {
+        accepted = accepted.slice(0, -1);
+    }
+    return { text: accepted, reasoning: reasoning.filter(Boolean).join('\n\n'), limited: content.length >= maxCharacters };
+}

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1222,7 +1222,11 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
     }
 
     if (shouldSaveGroup) {
-        await editGroup(groupId, false, false);
+        // SillyBunny: strict saves cannot acknowledge deferred group metadata writes.
+        if (throwOnError && !groups.some(candidate => candidate.id === group.id)) {
+            throw new Error('Group not found');
+        }
+        await editGroup(throwOnError ? group.id : groupId, throwOnError, false);
     }
 
     return true;
@@ -1544,7 +1548,7 @@ async function generateGroupWrapper(byAutoMode, type = null, params = {}) {
         setSendButtonState(true);
         setCharacterName('');
         setCharacterId(undefined);
-        const userInput = String($('#send_textarea').val());
+        const userInput = params.suppressUserMessage ? '' : String($('#send_textarea').val());
 
         // id of this specific batch for regeneration purposes
         group_generation_id = Date.now();
@@ -1663,7 +1667,7 @@ async function generateGroupWrapper(byAutoMode, type = null, params = {}) {
             let messageChunk = textResult?.messageChunk;
 
             if (messageChunk) {
-                while (shouldAutoContinue(messageChunk, type === 'impersonate')) {
+                while (shouldAutoContinue(messageChunk, type === 'impersonate', mergedParams)) {
                     textResult = await runWithGroupMemberModelOverride(group, characters[chId]?.avatar, () => Generate('continue', { automatic_trigger: byAutoMode, ...mergedParams, companionHistoryTarget: undefined }));
                     messageChunk = textResult?.messageChunk;
                 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -49,6 +49,7 @@ import { rotateSecret, SECRET_KEYS, secret_state, writeSecret } from './secrets.
 
 import { getEventSourceStream } from './sse-stream.js';
 import { fetchResumable } from './resumable-generation.js';
+import { applyGenerationRequestControls, isGenerationLengthFinish } from './generation-request-controls.js';
 import {
     createThumbnail,
     delay,
@@ -1928,6 +1929,7 @@ export async function prepareOpenAIMessages({
     jailbreakPromptOverride,
     messages,
     messageExamples,
+    responseLength = null,
 }, dryRun) {
     // Without a character selected, there is no way to accurately calculate tokens
     if (!promptManager.activeCharacter && dryRun) return [null, false];
@@ -1935,7 +1937,9 @@ export async function prepareOpenAIMessages({
     const chatCompletion = new ChatCompletion();
     if (power_user.console_log_prompts) chatCompletion.enableLogging();
 
-    const userSettings = promptManager.serviceSettings;
+    const userSettings = Number.isFinite(responseLength) && responseLength > 0
+        ? { ...promptManager.serviceSettings, openai_max_tokens: responseLength }
+        : promptManager.serviceSettings;
     chatCompletion.setTokenBudget(userSettings.openai_max_context, userSettings.openai_max_tokens);
 
     try {
@@ -5676,16 +5680,26 @@ export async function createGenerationParameters(settings, model, type, messages
  * @returns {Promise<unknown>}
  * @throws {Error}
  */
-async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, cacheScope = null } = {}) {
+async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, cacheScope = null, maxOutputTokens = 0, responseLength = null, preserveReasoningBudget = false } = {}) {
     // Provide default abort signal
     if (!signal) {
         signal = new AbortController().signal;
     }
 
     const model = getChatCompletionModel(oai_settings);
-    const { generate_data, stream, canMultiSwipe } = await createGenerationParameters(oai_settings, model, type, messages, { jsonSchema, cacheScope });
+    let { generate_data, stream, canMultiSwipe } = await createGenerationParameters(oai_settings, model, type, messages, { jsonSchema, cacheScope });
 
     await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
+
+    const requestControls = { maxOutputTokens, responseLength, preserveReasoningBudget };
+    if (generate_data.chat_completion_source === chat_completion_sources.CUSTOM) {
+        if ((Number.isFinite(maxOutputTokens) && maxOutputTokens > 0) || (Number.isFinite(responseLength) && responseLength > 0)) {
+            // SillyBunny: custom YAML is applied server-side, so its final payload owns the limit.
+            generate_data.request_controls = requestControls;
+        }
+    } else {
+        generate_data = applyGenerationRequestControls(generate_data, requestControls);
+    }
 
     if (generate_data.chat_completion_source === chat_completion_sources.CUSTOM && selected_custom_endpoint_preset?.secretId) {
         // SillyBunny: Custom endpoint profiles bind chat requests to their saved secret, not the last active CUSTOM key.
@@ -5722,6 +5736,9 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, ca
                 if (rawData === '[DONE]') return;
                 tryParseStreamingError(response, rawData);
                 const parsed = JSON.parse(rawData);
+                if (isGenerationLengthFinish(parsed)) {
+                    state.finishReason = 'length';
+                }
 
                 if (parsed.usage?.completion_tokens_details?.reasoning_tokens) {
                     state.reasoning_tokens = parsed.usage.completion_tokens_details.reasoning_tokens;

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -150,6 +150,7 @@ export function getContext() {
         deleteLastMessage,
         deleteMessage,
         generate: Generate,
+        generationSupportsRequestControls: true,
         sendStreamingRequest,
         sendGenerationRequest,
         stopGeneration,

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -9,6 +9,7 @@ import urlJoin from 'url-join';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
 import { getLinkApiBaseUrl, getLinkApiRequestFormat } from '../../../public/scripts/linkapi-utils.js';
 import { applyGrokModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model, zaiSupportsReasoningEffort } from '../../../public/scripts/openai-model-capabilities.js';
+import { applyGenerationRequestControls, requestUsesReasoning } from '../../../public/scripts/generation-request-controls.js';
 
 import {
     AIMLAPI_HEADERS,
@@ -3301,7 +3302,7 @@ export async function handleChatCompletionsGenerate(request, response) {
             request.body.messages = convertXAIMessages(request.body.messages, getPromptNames(request));
         }
 
-        const requestBody = {
+        let requestBody = {
             'messages': isTextCompletion === false ? request.body.messages : undefined,
             'prompt': isTextCompletion === true ? textPrompt : undefined,
             'model': request.body.model,
@@ -3344,6 +3345,20 @@ export async function handleChatCompletionsGenerate(request, response) {
 
         if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
             excludeKeysByYaml(requestBody, request.body.custom_exclude_body);
+            delete requestBody.request_controls;
+            // SillyBunny: enforce owned controls after custom body overrides, never on helper requests.
+            let reasoning;
+            if (hasCustomReasoningParamConfig(request.body)) {
+                const value = requestBody[request.body.custom_reasoning_param_name.trim()];
+                const format = request.body.custom_reasoning_param_format.trim();
+                const enabled = String(request.body.custom_reasoning_enabled_value ?? 'enabled').trim() || 'enabled';
+                const disabled = String(request.body.custom_reasoning_disabled_value ?? 'disabled').trim() || 'disabled';
+                const switchValue = format === 'thinking_object' ? value?.type : value;
+                if (format === 'boolean' && typeof value === 'boolean') reasoning = value;
+                if (['string', 'thinking_object'].includes(format) && [enabled, disabled].includes(switchValue)) reasoning = switchValue === enabled;
+                if (format === 'openai' && typeof value === 'string') reasoning = requestUsesReasoning({ ...requestBody, reasoning_effort: value });
+            }
+            requestBody = applyGenerationRequestControls(requestBody, { ...request.body.request_controls, reasoning });
         }
 
         if (isKimiK3Request) {

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -1296,7 +1296,7 @@ describe('chat integrity rotation', () => {
 
         expect(saveConditionalBody).not.toContain('waitUntilCondition(() => !isChatSaving');
         expect(saveConditionalBody).toContain('await saveChat(options);');
-        expect(saveConditionalBody).toContain('await saveGroupChat(selected_group, true, false, false, options);');
+        expect(saveConditionalBody).toContain('await saveGroupChat(selected_group, true, false, options.throwOnError ?? false, options)');
         expect(scriptSource).toContain('let chatSaveActivityCount = 0;');
         expect(scriptSource).toContain('function setChatSaveActive(isActive)');
         expect(scriptSource).toContain('isChatSaving = chatSaveActivityCount > 0;');

--- a/tests/guided-generations-correction-wiring.test.js
+++ b/tests/guided-generations-correction-wiring.test.js
@@ -11,7 +11,7 @@ const correctionSource = readFileSync(path.join(repoRoot, 'public', 'scripts', '
 describe('Guided Correction generation wiring', () => {
     test('retains correction targets without changing ordinary regeneration', () => {
         expect(scriptSource).toContain('@property {boolean} [preserveLastMessage]');
-        expect(scriptSource).toContain('preserveLastMessage = false, companionHistoryTarget = null } = {}, dryRun = false)');
+        expect(scriptSource).toContain('preserveLastMessage = false, companionHistoryTarget = null, suppressAutoContinue = false');
         expect(scriptSource).toContain('!(type === \'regenerate\' && preserveLastMessage)');
         expect(scriptSource).toContain('setInContextMessages(arrMes.length - injectedIndices.length, type, preserveLastMessage)');
         expect(scriptSource).toContain('(type === \'regenerate\' && !preserveLastMessage)');
@@ -28,7 +28,7 @@ describe('Guided Correction generation wiring', () => {
     });
 
     test('carries the companion rewrite target through group generation only', () => {
-        expect(scriptSource).toContain('generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget })');
+        expect(scriptSource).toContain('generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget, suppressUserMessage, ...requestControls })');
         expect(groupChatsSource).toContain("Generate(generateType, { automatic_trigger: byAutoMode, ...mergedParams })");
         expect(groupChatsSource).toContain("Generate('continue', { automatic_trigger: byAutoMode, ...mergedParams, companionHistoryTarget: undefined })");
     });

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -400,6 +400,7 @@ describe('in-chat agent post-processing runner', () => {
             getHiddenAgentIds: jest.fn(() => new Set(globalSettings.hiddenCompanionAgentIds ?? [])),
             getPromptTransformMode: jest.fn(agent => agent?.postProcess?.promptTransformMode === 'append' ? 'append' : 'rewrite'),
             isAgentHidden: jest.fn(agentId => new Set(globalSettings.hiddenCompanionAgentIds ?? []).has(String(agentId ?? '').trim())),
+            isAgentRuntimeAllowed: jest.fn(() => true),
             isTrackerFixAgent: jest.fn(agent => {
                 if (agent?.category !== 'tracker') return false;
                 if (agent.phase === 'post' || agent.phase === 'both') return true;

--- a/tests/in-chat-agents-runtime-filter.test.js
+++ b/tests/in-chat-agents-runtime-filter.test.js
@@ -1,0 +1,917 @@
+/* eslint-disable playwright/no-standalone-expect -- Jest test.each is not recognised by this rule. */
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const OWNER = 'SillyBunny-Story-Mode';
+const originalFetch = globalThis.fetch;
+let store;
+let runner;
+let context;
+let chat;
+let chatMetadata;
+let extensionSettings;
+let extensionPrompts;
+let eventSource;
+let saveSettingsDebounced;
+let runSidecarRetrieval;
+let getWorldInfoPrompt;
+let callGenericPopup;
+let confirmToolCall;
+let toolAction;
+let tools;
+
+function deferred() {
+    let resolve;
+    const promise = new Promise(done => { resolve = done; });
+    return { promise, resolve };
+}
+
+function loadAgents(...entries) {
+    store.loadAgents(entries.map((entry, order) => ({
+        name: entry.id,
+        prompt: entry.id,
+        enabled: true,
+        phase: 'post',
+        injection: { order },
+        postProcess: { promptTransformEnabled: true },
+        ...entry,
+    })));
+    return store.getAgents();
+}
+
+function addMessage() {
+    const message = { mes: 'original', name: 'Assistant', is_user: false, is_system: false, extra: {} };
+    chat.push(message);
+    return message;
+}
+
+beforeEach(async () => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    chat = [];
+    chatMetadata = {};
+    extensionSettings = {};
+    extensionPrompts = {};
+    saveSettingsDebounced = jest.fn();
+    runSidecarRetrieval = jest.fn();
+    getWorldInfoPrompt = jest.fn(async () => ({ worldInfoString: '' }));
+    callGenericPopup = jest.fn(async () => 2);
+    confirmToolCall = jest.fn(async () => true);
+    toolAction = jest.fn(async () => 'tool result');
+    tools = new Map();
+    const handlers = new Map();
+    eventSource = {
+        on(event, handler) {
+            const list = handlers.get(event) ?? [];
+            list.push(handler);
+            handlers.set(event, list);
+        },
+        async emit(event, ...args) {
+            for (const handler of handlers.get(event) ?? []) {
+                await handler(...args);
+            }
+        },
+    };
+    const eventTypes = Object.fromEntries([
+        'GENERATION_STARTED', 'GENERATION_AFTER_COMMANDS', 'GENERATION_ENDED', 'GENERATION_STOPPED',
+        'MESSAGE_RECEIVED', 'MESSAGE_EDITED', 'CHARACTER_MESSAGE_RENDERED', 'IMPERSONATE_READY',
+        'GENERATE_AFTER_COMBINE_PROMPTS', 'CHAT_COMPLETION_PROMPT_READY', 'MAIN_GENERATION_OUTPUT_READY',
+        'GENERATION_OUTPUT_BUFFERING_DECISION', 'CHAT_COMPLETION_SETTINGS_READY', 'CHAT_CHANGED',
+    ].map(name => [name, name]));
+    context = {
+        groupId: null,
+        chatId: 'chat-a',
+        chatMetadata,
+        mainApi: 'openai',
+        generateRaw: jest.fn(async () => 'last-output'),
+        saveChat: jest.fn(),
+    };
+    globalThis.fetch = jest.fn(async () => ({ ok: true }));
+    globalThis.document = {
+        body: { dataset: {} },
+        querySelector: jest.fn(() => null),
+        getElementById: jest.fn(() => null),
+        addEventListener: jest.fn(),
+    };
+    globalThis.HTMLSelectElement = class {};
+    globalThis.requestAnimationFrame = callback => setTimeout(callback, 0);
+    globalThis.toastr = Object.fromEntries(['clear', 'error', 'info', 'success', 'warning'].map(name => [name, jest.fn()]));
+    const jquery = { length: 0, each: jest.fn(), trigger: jest.fn() };
+    jquery.filter = jquery.first = () => jquery;
+    globalThis.$ = () => jquery;
+
+    jest.unstable_mockModule('../public/script.js', () => ({
+        chat,
+        chat_metadata: chatMetadata,
+        extension_prompts: extensionPrompts,
+        extension_prompt_roles: { SYSTEM: 0, USER: 1, ASSISTANT: 2 },
+        extension_prompt_types: { IN_PROMPT: 0, IN_CHAT: 1 },
+        ensureSwipes: jest.fn(),
+        setExtensionPrompt: (key, value) => { extensionPrompts[key] = { value }; },
+        substituteParams: value => String(value ?? ''),
+        substituteParamsExtended: value => String(value ?? ''),
+        generateQuietPrompt: (...args) => context.generateRaw(...args),
+        getCurrentChatId: () => context.chatId,
+        getRequestHeaders: () => ({}),
+        itemizedPrompts: [],
+        normalizeContentText: value => String(value ?? ''),
+        saveChatDebounced: jest.fn(),
+        saveSettingsDebounced,
+        stopGeneration: jest.fn(),
+        streamingProcessor: null,
+        syncMesToSwipe: jest.fn(),
+        updateMessageTokenAccounting: jest.fn(),
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+        extension_settings: extensionSettings,
+        getContext: () => context,
+    }));
+    jest.unstable_mockModule('../public/scripts/events.js', () => ({ eventSource, event_types: eventTypes }));
+    jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+        uuidv4: () => 'test-uuid',
+        regexFromString: value => {
+            const match = value.match(/^\/(.*)\/([a-z]*)$/);
+            return match ? new RegExp(match[1], match[2]) : new RegExp(value);
+        },
+    }));
+    jest.unstable_mockModule('../public/scripts/popup.js', () => ({
+        POPUP_RESULT: { CUSTOM2: 2 },
+        POPUP_TYPE: { TEXT: 1 },
+        callGenericPopup,
+    }));
+    jest.unstable_mockModule('../public/scripts/tool-calling.js', () => ({
+        ToolManager: {
+            RECURSE_LIMIT: 5,
+            registerFunctionTool: tool => tools.set(tool.name, tool),
+            unregisterFunctionTool: name => tools.delete(name),
+        },
+    }));
+    jest.unstable_mockModule('../public/scripts/world-info.js', () => ({ getWorldInfoPrompt }));
+    jest.unstable_mockModule('../public/scripts/reasoning.js', () => ({ removeReasoningFromString: value => value }));
+    jest.unstable_mockModule('../public/scripts/power-user.js', () => ({ power_user: {} }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({
+        getConnectionProfileDisplayName: id => id,
+        getConnectionProfileModelName: () => '',
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/tool-action-registry.js', () => ({
+        getToolAction: () => toolAction,
+        getToolFormatter: () => null,
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
+        getSettings: () => ({ pipelinePrompts: {}, pipelines: {} }),
+        replaceSettings: jest.fn(),
+        setSettings: jest.fn(),
+        deleteTree: jest.fn(),
+        syncTrackerUidsForLorebook: jest.fn(),
+        isPathfinderSelfWrite: () => false,
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/prompt-store.js', () => ({
+        initializePromptStore: jest.fn(),
+        setPromptStorePersistHook: jest.fn(),
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/default-prompts.js', () => ({
+        getDefaultPrompts: () => ({}),
+        getDefaultPipelines: () => ({}),
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js', () => ({
+        getPathfinderToolDefinitions: jest.fn(() => []),
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
+        getContextualLorebooks: () => [],
+        getForcedToolChoice: jest.fn(() => null),
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tool-confirmation.js', () => ({
+        shouldConfirmToolCall: () => true,
+        confirmToolCall,
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js', () => ({
+        PATHFINDER_RETRIEVAL_PROMPT_KEYS: ['pathfinder_sidecar_retrieval'],
+        runSidecarRetrieval,
+    }));
+    jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/auto-summary.js', () => ({
+        resetAutoSummaryCount: jest.fn(),
+        shouldAutoSummarize: () => false,
+    }));
+    store = await import('../public/scripts/extensions/in-chat-agents/agent-store.js');
+    runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+    runner.initAgentRunner();
+    store.setGlobalSettings({ promptTransformShowNotifications: false, postMainInterceptShowMessageFirst: false });
+});
+
+afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+    delete globalThis.document;
+    delete globalThis.HTMLSelectElement;
+    delete globalThis.requestAnimationFrame;
+    delete globalThis.toastr;
+    delete globalThis.$;
+});
+
+describe('runtime agent filters', () => {
+    test('keeps stored enablement and exports intact across favourite saves and stale-object toggles', async () => {
+        const [, cached] = loadAgents({ id: 'keep' }, { id: 'blocked', category: 'tool' }, { id: 'off', enabled: false });
+        const settingsBefore = structuredClone(store.getGlobalSettings());
+        const agentsBefore = structuredClone(store.exportAllAgents());
+        const predicate = jest.fn(agent => agent.id === 'keep');
+        store.setRuntimeAgentFilter(OWNER, predicate);
+
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['keep']);
+        expect(store.getEnabledToolAgents()).toEqual([]);
+        expect(store.getToolAgents()).toEqual([cached]);
+        expect(store.isAgentEnabledForCurrentScope(cached)).toBe(true);
+        expect(store.exportAllAgents()).toEqual(agentsBefore);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+
+        cached.favorite = true;
+        await store.saveAgent(cached);
+        const current = store.getAgentById('blocked');
+        expect(current).not.toBe(cached);
+        expect(JSON.parse(globalThis.fetch.mock.calls[0][1].body)).toEqual({ ...agentsBefore.agents[1], favorite: true });
+        store.setAgentEnabledForScope(cached, true);
+        expect(store.isAgentRuntimeAllowed(cached)).toBe(false);
+        expect(predicate.mock.calls.at(-1)[0]).toBe(current);
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['keep']);
+
+        store.setRuntimeAgentFilter(OWNER, null);
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['keep', 'blocked']);
+        expect(store.getEnabledToolAgents()).toEqual([current]);
+        expect(store.getAgentById('off').enabled).toBe(false);
+        expect(store.getGlobalSettings()).toEqual(settingsBefore);
+        expect(extensionSettings).toEqual({});
+        expect(saveSettingsDebounced).not.toHaveBeenCalled();
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('uses the current chat and settings without writing scoped IDs or legacy flags', () => {
+        loadAgents({ id: 'individual' }, { id: 'group' }, { id: 'both' }, { id: 'off', enabled: false });
+        store.setGlobalSettings({
+            separateRecentChats: true,
+            scopedEnabledAgentIdsInitialized: true,
+            enabledAgentIdsByChatType: { individual: ['individual', 'both'], group: ['group', 'both'] },
+        });
+        const settingsBefore = structuredClone(store.getGlobalSettings());
+        const agentsBefore = structuredClone(store.getAgents());
+        let settings = { agentGate: true, allowedAgents: ['both'] };
+        context.chatMetadata = { story_mode: { enabled: true } };
+        store.setRuntimeAgentFilter(OWNER, agent => !context.chatMetadata.story_mode.enabled
+            || !settings.agentGate || settings.allowedAgents.includes(agent.id));
+
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['both']);
+        expect(store.isAgentEnabledForCurrentScope(store.getAgentById('individual'))).toBe(true);
+        context.groupId = 'group-chat';
+        context.chatMetadata = { story_mode: { enabled: false } };
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['group', 'both']);
+        context.chatMetadata.story_mode.enabled = true;
+        settings = { agentGate: true, allowedAgents: ['group'] };
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['group']);
+        settings.agentGate = false;
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['group', 'both']);
+        settings.agentGate = true;
+        store.setRuntimeAgentFilter(OWNER, null);
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['group', 'both']);
+        context.groupId = null;
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['individual', 'both']);
+        expect(store.getGlobalSettings()).toEqual(settingsBefore);
+        expect(store.getAgents()).toEqual(agentsBefore);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(saveSettingsDebounced).not.toHaveBeenCalled();
+    });
+
+    test('validates registrations, combines owners, replaces filters, and fails closed quietly', () => {
+        loadAgents({ id: 'a' }, { id: 'b' });
+        store.setRuntimeAgentFilter(OWNER, agent => agent.id === 'a');
+        for (const owner of ['', ' ', null, 1, {}]) {
+            expect(() => store.setRuntimeAgentFilter(owner, null)).toThrow(TypeError);
+        }
+        for (const predicate of [undefined, false, 1, {}]) {
+            expect(() => store.setRuntimeAgentFilter(OWNER, predicate)).toThrow(TypeError);
+        }
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['a']);
+        store.setRuntimeAgentFilter('other', agent => agent.id === 'b');
+        expect(store.getEnabledAgents()).toEqual([]);
+        store.setRuntimeAgentFilter(OWNER, () => true);
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['b']);
+        store.setRuntimeAgentFilter('other', null);
+        store.setRuntimeAgentFilter('other', null);
+        expect(store.getEnabledAgents()).toHaveLength(2);
+
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        store.setRuntimeAgentFilter(OWNER, () => { throw new Error('predicate failed'); });
+        expect(store.getEnabledAgents()).toEqual([]);
+        expect(store.getEnabledAgents()).toEqual([]);
+        store.setRuntimeAgentFilter(OWNER, () => 'truthy is not a boolean');
+        expect(store.getEnabledAgents()).toEqual([]);
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        expect(saveSettingsDebounced).not.toHaveBeenCalled();
+        store.setRuntimeAgentFilter(OWNER, null);
+        store.setGlobalSettings({ enabled: false });
+        expect(store.getEnabledAgents()).toEqual([]);
+        expect(store.isAgentRuntimeAllowed(store.getAgentById('a'))).toBe(true);
+    });
+
+    test('keeps filters out of explicit settings saves and rejects stale records removed from the store', () => {
+        const [cached] = loadAgents({ id: 'agent' });
+        const settingsBefore = structuredClone(store.getGlobalSettings());
+        store.setRuntimeAgentFilter(OWNER, () => true);
+        store.persistAgentGlobalSettings();
+        expect(extensionSettings.inChatAgents.globalSettings).toEqual(settingsBefore);
+        expect(saveSettingsDebounced).toHaveBeenCalledTimes(1);
+        store.loadAgents([]);
+        expect(store.isAgentRuntimeAllowed(cached)).toBe(false);
+        store.setRuntimeAgentFilter(OWNER, null);
+        expect(store.isAgentRuntimeAllowed(cached)).toBe(true);
+    });
+});
+
+describe('runtime checks at agent dispatch', () => {
+    test.each(['rewrite', 'append'])('skips a cached %s agent after an earlier request without stopping permitted siblings', async mode => {
+        const agents = loadAgents(...['first', 'blocked', 'last'].map(id => ({
+            id, postProcess: { promptTransformEnabled: true, promptTransformMode: mode },
+        })));
+        store.setGlobalSettings({ appendAgentsExecutionMode: 'sequential' });
+        const allowed = new Set(agents.map(agent => agent.id));
+        store.setRuntimeAgentFilter(OWNER, agent => allowed.has(agent.id));
+        const message = addMessage();
+        const started = deferred();
+        const response = deferred();
+        context.generateRaw.mockImplementationOnce(() => { started.resolve(); return response.promise; });
+        const running = eventSource.emit('MESSAGE_RECEIVED', 0, 'normal');
+        await started.promise;
+        allowed.delete('blocked');
+        await store.saveAgent({ ...agents[1], favorite: true });
+        response.resolve('first-output');
+        await running;
+
+        expect(context.generateRaw.mock.calls.map(([request]) => request.prompt[0].content.split('\n')[0])).toEqual(['first', 'last']);
+        expect(message.mes).toContain('last-output');
+        expect(store.getAgentById('blocked').enabled).toBe(true);
+    });
+
+    test('rechecks cached utilities, regex scripts and the companion stage after prompt transforms', async () => {
+        loadAgents(
+            { id: 'first' },
+            { id: 'append', prompt: '', postProcess: { enabled: true, type: 'append', appendText: 'FORBIDDEN' } },
+            { id: 'extract', prompt: '', postProcess: { enabled: true, type: 'extract', extractPattern: '.+', extractVariable: 'forbidden' } },
+            { id: 'regex', prompt: '', regexScripts: [{ id: 'regex-script', findRegex: '/output/g', replaceString: 'FORBIDDEN' }] },
+            { id: 'companion', execution: 'companion' },
+        );
+        const message = addMessage();
+        const runCompanionStage = jest.fn(async () => []);
+        runner.registerCompanionRuntime({ runCompanionStage });
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id === 'first');
+            return 'first-output';
+        });
+        await eventSource.emit('MESSAGE_RECEIVED', 0, 'normal');
+
+        expect(message.mes).toBe('first-output');
+        expect(chatMetadata.agent_forbidden).toBeUndefined();
+        expect(message.extra.inChatAgents).toBeUndefined();
+        expect(runCompanionStage.mock.calls[0][0].activeAgents.map(agent => agent.id)).toEqual(['first']);
+    });
+
+    test.each(['GENERATE_AFTER_COMBINE_PROMPTS', 'CHAT_COMPLETION_PROMPT_READY', 'MAIN_GENERATION_OUTPUT_READY'])(
+        'rechecks cached interceptors in %s after each request', async event => {
+            loadAgents(...['first', 'blocked', 'last'].map(id => ({
+                id,
+                phase: 'pre',
+                preProcess: {
+                    mode: 'intercept',
+                    interceptTiming: event === 'MAIN_GENERATION_OUTPUT_READY' ? 'post-main-generation' : 'pre-generation',
+                    applyMode: 'wrap',
+                },
+            })));
+            await eventSource.emit('GENERATION_STARTED', 'normal', {}, false);
+            const started = deferred();
+            const response = deferred();
+            context.generateRaw.mockImplementationOnce(() => { started.resolve(); return response.promise; });
+            const data = { prompt: 'original', text: 'original', chat: [{ role: 'user', content: 'original' }] };
+            const running = eventSource.emit(event, data);
+            await started.promise;
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'blocked');
+            response.resolve('first-output');
+            await running;
+            expect(context.generateRaw.mock.calls.map(([request]) => request.prompt[0].content.split('\n')[0])).toEqual(['first', 'last']);
+        },
+    );
+
+    test('rechecks post-main interceptors after the review popup', async () => {
+        loadAgents({ id: 'blocked', phase: 'pre', preProcess: { mode: 'intercept', interceptTiming: 'post-main-generation' } });
+        store.setGlobalSettings({ postMainInterceptShowMessageFirst: true });
+        await eventSource.emit('GENERATION_STARTED', 'normal', {}, false);
+        const review = deferred();
+        callGenericPopup.mockReturnValueOnce(review.promise);
+        const data = { text: 'original' };
+        const running = eventSource.emit('MAIN_GENERATION_OUTPUT_READY', data);
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        review.resolve(2);
+        await running;
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(data.text).toBe('original');
+    });
+
+    test('rechecks prompt and feedback injection after Pathfinder retrieval', async () => {
+        loadAgents(
+            { id: 'pathfinder', category: 'tool', sourceTemplateId: 'tpl-pathfinder' },
+            { id: 'blocked', phase: 'pre' },
+            { id: 'keep', phase: 'pre' },
+        );
+        const injectCompanionFeedbackPrompts = jest.fn();
+        runner.registerCompanionRuntime({ injectCompanionFeedbackPrompts });
+        await eventSource.emit('GENERATION_STARTED', 'normal', {}, false);
+        const retrieval = deferred();
+        runSidecarRetrieval.mockReturnValueOnce(retrieval.promise);
+        const running = eventSource.emit('GENERATION_AFTER_COMMANDS', 'normal', {}, false);
+        store.setRuntimeAgentFilter(OWNER, agent => agent.id === 'keep');
+        retrieval.resolve();
+        await running;
+        expect(extensionPrompts.inchat_agent_blocked).toBeUndefined();
+        expect(extensionPrompts.inchat_agent_keep.value).toBe('keep');
+        expect(injectCompanionFeedbackPrompts.mock.calls[0][0].map(agent => agent.id)).toEqual(['keep']);
+    });
+
+    test('rechecks generation snapshots when a deferred post-generation timer runs', async () => {
+        loadAgents({ id: 'blocked' });
+        await eventSource.emit('GENERATION_STARTED', 'normal', {}, false);
+        addMessage();
+        await eventSource.emit('MESSAGE_RECEIVED', 0, 'normal');
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        await eventSource.emit('GENERATION_ENDED');
+        await jest.advanceTimersByTimeAsync(250);
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(chat[0].mes).toBe('original');
+        expect(store.getAgentById('blocked').enabled).toBe(true);
+    });
+
+    test('keeps manual runs of stored-disabled agents available but applies runtime exclusion after the editor wait', async () => {
+        loadAgents({ id: 'manual', enabled: false });
+        addMessage();
+        await runner.runAgentOnMessage('manual', 0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        const running = runner.runAgentOnMessage('manual', 0);
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        await expect(running).resolves.toBeNull();
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        store.setRuntimeAgentFilter(OWNER, null);
+        await runner.runAgentOnMessage('manual', 0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(2);
+        expect(store.getAgentById('manual').enabled).toBe(false);
+    });
+
+    test('rechecks sequential manual runs after waiting for another agent', async () => {
+        loadAgents({ id: 'first', enabled: false }, { id: 'blocked', enabled: false });
+        store.setGlobalSettings({ appendAgentsExecutionMode: 'sequential' });
+        addMessage();
+        const started = deferred();
+        const response = deferred();
+        context.generateRaw.mockImplementationOnce(() => { started.resolve(); return response.promise; });
+        const first = runner.runAgentOnMessage('first', 0);
+        await started.promise;
+        const queued = runner.runAgentOnMessage('blocked', 0);
+        store.setRuntimeAgentFilter(OWNER, agent => agent.id === 'first');
+        response.resolve('first-output');
+        await first;
+        await expect(queued).resolves.toBeNull();
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        expect(store.getAgents().map(agent => agent.enabled)).toEqual([false, false]);
+    });
+
+    test('rechecks tracker repair, metadata extraction and utility appends after the prompt pass', async () => {
+        loadAgents(
+            { id: 'first', category: 'tracker' },
+            { id: 'extract', category: 'tracker', postProcess: { enabled: true, type: 'extract', extractPattern: '.+', extractVariable: 'forbidden' } },
+            { id: 'append', category: 'tracker', prompt: '', postProcess: { enabled: true, type: 'append', appendText: 'FORBIDDEN' } },
+        );
+        const message = addMessage();
+        chatMetadata.agent_forbidden = 'previous';
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id === 'first');
+            return 'first-output';
+        });
+        await runner.runTrackerFixOnMessage(0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        expect(message.mes).toBe('first-output');
+        expect(chatMetadata.agent_forbidden).toBe('previous');
+    });
+
+    test.each(['normal', 'impersonate', 'companion_output'])('discards excluded prompt and regex results after an awaited %s pass', async generationType => {
+        const [agent] = loadAgents({ id: 'blocked', regexScripts: [{ findRegex: '/output/g', replaceString: 'FORBIDDEN' }] });
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, () => false);
+            return 'first-output';
+        });
+        const result = await runner.runSingleAgentPostPassesOnText(agent, 'original', generationType);
+        expect(result.text).toBe('original');
+    });
+
+    test('rechecks a companion request after its awaited context preparation', async () => {
+        const [agent] = loadAgents({ id: 'companion', execution: 'companion' });
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        const started = deferred();
+        const worldInfo = deferred();
+        getWorldInfoPrompt.mockImplementationOnce(() => { started.resolve(); return worldInfo.promise; });
+        const running = companions.runCompanionStage({ messageIndex: 0, message, activeAgents: [agent] });
+        await started.promise;
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        worldInfo.resolve({ worldInfoString: '' });
+        await running;
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(companions.getCompanionResults(message)).toEqual({});
+        expect(store.getAgentById(agent.id).enabled).toBe(true);
+    });
+
+    test('rechecks delayed companion dependencies instead of trusting cached active agents', async () => {
+        const agents = loadAgents(
+            { id: 'first', execution: 'companion' },
+            { id: 'blocked', execution: 'companion', companion: { dependencies: ['first'], waitForDependencies: true } },
+        );
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id === 'first');
+            return 'first-output';
+        });
+        await companions.runCompanionStage({ messageIndex: 0, message, activeAgents: agents });
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+    });
+
+    test('rechecks companion-output post passes after a prompt wait', async () => {
+        loadAgents({ id: 'companion', execution: 'companion' }, ...['first', 'blocked', 'last'].map(id => ({ id, conditions: { runOnCompanionOutputs: true } })));
+        addMessage();
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'blocked');
+            return 'first-output';
+        });
+        const result = await runner.runCompanionOutputPostPasses({ id: 'companion' }, 'original', { messageIndex: 0 });
+        expect(context.generateRaw.mock.calls.map(([request]) => request.prompt[0].content.split('\n')[0])).toEqual(['first', 'last']);
+        expect(result.text).toBe('last-output');
+    });
+
+    test('does not activate runtime-excluded keyword companions or change their saved toggle', async () => {
+        loadAgents({ id: 'blocked', execution: 'companion', conditions: { triggerKeywords: ['trigger'] } });
+        chat.push({ is_user: true, mes: 'trigger' });
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        const runCompanionStage = jest.fn(async () => []);
+        runner.registerCompanionRuntime({ runCompanionStage });
+        await eventSource.emit('GENERATION_STARTED', 'continue', {}, false);
+        addMessage();
+        await eventSource.emit('GENERATION_ENDED');
+        await eventSource.emit('MESSAGE_RECEIVED', 1, 'continue');
+        expect(runCompanionStage.mock.calls[0][0].activeAgents).toEqual([]);
+        expect(store.isAgentEnabledForCurrentScope(store.getAgentById('blocked'))).toBe(true);
+    });
+
+    test.each(['main', 'quiet', 'profile'])('blocks direct %s requests when the runtime predicate throws', async adapter => {
+        const [agent] = loadAgents({ id: 'blocked', connectionProfile: adapter === 'profile' ? 'profile' : '' });
+        context.mainApi = adapter === 'quiet' ? 'kobold' : 'openai';
+        const sendRequest = jest.fn();
+        context.ConnectionManagerRequestService = { sendRequest };
+        store.setRuntimeAgentFilter(OWNER, () => { throw new Error('predicate failed'); });
+        await expect(runner.requestPromptTransform(agent, [{ role: 'user', content: 'test' }], 100))
+            .rejects.toMatchObject({ name: 'AbortError' });
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(sendRequest).not.toHaveBeenCalled();
+        expect(runner.isAgentGenerationActive()).toBe(false);
+    });
+
+    test('rechecks cached tool registration and dispatch after confirmation without changing stored enablement', async () => {
+        const [agent] = loadAgents({ id: 'tool', category: 'tool', tools: [{ name: 'test-tool', actionKey: 'test' }] });
+        runner.syncToolAgentRegistrations();
+        const tool = tools.get('test-tool');
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        await expect(tool.shouldRegister()).resolves.toBe(false);
+        await expect(tool.action({})).resolves.toBe('');
+        expect(confirmToolCall).not.toHaveBeenCalled();
+
+        store.setRuntimeAgentFilter(OWNER, candidate => !candidate.favorite);
+        const confirmation = deferred();
+        confirmToolCall.mockReturnValueOnce(confirmation.promise);
+        const running = tool.action({ value: 1 });
+        await store.saveAgent({ ...agent, favorite: true });
+        confirmation.resolve(true);
+        await expect(running).resolves.toBe('');
+        expect(toolAction).not.toHaveBeenCalled();
+        store.setRuntimeAgentFilter(OWNER, null);
+        await expect(tool.action({ value: 2 })).resolves.toBe('tool result');
+        expect(toolAction).toHaveBeenCalledTimes(1);
+        expect(store.getAgentById('tool').enabled).toBe(true);
+    });
+
+    test('does not start a profile fallback request after exclusion during the primary request', async () => {
+        const [agent] = loadAgents({ id: 'profile', connectionProfile: 'test-profile' });
+        const response = deferred();
+        const sendRequest = jest.fn(() => response.promise);
+        context.ConnectionManagerRequestService = { sendRequest };
+        const running = runner.requestPromptTransform(agent, [{ role: 'user', content: 'test' }], 100);
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        response.resolve({ content: '' });
+        await expect(running).rejects.toMatchObject({ name: 'AbortError' });
+        expect(sendRequest).toHaveBeenCalledTimes(1);
+        expect(runner.isAgentGenerationActive()).toBe(false);
+    });
+
+    test('does not force tool use for a runtime-excluded Pathfinder with cached registrations', async () => {
+        const { getPathfinderToolDefinitions } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js');
+        const { getForcedToolChoice } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js');
+        getPathfinderToolDefinitions.mockReturnValue([{ name: 'Pathfinder_Summarize', actionKey: 'test' }]);
+        getForcedToolChoice.mockReturnValue('required');
+        loadAgents({ id: 'pathfinder', category: 'tool', sourceTemplateId: 'tpl-pathfinder' });
+        runner.syncToolAgentRegistrations();
+        const permitted = { tools: [{}], tool_choice: 'auto' };
+        await eventSource.emit('CHAT_COMPLETION_SETTINGS_READY', permitted);
+        expect(permitted.tool_choice).toBe('required');
+
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        const excluded = { tool_choice: 'auto' };
+        await eventSource.emit('CHAT_COMPLETION_SETTINGS_READY', excluded);
+        expect(excluded.tool_choice).toBe('auto');
+        expect(getForcedToolChoice).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('companion runtime filtering across waits', () => {
+    async function setupBatch() {
+        const agents = loadAgents(
+            { id: 'first', execution: 'companion', companion: { batch: true, batchAgentIds: ['second'] } },
+            { id: 'second', execution: 'companion' },
+        );
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        for (const agent of agents) {
+            companions.setCompanionResult(message, agent, { status: 'done', content: `${agent.id}-old`, tokenUsage: { inputTokens: 3, outputTokens: 2 } });
+        }
+        return { agents, message, companions, previous: structuredClone(companions.getCompanionResults(message)) };
+    }
+
+    const batchOutput = '<<<companion:first>>>first-new<<<end:first>>>\n<<<companion:second>>>second-new<<<end:second>>>';
+
+    test.each(['first', 'second'])('drops %s from a prepared batch after context loading and saving replaces its record', async blockedId => {
+        const { agents, message, companions, previous } = await setupBatch();
+        const started = deferred();
+        const worldInfo = deferred();
+        getWorldInfoPrompt.mockImplementationOnce(() => { started.resolve(); return worldInfo.promise; });
+        store.setRuntimeAgentFilter(OWNER, agent => !agent.favorite);
+        const running = companions.runCompanionStage({ messageIndex: 0, message, activeAgents: agents });
+        await started.promise;
+        await store.saveAgent({ ...store.getAgentById(blockedId), favorite: true });
+        worldInfo.resolve({ worldInfoString: '' });
+        await running;
+
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        expect(context.generateRaw.mock.calls[0][0].prompt[1].content).not.toContain('<<<companion:');
+        expect(companions.getCompanionResults(message)[blockedId]).toEqual(previous[blockedId]);
+        expect(companions.getCompanionResults(message)[blockedId === 'first' ? 'second' : 'first'].content).toBe('last-output');
+        expect(store.getAgentById(blockedId).enabled).toBe(true);
+        expect(saveSettingsDebounced).not.toHaveBeenCalled();
+    });
+
+    test.each(['first', 'second'])('does not apply %s when excluded during the combined network request', async blockedId => {
+        const { message, companions, previous } = await setupBatch();
+        let signal;
+        context.generateRaw.mockImplementationOnce(async request => {
+            signal = request.signal;
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== blockedId);
+            return batchOutput;
+        });
+        await companions.runCompanionsOnMessage(0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        expect(signal.aborted).toBe(false);
+        expect(companions.getCompanionResults(message)[blockedId]).toEqual(previous[blockedId]);
+        const permittedId = blockedId === 'first' ? 'second' : 'first';
+        expect(companions.getCompanionResults(message)[permittedId].content).toBe(`${permittedId}-new`);
+    });
+
+    test('checks every batch member again before a profile retry', async () => {
+        const { message, companions, previous } = await setupBatch();
+        store.setGlobalSettings({ companionConnectionProfile: 'profile' });
+        const sendRequest = jest.fn()
+            .mockImplementationOnce(async () => {
+                store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'second');
+                return { content: '' };
+            })
+            .mockResolvedValue({ content: 'first-new' });
+        context.ConnectionManagerRequestService = { sendRequest };
+        await companions.runCompanionsOnMessage(0);
+        expect(sendRequest).toHaveBeenCalledTimes(2);
+        expect(sendRequest.mock.calls[0][1][1].content).toContain('<<<companion:second>>>');
+        expect(sendRequest.mock.calls[1][1][1].content).not.toContain('<<<companion:');
+        expect(companions.getCompanionResults(message).second).toEqual(previous.second);
+        expect(companions.getCompanionResults(message).first.content).toBe('first-new');
+    });
+
+    test.each(['missing', 'error'])('checks individual fallback runs after a %s batch response', async failure => {
+        const { message, companions, previous } = await setupBatch();
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        context.generateRaw.mockImplementationOnce(async () => {
+            if (failure === 'error') throw new Error('request failed');
+            return 'unmarked response';
+        }).mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'second');
+            return 'first-new';
+        });
+        await companions.runCompanionsOnMessage(0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(2);
+        expect(companions.getCompanionResults(message).first.content).toBe('first-new');
+        expect(companions.getCompanionResults(message).second).toEqual(previous.second);
+    });
+
+    test('rechecks a batch member after token counting and after an earlier result event', async () => {
+        const { message, companions, previous } = await setupBatch();
+        context.generateRaw.mockResolvedValueOnce(batchOutput);
+        context.promptManager = { tokenHandler: { countUntrackedAsync: jest.fn(async value => {
+            if (value?.content === 'first-new') {
+                store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'first');
+            }
+            return 10;
+        }) } };
+        await companions.runCompanionsOnMessage(0);
+        expect(companions.getCompanionResults(message).first).toEqual(previous.first);
+        expect(companions.getCompanionResults(message).second.content).toBe('second-new');
+
+        store.setRuntimeAgentFilter(OWNER, null);
+        eventSource.on(companions.COMPANION_RESULTS_UPDATED_EVENT, ({ agentId }) => {
+            if (agentId === 'first' && companions.getCompanionResults(message).first?.status === 'done') {
+                store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'second');
+            }
+        });
+        context.promptManager = null;
+        context.generateRaw.mockResolvedValueOnce(batchOutput.replaceAll('-new', '-next'));
+        await companions.runCompanionsOnMessage(0);
+        expect(companions.getCompanionResults(message).first.content).toBe('first-next');
+        expect(companions.getCompanionResults(message).second.content).toBe('second-new');
+    });
+
+    test('rechecks a batch member after its output post-processing request', async () => {
+        const { message, companions, previous } = await setupBatch();
+        await store.saveAgent(store.normalizeAgent({ id: 'transformer', enabled: true, prompt: 'transform', phase: 'post', postProcess: { promptTransformEnabled: true }, conditions: { runOnCompanionOutputs: true, companionOutputTargetAgentIds: ['second'] } }));
+        context.generateRaw.mockResolvedValueOnce(batchOutput).mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'second');
+            return 'excluded transformed note';
+        });
+        await companions.runCompanionsOnMessage(0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(2);
+        expect(companions.getCompanionResults(message).second).toEqual(previous.second);
+        expect(companions.getCompanionResults(message).first.content).toBe('first-new');
+    });
+
+    test.each(['response', 'token-count', 'post-pass'])('restores a single companion excluded during %s without applying its result', async phase => {
+        const [agent] = loadAgents(
+            { id: 'companion', execution: 'companion' },
+            { id: 'transformer', conditions: { runOnCompanionOutputs: phase === 'post-pass' } },
+        );
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        companions.setCompanionResult(message, agent, { status: 'done', content: 'previous', tokenUsage: { inputTokens: 9, outputTokens: 3 } });
+        const previous = structuredClone(companions.getCompanionResults(message).companion);
+        const exclude = () => store.setRuntimeAgentFilter(OWNER, candidate => candidate.id !== agent.id);
+        context.generateRaw.mockImplementationOnce(async () => {
+            if (phase === 'response') exclude();
+            return 'new-note';
+        }).mockImplementationOnce(async () => { exclude(); return 'transformed-note'; });
+        context.promptManager = { tokenHandler: { countUntrackedAsync: async value => {
+            if (phase === 'token-count' && value?.content === 'new-note') exclude();
+            return 10;
+        } } };
+        await companions.runCompanionAgentOnMessage(agent.id, 0);
+        expect(companions.getCompanionResults(message).companion).toEqual(previous);
+    });
+
+    test('blocks direct no-request repairs while preserving stored-disabled manual behaviour without filters', async () => {
+        const [agent] = loadAgents({ id: 'tracker', enabled: false, execution: 'companion', category: 'tracker', postProcess: { enabled: true, type: 'extract', extractPattern: '\\[WORLD\\|[^\\]]*\\][\\s\\S]*?\\[\\/WORLD\\]', extractVariable: 'world_data' } });
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        companions.setCompanionResult(message, agent, { status: 'error', content: '[WORLD|Culture|Market]\ndetail: old\n/WORLD]', error: 'old error' });
+        const previous = structuredClone(companions.getCompanionResults(message).tracker);
+        store.setRuntimeAgentFilter(OWNER, () => false);
+        await expect(companions.runCompanionAgentOnMessage(agent.id, 0, { repair: true })).resolves.toBeNull();
+        expect(companions.getCompanionResults(message).tracker).toEqual(previous);
+        store.setRuntimeAgentFilter(OWNER, null);
+        await companions.runCompanionAgentOnMessage(agent.id, 0, { repair: true });
+        expect(companions.getCompanionResults(message).tracker.content).toBe('[WORLD|Culture|Market]\ndetail: old\n[/WORLD]');
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(store.getAgentById(agent.id).enabled).toBe(false);
+    });
+
+    test('rechecks cached no-request repairs after an earlier tracker finishes', async () => {
+        const agents = loadAgents(...['first', 'second'].map(id => ({ id, execution: 'companion', category: 'tracker', postProcess: { enabled: true, type: 'extract', extractPattern: '\\[WORLD\\|[^\\]]*\\][\\s\\S]*?\\[\\/WORLD\\]', extractVariable: 'world_data' } })));
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        companions.setCompanionResult(message, agents[1], { status: 'error', content: '[WORLD|Culture|Market]\ndetail: old\n/WORLD]', error: 'old error' });
+        const previous = structuredClone(companions.getCompanionResults(message).second);
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== 'second');
+            return '[WORLD|Culture|Market]\ndetail: new\n[/WORLD]';
+        });
+        await companions.runTrackerCompanionsOnMessage(0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        expect(companions.getCompanionResults(message).second).toEqual(previous);
+    });
+
+    test.each(['transformer', 'target'])('does not apply manual note post-processing when %s becomes excluded', async blockedId => {
+        const [target] = loadAgents({ id: 'target', execution: 'companion' }, { id: 'transformer' });
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        companions.setCompanionResult(message, target, { status: 'done', content: 'previous' });
+        const previous = structuredClone(companions.getCompanionResults(message).target);
+        context.generateRaw.mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, agent => agent.id !== blockedId);
+            return 'excluded edit';
+        });
+        await expect(companions.applyAgentPostPassesToCompanionResult('transformer', 0, 'target')).resolves.toBeNull();
+        expect(companions.getCompanionResults(message).target).toEqual(previous);
+    });
+
+    test('stops later output transforms when their companion becomes excluded', async () => {
+        const [agent] = loadAgents(
+            { id: 'companion', execution: 'companion' },
+            { id: 'first-transformer', conditions: { runOnCompanionOutputs: true } },
+            { id: 'later-transformer', conditions: { runOnCompanionOutputs: true } },
+        );
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        companions.setCompanionResult(message, agent, { status: 'done', content: 'previous' });
+        const previous = structuredClone(companions.getCompanionResults(message).companion);
+        context.generateRaw.mockResolvedValueOnce('new-note').mockImplementationOnce(async () => {
+            store.setRuntimeAgentFilter(OWNER, candidate => candidate.id !== agent.id);
+            return 'excluded-note';
+        });
+        await companions.runCompanionAgentOnMessage(agent.id, 0);
+        expect(context.generateRaw).toHaveBeenCalledTimes(2);
+        expect(companions.getCompanionResults(message).companion).toEqual(previous);
+    });
+
+    test('checks the note owner again when generation-state listeners change the gate before dispatch', async () => {
+        const [agent] = loadAgents({ id: 'companion', execution: 'companion' }, { id: 'transformer' });
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        companions.setCompanionResult(message, agent, { status: 'done', content: 'previous' });
+        const previous = structuredClone(companions.getCompanionResults(message).companion);
+        runner.onAgentGenerationStateChanged(active => {
+            if (active) store.setRuntimeAgentFilter(OWNER, candidate => candidate.id !== agent.id);
+        });
+        await companions.applyAgentPostPassesToCompanionResult('transformer', 0, agent.id);
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(companions.getCompanionResults(message).companion).toEqual(previous);
+    });
+
+    test('discards an excluded parallel append result before consolidating the companion note', async () => {
+        const [agent] = loadAgents(
+            { id: 'companion', execution: 'companion' },
+            ...['first', 'second'].map(id => ({ id, conditions: { runOnCompanionOutputs: true }, postProcess: { promptTransformEnabled: true, promptTransformMode: 'append' } })),
+        );
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        const started = deferred();
+        const response = deferred();
+        context.generateRaw.mockResolvedValueOnce('raw-note').mockResolvedValueOnce('first-addition')
+            .mockImplementationOnce(() => { started.resolve(); return response.promise; });
+        const running = companions.runCompanionAgentOnMessage(agent.id, 0);
+        await started.promise;
+        await jest.advanceTimersByTimeAsync(0);
+        store.setRuntimeAgentFilter(OWNER, candidate => candidate.id !== 'first');
+        response.resolve('second-addition');
+        await running;
+        expect(context.generateRaw).toHaveBeenCalledTimes(3);
+        expect(companions.getCompanionResults(message).companion.content).toBe('raw-note\n\nsecond-addition');
+    });
+
+    test.each([false, true])('discards generated repairs after exclusion (previous note: %s)', async hasPrevious => {
+        const [agent] = loadAgents({ id: 'tracker', execution: 'companion', category: 'tracker', postProcess: { enabled: true, type: 'extract', extractPattern: '\\[WORLD\\|[^\\]]*\\][\\s\\S]*?\\[\\/WORLD\\]', extractVariable: 'world_data' } });
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        if (hasPrevious) {
+            companions.setCompanionResult(message, agent, { status: 'done', content: 'broken previous note', tokenUsage: { inputTokens: 4, outputTokens: 2 } });
+        }
+        const previous = structuredClone(companions.getCompanionResults(message));
+        context.generateRaw.mockImplementationOnce(async request => {
+            store.setRuntimeAgentFilter(OWNER, () => false);
+            expect(request.signal.aborted).toBe(false);
+            return '[WORLD|Culture|Market]\ndetail: new\n[/WORLD]';
+        });
+        await companions.runCompanionAgentOnMessage(agent.id, 0, { repair: true });
+        expect(context.generateRaw).toHaveBeenCalledTimes(1);
+        expect(companions.getCompanionResults(message)).toEqual(previous);
+    });
+
+    test('restores a direct repair if the gate changes during its result notification', async () => {
+        const [agent] = loadAgents({ id: 'tracker', execution: 'companion', category: 'tracker', postProcess: { enabled: true, type: 'extract', extractPattern: '\\[WORLD\\|[^\\]]*\\][\\s\\S]*?\\[\\/WORLD\\]', extractVariable: 'world_data' } });
+        const message = addMessage();
+        const companions = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+        const { saveChatDebounced } = await import('../public/script.js');
+        companions.setCompanionResult(message, agent, { status: 'error', content: '[WORLD|Culture|Market]\ndetail: old\n/WORLD]', error: 'previous error' });
+        const previous = structuredClone(companions.getCompanionResults(message).tracker);
+        eventSource.on(companions.COMPANION_RESULTS_UPDATED_EVENT, () => {
+            store.setRuntimeAgentFilter(OWNER, () => false);
+        });
+        await companions.runCompanionAgentOnMessage(agent.id, 0, { repair: true });
+        expect(companions.getCompanionResults(message).tracker).toEqual(previous);
+        expect(context.generateRaw).not.toHaveBeenCalled();
+        expect(saveChatDebounced).not.toHaveBeenCalled();
+    });
+});

--- a/tests/story-mode-custom-request.test.js
+++ b/tests/story-mode-custom-request.test.js
@@ -1,0 +1,146 @@
+/* eslint-disable playwright/no-standalone-expect -- Jest test.each tables are not Playwright tests. */
+import { describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { parse } from 'acorn';
+import yaml from 'yaml';
+import { applyGenerationRequestControls, requestUsesReasoning } from '../public/scripts/generation-request-controls.js';
+import { applyKimiK3ModelParameterConstraints, isKimiK3Model } from '../public/scripts/openai-model-capabilities.js';
+import { CHAT_COMPLETION_SOURCES, OPENAI_REASONING_EFFORT_MODELS, OPENAI_VERBOSITY_MODELS } from '../src/constants.js';
+import { applyReasoningEffortNormalization, toWireReasoningEffort } from '../src/reasoning-effort.js';
+
+const files = ['endpoints/backends/chat-completions.js', 'util.js'];
+const sources = Object.fromEntries(files.map(file => {
+    const source = readFileSync(new URL(`../src/${file}`, import.meta.url), 'utf8');
+    return [file, { source, ast: parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) }];
+}));
+
+function load(context, file, names) {
+    const { source, ast } = sources[file];
+    for (const name of names) {
+        const node = ast.body.map(node => node.declaration ?? node).find(node => node.id?.name === name);
+        if (!node) throw new Error(`Missing declaration: ${name}`);
+        vm.runInContext(source.slice(node.start, node.end), context);
+    }
+}
+
+async function sendCustom(body) {
+    const context = vm.createContext({
+        AbortController, yaml,
+        console: { log: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        CHAT_COMPLETION_SOURCES, OPENAI_REASONING_EFFORT_MODELS, OPENAI_VERBOSITY_MODELS,
+        applyGenerationRequestControls, requestUsesReasoning, applyKimiK3ModelParameterConstraints, isKimiK3Model,
+        applyReasoningEffortNormalization, toWireReasoningEffort,
+        TEXT_COMPLETION_MODELS: [], SECRET_KEYS: { CUSTOM: 'custom' },
+        readSecret: () => 'test-secret',
+        embedOpenRouterMedia: () => {}, applyLocalPromptCacheScope: () => {}, abortOnRequestClose: () => {},
+        logVerboseGenerationRequest: () => {}, summarizeLlmPayloadForLog: value => value,
+        isExpectedStreamAbort: () => false,
+        fetch: jest.fn(async () => ({ ok: true, json: async () => ({ choices: [] }) })),
+    });
+    load(context, 'util.js', ['mergeObjectWithYaml', 'excludeKeysByYaml']);
+    load(context, files[0], ['hasCustomReasoningParamConfig', 'resolveCustomOpenAiReasoningEffort', 'shouldEnableCustomReasoning', 'applyCustomReasoningParameters', 'getSafeCompletionErrorStatus', 'handleChatCompletionsGenerate']);
+    const request = {
+        body: {
+            chat_completion_source: CHAT_COMPLETION_SOURCES.CUSTOM,
+            model: 'ordinary', messages: [{ role: 'user', content: 'prompt' }],
+            max_tokens: 8192, custom_url: 'https://example.invalid/v1',
+            ...body,
+        },
+        user: { directories: {} }, socket: { destroyed: false },
+    };
+    const response = { send: jest.fn(), status: jest.fn().mockReturnThis(), headersSent: false };
+    await context.handleChatCompletionsGenerate(request, response);
+    expect(response.status).not.toHaveBeenCalled();
+    expect(context.fetch).toHaveBeenCalledTimes(1);
+    const outgoing = JSON.parse(context.fetch.mock.calls[0][1].body);
+    expect(outgoing.request_controls).toBeUndefined();
+    return outgoing;
+}
+
+describe('final Custom request controls', () => {
+    test('caps the final ordinary payload after YAML overrides, including a max_completion_tokens override', async () => {
+        const result = await sendCustom({
+            include_reasoning: true,
+            custom_include_body: 'max_completion_tokens: 12000\nthinking:\n  type: disabled',
+            custom_exclude_body: '- max_tokens',
+            request_controls: { maxOutputTokens: 160 },
+        });
+        expect(result.max_completion_tokens).toBe(160);
+        expect(result.max_tokens).toBeUndefined();
+        expect(result.thinking).toEqual({ type: 'disabled' });
+    });
+
+    test.each(['enabled', 'adaptive'])('preserves an explicit %s thinking allowance after Custom overrides', async type => {
+        const result = await sendCustom({
+            custom_include_body: `max_tokens: 8192\nthinking:\n  type: ${type}\n  budget_tokens: 4096`,
+            request_controls: { maxOutputTokens: 160 },
+        });
+        expect(result.max_tokens).toBe(8192);
+        expect(result.thinking).toEqual({ type, budget_tokens: 4096 });
+    });
+
+    test.each([true, false])('detects the actual Custom thinking switch, not include_reasoning by itself: %s', async enabled => {
+        const result = await sendCustom({
+            include_reasoning: enabled,
+            custom_reasoning_param_name: 'thinking', custom_reasoning_param_format: 'thinking_object',
+            request_controls: { maxOutputTokens: 160 },
+        });
+        expect(result.max_tokens).toBe(enabled ? 8192 : 160);
+        expect(result.thinking.type).toBe(enabled ? 'enabled' : 'disabled');
+    });
+
+    test.each([true, false])('selection responseLength preserves the original total only with active thinking: %s', async enabled => {
+        const result = await sendCustom({
+            custom_include_body: `thinking:\n  type: ${enabled ? 'enabled' : 'disabled'}`,
+            request_controls: { responseLength: 64, preserveReasoningBudget: true },
+        });
+        expect(result.max_tokens).toBe(enabled ? 8192 : 64);
+    });
+
+    test('restores a response limit if Custom excludes removed all budget fields', async () => {
+        const result = await sendCustom({ custom_exclude_body: '- max_tokens', request_controls: { maxOutputTokens: 160 } });
+        expect(result.max_tokens).toBe(160);
+    });
+
+    test('leaves uncontrolled and invalid-limit requests unchanged', async () => {
+        const plain = await sendCustom({ custom_include_body: 'max_tokens: 12000' });
+        const invalid = await sendCustom({ custom_include_body: 'max_tokens: 12000', request_controls: { maxOutputTokens: '160' } });
+        expect(plain.max_tokens).toBe(12000);
+        expect(invalid.max_tokens).toBe(12000);
+    });
+
+    test('never forwards host control annotations from Custom YAML', async () => {
+        const result = await sendCustom({
+            custom_include_body: 'request_controls:\n  maxOutputTokens: 1\nmax_tokens: 12000',
+            request_controls: { maxOutputTokens: 160 },
+        });
+        expect(result.max_tokens).toBe(160);
+    });
+
+    test('preserves the exact Custom budget for a configured nonstandard thinking switch', async () => {
+        const result = await sendCustom({
+            include_reasoning: true,
+            custom_reasoning_param_name: 'reasoning_mode', custom_reasoning_param_format: 'string',
+            custom_reasoning_enabled_value: 'on', custom_reasoning_disabled_value: 'off',
+            custom_include_body: 'max_tokens: 12345',
+            request_controls: { responseLength: 64, preserveReasoningBudget: true },
+        });
+        expect(result.reasoning_mode).toBe('on');
+        expect(result.max_tokens).toBe(12345);
+    });
+
+    test.each(['boolean', 'string', 'thinking_object'])('uses the final overridden Custom thinking value: %s', async format => {
+        const off = format === 'boolean' ? 'false' : format === 'thinking_object' ? '{ type: off }' : 'off';
+        const result = await sendCustom({
+            include_reasoning: true,
+            custom_reasoning_param_name: 'reasoning_mode', custom_reasoning_param_format: format,
+            custom_reasoning_enabled_value: 'on', custom_reasoning_disabled_value: 'off',
+            custom_include_body: `reasoning_mode: ${off}\nmax_tokens: 12345`,
+            request_controls: { responseLength: 64, preserveReasoningBudget: true },
+        });
+        expect(result.max_tokens).toBe(64);
+        expect(result.thinking).toBeUndefined();
+        expect(result.reasoning).toBeUndefined();
+    });
+});

--- a/tests/story-mode-persistence.test.js
+++ b/tests/story-mode-persistence.test.js
@@ -1,0 +1,244 @@
+/* eslint-disable playwright/no-standalone-expect -- Jest test.each tables are not Playwright tests. */
+import { describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { parse } from 'acorn';
+
+const sources = Object.fromEntries(['script.js', 'scripts/extensions.js', 'scripts/group-chats.js', 'scripts/utils.js'].map(file => {
+    const source = readFileSync(new URL(`../public/${file}`, import.meta.url), 'utf8');
+    return [file, { source, ast: parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) }];
+}));
+
+// The host's lifecycle tests also execute extracted declarations to avoid booting the browser bundle.
+function load(context, file, names) {
+    const { source, ast } = sources[file];
+    for (const name of names) {
+        const node = ast.body.map(node => node.declaration ?? node).find(node => node.id?.name === name);
+        if (!node) throw new Error(`Missing declaration: ${name}`);
+        vm.runInContext(source.slice(node.start, node.end), context);
+    }
+}
+
+function saveContext(group = false) {
+    const context = vm.createContext({
+        console: { error: jest.fn(), warn: jest.fn() },
+        selected_group: group ? 'group' : null,
+        saveChat: jest.fn(async () => true),
+        saveGroupChat: jest.fn(async () => true),
+        cancelDebouncedChatSave: jest.fn(),
+        setChatSaveActive: jest.fn(),
+        saveTokenCache: jest.fn(async () => {}),
+        saveItemizedPrompts: jest.fn(async () => {}),
+        getCurrentChatId: () => 'story',
+    });
+    load(context, 'script.js', ['saveChatConditional', 'saveMetadata']);
+    return context;
+}
+
+describe('strict host chat saves', () => {
+    test.each([false, true])('returns success and forwards strict options (group: %s)', async group => {
+        const context = saveContext(group);
+        const options = { throwOnError: true, deferBackup: true, allowShrink: true };
+        await expect(context.saveMetadata(options)).resolves.toBe(true);
+        const helper = group ? context.saveGroupChat : context.saveChat;
+        expect(helper).toHaveBeenCalledWith(...(group ? ['group', true, false, true, options] : [options]));
+        expect(context.saveItemizedPrompts).toHaveBeenCalledWith('story');
+        expect(context.setChatSaveActive).toHaveBeenLastCalledWith(false);
+    });
+
+    test.each([false, undefined])('rejects a lower helper refusal (%s), while default callers receive false', async result => {
+        for (const group of [false, true]) {
+            const context = saveContext(group);
+            const helper = group ? context.saveGroupChat : context.saveChat;
+            helper.mockResolvedValue(result);
+            await expect(context.saveChatConditional({ throwOnError: true })).rejects.toThrow('Chat was not saved');
+            await expect(context.saveChatConditional()).resolves.toBe(false);
+            expect(context.saveTokenCache).not.toHaveBeenCalled();
+            expect(context.setChatSaveActive).toHaveBeenLastCalledWith(false);
+        }
+    });
+
+    test('preserves the original rejection and the default swallow behaviour', async () => {
+        const context = saveContext();
+        const error = new Error('network failure');
+        context.saveChat.mockRejectedValue(error);
+        await expect(context.saveMetadata({ throwOnError: true })).rejects.toBe(error);
+        await expect(context.saveMetadata()).resolves.toBe(false);
+        expect(context.setChatSaveActive).toHaveBeenLastCalledWith(false);
+    });
+
+    test.each(['http', 'integrity', 'missing'])('executes the queued character save through a real %s refusal', async failure => {
+        const context = saveContext();
+        Object.assign(context, {
+            structuredClone,
+            chatSaveQueue: Promise.resolve(),
+            chat: [{ mes: 'original', extra: {} }],
+            chat_metadata: {},
+            this_chid: 0,
+            characters: [{ name: 'Story', avatar: 'story.png', chat: failure === 'missing' ? '' : 'story' }],
+            name2: 'Story',
+            neutralCharacterName: 'Assistant',
+            cloneChatSavePayload: structuredClone,
+            getQueuedChatIntegrityKey: () => 'key',
+            applyQueuedChatIntegrity: jest.fn(),
+            rememberQueuedChatIntegrity: jest.fn(),
+            compressRequest: async value => value,
+            getRequestHeaders: () => ({}),
+            fetch: jest.fn(async () => ({ ok: false, statusText: 'failure', json: async () => ({ error: failure }) })),
+            Popup: { show: { input: async () => '' } },
+            window: { location: { reload: jest.fn() } },
+            toastr: { error: jest.fn() },
+            t: strings => strings.join(''),
+        });
+        load(context, 'script.js', ['saveChat', 'saveChatImmediately']);
+        await expect(context.saveMetadata({ throwOnError: true })).rejects.toThrow();
+        await expect(context.saveMetadata()).resolves.toBe(false);
+        expect(context.saveTokenCache).not.toHaveBeenCalled();
+    });
+
+    test.each(['group', 123])('waits for group metadata and rejects its HTTP failure instead of scheduling success: %s', async id => {
+        const context = saveContext(true);
+        Object.assign(context, {
+            structuredClone,
+            groupChatSaveQueue: Promise.resolve(),
+            selected_group: String(id),
+            groups: [{ id, chat_id: 'story', chats: ['story'] }],
+            chat: [{ mes: 'original', extra: {} }],
+            chat_metadata: {},
+            cloneGroupChatSavePayload: structuredClone,
+            applyQueuedGroupChatIntegrity: jest.fn(),
+            rememberQueuedGroupChatIntegrity: jest.fn(),
+            compressRequest: async value => value,
+            getRequestHeaders: () => ({}),
+            refreshCsrfToken: jest.fn(),
+            fetchWithCsrfRetry: jest.fn(async (url, build) => {
+                await build();
+                return { ok: true, json: async () => ({ integrity: 'saved' }) };
+            }),
+            fetch: jest.fn(async () => ({ ok: false })),
+            saveGroupDebounced: jest.fn(),
+        });
+        load(context, 'scripts/group-chats.js', ['saveGroupChat', 'saveGroupChatImmediately', 'editGroup', '_save']);
+        await expect(context.saveMetadata({ throwOnError: true })).rejects.toThrow('Could not save group');
+        expect(context.fetch).toHaveBeenCalledWith('/api/groups/edit', expect.any(Object));
+        expect(context.saveGroupDebounced).not.toHaveBeenCalled();
+        await expect(context.saveMetadata()).resolves.toBe(true);
+        expect(context.saveGroupDebounced).toHaveBeenCalledTimes(typeof id === 'string' ? 1 : 0);
+    });
+
+    test('propagates an actual group integrity decline without saving metadata or caches', async () => {
+        const context = saveContext(true);
+        Object.assign(context, {
+            structuredClone, groupChatSaveQueue: Promise.resolve(),
+            groups: [{ id: 'group', chat_id: 'story', chats: ['story'] }],
+            chat: [{ mes: 'original', extra: {} }], chat_metadata: {},
+            cloneGroupChatSavePayload: structuredClone,
+            applyQueuedGroupChatIntegrity: jest.fn(),
+            refreshCsrfToken: jest.fn(),
+            fetchWithCsrfRetry: jest.fn(async () => ({ ok: false, json: async () => ({ error: 'integrity' }) })),
+            Popup: { show: { input: async () => '' } },
+            window: { location: { reload: jest.fn() } },
+            t: strings => strings.join(''), editGroup: jest.fn(),
+        });
+        load(context, 'scripts/group-chats.js', ['saveGroupChat', 'saveGroupChatImmediately']);
+        await expect(context.saveMetadata({ throwOnError: true })).rejects.toThrow('Chat was not saved');
+        await expect(context.saveMetadata()).resolves.toBe(false);
+        expect(context.editGroup).not.toHaveBeenCalled();
+        expect(context.saveTokenCache).not.toHaveBeenCalled();
+        expect(context.saveItemizedPrompts).not.toHaveBeenCalled();
+    });
+});
+
+function fieldContext() {
+    const character = { avatar: 'story.png', data: { extensions: { story: { enabled: false }, other: 1 } } };
+    character.json_data = JSON.stringify({ data: structuredClone(character.data) });
+    const state = { characters: [character], characterId: 0 };
+    const form = { val: jest.fn() };
+    const context = vm.createContext({
+        console: { error: jest.fn(), warn: jest.fn() },
+        getContext: () => state,
+        getRequestHeaders: () => ({}),
+        UNSET_VALUE: '__@@UNSET@@__',
+        $: () => form,
+        fetch: jest.fn(async () => ({ ok: true })),
+    });
+    load(context, 'scripts/utils.js', ['setValueByPath', 'deleteValueByPath']);
+    load(context, 'scripts/extensions.js', ['writeExtensionField']);
+    return { context, state, character, form };
+}
+
+describe('strict host extension field writes', () => {
+    test.each(['http', 'network'])('does not mutate the card, JSON or form on %s failure', async failure => {
+        const { context, character, form } = fieldContext();
+        const original = structuredClone(character);
+        context.fetch.mockImplementation(async () => {
+            character.data.extensions.other = 2;
+            if (failure === 'network') throw new Error('network failure');
+            return { ok: false, statusText: 'failure' };
+        });
+        await expect(context.writeExtensionField(0, 'story', { enabled: true }, { throwOnError: true })).rejects.toThrow();
+        expect(character.data.extensions).toEqual({ story: { enabled: false }, other: 2 });
+        expect(character.json_data).toBe(original.json_data);
+        expect(form.val).not.toHaveBeenCalled();
+    });
+
+    test('commits the sent value only after success and keeps unrelated concurrent changes', async () => {
+        const { context, state, character, form } = fieldContext();
+        let respond;
+        context.fetch.mockReturnValue(new Promise(resolve => { respond = resolve; }));
+        const value = { enabled: true };
+        const pending = context.writeExtensionField(0, 'story', value, { throwOnError: true });
+        expect(character.data.extensions.story.enabled).toBe(false);
+        expect(form.val).not.toHaveBeenCalled();
+
+        value.enabled = false;
+        character.data.extensions.other = 2;
+        character.json_data = JSON.stringify({ data: { extensions: { ...character.data.extensions, newer: 3 } } });
+        state.characters.unshift({ avatar: 'other.png' });
+        state.characterId = 0;
+        respond({ ok: true });
+        await expect(pending).resolves.toBe(true);
+        expect(character.data.extensions).toEqual({ story: { enabled: true }, other: 2 });
+        expect(JSON.parse(character.json_data).data.extensions).toEqual({ story: { enabled: true }, other: 2, newer: 3 });
+        expect(form.val).not.toHaveBeenCalled();
+        expect(JSON.parse(context.fetch.mock.calls[0][1].body)).toEqual({ avatar: 'story.png', data: { extensions: { story: { enabled: true } } } });
+    });
+
+    test('updates the active form after strict success and keeps the UNSET request shape', async () => {
+        const { context, character, form } = fieldContext();
+        await expect(context.writeExtensionField('0', 'story', context.UNSET_VALUE, { throwOnError: true })).resolves.toBe(true);
+        expect(character.data.extensions).toEqual({ other: 1 });
+        expect(JSON.parse(character.json_data).data.extensions).toEqual({ other: 1 });
+        expect(form.val).toHaveBeenCalledWith(character.json_data);
+        expect(JSON.parse(context.fetch.mock.calls[0][1].body).data.extensions.story).toBe(context.UNSET_VALUE);
+    });
+
+    test('retains optimistic mutation and undefined return for default HTTP failures', async () => {
+        const { context, character, form } = fieldContext();
+        context.fetch.mockResolvedValue({ ok: false, statusText: 'failure' });
+        await expect(context.writeExtensionField(0, 'story', true)).resolves.toBeUndefined();
+        expect(character.data.extensions.story).toBe(true);
+        expect(form.val).toHaveBeenCalledWith(character.json_data);
+    });
+
+    test('rejects a missing card or identity before sending a strict request', async () => {
+        const { context, character } = fieldContext();
+        await expect(context.writeExtensionField(5, 'story', true, { throwOnError: true })).rejects.toThrow('Character not found');
+        delete character.avatar;
+        await expect(context.writeExtensionField(0, 'story', true, { throwOnError: true })).rejects.toThrow('identity');
+        expect(context.fetch).not.toHaveBeenCalled();
+        await expect(context.writeExtensionField(5, 'story', true)).resolves.toBeUndefined();
+    });
+
+    test('does not commit to a different card if the target disappears during the request', async () => {
+        const { context, state, character, form } = fieldContext();
+        context.fetch.mockImplementation(async () => {
+            state.characters = [{ avatar: 'replacement.png', data: { extensions: {} } }];
+            return { ok: true };
+        });
+        await expect(context.writeExtensionField(0, 'story', true, { throwOnError: true })).rejects.toThrow('no longer available');
+        expect(character.data.extensions.story.enabled).toBe(false);
+        expect(state.characters[0].data.extensions).toEqual({});
+        expect(form.val).not.toHaveBeenCalled();
+    });
+});

--- a/tests/story-mode-request-controls.test.js
+++ b/tests/story-mode-request-controls.test.js
@@ -1,0 +1,717 @@
+/* eslint-disable playwright/no-standalone-expect -- Jest test.each tables are not Playwright tests. */
+import { describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
+import vm from 'node:vm';
+import { parse } from 'acorn';
+import { applyGenerationRequestControls, isGenerationLengthFinish, limitGenerationProse, requestUsesReasoning } from '../public/scripts/generation-request-controls.js';
+import { applyClaudeModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model } from '../public/scripts/openai-model-capabilities.js';
+import { resolveGenerationOutputBufferState, resolveGenerationUnblockState, resolveStopGenerationState } from '../public/scripts/generation-lifecycle/index.js';
+import { event_types } from '../public/scripts/events.js';
+import { OVERSWIPE_BEHAVIOR, SWIPE_DIRECTION, SWIPE_SOURCE, SWIPE_STATE } from '../public/scripts/constants.js';
+
+const sources = Object.fromEntries(['script.js', 'scripts/openai.js', 'scripts/reasoning.js', 'scripts/group-chats.js', 'scripts/utils.js', 'scripts/st-context.js', 'scripts/sse-stream.js', 'scripts/textgen-settings.js'].map(file => {
+    const source = readFileSync(new URL(`../public/${file}`, import.meta.url), 'utf8');
+    return [file, { source, ast: parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) }];
+}));
+
+// Like the host lifecycle tests, run real declarations without booting the browser application.
+function load(context, file, names) {
+    const { source, ast } = sources[file];
+    for (const name of names) {
+        const node = ast.body.map(node => node.declaration ?? node)
+            .find(node => node.id?.name === name || node.declarations?.some(item => item.id.name === name));
+        if (!node) throw new Error(`Missing declaration: ${name}`);
+        vm.runInContext(source.slice(node.start, node.end), context);
+    }
+}
+
+function makeRuntime({ api = 'openai', model = 'gpt-4o', stream = false, buffer = false, composer = '' } = {}) {
+    const eventSource = new EventEmitter();
+    eventSource.emit = jest.fn(async (name, ...args) => {
+        for (const listener of eventSource.rawListeners(name)) await listener(...args);
+    });
+    eventSource.emitAndWait = eventSource.emit;
+    const textarea = { value: composer, dispatchEvent: jest.fn() };
+    const element = { isConnected: true, getAttribute: () => '0', querySelector: () => ({ isConnected: true }) };
+    const dom = {
+        0: textarea,
+        val: jest.fn(value => {
+            if (value === undefined) return textarea.value;
+            textarea.value = value;
+            return dom;
+        }),
+        trigger: jest.fn(),
+    };
+    const context = vm.createContext({
+        AbortController, AbortSignal, Event, MessageEvent, TextDecoderStream, TransformStream, structuredClone,
+        console: { log: jest.fn(), info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn(), trace: jest.fn() },
+        main_api: api,
+        name1: 'User', name2: 'Story', this_chid: 0,
+        selected_group: null, is_group_generating: false, is_send_press: false,
+        menu_type: 'character_edit', online_status: model,
+        characters: [{ name: 'Story', avatar: 'story.png', chat: 'story', data: { extensions: {} } }],
+        chat: [{ name: 'Story', mes: 'Existing prose. ', extra: {}, is_user: false }],
+        chat_metadata: {}, generationChatFilter: null, pendingGeneratedMessageExtra: null,
+        generation_started: null, abortController: null, streamingProcessor: null,
+        amount_gen: 8192, max_context: 32768, kobold_horde_model: '',
+        openai_messages_count: 1, itemizedPrompts: [], extension_prompts: {},
+        power_user: {
+            instruct: { enabled: false }, sysprompt: { enabled: false }, context: {},
+            reasoning: { prefix: '<think>', suffix: '</think>', separator: '\n', auto_parse: true, add_to_prompts: false },
+            auto_continue: { enabled: true, target_length: 1, allow_chat_completions: true },
+            streaming_fps: 30, trim_spaces: false, message_token_count_enabled: false,
+        },
+        oai_settings: {
+            chat_completion_source: 'openai', openai_model: model, custom_model: model, openai_max_tokens: 8192,
+            stream_openai: stream, show_thoughts: true, reasoning_effort: 'none', continue_postfix: '',
+            send_if_empty: '', custom_reasoning_param_format: 'openai', custom_reasoning_param_name: 'reasoning_effort',
+        },
+        textgen_settings: { type: 'llamacpp' },
+        textgen_types: { LLAMACPP: 'llamacpp', OLLAMA: 'ollama', OPENROUTER: 'openrouter' },
+        kai_settings: { preset_settings: 'gui' }, kai_flags: {}, horde_settings: {},
+        nai_settings: { preset_settings_novel: 'preset', model_novel: 'erato' },
+        novelai_settings: [{}], novelai_setting_names: { preset: 0 },
+        extension_settings: { note: {} }, extension_prompt_types: { IN_CHAT: 1, IN_PROMPT: 0, BEFORE_PROMPT: 2, NONE: -1 },
+        extension_prompt_roles: { SYSTEM: 0 }, depth_prompt_depth_default: 4, depth_prompt_role_default: 'system',
+        persona_description_positions: { IN_PROMPT: 0 },
+        inject_ids: { DEPTH_PROMPT: 'depth', STORY_STRING: 'story', QUIET_PROMPT: 'quiet' },
+        world_info_include_names: true, wi_anchor_position: { before: 0 },
+        GENERATION_TYPE_TRIGGERS: ['continue', 'quiet', 'normal'], IGNORE_SYMBOL: 'ignore',
+        system_message_types: { NARRATOR: 'narrator', GENERIC: 'generic', EMPTY: 'empty' },
+        IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY: 'transforms', IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY: 'intercepts',
+        NOTE_MODULE_NAME: 'note', MIN_LENGTH: 16, selected_custom_endpoint_preset: null,
+        regex_placement: { REASONING: 1, USER_INPUT: 2, AI_OUTPUT: 3 },
+        CHAT_RENDER_LIFECYCLE_ROUTE: { STREAM_PROGRESS: 'stream' },
+        scrollLock: false, scrollLockImmunityUntil: 0,
+        document: { querySelector: selector => selector === '#send_textarea' ? textarea : element },
+        HTMLElement: class {},
+        $: () => dom, chatElement: { find: () => ({}) },
+        eventSource, event_types,
+        resolveGenerationOutputBufferState, resolveGenerationUnblockState, resolveStopGenerationState,
+        applyGenerationRequestControls, isGenerationLengthFinish, limitGenerationProse,
+        applyClaudeModelParameterConstraints, applyKimiK3ModelParameterConstraints, isKimiK3Model,
+        getLinkApiRequestFormat: () => 'openai',
+        getRequestHeaders: () => ({}),
+        getCharacterCardFields: () => Object.fromEntries(['description', 'personality', 'persona', 'scenario', 'mesExamples', 'system', 'jailbreak', 'charDepthPrompt', 'creatorNotes'].map(key => [key, ''])),
+        getGroupDepthPrompts: () => [], getExtensionPromptRoleByName: () => 0,
+        hasCompanionChatHistoryForHiddenHost: () => false,
+        selectCompanionChatHistory: () => [], consolidateCompanionChatHistory: () => ({ host: null, entries: [] }),
+        resolveRegexScriptsForSnapshot: () => [], shouldRetainContextAtDepth: () => true,
+        stripHtmlTagsFromContext: value => value, stripOocBlocksFromContext: value => value,
+        getRegexedString: value => value, appendFileContent: async () => '',
+        hasPromptPayload: message => Boolean(message.mes || message.extra?.reasoning),
+        getMaxPromptTokens: () => 24576, getMaxResponseTokens: () => 8192,
+        runGenerationInterceptors: jest.fn(async () => false),
+        getGuidanceScale: () => null, parseMesExamples: () => [],
+        getWorldInfoPrompt: async () => ({ worldInfoString: '', worldInfoBefore: '', worldInfoAfter: '', worldInfoExamples: [], worldInfoDepth: [] }),
+        buildWorldInfoScanChat: messages => messages,
+        getExtensionPrompt: async () => '', renderStoryString: () => '', doChatInject: async () => [],
+        formatMessageHistoryItem: message => message.mes + '\n',
+        getTokenCountAsync: jest.fn(async () => 0),
+        getTokenCount: jest.fn(() => { throw new Error('Synchronous token counting is forbidden in controlled streams'); }),
+        getCustomStoppingStrings: () => [], getStoppingStrings: () => [], getGroupNames: () => [],
+        substituteParams: value => value, baseChatReplace: value => value,
+        extractMessageBias: () => '', getEffectivePromptBias: () => '',
+        shiftDownByOne: value => value - 1, shiftUpByOne: value => value + 1,
+        adjustNovelInstructionPrompt: value => value,
+        getAllExtensionPrompts: async () => '', getFriendlyTokenizerName: () => ({ tokenizerName: 'test' }),
+        getPresetManager: () => ({ getSelectedPresetName: () => 'preset' }),
+        isStreamingEnabled: () => stream, isHordeGenerationNotAllowed: () => false, pingServer: async () => true,
+        hasPendingFileAttachment: () => false, shouldBatchMobileChatRendering: () => false,
+        prepareOpenAIMessages: async ({ messages }) => [messages, false],
+        setOpenAIMessages: messages => messages.map(message => ({ role: message.is_user ? 'user' : 'assistant', content: message.mes })),
+        setOpenAIMessageExamples: () => [],
+        createRawPrompt: (prompt, rawApi) => rawApi === 'openai' ? [{ role: 'user', content: prompt }] : prompt,
+        getTextGenGenerationData: jest.fn(async (prompt, maxTokens) => {
+            const data = { prompt, model, max_new_tokens: maxTokens, max_tokens: maxTokens, n_predict: maxTokens, num_predict: maxTokens, include_reasoning: true };
+            await eventSource.emit(event_types.TEXT_COMPLETION_SETTINGS_READY, data);
+            return data;
+        }),
+        getNovelGenerationData: (prompt, settings, maxLength) => ({ input: prompt, model: 'erato', max_length: maxLength }),
+        cleanUpMessage: ({ getMessage }) => getMessage,
+        extractMultiSwipes: () => [], extractTitleFromData: () => '', extractImagesFromData: () => [], extractReasoningSignatureFromData: () => null,
+        getGeneratingApi: () => api, getGeneratingModel: () => model, getCurrentReasoningEffort: () => '',
+        getMessageTimeStamp: () => '2026-09-05',
+        updateMessageTokenAccounting: async message => ({ outputTokens: 0, reasoningTokens: message.extra?.reasoning_tokens ?? 0 }),
+        saveChatConditional: jest.fn(async () => true),
+        getPositiveTokenCount: value => Number(value) || 0,
+        formatGenerationTimer: () => ({}), messageFormatting: value => value,
+        balanceStreamingMarkdown: value => value,
+        Stopwatch: class { async tick(callback) { await callback(); } },
+        getStreamingUpdateInterval: value => value,
+        delay: async () => {},
+        toastr: { error: jest.fn(), warning: jest.fn() }, t: strings => strings.join(''),
+        REVERSE_PROXY_SUPPORTED_SOURCES: [], openai_max_stop_strings: 4,
+        ToolManager: {
+            RECURSE_LIMIT: 5, isToolCallingSupported: () => false, canPerformToolCalls: () => false,
+            hasToolCalls: () => false, registerFunctionToolsOpenAI: async () => {},
+            invokeFunctionTools: async () => ({ invocations: [], stealthCalls: [] }),
+            parseToolCalls: () => {}, saveFunctionToolInvocations: jest.fn(async () => {}),
+        },
+    });
+    for (const name of ['unshallowCharacter', 'removeDepthPrompts', 'setExtensionPrompt', 'deleteItemizedPromptForMessage', 'removeLastMessage', 'requestMobileChatBottomPin', 'hideSwipeButtons', 'showSwipeButtons', 'setFloatingPrompt', 'flushWIInjections', 'flushEphemeralStoppingStrings', 'addPersonaDescriptionExtensionPrompt', 'setInContextMessages', 'setGenerationProgress', 'showStopButton', 'parseAndSaveLogprobs', 'playMessageSound', 'processImageAttachment', 'addOneMessage', 'statMesProcess', 'saveLogprobsForActiveMessage', 'appendMediaToMessage', 'addCopyToCodeBlocks', 'updateSwipeCounter', 'applyStreamingVisibleWrite', 'scrollStartedStreamingMessageThroughLifecycle', 'scrollChatToBottom', 'checkQuotaError', 'checkModerationError', 'tryParseStreamingError']) {
+        context[name] = jest.fn();
+    }
+    for (const name of ['shouldReduceStreamingDomWork', 'shouldGuardMobileChatScroll', 'shouldPinMobileChatToBottom', 'isAndroidStreamingPlatform', 'shouldUsePlainTextStreamingPreview', 'isChatRenderLifecycleRolloutEnabled', 'isHiddenReasoningModel']) {
+        context[name] = () => false;
+    }
+    context.activateSendButtons = jest.fn(() => { context.is_send_press = false; });
+    context.textgenerationwebui_settings = context.textgen_settings;
+    context.deactivateSendButtons = jest.fn(() => { context.is_send_press = true; });
+    context.executeSlashCommandsOnChatInput = jest.fn();
+    context.sendMessageAsUser = jest.fn(async text => { context.chat.push({ mes: text, is_user: true, extra: {} }); });
+    context.sendSystemMessage = jest.fn();
+    context.parseChatCompletionLogprobs = () => null;
+
+    load(context, 'scripts/utils.js', ['escapeRegex', 'trimSpaces']);
+    load(context, 'scripts/openai.js', ['chat_completion_sources', 'reasoning_effort_types', 'verbosity_levels', 'getReasoningEffort', 'getVerbosity', 'shouldRequestReasoning', 'getChatCompletionModel', 'createGenerationParameters', 'sendOpenAIRequest', 'getStreamingReply']);
+    load(context, 'scripts/sse-stream.js', ['EventSourceStream']);
+    context.getEventSourceStream = vm.runInContext('() => new EventSourceStream()', context);
+    context.appendAutoAppendReasoningInstruction = messages => messages;
+    load(context, 'scripts/reasoning.js', ['ReasoningType', 'ReasoningState', 'PromptReasoning', 'ReasoningHandler', 'parseReasoningFromString', 'extractReasoningFromData']);
+    context.getReasoningParseTemplates = () => [context.power_user.reasoning];
+    vm.runInContext('ReasoningHandler.prototype.updateDom = () => {};', context);
+    load(context, 'script.js', ['Generate', 'StreamingProcessor', 'sendGenerationRequest', 'sendStreamingRequest', 'getGenerateUrl', 'saveReply', 'getNextMessageId', 'getBiasStrings', 'processCommands', 'extractMessageFromData', 'normalizeContentText', 'stringifyUnknown', 'shouldBufferMainGenerationOutput', 'applyMainGenerationOutputInterceptors', 'unblockGeneration', 'clearStreamingProcessorIfCurrent', 'shouldAutoContinue', 'triggerAutoContinue', 'syncMesToSwipe', 'stopGeneration', 'generateRaw', 'generateRawData', 'generateQuietPrompt', 'TempResponseLength', 'addChatsPreamble', 'addChatsSeparator', 'consumePendingGeneratedMessageExtra']);
+    context.removeReasoningFromString = text => context.parseReasoningFromString(text)?.content ?? text;
+
+    const requests = [];
+    context.reply = 'New prose. ';
+    context.reasoning = '';
+    context.chunks = [];
+    context.fetchResumable = jest.fn(async (url, init) => {
+        const body = JSON.parse(init.body);
+        requests.push({ url, body, signal: init.signal });
+        return { ok: true, json: async () => {
+            if (api === 'openai') return { choices: [{ message: { content: context.reply, reasoning_content: context.reasoning } }] };
+            if (api === 'kobold') return { results: [{ text: context.reply }] };
+            if (api === 'novel') return { output: context.reply };
+            return { choices: [{ text: context.reply }], thinking: context.reasoning };
+        } };
+    });
+    context.generateHorde = jest.fn(async (prompt, data, signal) => {
+        requests.push({ body: data, signal });
+        return { text: context.reply };
+    });
+    if (stream) {
+        // Mock only the provider transport; execute the actual stream processor and finalisation.
+        const transport = jest.fn(async (data, signal) => {
+            requests.push({ body: data, signal });
+            return async function* () {
+                for (const chunk of context.chunks) {
+                    if (signal.aborted) throw signal.reason;
+                    yield { swipes: [], toolCalls: [], state: {}, ...chunk };
+                }
+            };
+        });
+        context.generateTextGenWithStreaming = transport;
+        context.generateKoboldWithStreaming = transport;
+        context.generateNovelWithStreaming = transport;
+    }
+    if (buffer) eventSource.on(event_types.GENERATION_OUTPUT_BUFFERING_DECISION, data => { data.hasPostMainInterceptors = true; });
+    return { context, requests, textarea, dom, eventSource, StreamingProcessor: vm.runInContext('StreamingProcessor', context) };
+}
+
+describe('request-local output controls', () => {
+    test.each([undefined, 0, -1, NaN, Infinity, '160'])('leaves presets alone for an inactive limit: %s', maxOutputTokens => {
+        const preset = { max_tokens: 8192, max_new_tokens: 8192 };
+        expect(applyGenerationRequestControls(preset, { maxOutputTokens })).toBe(preset);
+    });
+
+    test('caps all consumed response fields, not context or thinking fields, without mutating the input', () => {
+        const preset = { max_tokens: 8192, max_completion_tokens: 8192, max_new_tokens: 8192, max_length: 8192, n_predict: 8192, num_predict: -1, options: { num_predict: 8192 }, min_tokens: 300, max_context_length: 32768, include_reasoning: true, thinking: { type: 'disabled' } };
+        const limited = applyGenerationRequestControls(preset, { maxOutputTokens: 160 });
+        for (const field of ['max_tokens', 'max_completion_tokens', 'max_new_tokens', 'max_length', 'n_predict', 'num_predict', 'min_tokens']) expect(limited[field]).toBe(160);
+        expect(limited.options.num_predict).toBe(160);
+        expect(limited.max_context_length).toBe(32768);
+        expect(limited.thinking).toEqual({ type: 'disabled' });
+        expect(preset.max_tokens).toBe(8192);
+        expect(preset.options.num_predict).toBe(8192);
+    });
+
+    test.each([
+        { model: 'gpt-4o', include_reasoning: true },
+        { model: 'gpt-4o', include_reasoning: true, reasoning_effort: 'high' },
+        { model: 'gpt-5.1', max_completion_tokens: 8192, reasoning_effort: 'none' },
+        { model: 'qwen3', thinking: { type: 'disabled', budget_tokens: 4096 } },
+        { model: 'qwen3', think: false },
+        { model: 'grok-4-fast-non-reasoning' },
+        { model: 'ordinary', max_completion_tokens: 8192 },
+    ])('does not invent a reasoning allowance for %j', data => {
+        expect(requestUsesReasoning(data)).toBe(false);
+        expect(applyGenerationRequestControls({ max_tokens: 8192, ...data }, { maxOutputTokens: 160 }).max_tokens).toBe(160);
+    });
+
+    test.each([
+        { model: 'openai/o3', max_completion_tokens: 8192 },
+        { model: 'gpt-5.1', reasoning_effort: 'high' },
+        { model: 'gpt-6-astra' },
+        { model: 'deepseek-reasoner', reasoning_effort: 'none' },
+        { model: 'deepseek-ai/DeepSeek-R1' },
+        { model: 'moonshot/kimi-k3' },
+        { model: 'moonshot/kimi-k2-thinking', reasoning_effort: 'none' },
+        { model: 'gemini-2.0-flash-thinking-exp', reasoning_effort: 'none' },
+        { model: 'qwen3-32b' },
+        { model: 'ordinary', thinking: { type: 'enabled', budget_tokens: 4096 } },
+        { model: 'ordinary', thinking: { type: 'adaptive' } },
+        { model: 'ordinary', reasoning: { max_tokens: 4096 } },
+    ])('keeps the total reasoning allowance for %j', data => {
+        const preset = { max_tokens: 8192, ...data };
+        expect(requestUsesReasoning(preset)).toBe(true);
+        expect(applyGenerationRequestControls(preset, { maxOutputTokens: 160 })).toBe(preset);
+        expect(applyGenerationRequestControls(preset, { responseLength: 64, preserveReasoningBudget: true })).toBe(preset);
+    });
+
+    test('ordinary helper responseLength can exceed the preset while a prose cap never raises it', () => {
+        const preset = { model: 'gpt-4o', max_tokens: 128, include_reasoning: true };
+        expect(applyGenerationRequestControls(preset, { responseLength: 1024, preserveReasoningBudget: true }).max_tokens).toBe(1024);
+        expect(applyGenerationRequestControls(preset, { maxOutputTokens: 160 }).max_tokens).toBe(128);
+    });
+
+    test('uses known local or Horde models when the request has no model field', () => {
+        const preset = { max_length: 8192 };
+        expect(applyGenerationRequestControls(preset, { maxOutputTokens: 160, model: 'deepseek-r1' })).toBe(preset);
+        expect(applyGenerationRequestControls(preset, { maxOutputTokens: 160, model: ['ordinary', 'deepseek-r1'] })).toBe(preset);
+        expect(applyGenerationRequestControls({ ...preset, model: 'ordinary' }, { maxOutputTokens: 160, model: 'deepseek-r1' }).max_length).toBe(160);
+    });
+
+    test('separates completed, partial and multiple inline thinking blocks', () => {
+        const { context } = makeRuntime();
+        const limit = text => limitGenerationProse(text, 2, context.power_user.reasoning, '', true);
+        expect(limit('<think>' + 'reasoning '.repeat(100))).toMatchObject({ text: '', limited: false });
+        expect(limit('<thi')).toMatchObject({ text: '', limited: false });
+        expect(limit('<thinking>one</thinking>abcd<think>two</think>efgh-more')).toEqual({ text: 'abcdefgh', reasoning: 'one\n\ntwo', limited: true });
+        expect(limit('abc\uD83D\uDE00xxxx')).toMatchObject({ text: 'abc\uD83D\uDE00xxx', limited: true });
+        expect(limitGenerationProse('abc\uD83D\uDE00', 1, context.power_user.reasoning).text).toBe('abc');
+    });
+
+    test('advertises the exact integration capability on the context object', () => {
+        expect(sources['scripts/st-context.js'].source).toContain('generationSupportsRequestControls: true');
+    });
+
+    test('length metadata ignores absent or malformed choices and secondary swipes', () => {
+        for (const data of [null, {}, { choices: {} }, { choices: [null] }, { choices: [{ index: 1, finish_reason: 'length' }] }]) {
+            expect(isGenerationLengthFinish(data)).toBe(false);
+        }
+        expect(isGenerationLengthFinish({ delta: { stop_reason: 'max_tokens' } })).toBe(true);
+        expect(isGenerationLengthFinish({ candidates: [{ finishReason: 'MAX_TOKENS' }] })).toBe(true);
+    });
+});
+
+describe('owned host generation flow', () => {
+    test('suppressed continuation ignores draft commands and extends the same assistant block', async () => {
+        const { context, textarea, requests } = makeRuntime({ composer: '/delete everything' });
+        const original = context.chat[0];
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(context.executeSlashCommandsOnChatInput).not.toHaveBeenCalled();
+        expect(context.sendMessageAsUser).not.toHaveBeenCalled();
+        expect(context.removeLastMessage).not.toHaveBeenCalled();
+        expect(context.chat).toHaveLength(1);
+        expect(context.chat[0]).toBe(original);
+        expect(original.mes).toBe('Existing prose. New prose. ');
+        expect(textarea.value).toBe('/delete everything');
+        expect(requests[0].body.max_tokens).toBe(160);
+        expect(context.power_user.auto_continue.enabled).toBe(true);
+        expect(context.oai_settings.openai_max_tokens).toBe(8192);
+        expect(context.getTokenCount).not.toHaveBeenCalled();
+    });
+
+    test('preserves composer consumption and slash-command execution for default callers', async () => {
+        const command = makeRuntime({ composer: '/echo hello' });
+        await command.context.Generate('continue');
+        expect(command.context.executeSlashCommandsOnChatInput).toHaveBeenCalledTimes(1);
+        expect(command.requests).toHaveLength(0);
+        const draft = makeRuntime({ composer: 'A draft.' });
+        await draft.context.Generate('continue', { suppressAutoContinue: true });
+        expect(draft.context.sendMessageAsUser).toHaveBeenCalledWith('A draft.', '');
+        expect(draft.textarea.value).toBe('');
+    });
+
+    test('suppression does not delete the preceding assistant message or consume attachments on a normal request', async () => {
+        const { context, textarea } = makeRuntime({ composer: '/echo untouched' });
+        context.hasPendingFileAttachment = () => true;
+        const original = context.chat[0];
+        await context.Generate('normal', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(context.chat).toHaveLength(2);
+        expect(context.chat[0]).toBe(original);
+        expect(context.removeLastMessage).not.toHaveBeenCalled();
+        expect(context.sendMessageAsUser).not.toHaveBeenCalled();
+        expect(context.executeSlashCommandsOnChatInput).not.toHaveBeenCalled();
+        expect(textarea.value).toBe('/echo untouched');
+    });
+
+    test.each(['openai', 'textgenerationwebui', 'kobold', 'koboldhorde', 'novel'])('caps the owned %s request after a nested quiet call', async api => {
+        const { context, requests, eventSource } = makeRuntime({ api });
+        let nested = false;
+        eventSource.on(event_types.GENERATE_AFTER_DATA, async () => {
+            if (nested) return;
+            nested = true;
+            await context.generateQuietPrompt({ quietPrompt: 'helper', responseLength: 64, preserveReasoningBudget: true });
+        });
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        const field = ['kobold', 'koboldhorde', 'novel'].includes(api) ? 'max_length' : 'max_tokens';
+        expect(requests.map(request => request.body[field])).toEqual([64, 160]);
+        expect(context.amount_gen).toBe(8192);
+        expect(context.oai_settings.openai_max_tokens).toBe(8192);
+    });
+
+    test('a nested SETTINGS_READY helper cannot take the owning OpenAI cap', async () => {
+        const { context, requests, eventSource } = makeRuntime();
+        let nested = false;
+        eventSource.on(event_types.CHAT_COMPLETION_SETTINGS_READY, async () => {
+            if (nested) return;
+            nested = true;
+            await context.generateRaw({ prompt: 'helper', responseLength: 64, preserveReasoningBudget: true });
+        });
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(requests.map(request => request.body.max_tokens)).toEqual([64, 160]);
+    });
+
+    test('hands Custom controls to the final server payload without changing the preset allowance', async () => {
+        const { context, requests } = makeRuntime();
+        context.oai_settings.chat_completion_source = 'custom';
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        await context.generateRaw({ prompt: 'helper', responseLength: 64, preserveReasoningBudget: true });
+        await context.generateRaw({ prompt: 'ordinary helper' });
+        expect(requests[0].body.request_controls).toEqual({ maxOutputTokens: 160, responseLength: null, preserveReasoningBudget: false });
+        expect(requests[1].body.request_controls).toEqual({ maxOutputTokens: 0, responseLength: 64, preserveReasoningBudget: true });
+        expect(requests[2].body.request_controls).toBeUndefined();
+        expect(requests.map(request => request.body.max_tokens)).toEqual([8192, 8192, 8192]);
+    });
+
+    test('caps max_completion_tokens on a real disabled-reasoning OpenAI payload', async () => {
+        const { context, requests } = makeRuntime({ model: 'gpt-5.1' });
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(requests[0].body.max_completion_tokens).toBe(160);
+        expect(requests[0].body.max_tokens).toBeUndefined();
+        expect(requests[0].body.reasoning_effort).toBe('none');
+    });
+
+    test('forwards controls through the group wrapper without consuming a suppressed draft or auto-continuing', async () => {
+        const { context, requests, textarea, eventSource } = makeRuntime({ composer: '/echo draft' });
+        Object.assign(context, {
+            selected_group: 'group', menu_type: 'group_edit',
+            groups: [{ id: 'group', members: ['story.png'], disabled_members: [] }],
+            group_generation_id: null, groupChatQueueOrder: new Map(),
+            group_activation_strategy: { NATURAL: 0, LIST: 1, MANUAL: 2, POOLED: 3 },
+            getGroupEnabledMembers: group => group.members,
+            getSelectedGroupSpeakerChid: () => -1,
+            findDirectlyAddressedMember: jest.fn(() => -1),
+            isAddressedToEntireGroup: () => false,
+            limitGroupSpeakersForControl: members => members,
+            buildContextAwareGroupPrompt: () => '',
+            runWithGroupMemberModelOverride: (group, avatar, task) => task(),
+            setCharacterId: id => { context.this_chid = id; },
+            setCharacterName: name => { context.name2 = name; },
+            setSendButtonState: jest.fn(), setGroupTypingIndicator: jest.fn(),
+            unshallowGroupMembers: jest.fn(),
+        });
+        context.chat[0].original_avatar = 'story.png';
+        load(context, 'scripts/group-chats.js', ['generateGroupWrapper', 'activateSwipe']);
+        const starts = [];
+        eventSource.on(event_types.GENERATION_STARTED, (type, options) => starts.push({ type, options }));
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(requests).toHaveLength(1);
+        expect(requests[0].body.max_tokens).toBe(160);
+        expect(starts).toHaveLength(2);
+        expect(starts[1].options).toMatchObject({ suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(context.findDirectlyAddressedMember).toHaveBeenCalledWith(context.groups[0], 'Existing prose. ');
+        expect(context.sendMessageAsUser).not.toHaveBeenCalled();
+        expect(context.executeSlashCommandsOnChatInput).not.toHaveBeenCalled();
+        expect(textarea.value).toBe('/echo draft');
+        expect(context.getTokenCount).not.toHaveBeenCalled();
+    });
+
+    test.each([false, true])('tool successors retain controls but tool helpers do not (stream: %s)', async stream => {
+        const { context, requests } = makeRuntime({ api: stream ? 'textgenerationwebui' : 'openai', stream });
+        context.ToolManager.canPerformToolCalls = () => true;
+        context.ToolManager.hasToolCalls = jest.fn().mockReturnValueOnce(true).mockReturnValue(false);
+        context.chunks = [{ text: 'tool reply', toolCalls: [{ id: 'tool' }] }];
+        context.ToolManager.invokeFunctionTools = jest.fn(async () => ({ invocations: [], stealthCalls: [] })).mockImplementationOnce(async () => {
+            await context.generateRaw({ prompt: 'tool helper', responseLength: 64, preserveReasoningBudget: true });
+            context.chunks = [{ text: 'successor' }];
+            return { invocations: [{ id: 'tool' }], stealthCalls: [] };
+        });
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(requests.map(request => request.body.max_tokens)).toEqual([160, 64, 160]);
+        expect(context.ToolManager.saveFunctionToolInvocations).toHaveBeenCalledTimes(1);
+        expect(context.getTokenCount).not.toHaveBeenCalled();
+        expect(context.power_user.auto_continue.enabled).toBe(true);
+    });
+
+    test.each(['generateRaw', 'generateQuietPrompt'])('%s preserves the original reasoning budget before any preset override', async method => {
+        for (const model of ['gpt-4o', 'o3']) {
+            const { context, requests } = makeRuntime({ model });
+            await context[method]({ prompt: 'selection', quietPrompt: 'selection', responseLength: 64, preserveReasoningBudget: true });
+            expect(requests[0].body.max_tokens ?? requests[0].body.max_completion_tokens).toBe(model === 'o3' ? 8192 : 64);
+            expect(context.oai_settings.openai_max_tokens).toBe(8192);
+        }
+    });
+
+    test.each(['generateRaw', 'generateQuietPrompt'])('%s keeps the legacy responseLength override unless preservation is requested', async method => {
+        const { context, requests } = makeRuntime({ model: 'o3' });
+        await context[method]({ prompt: 'selection', quietPrompt: 'selection', responseLength: 64 });
+        expect(requests[0].body.max_completion_tokens).toBe(64);
+        expect(context.oai_settings.openai_max_tokens).toBe(8192);
+    });
+
+    test.each(['generateRaw', 'generateQuietPrompt'])('%s preserves the exact real text-completion reasoning payload, not a backend default', async method => {
+        const { context, requests } = makeRuntime({ api: 'textgenerationwebui', model: 'deepseek-r1' });
+        load(context, 'scripts/textgen-settings.js', ['textgen_types', 'getTextGenModel', 'createTextGenGenerationData', 'getTextGenGenerationData', 'replaceMacrosInList']);
+        Object.assign(context, vm.runInContext('textgen_types', context), {
+            isDynamicTemperatureSupported: () => false,
+            getCustomTokenBans: () => ({ banned_tokens: [], banned_strings: [] }),
+            isObject: value => value !== null && typeof value === 'object',
+            toIntArray: () => [], shouldUseLocalPromptCache: () => false,
+            getTextGenServer: () => 'http://example.invalid',
+        });
+        Object.assign(context.textgenerationwebui_settings, { llamacpp_model: 'deepseek-r1', temp: 0.6, min_length: 128, top_p: 0.9, include_reasoning: true });
+        const settings = structuredClone(context.textgenerationwebui_settings);
+        await context[method]({ prompt: 'helper', quietPrompt: 'helper' });
+        await context[method]({ prompt: 'helper', quietPrompt: 'helper', responseLength: 64, preserveReasoningBudget: true });
+        expect(requests[1].body).toEqual(requests[0].body);
+        expect(requests[1].body).toMatchObject({ max_tokens: 8192, max_new_tokens: 8192, n_predict: 8192, num_predict: 8192 });
+        expect(context.textgenerationwebui_settings).toEqual(settings);
+        expect(context.amount_gen).toBe(8192);
+    });
+
+    test('reserves a local prompt budget without mutating the OpenAI preset', async () => {
+        const { context } = makeRuntime();
+        const setTokenBudget = jest.fn();
+        context.ChatCompletion = class {
+            setTokenBudget = setTokenBudget;
+            buildRuntimeAgentMessages() {}
+            getChat() { return []; }
+        };
+        context.promptManager = {
+            serviceSettings: { openai_max_context: 32768, openai_max_tokens: 8192 },
+            setChatCompletion: jest.fn(), render: jest.fn(), tokenHandler: { counts: false },
+        };
+        context.preparePromptsForChatCompletion = async () => [];
+        context.populateChatCompletion = async () => {};
+        context.shouldCheckPostInterceptChatBudget = () => false;
+        load(context, 'scripts/openai.js', ['prepareOpenAIMessages']);
+        await context.prepareOpenAIMessages({ messages: [], responseLength: 1024 }, false);
+        expect(setTokenBudget).toHaveBeenCalledWith(32768, 1024);
+        expect(context.promptManager.serviceSettings.openai_max_tokens).toBe(8192);
+    });
+
+    test('auto-continue forwards owned options through its existing click handler', () => {
+        const { context, dom } = makeRuntime();
+        const controls = { maxOutputTokens: 160, suppressUserMessage: true };
+        context.power_user.auto_continue.target_length = 100;
+        context.getTokenCount = () => 1;
+        context.triggerAutoContinue('enough prose', false, controls);
+        expect(dom.trigger).toHaveBeenCalledWith('click', { generationOptions: controls });
+        expect(sources['script.js'].source).toContain('...customData?.generationOptions,');
+        expect(context.power_user.auto_continue.enabled).toBe(true);
+    });
+
+    test('the context swipe entry point forwards retry controls into the real successor request', async () => {
+        const { context, requests, textarea, eventSource } = makeRuntime({ composer: '/echo untouched' });
+        const messageDom = { 0: { scrollHeight: 100 }, length: 1 };
+        for (const method of ['children', 'filter', 'find', 'css', 'animate', 'html', 'text']) messageDom[method] = () => messageDom;
+        messageDom.width = () => 100;
+        messageDom.scrollTop = () => 0;
+        messageDom.prop = () => 1000;
+        messageDom.outerHeight = () => 100;
+        Object.assign(context, {
+            OVERSWIPE_BEHAVIOR, SWIPE_DIRECTION, SWIPE_SOURCE, SWIPE_STATE,
+            chatElement: messageDom, swipeState: SWIPE_STATE.NONE, this_edit_mes_id: -1,
+            animation_duration: 0, cancelDebouncedChatSave: jest.fn(), saveChatDebounced: jest.fn(),
+            getOverswipeBehavior: () => OVERSWIPE_BEHAVIOR.REGENERATE,
+            updateReasoningUI: jest.fn(), settleSwipeReplacementAnchor: jest.fn(),
+            clamp: (value, min, max) => Math.min(max, Math.max(min, value)),
+        });
+        context.document.body = { dataset: {} };
+        load(context, 'script.js', ['swipe']);
+        // getContext exposes this same function as swipe.to, not the legacy right wrapper.
+        const contextSwipe = { to: context.swipe };
+        const controls = { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 };
+        const starts = [];
+        eventSource.on(event_types.GENERATION_STARTED, (type, options) => starts.push({ type, options }));
+        context.reply = 'abcdefgh-overrun';
+        await contextSwipe.to(null, 'right', { source: SWIPE_SOURCE.SLASH_COMMAND, forceDuration: 0, generationOptions: controls });
+        expect(requests).toHaveLength(1);
+        expect(requests[0].body.max_tokens).toBe(2);
+        expect(starts).toEqual([{ type: 'swipe', options: expect.objectContaining(controls) }]);
+        expect(context.chat[0].mes).toBe('abcdefgh');
+        expect(context.chat[0].swipes).toEqual(['Existing prose. ', 'abcdefgh']);
+        expect(textarea.value).toBe('/echo untouched');
+        expect(context.swipeState).toBe(SWIPE_STATE.NONE);
+    });
+
+    test('separates and locally caps non-streamed reasoning without cancelling or losing the existing block', async () => {
+        const { context, requests, eventSource } = makeRuntime({ model: 'o3' });
+        context.reply = '<think>' + 'reasoning '.repeat(200) + '</think>' + 'p'.repeat(900);
+        const received = jest.fn();
+        eventSource.on(event_types.MESSAGE_RECEIVED, received);
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(requests[0].body.max_completion_tokens).toBe(8192);
+        expect(context.chat[0].mes).toBe('Existing prose. ' + 'p'.repeat(640));
+        expect(context.chat[0].extra.reasoning).toBe('reasoning '.repeat(200));
+        expect(result.finishReason).toBe('length');
+        expect(context.abortController.signal.aborted).toBe(false);
+        expect(received).toHaveBeenCalledTimes(1);
+    });
+
+    test('never treats a Gemini thinking-only response as prose through the extraction fallback', async () => {
+        const { context } = makeRuntime();
+        context.oai_settings.chat_completion_source = 'makersuite';
+        context.oai_settings.google_model = 'gemini-2.5-flash';
+        context.fetchResumable.mockResolvedValue({ ok: true, json: async () => ({
+            choices: [{ message: { content: '' } }],
+            responseContent: { parts: [{ thought: true, text: 'thinking '.repeat(1000) }] },
+        }) });
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(context.chat[0].mes).toBe('Existing prose. ');
+        expect(context.chat[0].extra.reasoning).toBe('thinking '.repeat(1000));
+        expect(context.toastr.warning).toHaveBeenCalledTimes(1);
+        expect(result.finishReason).toBeNull();
+        expect(context.extractMessageFromData({ responseContent: { parts: [null, { thought: true, text: 'hidden' }, { text: 'prose' }] } })).toBe('prose');
+        expect(context.extractMessageFromData({ responseContent: { parts: 'plain fallback' } })).toBe('plain fallback');
+    });
+
+    test.each(['nonstream', 'stream', 'buffer'])('retains the accepted partial sentence on length completion: %s', async mode => {
+        const { context } = makeRuntime({ api: 'textgenerationwebui', model: 'deepseek-r1', stream: mode !== 'nonstream', buffer: mode === 'buffer' });
+        context.power_user.trim_sentences = true;
+        context.reply = 'abcdefgh-overrun';
+        context.chunks = [{ text: context.reply }];
+        load(context, 'scripts/utils.js', ['trimToEndSentence']);
+        load(context, 'script.js', ['cleanUpMessage']);
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(context.chat[0].mes).toBe('Existing prose. abcdefgh');
+        expect(result.finishReason).toBe('length');
+    });
+
+    test.each(['nonstream', 'stream', 'buffer'])('continues an incomplete thinking prefix without consuming the new prose: %s', async mode => {
+        const { context } = makeRuntime({ api: 'textgenerationwebui', model: 'deepseek-r1', stream: mode !== 'nonstream', buffer: mode === 'buffer' });
+        context.chat[0].mes = '';
+        context.chat[0].extra.reasoning = 'prior ';
+        context.reply = 'more</think>abcdefgh-overrun';
+        context.chunks = [{ text: context.reply }];
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(context.chat[0].mes).toBe('abcdefgh');
+        expect(context.chat[0].extra.reasoning).toBe('prior more');
+        expect(result.finishReason).toBe('length');
+    });
+
+    test.each(['nonstream', 'stream', 'buffer'])('keeps all reasoning continuation text when whitespace trimming is enabled: %s', async mode => {
+        const { context } = makeRuntime({ api: 'textgenerationwebui', model: 'deepseek-r1', stream: mode !== 'nonstream', buffer: mode === 'buffer' });
+        context.power_user.trim_spaces = true;
+        context.chat[0].mes = '';
+        context.chat[0].extra.reasoning = ' prior ';
+        context.reply = 'more</think>abcdefgh-overrun';
+        context.chunks = [{ text: context.reply }];
+        await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(context.chat[0].mes).toBe('abcdefgh');
+        expect(context.chat[0].extra.reasoning.trim()).toBe('prior more');
+    });
+
+    test.each(['nonstream', 'stream', 'buffer'])('retains a final literal less-than sign rather than dropping a suspected thinking tag: %s', async mode => {
+        const { context } = makeRuntime({ api: 'textgenerationwebui', stream: mode !== 'nonstream', buffer: mode === 'buffer' });
+        context.reply = 'a <';
+        context.chunks = [{ text: context.reply }];
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(context.chat[0].mes).toBe('Existing prose. a <');
+        expect(result.finishReason).toBeNull();
+    });
+
+    test.each(['nonstream', 'stream', 'buffer'])('honours the provider length ending before the character estimate: %s', async mode => {
+        const { context, eventSource } = makeRuntime({ stream: mode !== 'nonstream', buffer: mode === 'buffer' });
+        context.power_user.trim_sentences = true;
+        load(context, 'scripts/utils.js', ['trimToEndSentence']);
+        load(context, 'script.js', ['cleanUpMessage']);
+        context.fetchResumable.mockImplementation(async () => mode === 'nonstream'
+            ? new Response(JSON.stringify({ choices: [{ message: { content: 'partial' }, finish_reason: 'length' }] }))
+            : new Response('data: {"choices":[{"index":0,"delta":{"content":"partial"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"length"}]}\n\ndata: [DONE]\n\n'));
+        const received = [];
+        eventSource.on(event_types.MESSAGE_RECEIVED, () => received.push(context.chat[0].mes));
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 160 });
+        expect(result.finishReason).toBe('length');
+        expect(context.chat[0].mes).toBe('Existing prose. partial');
+        expect(received).toEqual(['Existing prose. partial']);
+        expect(eventSource.emit.mock.calls.some(([name]) => name === event_types.GENERATION_STOPPED)).toBe(false);
+    });
+
+    test.each([false, true])('streamed cap completes once, including buffering: %s', async buffer => {
+        const { context, requests, eventSource, StreamingProcessor } = makeRuntime({ api: 'textgenerationwebui', model: 'deepseek-r1', stream: true, buffer });
+        context.chunks = [
+            { text: '', state: { reasoning: 'hidden '.repeat(400) } },
+            { text: 'abcd', state: { reasoning: 'hidden '.repeat(400) } },
+            { text: 'abcd', state: { reasoning: 'hidden '.repeat(500) } },
+            { text: 'abcdefgh-overrun', state: { reasoning: 'hidden '.repeat(500) } },
+            { text: 'must not be accepted' },
+        ];
+        const finalise = jest.spyOn(StreamingProcessor.prototype, 'onFinishStreaming');
+        let processor;
+        const postAgent = jest.fn();
+        eventSource.on(event_types.MESSAGE_RECEIVED, () => {
+            processor ??= context.streamingProcessor;
+            if (!processor.isStopped && !processor.abortController.signal.aborted) postAgent(context.chat[0].mes);
+        });
+        const intercepted = [];
+        eventSource.on(event_types.MAIN_GENERATION_OUTPUT_READY, data => { intercepted.push(data.text); });
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(requests[0].body.max_tokens).toBe(8192);
+        expect(requests[0].signal.aborted).toBe(true);
+        expect(processor.abortController.signal.aborted).toBe(false);
+        expect(processor.isCancelled).toBe(false);
+        expect(processor.isStopped).toBe(false);
+        expect(processor.isFinished).toBe(true);
+        expect(result.finishReason).toBe('length');
+        expect(context.chat[0].mes).toBe('Existing prose. abcdefgh');
+        expect(postAgent).toHaveBeenCalledTimes(1);
+        expect(finalise).toHaveBeenCalledTimes(buffer ? 0 : 1);
+        expect(intercepted).toEqual(buffer ? ['Existing prose. abcdefgh'] : []);
+        expect(context.saveChatConditional).toHaveBeenCalledTimes(1);
+        expect(context.getTokenCount).not.toHaveBeenCalled();
+        expect(eventSource.emit.mock.calls.some(([name]) => name === event_types.GENERATION_STOPPED)).toBe(false);
+        expect(context.streamingProcessor).toBeNull();
+    });
+
+    test.each([false, true])('inline thinking and repeated text do not consume the stream budget (buffer: %s)', async buffer => {
+        const { context, StreamingProcessor } = makeRuntime({ api: 'textgenerationwebui', stream: true, buffer });
+        const processor = new StreamingProcessor('continue', false, new Date(), '', {}, { maxOutputTokens: 2 });
+        processor.messageId = 0;
+        context.streamingProcessor = processor;
+        processor.generator = async function* () {
+            yield { text: '<think>' + 'x'.repeat(1000), state: {}, swipes: [] };
+            yield { text: '<think>' + 'x'.repeat(1000), state: {}, swipes: [] };
+            yield { text: '<think>' + 'x'.repeat(1000) + '</think>abcd', state: {}, swipes: [] };
+            yield { text: '<think>' + 'x'.repeat(1000) + '</think>abcd', state: {}, swipes: [] };
+        };
+        await (buffer ? processor.generateBuffered() : processor.generate());
+        expect(processor.result).toBe('abcd');
+        expect(processor.finishReason).toBeNull();
+        expect(processor.requestAbortController.signal.aborted).toBe(false);
+        expect(processor.pendingReasoning).toBe('x'.repeat(1000));
+        expect(context.getTokenCount).not.toHaveBeenCalled();
+    });
+
+    test.each([false, true])('explicit cancellation stays cancelled, not a length completion (buffer: %s)', async buffer => {
+        const { context, eventSource } = makeRuntime({ api: 'textgenerationwebui', stream: true, buffer });
+        let processor;
+        context.generateTextGenWithStreaming = async (data, signal) => {
+            processor = context.streamingProcessor;
+            return async function* () {
+                yield { text: 'abcd', state: {}, swipes: [] };
+                context.stopGeneration();
+                throw signal.reason;
+            };
+        };
+        const received = jest.fn();
+        eventSource.on(event_types.MESSAGE_RECEIVED, received);
+        const result = await context.Generate('continue', { suppressUserMessage: true, suppressAutoContinue: true, maxOutputTokens: 2 });
+        expect(result).toBeUndefined();
+        expect(processor.result).toBe('abcd');
+        expect(processor.finishReason).toBeNull();
+        expect(processor.isCancelled).toBe(true);
+        expect(processor.isStopped).toBe(true);
+        expect(processor.abortController.signal.aborted).toBe(true);
+        expect(processor.requestAbortController.signal.aborted).toBe(true);
+        expect(context.saveChatConditional).not.toHaveBeenCalled();
+        expect(received).not.toHaveBeenCalled();
+        expect(context.chat[0].mes).toBe(buffer ? 'Existing prose. ' : 'Existing prose. abcd');
+    });
+});


### PR DESCRIPTION
I added the support Story Mode needed from SillyBunny itself. Previously, controlling one continuation could involve changing shared settings, and failed saves didn't reliably report failure. This prevents Story Mode from changing your setup and breaking things. Useful for the eventual future PR for Story Mode as a full feature implementation.

**What Changed**
- Replies can have their own length limit without changing your preset or accidentally limiting an agent's separate reply.
- Auto-continue can be skipped for one action without switching it off in your saved settings.
- Retry can leave the message box alone, instead of sending your unfinished draft or removing the reply it was meant to continue.
- Agents can be paused temporarily without changing their saved on/off switches. Saving an agent or changing chats won't accidentally make that pause permanent. Waiting agents and companions also check whether they're still allowed to run.
- Short rewrites can keep a thinking model's normal thinking allowance. Reaching a passage's length limit finishes the reply normally, rather than treating it as cancelled and skipping the usual follow-up work.
- Extensions can now confirm whether chat and character changes actually saved. Failed character saves no longer update the local card as though they succeeded.

These controls are optional. Existing settings keep their usual behaviour unless an extension asks to use them. Story Mode's layout, editing and Undo/Redo fixes are in its own repository, not this PR.
