### PR TITLE
fix(ios26+): correctly identify iOS versions

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -2808,7 +2808,7 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     #right-nav-panel.openDrawer,
     #top-settings-holder #right-nav-panel.openDrawer,
     :root[data-sb-character-drawer-lock='right'] #right-nav-panel.openDrawer {
-        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
+        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px) + var(--sb-shell-viewport-top, 0px)) !important;
         bottom: auto !important;
         box-sizing: border-box !important;
         height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
@@ -2892,10 +2892,15 @@ html.sb-ios-keyboard-inset-active #right-nav-panel.openDrawer > .scrollableInner
     }
 
     #form_sheld {
-        padding: 0 0 env(safe-area-inset-bottom, 0px) !important;
+        padding: 0 0 max(var(--sb-ios-composer-controls-clearance, 0px), env(safe-area-inset-bottom, 0px)) !important;
         margin: 0 !important;
         width: 100% !important;
         max-width: none !important;
+    }
+
+    /* Safari's floating form controls can overlap the reported visible viewport. */
+    html.sb-ios-composer-keyboard-controls-active #form_sheld {
+        --sb-ios-composer-controls-clearance: 48px;
     }
 
     #send_form {

--- a/public/scripts/mobile-send-button.js
+++ b/public/scripts/mobile-send-button.js
@@ -26,7 +26,10 @@ export function isLegacyIOSWebKitPlatform(navigatorRef = globalThis.navigator) {
         return false;
     }
 
-    const match = String(navigatorRef.userAgent || '').match(/\bCPU(?: iPhone)? OS (\d+)(?:[_\s]|$)/i);
+    const userAgent = String(navigatorRef.userAgent || '');
+    // Safari 26+ freezes the CPU OS token at iOS 18; its Version token remains accurate.
+    const match = userAgent.match(/\bVersion\/(\d+)(?:[.\s]|$)/i)
+        ?? userAgent.match(/\bCPU(?: iPhone)? OS (\d+)(?:[_\s]|$)/i);
     const majorVersion = Number(match?.[1]);
     return Number.isInteger(majorVersion) && majorVersion < IOS_STABLE_COMPOSER_VIEWPORT_MAJOR;
 }

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -1063,6 +1063,7 @@ function clampBoundNumber(value, min, max) {
  * @param {boolean} [options.isOpen=false] Whether the drawer has the openDrawer class.
  * @param {boolean} [options.isViewportBound=false] Whether the drawer carries the bound dataset marker.
  * @param {number} [options.viewportHeight=0] Current shell viewport height in px.
+ * @param {number} [options.viewportTop=0] Visible viewport offset in px.
  * @param {number} [options.baseTopOffset=0] Resolved shell topbar offset in px.
  * @param {number} [options.shellGap=0] Drawer --sb-mobile-shell-gap value in px.
  * @returns {{action: string, styleWrites: Array<{property: string, value: string, priority: string}>, styleRemovals: string[]}}
@@ -1072,6 +1073,7 @@ export function resolveMobileDrawerBounds({
     isOpen = false,
     isViewportBound = false,
     viewportHeight = 0,
+    viewportTop = 0,
     baseTopOffset = 0,
     shellGap = 0,
 } = {}) {
@@ -1086,6 +1088,7 @@ export function resolveMobileDrawerBounds({
     }
 
     const safeViewportHeight = Math.max(0, normalizeNumber(viewportHeight));
+    const safeViewportTop = Math.max(0, Math.round(normalizeNumber(viewportTop)));
     const safeBaseTopOffset = Math.max(0, Math.round(normalizeNumber(baseTopOffset)));
     const topOffset = clampBoundNumber(Math.round(safeBaseTopOffset + normalizeNumber(shellGap)), 0, safeViewportHeight);
     const availableHeight = Math.max(0, safeViewportHeight - topOffset);
@@ -1093,7 +1096,7 @@ export function resolveMobileDrawerBounds({
     return {
         action: MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND,
         styleWrites: [
-            { property: 'top', value: `${topOffset}px`, priority: 'important' },
+            { property: 'top', value: `${safeViewportTop + topOffset}px`, priority: 'important' },
             { property: 'bottom', value: 'auto', priority: 'important' },
             { property: 'box-sizing', value: 'border-box', priority: 'important' },
             { property: 'height', value: `${availableHeight}px`, priority: 'important' },

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2691,6 +2691,10 @@ function shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize) {
         return false;
     }
 
+    if (isMobileViewport() && !isLegacyIOSWebKitPlatform()) {
+        return false;
+    }
+
     const activeElement = document.activeElement;
     if (isChatComposerEditableElement(activeElement)) {
         return false;
@@ -2771,13 +2775,18 @@ function handleMobileKeyboardFocusOut() {
 function syncIOSKeyboardBottomInset() {
     const root = document.documentElement;
     let bottomInset = 0;
+    let composerControlsActive = false;
 
     if (isIOSWebKitPlatform()) {
         const layoutViewport = getLayoutViewportSize();
         const visualViewportSize = getVisualViewportSize(layoutViewport);
 
         if (isVisualViewportKeyboardOpen(layoutViewport, visualViewportSize)) {
-            bottomInset = Math.max(0, Math.round(layoutViewport.height - visualViewportSize.top - visualViewportSize.height));
+            if (isMobileViewport() && !isLegacyIOSWebKitPlatform()) {
+                composerControlsActive = isChatComposerEditableElement(document.activeElement);
+            } else {
+                bottomInset = Math.max(0, Math.round(layoutViewport.height - visualViewportSize.top - visualViewportSize.height));
+            }
         }
     }
 
@@ -2790,6 +2799,7 @@ function syncIOSKeyboardBottomInset() {
     // viewports (iPadOS desktop-mode Safari) gate the padding on this class so
     // desktop layouts only pick it up while the software keyboard is open.
     root.classList.toggle('sb-ios-keyboard-inset-active', bottomInset > 0);
+    root.classList.toggle('sb-ios-composer-keyboard-controls-active', composerControlsActive);
 }
 
 function getShellViewportSize() {
@@ -2802,9 +2812,8 @@ function getShellViewportSize() {
         return { ...layoutViewport, height, bottom: height };
     }
 
-    // SillyBunny: iOS keyboard edits inside shell panels should not feed Safari
-    // visualViewport jitter back into shell geometry. The chat composer remains
-    // on the visible viewport so the keyboard accessory bar cannot cover it.
+    // Older iOS and wide iPad panels retain the stable layout; modern phone
+    // panels fit the visible viewport without a second keyboard-sized reserve.
     if (shouldUseStableIOSPanelViewport(layoutViewport, visualViewportSize)) {
         return layoutViewport;
     }
@@ -2829,8 +2838,7 @@ function syncShellViewportBounds() {
     setRootViewportProperty('--sb-shell-viewport-height', `${viewportSize.height}px`);
     setRootViewportProperty('--sb-shell-measured-top-offset', `${topOffset}px`);
     setRootViewportProperty('--sb-shell-available-height', `${Math.max(0, viewportSize.height - topOffset)}px`);
-    // SillyBunny: iOS Safari shifts the visual viewport while the keyboard opens;
-    // panel edits keep the stable top, while composer edits follow the visible top.
+    // SillyBunny: Safari can pan the visible viewport without resizing it.
     setRootViewportProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
 
     // SillyBunny: browser-fixes.js may reset document scroll mid-edit once the
@@ -3078,6 +3086,7 @@ function syncMobileShellDrawerBounds() {
             isOpen,
             isViewportBound: drawer.dataset.sbMobileViewportBound === 'true',
             viewportHeight: viewportSize?.height ?? 0,
+            viewportTop: viewportSize?.top ?? 0,
             baseTopOffset,
             shellGap: drawerStyles ? Number.parseFloat(drawerStyles.getPropertyValue('--sb-mobile-shell-gap')) || 0 : 0,
         }));
@@ -17520,6 +17529,8 @@ function initAll() {
     if (isIOSWebKitPlatform()) {
         document.addEventListener('focusin', syncIOSKeyboardBottomInset);
         document.addEventListener('focusout', syncIOSKeyboardBottomInset);
+        document.addEventListener('focusin', queueMobileViewportStateSync);
+        document.addEventListener('focusout', queueMobileViewportStateSync);
     }
 
     if (isLegacyIOSWebKitPlatform()) {

--- a/tests/mobile-ios26-keyboard-layout.e2e.js
+++ b/tests/mobile-ios26-keyboard-layout.e2e.js
@@ -1,0 +1,216 @@
+/* global document, window, navigator, getComputedStyle */
+import fs from 'node:fs/promises';
+import { expect, test } from '@playwright/test';
+
+const publicRoot = new URL('../public/', import.meta.url);
+const safariUA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Mobile/15E148 Safari/604.1';
+const controlsClass = /\bsb-ios-composer-keyboard-controls-active\b/;
+
+// Known top-level functions end at a column-zero brace; no application bootstrap is loaded.
+function extractFunction(source, name) {
+    const match = source.match(new RegExp(`^(?:export )?(function ${name}\\([\\s\\S]*?^}$)`, 'm'));
+    if (!match) throw new Error(`Missing production function: ${name}`);
+    return match[1];
+}
+
+function extractDeclaration(source, name) {
+    const match = source.match(new RegExp(`^(?:export )?((?:const|let) ${name} = [\\s\\S]*?;)`, 'm'));
+    if (!match) throw new Error(`Missing production declaration: ${name}`);
+    return match[1];
+}
+
+test.use({ viewport: { width: 390, height: 844 }, userAgent: safariUA, reducedMotion: 'reduce' });
+
+async function mountFixture(page, { platform = 'iPhone', userAgent = safariUA } = {}) {
+    const errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.route('**/*', route => route.abort());
+    await page.setContent(`<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head><body>
+        <div id="sheld"><div id="chat"></div><div id="form_sheld"><form id="send_form">
+            <div id="nonQRFormItems"><div id="leftSendForm"></div><textarea id="send_textarea"></textarea><div id="rightSendForm"></div></div>
+        </form></div></div>
+        <div id="user-settings-block" class="drawer-content sb-shell-root">
+            <div class="sb-shell-frame"><div class="sb-shell-main"><div class="sb-shell-body">
+                <div class="sb-shell-panel sb-shell-panel-active"><div class="sb-shell-panel-scroller">
+                    <input id="first-setting" aria-label="First setting">
+                    ${Array.from({ length: 30 }, (_, index) => `<p>Setting row ${index}</p>`).join('')}
+                    <textarea id="last-setting" aria-label="Last setting"></textarea>
+                </div></div>
+            </div></div></div>
+        </div>
+    </body></html>`);
+    for (const [file, media] of [
+        ['style.css', 'all'],
+        ['css/mobile-styles.css', '(max-width: 768px)'],
+        ['css/sillybunny-theme.css', 'all'],
+        ['css/sillybunny-paper-theme.css', '(max-width: 768px)'],
+        ['css/sillybunny-tabs.css', 'all'],
+        ['css/sillybunny-mobile-shell.css', '(max-width: 768px)'],
+    ]) {
+        const style = await page.addStyleTag({ content: await fs.readFile(new URL(file, publicRoot), 'utf8') });
+        await style.evaluate((element, media) => { element.media = media; }, media);
+    }
+    await page.evaluate(({ platform, userAgent }) => {
+        Object.defineProperties(navigator, {
+            platform: { configurable: true, value: platform },
+            userAgent: { configurable: true, value: userAgent },
+            maxTouchPoints: { configurable: true, value: 5 },
+        });
+        const viewport = new window.EventTarget();
+        Object.assign(viewport, { width: window.innerWidth, height: 844, offsetTop: 0, offsetLeft: 0, scale: 1 });
+        Object.defineProperty(window, 'visualViewport', { configurable: true, value: viewport });
+    }, { platform, userAgent });
+
+    const [tabs, lifecycle, sendButton] = await Promise.all([
+        'scripts/sillybunny-tabs.js', 'scripts/mobile-shell-lifecycle/index.js', 'scripts/mobile-send-button.js',
+    ].map(file => fs.readFile(new URL(file, publicRoot), 'utf8')));
+    const bindings = tabs.match(/ {4}window\.addEventListener\('resize', queueMobileViewportStateSync,[\s\S]*?(?= {4}\/\/ SillyBunny: re-sync shell width)/)?.[0];
+    if (!bindings) throw new Error('Missing production viewport/focus bindings');
+    await page.addScriptTag({ content: [
+        ...['IOS_STABLE_COMPOSER_VIEWPORT_MAJOR'].map(name => extractDeclaration(sendButton, name)),
+        ...['isIOSWebKitPlatform', 'isLegacyIOSWebKitPlatform'].map(name => extractFunction(sendButton, name)),
+        ...['MOBILE_SHELL_DRAWER_BOUND_ACTION', 'MOBILE_SHELL_DRAWER_BOUND_STYLE_PROPERTIES', 'MOBILE_SHELL_VIEWPORT_SYNC_STEP'].map(name => extractDeclaration(lifecycle, name)),
+        ...['normalizeNumber', 'clampBoundNumber', 'resolveMobileDrawerBounds', 'resolveMobileViewportSyncPlan'].map(name => extractFunction(lifecycle, name)),
+        ...['SB_MOBILE_MEDIA_QUERY', 'MOBILE_COMPOSER_KEYBOARD_PAN_EPSILON_PX', 'MOBILE_COMPOSER_KEYBOARD_PRESHIFT_WINDOW_MS',
+            'MOBILE_IOS_KEYBOARD_MIN_HEIGHT_PX', 'sbLastIOSKeyboardHeight', 'sbComposerKeyboardPreShiftDeadline',
+            'sbComposerKeyboardSettleTimer', 'sbMobileViewportStateFrameId', 'sbIsSyncingRailActions', 'sbMobileFocusedInputScrollTimer',
+        ].map(name => extractDeclaration(tabs, name)),
+        ...['isMobileViewport', 'isTouchOnlyDesktopViewport', 'readFiniteViewportNumber', 'getLayoutViewportSize', 'getVisualViewportSize',
+            'isEditableElement', 'isMobileShellPanelEditableElement', 'isChatComposerEditableElement', 'hasOpenMobileShellDrawer',
+            'shouldUseStableIOSPanelViewport', 'isVisualViewportKeyboardOpen', 'getComposerKeyboardInset',
+            'handleComposerKeyboardFocusIn', 'handleMobileKeyboardFocusOut', 'syncIOSKeyboardBottomInset',
+            'getShellViewportSize', 'syncShellViewportBounds', 'getResolvedShellTopbarOffset', 'getMobileShellBoundDrawers',
+            'applyMobileDrawerBoundsDecision', 'syncMobileShellDrawerBounds', 'syncMobileViewportState', 'queueMobileViewportStateSync',
+            'getMobileFocusedInputScroller', 'syncMobileFocusedInputScroll', 'scheduleMobileFocusedInputScroll',
+        ].map(name => extractFunction(tabs, name)),
+        // Only unrelated navigation, branding, popup and app construction work is stubbed.
+        ...['closeMobileNav', 'closeMobileChatTools', 'syncMobileShellRailActions', 'syncDesktopShellSizing', 'applyTopbarOffset',
+            'syncChatbarVisibilityState', 'updateTopBarBrand', 'scheduleTopbarContextRefresh', 'syncMobileModalState', 'scheduleMobilePopupKeyboardSync',
+        ].map(name => `function ${name}() {}`),
+        `const sbMobileShellLifecycle = {
+            drawerBounds: { action: MOBILE_SHELL_DRAWER_BOUND_ACTION, resolveBounds: resolveMobileDrawerBounds },
+            viewportSync: { step: MOBILE_SHELL_VIEWPORT_SYNC_STEP, resolveSyncPlan: resolveMobileViewportSyncPlan },
+        };`,
+        bindings,
+        'syncMobileViewportState();',
+    ].join('\n') });
+    if (errors.length) throw new Error(errors.join('\n'));
+    return errors;
+}
+
+async function setVisualViewport(page, height, offsetTop = 0, event = 'resize') {
+    await page.evaluate(({ height, offsetTop, event }) => {
+        Object.assign(window.visualViewport, { height, offsetTop });
+        window.visualViewport.dispatchEvent(new window.Event(event));
+    }, { height, offsetTop, event });
+}
+
+async function drawerGeometry(page) {
+    return page.locator('#user-settings-block').evaluate(drawer => {
+        const rect = drawer.getBoundingClientRect();
+        return { top: rect.top, bottom: rect.bottom, height: rect.height };
+    });
+}
+
+test('modern iOS reserves composer controls only while focused with the keyboard open', async ({ page }) => {
+    const errors = await mountFixture(page);
+    const root = page.locator('html');
+    const composer = page.locator('#form_sheld');
+    await page.locator('#send_textarea').focus();
+    await expect(composer).toHaveCSS('padding-bottom', '0px');
+    await expect(root).not.toHaveClass(controlsClass);
+
+    // Chromium does not implement the iOS-only CSS supports block; composer geometry uses offset zero.
+    await setVisualViewport(page, 500);
+    await expect(root).toHaveClass(controlsClass);
+    await expect(composer).toHaveCSS('padding-bottom', '48px');
+    const bounds = await composer.boundingBox();
+    expect(bounds.y + bounds.height).toBeLessThanOrEqual(500);
+    expect(bounds.y + bounds.height).toBeGreaterThanOrEqual(498);
+
+    // No resize or direct sync: both focusout and focusin must use the production queue.
+    await page.locator('#send_textarea').evaluate(textarea => textarea.blur());
+    await expect(root).not.toHaveClass(controlsClass);
+    await expect(composer).toHaveCSS('padding-bottom', '0px');
+    await page.locator('#send_textarea').focus();
+    await expect(composer).toHaveCSS('padding-bottom', '48px');
+    await page.locator('#user-settings-block').evaluate(drawer => drawer.classList.add('openDrawer'));
+    await page.locator('#first-setting').focus();
+    await expect(composer).toHaveCSS('padding-bottom', '0px');
+    await expect(root).not.toHaveClass(controlsClass);
+    await expect(page.locator('.sb-shell-panel-scroller')).toHaveCSS('padding-bottom', '34px');
+    await expect.poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--sb-ios-keyboard-bottom-inset'))).toBe('0px');
+    expect(await page.evaluate(() => [window.innerWidth, window.innerHeight, window.visualViewport.height])).toEqual([390, 844, 500]);
+
+    await page.locator('#user-settings-block').evaluate(drawer => drawer.classList.remove('openDrawer'));
+    await page.locator('#send_textarea').focus();
+    await expect(composer).toHaveCSS('padding-bottom', '48px');
+    await setVisualViewport(page, 844);
+    await expect(root).not.toHaveClass(controlsClass);
+    await expect(composer).toHaveCSS('padding-bottom', '0px');
+    expect(errors).toEqual([]);
+});
+
+test('settings follow the visual bottom and keep the final field reachable after viewport panning', async ({ page }) => {
+    const errors = await mountFixture(page);
+    await page.locator('#user-settings-block').evaluate(drawer => drawer.classList.add('openDrawer'));
+    await page.locator('#first-setting').focus();
+    await setVisualViewport(page, 500);
+    await expect.poll(async () => (await drawerGeometry(page)).bottom).toBeCloseTo(500, 0);
+    const initial = await drawerGeometry(page);
+    expect(initial.height).toBeGreaterThan(300);
+    await setVisualViewport(page, 500, 40, 'scroll');
+    await expect.poll(async () => (await drawerGeometry(page)).bottom).toBeCloseTo(540, 0);
+    const shifted = await drawerGeometry(page);
+    expect(shifted.top - initial.top).toBeCloseTo(40, 0);
+    expect(shifted.height).toBeCloseTo(initial.height, 0);
+    await expect(page.locator('.sb-shell-panel-scroller')).toHaveCSS('padding-bottom', '34px');
+
+    // Remove inline bounds to exercise the final real CSS fallback independently of the JS writes.
+    await page.locator('#user-settings-block').evaluate(drawer => drawer.removeAttribute('style'));
+    const cssOnly = await drawerGeometry(page);
+    expect(cssOnly.bottom).toBeCloseTo(540, 0);
+    expect(cssOnly.top).toBeCloseTo(shifted.top, 0);
+    expect(cssOnly.height).toBeCloseTo(shifted.height, 0);
+
+    await page.locator('#last-setting').focus();
+    await expect.poll(() => page.locator('#last-setting').evaluate(field => {
+        const rect = field.getBoundingClientRect();
+        const scroller = field.closest('.sb-shell-panel-scroller');
+        const visible = scroller.getBoundingClientRect();
+        return scroller.scrollTop > 0 && rect.top >= visible.top && rect.bottom <= Math.min(visible.bottom, 540);
+    })).toBe(true);
+    await expect(page.locator('#last-setting')).toBeFocused();
+    await page.locator('#last-setting').fill('Still reachable');
+    await expect(page.locator('#last-setting')).toHaveValue('Still reachable');
+    expect(await page.evaluate(() => [window.innerWidth, window.innerHeight])).toEqual([390, 844]);
+
+    await setVisualViewport(page, 844);
+    await expect.poll(async () => (await drawerGeometry(page)).bottom).toBeCloseTo(844, 0);
+    await expect(page.locator('#form_sheld')).toHaveCSS('padding-bottom', '0px');
+    expect(errors).toEqual([]);
+});
+
+for (const scenario of [
+    { name: 'legacy iOS phone', width: 390, platform: 'iPhone', userAgent: safariUA.replace('Version/26.1', 'Version/18.7'), inset: '304px' },
+    { name: 'wide modern iPad', width: 900, platform: 'MacIntel', userAgent: safariUA.replace('iPhone; CPU iPhone OS 18_7 like Mac OS X', 'Macintosh; Intel Mac OS X 10_15_7'), inset: '304px' },
+    { name: 'non-iOS phone', width: 390, platform: 'Linux armv8l', userAgent: 'Chrome/140.0', inset: '0px' },
+]) {
+    test(`${scenario.name} retains its keyboard inset policy without composer controls padding`, async ({ page }) => {
+        await page.setViewportSize({ width: scenario.width, height: 844 });
+        const errors = await mountFixture(page, scenario);
+        await page.locator('#user-settings-block').evaluate(drawer => drawer.classList.add('openDrawer'));
+        await page.locator('#first-setting').focus();
+        await setVisualViewport(page, 500, 40);
+        await expect.poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--sb-ios-keyboard-bottom-inset'))).toBe(scenario.inset);
+        await expect.poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--sb-shell-viewport-height'))).toBe(scenario.inset === '0px' ? '500px' : '844px');
+        await expect(page.locator('html')).not.toHaveClass(controlsClass);
+        await page.locator('#send_textarea').focus();
+        await expect(page.locator('html')).not.toHaveClass(controlsClass);
+        expect(await page.locator('#form_sheld').evaluate(form => getComputedStyle(form).paddingBottom)).not.toBe('48px');
+        await setVisualViewport(page, 844);
+        await expect.poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--sb-ios-keyboard-bottom-inset'))).toBe('0px');
+        await expect(page.locator('html')).not.toHaveClass(/\bsb-ios-keyboard-inset-active\b/);
+        expect(errors).toEqual([]);
+    });
+}

--- a/tests/mobile-send-button.test.js
+++ b/tests/mobile-send-button.test.js
@@ -54,6 +54,36 @@ describe('mobile send button helpers', () => {
         })).toBe(false);
     });
 
+    test('uses the Safari version instead of the frozen CPU OS version', () => {
+        for (const [safariVersion, osVersion, legacy] of [
+            ['18.6', '18_6', true],
+            ['18.7', '18_7', true],
+            ['26.0', '18_6', false],
+            ['26.0', '18_6_2', false],
+            ['26.1', '18_7', false],
+            ['27.0', '18_7', false],
+        ]) {
+            expect(isLegacyIOSWebKitPlatform({
+                platform: 'iPhone',
+                maxTouchPoints: 5,
+                userAgent: `Mozilla/5.0 (iPhone; CPU iPhone OS ${osVersion} like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${safariVersion} Mobile/15E148 Safari/604.1`,
+            })).toBe(legacy);
+        }
+    });
+
+    test('detects Safari versions in iPadOS desktop mode', () => {
+        for (const [safariVersion, legacy] of [
+            ['18.6', true],
+            ['26.0', false],
+        ]) {
+            expect(isLegacyIOSWebKitPlatform({
+                platform: 'MacIntel',
+                maxTouchPoints: 5,
+                userAgent: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${safariVersion} Safari/605.1.15`,
+            })).toBe(legacy);
+        }
+    });
+
     test('checks whether a touch ended inside the send button', () => {
         const button = { contains: target => target === 'inside' };
         expect(touchEndedInsideElement(createTouchEvent('touchend'), button, {

--- a/tests/mobile-shell-lifecycle-drawer-bounds.test.js
+++ b/tests/mobile-shell-lifecycle-drawer-bounds.test.js
@@ -39,6 +39,22 @@ describe('mobile shell drawer bounds lifecycle', () => {
         ]);
     });
 
+    test('follows the visible viewport offset without subtracting it from height', () => {
+        for (const [viewportTop, expectedTop] of [[40, '99px'], [-40, '59px'], [Number.NaN, '59px']]) {
+            const decision = resolveMobileDrawerBounds({
+                isMobileViewport: true,
+                isOpen: true,
+                viewportHeight: 500,
+                viewportTop,
+                baseTopOffset: 56,
+                shellGap: 3,
+            });
+
+            expect(decision.styleWrites).toContainEqual({ property: 'top', value: expectedTop, priority: 'important' });
+            expect(decision.styleWrites).toContainEqual({ property: 'height', value: '441px', priority: 'important' });
+        }
+    });
+
     test('clamps the top offset to the viewport and never yields negative height', () => {
         const decision = resolveMobileDrawerBounds({
             isMobileViewport: true,


### PR DESCRIPTION
The old keyboard workaround works okay with older iOS versions - but not iOS 26+ which I have due to incorrectly stating the version number in SillyBunny. This fixes that.
Also reduces unnecessary iOS 26+ padding between keyboard and input box.