### PR TITLE
feat(openrouter): automate provider list using OpenRouter endpoint

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -84,7 +84,7 @@ import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
-import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { setOpenRouterProviders, syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
 import {
@@ -2688,6 +2688,8 @@ function toggleInlineSelectPickerOption(select, value) {
             if (option.value === value) {
                 if (!option.disabled || option.selected) {
                     option.selected = !option.selected;
+                    // SillyBunny: match desktop OpenRouter routing priority, newest selection last.
+                    if (option.selected && select.classList.contains('openrouter_providers')) select.append(option);
                 }
                 break;
             }
@@ -2793,6 +2795,16 @@ function bindInlineSelectPickerSelect(select, control) {
 
     select.dataset.sbInlineSelectPickerBound = 'true';
     select.classList.add('sb-inline-select-picker-control');
+
+    // SillyBunny: repaint an open provider menu after async updates without saving settings.
+    if (select.classList.contains('openrouter_providers')) {
+        $(select).on('change.select2', () => {
+            const menu = document.getElementById(`${select.id}_menu`);
+            if (shouldUseInlineModelSelectPicker() && menu && !menu.hidden) {
+                openInlineSelectPicker(select, { ...control, forceOpen: true });
+            }
+        });
+    }
 
     const openPicker = event => {
         if (!shouldUseInlineModelSelectPicker()) {
@@ -7085,7 +7097,8 @@ function loadOpenAISettings(data, settings) {
     setToolReasoningControls();
     setAutoAppendReasoningTagControls();
 
-    $('#openrouter_providers_chat').trigger('change');
+    // SillyBunny: saved provider names must survive catalogue failures and absent providers.
+    setOpenRouterProviders('#openrouter_providers_chat', oai_settings.openrouter_providers);
     $('#openrouter_quantizations_chat').trigger('change');
     updateNanoGptProviderControls();
     rebuildOpenAIModelSelect();
@@ -8046,7 +8059,7 @@ function onSettingsPresetChange() {
         // These cannot be changed via preset if unbound to connection
         if (oai_settings.bind_preset_to_connection) {
             $('#chat_completion_source').trigger('change');
-            $('#openrouter_providers_chat').trigger('change');
+            setOpenRouterProviders('#openrouter_providers_chat', oai_settings.openrouter_providers);
             $('#openrouter_quantizations_chat').trigger('change');
             updateNanoGptProviderControls();
         }
@@ -11214,14 +11227,7 @@ export function initOpenAI() {
     });
 
     $('#openrouter_providers_chat').on('change', function () {
-        const selectedProviders = $(this).val();
-
-        // Not a multiple select?
-        if (!Array.isArray(selectedProviders)) {
-            return;
-        }
-
-        oai_settings.openrouter_providers = selectedProviders;
+        oai_settings.openrouter_providers = Array.from(this.selectedOptions, option => option.value);
 
         updateOpenRouterProvidersWarning('#openrouter_providers_chat');
         saveSettingsDebounced();

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -24,93 +24,8 @@ function shouldUseNativeApiSelects() {
     return isMobile() || (window.matchMedia?.('(max-width: 768px)').matches ?? false);
 }
 
-/**
- * List of OpenRouter providers.
- * @type {string[]}
- */
-const OPENROUTER_PROVIDERS = [
-    // Providers endpoint: https://openrouter.ai/api/v1/providers
-    // The list should resemble the sidebar from https://openrouter.ai/models
-    // Their docs no longer displays the list, which had "super dead" ones at top, thankfully gone from /v1/providers
-    'AI21',
-    'AionLabs',
-    'Alibaba',
-    'AkashML',
-    'Amazon Bedrock',
-    'Amazon Nova',
-    'Ambient',
-    'Anthropic',
-    'Arcee AI',
-    'AtlasCloud',
-    'Avian',
-    'Azure',
-    'Baidu',
-    'BaseTen',
-    'Black Forest Labs',
-    'Cerebras',
-    'Chutes',
-    'Cirrascale',
-    'Clarifai',
-    'Cloudflare',
-    'Cohere',
-    'Crusoe',
-    'DeepInfra',
-    'DeepSeek',
-    'DekaLLM',
-    'FakeProvider',
-    'Featherless',
-    'Fireworks',
-    'Friendli',
-    'GMICloud',
-    'Google',
-    'Google AI Studio',
-    'Groq',
-    'Hyperbolic',
-    'Inception',
-    'Inceptron',
-    'InferenceNet',
-    'Infermatic',
-    'Inflection',
-    'Io Net',
-    'Ionstream',
-    'Liquid',
-    'Mancer 2',
-    'Mara',
-    'Minimax',
-    'Mistral',
-    'ModelRun',
-    'Modular',
-    'Moonshot AI',
-    'Morph',
-    'NCompass',
-    'Nebius',
-    'NextBit',
-    'Novita',
-    'Nvidia',
-    'OpenAI',
-    'OpenInference',
-    'Parasail',
-    'Perplexity',
-    'Phala',
-    'Recraft',
-    'Reka',
-    'Relace',
-    'SambaNova',
-    'Seed',
-    'SiliconFlow',
-    'Sourceful',
-    'Stealth',
-    'StepFun',
-    'StreamLake',
-    'Switchpoint',
-    'Together',
-    'Upstage',
-    'Venice',
-    'WandB',
-    'xAI',
-    'Xiaomi',
-    'Z.AI',
-];
+// SillyBunny: share in-flight catalogue requests, not a hardcoded provider list.
+let openRouterProvidersRequest = null;
 
 /**
  * List of NanoGPT providers.
@@ -491,12 +406,62 @@ export function updateOpenRouterProvidersWarning(providersSelector) {
     $warning.toggleClass('displayNone', !showWarning);
 }
 
+/**
+ * Restore saved provider names and priority even before the live catalogue arrives.
+ * @param {string} providersSelector
+ * @param {string[]} selectedProviders
+ * @param {string[]} [providerNames]
+ */
+export function setOpenRouterProviders(providersSelector, selectedProviders, providerNames) {
+    const select = $(providersSelector)[0];
+    if (!select) return;
+
+    const options = new Map(Array.from(select.options, option => [option.value, option]));
+    const selected = Array.isArray(selectedProviders) ? selectedProviders.filter(name => typeof name === 'string' && name.trim()) : [];
+    const names = (providerNames ?? [...options.keys()]).filter(name => !selected.includes(name)).sort((a, b) => a.localeCompare(b));
+    select.replaceChildren(...Array.from(new Set([...names, ...selected]), name => {
+        const option = options.get(name) ?? new Option(name, name);
+        option.selected = selected.includes(name);
+        return option;
+    }));
+    $(select).trigger('change.select2');
+    updateOpenRouterProvidersWarning(providersSelector);
+}
+
 export async function syncOpenRouterProvidersForModel(modelId, providersSelector) {
     const $providers = $(providersSelector);
+    if (!$providers.length) return;
+
+    // SillyBunny: a late catalogue or model response must not overwrite a newer selection.
+    const request = {};
+    $providers.data('openrouterRequest', request);
 
     const refreshWarningState = () => {
         updateOpenRouterProvidersWarning(providersSelector);
     };
+
+    try {
+        openRouterProvidersRequest ??= fetch('/api/openrouter/providers', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+        }).then(async response => {
+            if (!response.ok) throw new Error(`OpenRouter providers request failed: ${response.status}`);
+            const names = await response.json();
+            if (!Array.isArray(names) || !names.length || !names.every(name => typeof name === 'string' && name.trim())) {
+                throw new Error('Invalid OpenRouter providers response');
+            }
+            return names;
+        }).finally(() => {
+            openRouterProvidersRequest = null;
+        });
+        const names = await openRouterProvidersRequest;
+        if ($providers.data('openrouterRequest') !== request) return;
+        setOpenRouterProviders(providersSelector, Array.from($providers[0].selectedOptions, option => option.value), names);
+    } catch (error) {
+        console.warn('Failed to refresh OpenRouter provider catalogue', error);
+    }
+
+    if ($providers.data('openrouterRequest') !== request) return;
 
     if (!modelId || !modelId.includes('/')) {
         $providers.find('option').prop('disabled', false);
@@ -512,12 +477,15 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
             body: JSON.stringify({ model: modelId }),
         });
 
+        if ($providers.data('openrouterRequest') !== request) return;
+
         if (!response.ok) {
             refreshWarningState();
             return;
         }
 
         const providerNames = await response.json();
+        if ($providers.data('openrouterRequest') !== request) return;
 
         if (!Array.isArray(providerNames) || providerNames.length === 0) {
             $providers.find('option').prop('disabled', false);
@@ -1501,11 +1469,8 @@ export function initTextGenModels() {
     $('#featherless_model').on('change', () => onFeatherlessModelSelect(String($('#featherless_model').val())));
 
     const providersSelect = $('.openrouter_providers');
-    for (const provider of OPENROUTER_PROVIDERS) {
-        providersSelect.append($('<option>', {
-            value: provider,
-            text: provider,
-        }));
+    for (const selector of Object.keys(OPENROUTER_PROVIDER_WARNING_SELECTORS)) {
+        void syncOpenRouterProvidersForModel('', selector);
     }
 
     const nanoGptProvidersSelect = $('#nanogpt_allowed_providers, #nanogpt_ignored_providers');
@@ -1622,6 +1587,13 @@ export function initTextGenModels() {
         searchInputCssClass: 'text_pole',
         width: '100%',
         closeOnSelect: false,
+    });
+    // SillyBunny: refresh open results after async updates, surviving shell reinitialisation.
+    $(document).on('change.select2', '.openrouter_providers', function () {
+        const select2 = $(this).data('select2');
+        if (select2?.isOpen()) {
+            select2.trigger('query', { term: select2.selection.$search.val() || '' });
+        }
     });
     providersSelect.on('select2:select', function (/** @type {any} */ evt) {
         const element = evt.params.data.element;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -33,7 +33,7 @@ import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { fetchResumable } from './resumable-generation.js';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from './local-url-utils.js';
-import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, setOpenRouterProviders, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
 import { getSortableDelay, onlyUnique, arraysEqual, isObject } from './utils.js';
@@ -680,7 +680,8 @@ export async function loadTextGenSettings(data, loadedSettings) {
     }
 
     $('#textgen_type').val(textgenerationwebui_settings.type);
-    $('#openrouter_providers_text').val(textgenerationwebui_settings.openrouter_providers).trigger('change');
+    // SillyBunny: restore saved providers without waiting for the live catalogue or saving an empty selection.
+    setOpenRouterProviders('#openrouter_providers_text', textgenerationwebui_settings.openrouter_providers);
     $('#openrouter_quantizations_text').val(textgenerationwebui_settings.openrouter_quantizations).trigger('change');
     showSamplerControls(textgenerationwebui_settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
@@ -1160,14 +1161,7 @@ export function initTextGenSettings() {
     $('#textgen_logit_bias_new_entry').on('click', () => createNewLogitBiasEntry(textgenerationwebui_settings.logit_bias, BIAS_KEY));
 
     $('#openrouter_providers_text').on('change', function () {
-        const selectedProviders = $(this).val();
-
-        // Not a multiple select?
-        if (!Array.isArray(selectedProviders)) {
-            return;
-        }
-
-        textgenerationwebui_settings.openrouter_providers = selectedProviders;
+        textgenerationwebui_settings.openrouter_providers = Array.from(this.selectedOptions, option => option.value);
 
         updateOpenRouterProvidersWarning('#openrouter_providers_text');
         saveSettingsDebounced();

--- a/src/endpoints/openrouter.js
+++ b/src/endpoints/openrouter.js
@@ -7,6 +7,29 @@ import { OPENROUTER_HEADERS } from '../constants.js';
 export const router = express.Router();
 const API_OPENROUTER = 'https://openrouter.ai/api/v1';
 
+// SillyBunny: use OpenRouter's catalogue without exposing keys or maintaining provider names.
+router.post('/providers', async (_req, res) => {
+    try {
+        const response = await fetch(`${API_OPENROUTER}/providers`, {
+            headers: { 'Accept': 'application/json' },
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!response.ok) return res.sendStatus(502);
+
+        /** @type {any} */
+        const data = await response.json();
+        if (!Array.isArray(data?.data)) return res.sendStatus(502);
+
+        const names = data.data.map(provider => provider?.name).filter(name => typeof name === 'string' && name.trim());
+        if (!names.length) return res.sendStatus(502);
+
+        return res.json([...new Set(names)].sort((a, b) => a.localeCompare(b)));
+    } catch (error) {
+        console.warn('Failed to fetch OpenRouter provider catalogue', error);
+        return res.sendStatus(502);
+    }
+});
+
 router.post('/models/providers', async (req, res) => {
     try {
         const { model } = req.body;

--- a/tests/openrouter-providers.e2e.js
+++ b/tests/openrouter-providers.e2e.js
@@ -1,0 +1,103 @@
+/* global $, document, window, setOpenRouterProviders, syncOpenRouterProvidersForModel, bindInlineSelectPickerSelect */
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const models = readFileSync(new URL('../public/scripts/textgen-models.js', import.meta.url), 'utf8');
+const openai = readFileSync(new URL('../public/scripts/openai.js', import.meta.url), 'utf8');
+const providerCode = models.slice(models.indexOf('const OPENROUTER_PROVIDER_WARNING_SELECTORS'), models.indexOf('let nanoGptProvidersRequest')).replaceAll('export ', '');
+const pickerCode = openai.slice(openai.indexOf('function getInlineSelectPickerEntries('), openai.indexOf('function bindInlineSelectPickerControl('));
+const desktopCode = models.slice(models.indexOf('    providersSelect.select2({'), models.indexOf('    nanoGptProvidersSelect.select2({'));
+
+for (const mobile of [false, true]) {
+    test(`live provider catalogue preserves choices and ignores stale responses (${mobile ? 'mobile' : 'desktop'})`, async ({ page }) => {
+        await page.setViewportSize({ width: mobile ? 390 : 1440, height: 900 });
+        await page.setContent(['text', 'chat'].map(mode => `<div><select multiple class="openrouter_providers" id="openrouter_providers_${mode}"></select></div>`).join(''));
+        await page.addScriptTag({ path: fileURLToPath(new URL('../public/lib/jquery-3.5.1.min.js', import.meta.url)) });
+        await page.addScriptTag({ path: fileURLToPath(new URL('../public/lib/select2.min.js', import.meta.url)) });
+        await page.addScriptTag({ content: `
+            let openRouterProvidersRequest = null;
+            const getRequestHeaders = () => ({});
+            const isMobile = () => ${mobile};
+            const t = strings => strings[0];
+            const bindModelSelectPickerDocumentListener = () => {};
+            const closeModelSelectPickerMenus = () => {};
+            const scrollElementIntoNearestPanelScroller = () => {};
+            window.pending = [];
+            window.fetch = (url, options) => new Promise(resolve => pending.push({ url, options, resolve }));
+            ${providerCode}
+            ${pickerCode}
+            const providersSelect = $('.openrouter_providers');
+            const select2Defaults = {};
+            if (!isMobile()) {
+                ${desktopCode}
+                for (const select of providersSelect) {
+                    const config = $(select).data('select2').options.options;
+                    $(select).select2('destroy').select2(config);
+                }
+            }
+        ` });
+
+        await page.evaluate(() => {
+            window.changes = 0;
+            $('.openrouter_providers').on('change', () => window.changes++);
+            for (const mode of ['text', 'chat']) {
+                const selector = `#openrouter_providers_${mode}`;
+                setOpenRouterProviders(selector, ['Zeta', 'Missing']);
+                bindInlineSelectPickerSelect(document.querySelector(selector), {});
+            }
+            window.loading = Promise.all(['text', 'chat'].map(mode => syncOpenRouterProvidersForModel('test/old', `#openrouter_providers_${mode}`)));
+        });
+        if (mobile) await page.locator('#openrouter_providers_chat').press('Enter');
+        else await page.evaluate(() => $('#openrouter_providers_chat').select2('open'));
+        expect(await page.evaluate(() => window.pending.length)).toBe(1);
+        // A saved preset or user change during loading must win over the earlier selection.
+        await page.evaluate(() => {
+            setOpenRouterProviders('#openrouter_providers_chat', ['Missing', 'Zeta']);
+            window.pending.shift().resolve({ ok: true, json: async () => ['Alpha', 'Zeta', '<img src=x>'] });
+        });
+        await expect.poll(() => page.evaluate(() => window.pending.length)).toBe(2);
+        await page.evaluate(async () => {
+            for (const request of window.pending.splice(0)) request.resolve({ ok: true, json: async () => ['Alpha', 'Zeta'] });
+            await window.loading;
+        });
+        for (const mode of ['text', 'chat']) {
+            await expect(page.locator(`#openrouter_providers_${mode} option`)).toHaveCount(4);
+        }
+        expect(await page.evaluate(() => Array.from(document.querySelector('#openrouter_providers_chat').selectedOptions, option => option.value))).toEqual(['Missing', 'Zeta']);
+        await expect(page.locator('img')).toHaveCount(0);
+        expect(await page.evaluate(() => window.changes)).toBe(0);
+        const menu = page.locator(mobile ? '#openrouter_providers_chat_menu' : '#select2-openrouter_providers_chat-results');
+        await expect(menu.getByRole('option', { name: 'Alpha', exact: true })).toBeVisible();
+        await menu.getByRole('option', { name: 'Alpha', exact: true }).click();
+        expect(await page.evaluate(() => Array.from(document.querySelector('#openrouter_providers_chat').selectedOptions, option => option.value))).toEqual(['Missing', 'Zeta', 'Alpha']);
+        const remove = mobile
+            ? menu.getByRole('option', { name: 'Missing', exact: true })
+            : page.locator('#openrouter_providers_chat + .select2 .select2-selection__choice[title="Missing"] .select2-selection__choice__remove');
+        await remove.click();
+        expect(await page.evaluate(() => Array.from(document.querySelector('#openrouter_providers_chat').selectedOptions, option => option.value))).toEqual(['Zeta', 'Alpha']);
+        const changes = await page.evaluate(() => window.changes);
+        expect(changes).toBeGreaterThan(0);
+
+        // Failed refreshes retain the last catalogue; newer model availability wins.
+        await page.evaluate(() => {
+            window.old = syncOpenRouterProvidersForModel('test/old', '#openrouter_providers_chat');
+            window.pending.shift().resolve({ ok: false, status: 502 });
+        });
+        await expect.poll(() => page.evaluate(() => window.pending.length)).toBe(1);
+        await page.evaluate(() => {
+            window.newer = syncOpenRouterProvidersForModel('test/new', '#openrouter_providers_chat');
+            window.pending.pop().resolve({ ok: true, json: async () => [] });
+        });
+        await expect.poll(() => page.evaluate(() => window.pending.length)).toBe(2);
+        await page.evaluate(async () => {
+            window.pending.pop().resolve({ ok: true, json: async () => ['Alpha'] });
+            await window.newer;
+            window.pending.pop().resolve({ ok: true, json: async () => ['Zeta'] });
+            await window.old;
+        });
+        await expect(page.locator('#openrouter_providers_chat option')).toHaveCount(4);
+        expect(await page.locator('#openrouter_providers_chat option:enabled').allTextContents()).toEqual(['Alpha']);
+        expect(await page.evaluate(() => window.changes)).toBe(changes);
+    });
+}

--- a/tests/openrouter-providers.test.js
+++ b/tests/openrouter-providers.test.js
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+const source = readFileSync(new URL('../src/endpoints/openrouter.js', import.meta.url), 'utf8');
+const routeSource = source.slice(source.indexOf('const API_OPENROUTER ='), source.indexOf('router.post(\'/models/providers\''));
+
+describe('OpenRouter POST /providers', () => {
+    let fetch;
+    let handler;
+    let res;
+
+    beforeEach(() => {
+        fetch = jest.fn();
+        res = { json: jest.fn(), sendStatus: jest.fn() };
+        const post = jest.fn();
+        runInNewContext(routeSource, {
+            router: { post },
+            fetch,
+            AbortSignal,
+            console: { warn: jest.fn() },
+        });
+        handler = post.mock.calls.find(([path]) => path === '/providers')[1];
+    });
+
+    test('uses the fixed public URL without auth and returns sorted, deduplicated valid names', async () => {
+        fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                data: [
+                    { name: 'Zeta' }, { name: 'Alpha' }, { name: 'Zeta' }, { name: 'Beta' },
+                    null, {}, { name: 42 }, { name: '' }, { name: '   ' },
+                ],
+            }),
+        });
+
+        await handler({
+            body: { url: 'https://example.invalid/providers', api_key: 'do-not-forward' },
+            headers: { authorization: 'Bearer do-not-forward' },
+        }, res);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = fetch.mock.calls[0];
+        expect(url).toBe('https://openrouter.ai/api/v1/providers');
+        expect(options.headers).toEqual({ Accept: 'application/json' });
+        expect(options.method ?? 'GET').toBe('GET');
+        expect(options.body).toBeUndefined();
+        expect(options.signal).toBeInstanceOf(AbortSignal);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(res.json).toHaveBeenCalledWith(['Alpha', 'Beta', 'Zeta']);
+        expect(res.sendStatus).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        ['upstream HTTP failure', { ok: false }],
+        ['null payload', { ok: true, json: async () => null }],
+        ['missing data', { ok: true, json: async () => ({}) }],
+        ['non-array data', { ok: true, json: async () => ({ data: {} }) }],
+        ['empty catalogue', { ok: true, json: async () => ({ data: [] }) }],
+        ['no valid names', { ok: true, json: async () => ({ data: [null, {}, { name: 1 }, { name: '' }, { name: ' \t' }] }) }],
+        ['invalid JSON', { ok: true, json: async () => { throw new SyntaxError('Invalid JSON'); } }],
+    ])('returns 502 for %s', async (_name, response) => {
+        fetch.mockResolvedValue(response);
+
+        await handler({}, res);
+
+        expect(res.sendStatus).toHaveBeenCalledTimes(1);
+        expect(res.sendStatus).toHaveBeenCalledWith(502);
+        expect(res.json).not.toHaveBeenCalled();
+    });
+
+    test('returns 502 when the request throws', async () => {
+        fetch.mockRejectedValue(new Error('Network unavailable'));
+
+        await handler({}, res);
+
+        expect(res.sendStatus).toHaveBeenCalledTimes(1);
+        expect(res.sendStatus).toHaveBeenCalledWith(502);
+        expect(res.json).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
OpenRouter already has a providers endpoint. No hardcoding needed. It will now populate with updated ones depending on OpenRouter’s API.