### PR TITLE
fix(pathfinder): general bug fixes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2460,6 +2460,7 @@ function getMobileMessageUpdateQueue() {
 }
 
 function applyStreamingVisibleWrite(messageId, {
+    isCurrent,
     messageTextDom,
     messageTimerDom,
     messageTokenCounterDom,
@@ -2473,6 +2474,8 @@ function applyStreamingVisibleWrite(messageId, {
     shouldUseStreamFadeIn,
     bypassFadeIn,
 }, { isFinal = false } = {}) {
+    if (isCurrent && !isCurrent()) return false;
+    if (messageDom instanceof HTMLElement && (!messageDom.isConnected || messageDom.getAttribute('mesid') !== String(messageId))) return false;
     if (shouldRefreshTokenCount && messageTokenCounterDom instanceof HTMLElement) {
         messageTokenCounterDom.textContent = `${currentTokenCount}t`;
     }
@@ -5448,7 +5451,8 @@ export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = fals
         // generation, regardless of whether Generate succeeded, failed, threw,
         // or returned null data. Without this, memory refresh and other quiet
         // generation callers can leave the chat input locked. (#527)
-        activateSendButtons();
+        if (!activeGenerationRun) activateSendButtons();
+        else if (abortController === quietAbortController) abortController = activeGenerationRun.controller;
     }
 }
 
@@ -5892,6 +5896,7 @@ function showStopButton() {
 }
 
 function hideStopButton({ emitGenerationEnded = true } = {}) {
+    const generationContext = activeGenerationRun?.context;
     // prevent NOOP, because hideStopButton() gets called multiple times
     // SillyBunny: read visibility before dropping the class. On mobile, mobile-styles.css forces
     // `#send_form:not(.sb-generating-controls) #mes_stop` to display:none !important, so checking
@@ -5901,7 +5906,7 @@ function hideStopButton({ emitGenerationEnded = true } = {}) {
     if (wasVisible) {
         $('#mes_stop').css({ 'display': 'none' });
         if (emitGenerationEnded) {
-            eventSource.emit(event_types.GENERATION_ENDED, chat.length);
+            eventSource.emit(event_types.GENERATION_ENDED, chat.length, ...(generationContext ? [generationContext] : []));
         }
     }
 }
@@ -5956,6 +5961,12 @@ class StreamingProcessor {
      * @param {PromptReasoning} promptReasoning Prompt reasoning instance
      */
     constructor(type, forceName2, timeStarted, continueMessage, promptReasoning) {
+        // SillyBunny: stream writes belong to one run and message, not a reusable chat index.
+        this.originRun = activeGenerationRun;
+        this.originChatId = getCurrentChatId();
+        this.originChatGeneration = chatGeneration;
+        this.message = null;
+        this.swipeId = undefined;
         this.result = '';
         this.messageId = -1;
         /** @type {HTMLElement} */
@@ -5987,6 +5998,11 @@ class StreamingProcessor {
         this.toolCalls = [];
         // Initialize reasoning in its own handler
         this.reasoningHandler = new ReasoningHandler(timeStarted);
+        // Reasoning completion can await an event before updating its DOM.
+        const updateReasoningDom = this.reasoningHandler.updateDom.bind(this.reasoningHandler);
+        this.reasoningHandler.updateDom = messageId => {
+            if (this.#isCurrent(messageId)) updateReasoningDom(messageId);
+        };
         /** @type {PromptReasoning} */
         this.promptReasoning = promptReasoning;
         /** @type {string[]} */
@@ -5997,6 +6013,15 @@ class StreamingProcessor {
         this.reasoningTokens = 0;
         /** @type {string?} Latest reasoning received from the stream, applied on UI ticks */
         this.pendingReasoning = null;
+    }
+
+    #isCurrent(messageId = this.messageId, allowStopped = false) {
+        return (allowStopped || (!this.isStopped && !this.abortController.signal.aborted))
+            && (allowStopped || (this.isCurrentGeneration?.() ?? true))
+            && streamingProcessor === this && activeGenerationRun === this.originRun
+            && chatGeneration === this.originChatGeneration && getCurrentChatId() === this.originChatId
+            && (this.type === 'impersonate' || messageId < 0 || (this.message !== null
+                && chat[messageId] === this.message && (this.swipeId === undefined || this.message.swipe_id === this.swipeId)));
     }
 
     #applyPendingReasoning() {
@@ -6011,9 +6036,10 @@ class StreamingProcessor {
      * @param {boolean?} continueOnReasoning If continuing on reasoning
      */
     async #checkDomElements(messageId, continueOnReasoning = null) {
+        if (!this.#isCurrent(messageId)) return;
         const cachedMessageDomInvalid = this.messageDom !== null
             && (!this.messageDom.isConnected || this.messageDom.getAttribute('mesid') !== String(messageId));
-        const cachedMessageTextDomInvalid = this.messageTextDom !== null && !this.messageTextDom.isConnected;
+        const cachedMessageTextDomInvalid = this.messageTextDom != null && !this.messageTextDom.isConnected;
 
         if (cachedMessageDomInvalid || cachedMessageTextDomInvalid) {
             // SillyBunny: refresh stale stream targets after chat-window pruning or tail-gap re-renders.
@@ -6032,6 +6058,7 @@ class StreamingProcessor {
         if (continueOnReasoning) {
             await this.reasoningHandler.process(messageId, false, this.promptReasoning);
         }
+        if (!this.#isCurrent(messageId)) return;
         if (this.reasoningHandler.hasReasoningContent()) {
             this.reasoningHandler.updateDom(messageId);
         }
@@ -6054,18 +6081,21 @@ class StreamingProcessor {
     }
 
     markUIGenStarted() {
+        if (!this.#isCurrent()) return;
         deactivateSendButtons();
     }
 
     markUIGenStopped({ emitGenerationEnded = true, emitGenerationStopped = false } = {}) {
+        if (!this.#isCurrent(this.messageId, true)) return;
         if (emitGenerationStopped) {
-            eventSource.emit(event_types.GENERATION_STOPPED);
+            eventSource.emit(event_types.GENERATION_STOPPED, ...(this.agentGenerationContext ? [this.agentGenerationContext] : []));
         }
 
         unblockGeneration(this.type, { emitGenerationEnded });
     }
 
     async onStartStreaming(text) {
+        if (!this.#isCurrent()) return -1;
         const continueOnReasoning = !!(this.type === 'continue' && this.promptReasoning.prefixReasoning);
         if (continueOnReasoning) {
             this.reasoningHandler.initContinue(this.promptReasoning);
@@ -6077,9 +6107,16 @@ class StreamingProcessor {
             this.sendTextarea.value = '';
             this.sendTextarea.dispatchEvent(new Event('input', { bubbles: true }));
         } else {
-            await saveReply({ type: this.type, getMessage: text, fromStreaming: true });
+            const saving = saveReply({ type: this.type, getMessage: text, fromStreaming: true, isCurrent: () => this.#isCurrent() });
             messageId = chat.length - 1;
+            this.messageId = messageId;
+            this.message = chat[messageId];
+            this.swipeId = this.message?.swipe_id;
+            await saving;
+            if (!this.#isCurrent(messageId)) return -1;
+            this.swipeId = this.message.swipe_id;
             await this.#checkDomElements(messageId, continueOnReasoning);
+            if (!this.#isCurrent(messageId)) return -1;
             this.markUIGenStarted();
         }
         hideSwipeButtons({ hideCounters: true });
@@ -6090,6 +6127,7 @@ class StreamingProcessor {
     }
 
     async onProgressStreaming(messageId, text, isFinal) {
+        if (!this.#isCurrent(messageId)) return;
         const isImpersonate = this.type == 'impersonate';
         const isContinue = this.type == 'continue';
         const shouldReduceStreamingWork = shouldReduceStreamingDomWork(globalThis.navigator, {
@@ -6130,6 +6168,7 @@ class StreamingProcessor {
         } else {
             const mesChanged = chat[messageId].mes !== processedText;
             await this.#checkDomElements(messageId);
+            if (!this.#isCurrent(messageId)) return;
             this.#updateMessageBlockVisibility();
             const currentTime = new Date();
             chat[messageId].mes = processedText;
@@ -6147,6 +6186,7 @@ class StreamingProcessor {
             // Update reasoning
             this.#applyPendingReasoning();
             await this.reasoningHandler.process(messageId, mesChanged, this.promptReasoning);
+            if (!this.#isCurrent(messageId)) return;
             processedText = chat[messageId].mes;
 
             // Token count update.
@@ -6160,6 +6200,7 @@ class StreamingProcessor {
                     countOutput: shouldRefreshTokenCount,
                     countReasoning: shouldRefreshTokenCount,
                 });
+                if (!this.#isCurrent(messageId)) return;
                 currentTokenCount = outputTokens;
                 currentReasoningTokens = reasoningTokens;
             }
@@ -6225,6 +6266,7 @@ class StreamingProcessor {
             this.#queueStreamingVisibleWrite({
                 messageId,
                 write: {
+                    isCurrent: () => this.#isCurrent(messageId),
                     messageTextDom: this.messageTextDom,
                     messageTimerDom: this.messageTimerDom,
                     messageTokenCounterDom: this.messageTokenCounterDom,
@@ -6271,12 +6313,15 @@ class StreamingProcessor {
      * @param {boolean} options.unlockUI - Whether to unlock the generation UI.
      */
     async finalizeIntermediaryMessage(messageId, text, { unlockUI = true }) {
+        if (!this.#isCurrent(messageId)) return;
         await this.onProgressStreaming(messageId, text, true);
+        if (!this.#isCurrent(messageId)) return;
         const messageElement = chatElement.find(`.mes[mesid="${messageId}"]`);
         const message = chat[messageId];
         addCopyToCodeBlocks(messageElement);
 
         await this.reasoningHandler.finish(messageId);
+        if (!this.#isCurrent(messageId)) return;
 
         if (Array.isArray(this.swipes) && this.swipes.length > 0) {
             const swipeInfoExtra = structuredClone(message.extra ?? {});
@@ -6303,6 +6348,7 @@ class StreamingProcessor {
 
         if (Array.isArray(this.images) && this.images.length > 0) {
             await processImageAttachment(message, { imageUrls: this.images });
+            if (!this.#isCurrent(messageId)) return;
             appendMediaToMessage(message, $(this.messageDom));
         }
 
@@ -6318,28 +6364,32 @@ class StreamingProcessor {
 
         if (this.type !== 'impersonate') {
             await eventSource.emit(event_types.MESSAGE_RECEIVED, this.messageId, this.type);
+            if (!this.#isCurrent(messageId)) return;
             await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, this.messageId, this.type);
         } else {
             await eventSource.emit(event_types.IMPERSONATE_READY, text);
         }
+        if (!this.#isCurrent(messageId)) return;
 
         updateSwipeCounter(messageId, { message, messageElement });
     }
 
     async onFinishStreaming(messageId, text) {
         await this.finalizeIntermediaryMessage(messageId, text, { unlockUI: true });
+        if (!this.#isCurrent(messageId)) return;
 
         const isAborted = this.abortController.signal.aborted;
         if (!isAborted && power_user.auto_swipe && generatedTextFiltered(text)) {
             return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
         }
         await saveChatConditional();
+        if (!this.#isCurrent(messageId)) return;
 
         playMessageSound();
     }
 
     onErrorStreaming() {
-        if (this.isFinished) {
+        if (this.isFinished || !this.#isCurrent(this.messageId, true)) {
             return;
         }
 
@@ -6357,6 +6407,7 @@ class StreamingProcessor {
     }
 
     setFirstSwipe(messageId) {
+        if (!this.#isCurrent(messageId, true)) return;
         if (this.type !== 'swipe' && this.type !== 'impersonate') {
             if (Array.isArray(chat[messageId].swipes) && chat[messageId].swipes.length === 1 && chat[messageId].swipe_id === 0) {
                 chat[messageId].swipes[0] = chat[messageId].mes;
@@ -6400,7 +6451,7 @@ class StreamingProcessor {
                 if (!this.timeToFirstToken) {
                     this.timeToFirstToken = now - this.createdAt.getTime();
                 }
-                if (this.isStopped || this.abortController.signal.aborted) {
+                if (!this.#isCurrent()) {
                     this.isStopped = true;
                     this.isFinished = true;
                     return this.result;
@@ -6448,6 +6499,7 @@ class StreamingProcessor {
             this.messageId = await this.onStartStreaming(this.firstMessageText);
             await delay(1); // delay for message to be rendered
         }
+        if (!this.#isCurrent()) { this.isFinished = true; return this.result; }
 
         // Stopping strings are expensive to calculate, especially with macros enabled. To remove stopping strings
         // when streaming, we cache the result of getStoppingStrings instead of calling it once per token.
@@ -6467,7 +6519,7 @@ class StreamingProcessor {
                 if (!this.timeToFirstToken) {
                     this.timeToFirstToken = now - this.createdAt.getTime();
                 }
-                if (this.isStopped || this.abortController.signal.aborted) {
+                if (!this.#isCurrent()) {
                     this.setFirstSwipe(this.messageId);
                     this.isStopped = true;
                     this.isFinished = true;
@@ -6487,7 +6539,9 @@ class StreamingProcessor {
                 this.reasoningSignature = state?.signature ?? null;
                 this.reasoningTokens = state?.reasoning_tokens ?? 0;
                 await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, text);
+                if (!this.#isCurrent()) { this.isFinished = true; return this.result; }
                 await sw.tick(async () => await this.onProgressStreaming(this.messageId, this.continueMessage + text));
+                if (!this.#isCurrent()) { this.isFinished = true; return this.result; }
             }
             const seconds = (timestamps[timestamps.length - 1] - timestamps[0]) / 1000;
             console.warn(`Stream stats: ${timestamps.length} tokens, ${seconds.toFixed(2)} seconds, rate: ${Number(timestamps.length / seconds).toFixed(2)} TPS`);
@@ -6937,6 +6991,13 @@ function removeLastMessage(messageId = null) {
 let generationChatFilter = null;
 let pendingGeneratedMessageExtra = null;
 let pendingUserMessageExtra = null;
+let agentGenerationContextProvider = null;
+let activeGenerationRun = null;
+
+// SillyBunny: the extension registers its getter without a host-to-extension import cycle.
+export function setAgentGenerationContextProvider(provider) {
+    agentGenerationContextProvider = typeof provider === 'function' ? provider : null;
+}
 
 export function setGenerationChatFilter(filter) {
     generationChatFilter = typeof filter === 'function' ? filter : null;
@@ -6969,1405 +7030,1510 @@ function consumePendingUserMessageExtra(message) {
 }
 
 export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, jsonSchema = null, depth = 0, suppressUserMessage = false, cacheScope = null, preserveLastMessage = false, companionHistoryTarget = null } = {}, dryRun = false) {
-    console.log('Generate entered');
-    setGenerationProgress(0);
-    generation_started = new Date();
+    if (!dryRun && signal?.aborted) return;
 
-    // Prevent generation from shallow characters
-    await unshallowCharacter(this_chid);
-
-    // Occurs every time, even if the generation is aborted due to slash commands execution
-    await eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope, preserveLastMessage }, dryRun);
-
-    // Don't recreate abort controller if signal is passed
-    if (!(abortController && signal)) {
+    // SillyBunny: keep cancellation and terminal cleanup attached to this invocation,
+    // not to a successor group member, tool pass, or a newly selected chat.
+    const parentRun = activeGenerationRun;
+    const isAuxiliaryGeneration = type === 'quiet' && Boolean(parentRun && !parentRun.isGroupDispatch);
+    const previousAbortController = abortController;
+    const externalSignal = signal;
+    if (!dryRun && (isAuxiliaryGeneration || !abortController || abortController.signal !== signal)) {
         abortController = new AbortController();
     }
-
-    // OpenAI doesn't need instruct mode. Use OAI main prompt instead.
-    const isInstruct = power_user.instruct.enabled && main_api !== 'openai';
-    const isImpersonate = type == 'impersonate';
-    const resolvedCacheScope = cacheScope ?? (type === 'quiet' ? 'auxiliary' : 'main');
-    const shouldConsumeUserInput = type !== 'regenerate' && type !== 'swipe' && type !== 'quiet' && !isImpersonate && !dryRun && !depth && !suppressUserMessage;
-    let textareaText = '';
-    let renderedUserMessage = false;
-
-    if (!(dryRun || depth || type == 'regenerate' || type == 'swipe' || type == 'quiet')) {
-        const interruptedByCommand = await processCommands(String($('#send_textarea').val()));
-
-        if (interruptedByCommand) {
-            //$("#send_textarea").val('')[0].dispatchEvent(new Event('input', { bubbles:true }));
-            unblockGeneration(type);
-            return Promise.resolve();
+    const requestController = dryRun ? null : abortController;
+    const originChatId = getCurrentChatId();
+    const originChatGeneration = chatGeneration;
+    const getAgentGenerationContext = agentGenerationContextProvider ?? (() => null);
+    const cancelRevision = getAgentGenerationContext()?.cancelRevision;
+    let agentGenerationContext = null;
+    let activeStream = null;
+    let delegatedGeneration = false;
+    const run = !dryRun && !isAuxiliaryGeneration ? {
+        controller: requestController,
+        type,
+        isGroupDispatch: Boolean(selected_group && !is_group_generating),
+        terminal: false,
+    } : null;
+    if (run) {
+        activeGenerationRun = run;
+    }
+    const isCurrent = () => {
+        const context = getAgentGenerationContext();
+        return (dryRun || !requestController.signal.aborted)
+            && getCurrentChatId() === originChatId && chatGeneration === originChatGeneration
+            && (!run || activeGenerationRun === run)
+            && (!isAuxiliaryGeneration || activeGenerationRun === parentRun)
+            && (dryRun || cancelRevision === undefined || context?.cancelRevision === cancelRevision)
+            && (!agentGenerationContext || context?.runId === agentGenerationContext.runId);
+    };
+    const onEnded = () => { if (run && activeGenerationRun === run) run.terminal = true; };
+    const onStopped = () => {
+        if ((run && activeGenerationRun === run) || (isAuxiliaryGeneration && activeGenerationRun === parentRun)) {
+            onEnded();
+            requestController.abort();
         }
-    }
-
-    const lastMessage = chat[chat.length - 1];
-
-    if (!selected_group) {
-        if (shouldConsumeUserInput) {
-            is_send_press = true;
-            textareaText = String($('#send_textarea').val());
-            $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
-        } else {
-            textareaText = '';
-            if (chat.length && lastMessage.is_user) {
-                //do nothing? why does this check exist?
-            // SillyBunny: Guided Correction regenerates against the existing assistant reply.
-            } else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && !depth && chat.length && !(type === 'regenerate' && preserveLastMessage)) {
-                if (type === 'regenerate') {
-                    requestMobileChatBottomPin();
-                }
-                const deletedMessageId = chat.length - 1;
-                deleteItemizedPromptForMessage(deletedMessageId);
-                chat.length = deletedMessageId;
-                await removeLastMessage(deletedMessageId);
-                await eventSource.emit(event_types.MESSAGE_DELETED, deletedMessageId);
-            }
-        }
-
-        if (!dryRun) {
-            deactivateSendButtons();
-        }
-    }
-
-    let { messageBias, promptBias, isUserPromptBias } = getBiasStrings(textareaText, type);
-
-    // These generation types should not attach pending files to the chat
-    const noAttachTypes = [
-        'regenerate',
-        'swipe',
-        'impersonate',
-        'quiet',
-        'continue',
-    ];
-
-    if ((textareaText != '' || (hasPendingFileAttachment() && !noAttachTypes.includes(type))) && !automatic_trigger && type !== 'quiet' && !dryRun && !depth && !selected_group) {
-        // If user message contains no text other than bias - send as a system message
-        if (messageBias && !removeMacros(textareaText)) {
-            sendSystemMessage(system_message_types.GENERIC, ' ', { bias: messageBias });
-        } else {
-            await sendMessageAsUser(textareaText, messageBias);
-        }
-        renderedUserMessage = true;
-    } else if (textareaText == '' && !automatic_trigger && !dryRun && [undefined, 'normal'].includes(type) && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0 && !depth && !suppressUserMessage && !selected_group) {
-        // Use send_if_empty if set and the user message is empty. Only when sending messages normally
-        await sendMessageAsUser(oai_settings.send_if_empty.trim(), messageBias);
-        renderedUserMessage = true;
-    }
-
-    if (renderedUserMessage && shouldBatchMobileChatRendering()) {
-        await waitForNextFrame();
-    }
-
-    // Occurs only if the generation is not aborted due to slash commands execution
-    const companionFeedbackTarget = companionHistoryTarget
-        ?? (type === 'continue' || type === 'swipe' || type === 'regenerate' ? lastMessage : null);
-    await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget }, dryRun);
-
-    if (main_api == 'kobold' && kai_settings.streaming_kobold && !kai_flags.can_use_streaming) {
-        toastr.error(t`Streaming is enabled, but the version of Kobold used does not support token streaming.`, undefined, { timeOut: 10000, preventDuplicates: true });
-        unblockGeneration(type);
-        return Promise.resolve();
-    }
-
-    if (isHordeGenerationNotAllowed()) {
-        unblockGeneration(type);
-        return Promise.resolve();
-    }
-
+    };
+    const onChatChanged = () => {
+        if (getCurrentChatId() !== originChatId || chatGeneration !== originChatGeneration) requestController?.abort();
+    };
+    const onAbort = () => requestController?.abort(externalSignal.reason);
+    const stopStream = () => activeStream?.onStopStreaming();
     if (!dryRun) {
-        // Hide swipes if not in a dry run.
-        hideSwipeButtons();
-        // If generated any message, set the flag to indicate it can't be recreated again.
-        chat_metadata.tainted = true;
+        signal = requestController.signal;
+        externalSignal?.addEventListener('abort', onAbort, { once: true });
+        requestController.signal.addEventListener('abort', stopStream, { once: true });
+        if (run) {
+            eventSource.makeFirst(event_types.GENERATION_ENDED, onEnded);
+            eventSource.makeFirst(event_types.GENERATION_STOPPED, onStopped);
+        } else {
+            eventSource.on(event_types.GENERATION_STOPPED, onStopped);
+        }
+        eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
     }
 
-    if (selected_group && !is_group_generating) {
-        if (!dryRun) {
-            // Returns the promise that generateGroupWrapper returns; resolves when generation is done
-            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget });
+    try {
+        console.log('Generate entered');
+        if (!dryRun && !isAuxiliaryGeneration) {
+            setGenerationProgress(0);
+            generation_started = new Date();
         }
 
-        const characterIndexMap = new Map(characters.map((char, index) => [char.avatar, index]));
-        const group = groups.find((x) => x.id === selected_group);
+        // Prevent generation from shallow characters
+        await unshallowCharacter(this_chid);
+        if (!isCurrent()) return;
 
-        const enabledMembers = group.members.reduce((acc, member) => {
-            if (!group.disabled_members.includes(member) && !acc.includes(member)) {
-                acc.push(member);
+        // Occurs every time, even if the generation is aborted due to slash commands execution
+        await eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope, preserveLastMessage, isAuxiliaryGeneration }, dryRun);
+        if (!isCurrent()) return;
+        agentGenerationContext = !dryRun && !isAuxiliaryGeneration && !run?.isGroupDispatch ? getAgentGenerationContext() : null;
+        if (run) run.context = agentGenerationContext;
+
+        // OpenAI doesn't need instruct mode. Use OAI main prompt instead.
+        const isInstruct = power_user.instruct.enabled && main_api !== 'openai';
+        const isImpersonate = type == 'impersonate';
+        const resolvedCacheScope = cacheScope ?? (type === 'quiet' ? 'auxiliary' : 'main');
+        const shouldConsumeUserInput = type !== 'regenerate' && type !== 'swipe' && type !== 'quiet' && !isImpersonate && !dryRun && !depth && !suppressUserMessage;
+        let textareaText = '';
+        let renderedUserMessage = false;
+
+        if (!(dryRun || depth || type == 'regenerate' || type == 'swipe' || type == 'quiet')) {
+            const interruptedByCommand = await processCommands(String($('#send_textarea').val()));
+            if (!isCurrent()) return;
+
+            if (interruptedByCommand) {
+            //$("#send_textarea").val('')[0].dispatchEvent(new Event('input', { bubbles:true }));
+                unblockGeneration(type);
+                return Promise.resolve();
             }
-            return acc;
-        }, []);
+        }
 
-        const memberIds = enabledMembers
-            .map((member) => characterIndexMap.get(member))
-            .filter((index) => index !== undefined && index !== null);
+        const lastMessage = chat[chat.length - 1];
 
-        if (memberIds.length > 0) {
-            if (menu_type != 'character_edit') setCharacterId(memberIds[0]);
-            setCharacterName('');
-        } else {
-            console.log('No enabled members found');
+        if (!selected_group) {
+            if (shouldConsumeUserInput) {
+                is_send_press = true;
+                textareaText = String($('#send_textarea').val());
+                $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
+            } else {
+                textareaText = '';
+                if (chat.length && lastMessage.is_user) {
+                //do nothing? why does this check exist?
+                    // SillyBunny: Guided Correction regenerates against the existing assistant reply.
+                } else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && !depth && chat.length && !(type === 'regenerate' && preserveLastMessage)) {
+                    if (type === 'regenerate') {
+                        requestMobileChatBottomPin();
+                    }
+                    const deletedMessageId = chat.length - 1;
+                    deleteItemizedPromptForMessage(deletedMessageId);
+                    chat.length = deletedMessageId;
+                    await removeLastMessage(deletedMessageId);
+                    if (!isCurrent()) return;
+                    await eventSource.emit(event_types.MESSAGE_DELETED, deletedMessageId);
+                }
+            }
+
+            if (!dryRun && !isAuxiliaryGeneration) {
+                deactivateSendButtons();
+            }
+        }
+
+        let { messageBias, promptBias, isUserPromptBias } = getBiasStrings(textareaText, type);
+
+        // These generation types should not attach pending files to the chat
+        const noAttachTypes = [
+            'regenerate',
+            'swipe',
+            'impersonate',
+            'quiet',
+            'continue',
+        ];
+
+        if ((textareaText != '' || (hasPendingFileAttachment() && !noAttachTypes.includes(type))) && !automatic_trigger && type !== 'quiet' && !dryRun && !depth && !selected_group) {
+        // If user message contains no text other than bias - send as a system message
+            if (messageBias && !removeMacros(textareaText)) {
+                sendSystemMessage(system_message_types.GENERIC, ' ', { bias: messageBias });
+            } else {
+                await sendMessageAsUser(textareaText, messageBias);
+            }
+            renderedUserMessage = true;
+        } else if (textareaText == '' && !automatic_trigger && !dryRun && [undefined, 'normal'].includes(type) && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0 && !depth && !suppressUserMessage && !selected_group) {
+        // Use send_if_empty if set and the user message is empty. Only when sending messages normally
+            await sendMessageAsUser(oai_settings.send_if_empty.trim(), messageBias);
+            renderedUserMessage = true;
+        }
+
+        if (renderedUserMessage && shouldBatchMobileChatRendering()) {
+            await waitForNextFrame();
+        }
+        if (!isCurrent()) return;
+
+        // Occurs only if the generation is not aborted due to slash commands execution
+        const companionFeedbackTarget = companionHistoryTarget
+        ?? (type === 'continue' || type === 'swipe' || type === 'regenerate' ? lastMessage : null);
+        await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget, isAuxiliaryGeneration }, dryRun);
+        if (!isCurrent()) return;
+
+        if (main_api == 'kobold' && kai_settings.streaming_kobold && !kai_flags.can_use_streaming) {
+            toastr.error(t`Streaming is enabled, but the version of Kobold used does not support token streaming.`, undefined, { timeOut: 10000, preventDuplicates: true });
             unblockGeneration(type);
             return Promise.resolve();
         }
-    }
 
-    //#########QUIET PROMPT STUFF##############
-    //this function just gives special care to novel quiet instruction prompts
-    if (quiet_prompt) {
-        quiet_prompt = substituteParams(quiet_prompt);
-        quiet_prompt = main_api == 'novel' && !quietToLoud ? adjustNovelInstructionPrompt(quiet_prompt) : quiet_prompt;
-    }
+        if (isHordeGenerationNotAllowed()) {
+            unblockGeneration(type);
+            return Promise.resolve();
+        }
 
-    const hasBackendConnection = online_status !== 'no_connection';
+        if (!dryRun && !isAuxiliaryGeneration) {
+        // Hide swipes if not in a dry run.
+            hideSwipeButtons();
+            // If generated any message, set the flag to indicate it can't be recreated again.
+            chat_metadata.tainted = true;
+        }
 
-    // We can't do anything because we're not in a chat right now. (Unless it's a dry run, in which case we need to
-    // assemble the prompt so we can count its tokens regardless of whether a chat is active.)
-    if (!dryRun && !hasBackendConnection) {
-        is_send_press = false;
+        if (selected_group && !is_group_generating) {
+            if (!dryRun) {
+            // Returns the promise that generateGroupWrapper returns; resolves when generation is done
+                return await generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget });
+            }
+
+            const characterIndexMap = new Map(characters.map((char, index) => [char.avatar, index]));
+            const group = groups.find((x) => x.id === selected_group);
+
+            const enabledMembers = group.members.reduce((acc, member) => {
+                if (!group.disabled_members.includes(member) && !acc.includes(member)) {
+                    acc.push(member);
+                }
+                return acc;
+            }, []);
+
+            const memberIds = enabledMembers
+                .map((member) => characterIndexMap.get(member))
+                .filter((index) => index !== undefined && index !== null);
+
+            if (memberIds.length > 0) {
+                if (menu_type != 'character_edit') setCharacterId(memberIds[0]);
+                setCharacterName('');
+            } else {
+                console.log('No enabled members found');
+                unblockGeneration(type);
+                return Promise.resolve();
+            }
+        }
+
+        //#########QUIET PROMPT STUFF##############
+        //this function just gives special care to novel quiet instruction prompts
+        if (quiet_prompt) {
+            quiet_prompt = substituteParams(quiet_prompt);
+            quiet_prompt = main_api == 'novel' && !quietToLoud ? adjustNovelInstructionPrompt(quiet_prompt) : quiet_prompt;
+        }
+
+        const hasBackendConnection = online_status !== 'no_connection';
+
+        // We can't do anything because we're not in a chat right now. (Unless it's a dry run, in which case we need to
+        // assemble the prompt so we can count its tokens regardless of whether a chat is active.)
+        if (!dryRun && !hasBackendConnection) {
         // SillyBunny: reactivate send buttons on early exit so the UI is not
         // left locked when there is no backend connection. (#527)
-        activateSendButtons();
-        return Promise.resolve();
-    }
-
-    const isContinue = type == 'continue';
-
-    // Rewrite the generation timer to account for the time passed for all the continuations.
-    if (isContinue && chat.length) {
-        const prevFinished = lastMessage.gen_finished;
-        const prevStarted = lastMessage.gen_started;
-
-        if (prevFinished && prevStarted) {
-            const timePassed = Number(prevFinished) - Number(prevStarted);
-            generation_started = new Date(Date.now() - timePassed);
-            lastMessage.gen_started = generation_started;
+            unblockGeneration(type);
+            return Promise.resolve();
         }
-    }
 
-    //*********************************
-    //PRE FORMATING STRING
-    //*********************************
+        const isContinue = type == 'continue';
 
-    if (!dryRun) {
+        // Rewrite the generation timer to account for the time passed for all the continuations.
+        if (!dryRun && isContinue && chat.length) {
+            const prevFinished = lastMessage.gen_finished;
+            const prevStarted = lastMessage.gen_started;
+
+            if (prevFinished && prevStarted) {
+                const timePassed = Number(prevFinished) - Number(prevStarted);
+                generation_started = new Date(Date.now() - timePassed);
+                lastMessage.gen_started = generation_started;
+            }
+        }
+
+        //*********************************
+        //PRE FORMATING STRING
+        //*********************************
+
+        if (!dryRun) {
         // Ping after rendering the local user message so slow WebKit networking cannot delay the visible send.
-        const pingResult = await pingServer();
+            const pingResult = await pingServer();
+            if (!isCurrent()) return;
 
-        if (!pingResult) {
-            unblockGeneration(type);
-            toastr.error(t`Verify that the server is running and accessible.`, t`ST Server cannot be reached`);
-            throw new Error('Server unreachable');
-        }
-    }
-
-    let {
-        description,
-        personality,
-        persona,
-        scenario,
-        mesExamples,
-        system,
-        jailbreak,
-        charDepthPrompt,
-        creatorNotes,
-    } = getCharacterCardFields();
-
-    // Depth prompt (character-specific A/N)
-    removeDepthPrompts();
-    const groupDepthPrompts = getGroupDepthPrompts(selected_group, Number(this_chid));
-
-    if (selected_group && Array.isArray(groupDepthPrompts) && groupDepthPrompts.length > 0) {
-        groupDepthPrompts.forEach((value, index) => {
-            const role = getExtensionPromptRoleByName(value.role);
-            setExtensionPrompt(inject_ids.DEPTH_PROMPT_INDEX(index), value.text, extension_prompt_types.IN_CHAT, value.depth, extension_settings.note.allowWIScan, role);
-        });
-    } else {
-        const depthPromptText = charDepthPrompt || '';
-        const depthPromptDepth = characters[this_chid]?.data?.extensions?.depth_prompt?.depth ?? depth_prompt_depth_default;
-        const depthPromptRole = getExtensionPromptRoleByName(characters[this_chid]?.data?.extensions?.depth_prompt?.role ?? depth_prompt_role_default);
-        setExtensionPrompt(inject_ids.DEPTH_PROMPT, depthPromptText, extension_prompt_types.IN_CHAT, depthPromptDepth, extension_settings.note.allowWIScan, depthPromptRole);
-    }
-
-    // First message in fresh 1-on-1 chat reacts to user/character settings changes
-    const firstChatMessage = chat[0];
-    const firstMessageVariants = !world_info_include_names && firstChatMessage
-        ? substituteWorldInfoGreeting(firstChatMessage.mes, substituteParams, { char: name2, user: name1 })
-        : undefined;
-    const firstPromptMessage = firstChatMessage
-        ? (firstMessageVariants?.prompt ?? substituteParams(firstChatMessage.mes))
-        : undefined;
-
-    // Collect messages with usable content
-    const canUseTools = ToolManager.isToolCallingSupported();
-    const canPerformToolCalls = !dryRun && ToolManager.canPerformToolCalls(type) && depth < ToolManager.RECURSE_LIMIT;
-    let coreChat = chat.filter(x => !x.is_system
-        || (canUseTools && Array.isArray(x.extra?.tool_invocations))
-        || hasCompanionChatHistoryForHiddenHost(x));
-    if (generationChatFilter) {
-        coreChat = coreChat.filter((message, index) => generationChatFilter(message, index, coreChat));
-    }
-    if (type === 'swipe') {
-        coreChat.pop();
-    }
-    const companionRewriteTarget = companionHistoryTarget
-        ?? (isContinue || type === 'swipe' || type === 'regenerate' ? lastMessage : null);
-    const companionCandidateMessages = coreChat.filter(message =>
-        message !== companionRewriteTarget
-        && !message.extra?.[IGNORE_SYMBOL],
-    );
-    const companionPolicyMessages = (companionRewriteTarget && !chat.includes(companionRewriteTarget)
-        ? [...chat, companionRewriteTarget]
-        : chat
-    ).filter(message => !message.extra?.[IGNORE_SYMBOL]);
-    const companionChatHistory = selectCompanionChatHistory(companionCandidateMessages, {
-        policyMessages: companionPolicyMessages,
-    });
-    const {
-        host: consolidatedCompanionHistoryHost,
-        entries: consolidatedRetainedEntries,
-    } = consolidateCompanionChatHistory(companionCandidateMessages, companionChatHistory, sourceMessage => content => substituteParams(content, {
-        name2Override: String(sourceMessage.name ?? '').trim() || undefined,
-        original: sourceMessage.is_system ? '' : sourceMessage.mes,
-    }), message => !Array.isArray(message?.extra?.tool_invocations));
-    const consolidatedRetainedContributions = consolidatedRetainedEntries.map(({ message: sourceMessage, contribution }) => {
-        const sourceIndex = coreChat.indexOf(sourceMessage);
-        const regexType = sourceMessage.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
-        const options = { isPrompt: true, depth: (coreChat.length - sourceIndex - (isContinue ? 2 : 1)) };
-        const agentRegexScripts = resolveRegexScriptsForSnapshot(sourceMessage?.extra?.inChatAgents);
-        let promptContent = contribution.content;
-        if (agentRegexScripts.length > 0) {
-            const agentPlacement = sourceMessage.is_user ? AGENT_REGEX_PLACEMENT.USER_INPUT : AGENT_REGEX_PLACEMENT.AI_OUTPUT;
-            promptContent = applyRegexScriptList(promptContent, agentRegexScripts, agentPlacement, {
-                ...options,
-                characterOverride: name2,
-                substituteParamsFn: substituteParams,
-                substituteParamsExtendedFn: substituteParamsExtended,
-            });
-        }
-        const worldInfoContent = promptContent === contribution.content
-            ? undefined
-            : getRegexedString(contribution.content, regexType, options);
-        promptContent = getRegexedString(promptContent, regexType, options);
-        const contextDepth = Math.max(0, coreChat.length - sourceIndex - 1);
-        const retainOoc = shouldRetainContextAtDepth(contextDepth, power_user.ooc_context_depth);
-        const retainHtml = shouldRetainContextAtDepth(contextDepth, power_user.html_context_depth);
-
-        return {
-            contribution: {
-                ...contribution,
-                content: stripHtmlTagsFromContext(stripOocBlocksFromContext(promptContent, retainOoc), retainHtml),
-            },
-            worldInfoContent: worldInfoContent === undefined
-                ? undefined
-                : stripHtmlTagsFromContext(stripOocBlocksFromContext(worldInfoContent, retainOoc), retainHtml),
-        };
-    });
-    coreChat = coreChat.filter(chatItem => !chatItem.is_system
-        || (canUseTools && Array.isArray(chatItem.extra?.tool_invocations))
-        || chatItem === consolidatedCompanionHistoryHost);
-
-    const worldInfoMessageVariants = new Map();
-    coreChat = await Promise.all(coreChat.map(async (/** @type {ChatMessage} */ chatItem, index) => {
-        const originalMessage = chatItem === firstChatMessage ? firstPromptMessage : chatItem.mes;
-        const worldInfoSourceMessage = chatItem === firstChatMessage && firstMessageVariants !== undefined
-            ? firstMessageVariants.worldInfo
-            : originalMessage;
-        const isConsolidatedCompanionHost = chatItem === consolidatedCompanionHistoryHost;
-        const hiddenCompanionHistory = chatItem.is_system && isConsolidatedCompanionHost;
-        // SillyBunny: project opted-in companion notes into prompt history without changing stored chat text.
-        const retainedContributions = isConsolidatedCompanionHost
-            ? consolidatedRetainedContributions.map(item => item.contribution).filter(contribution => contribution.content)
-            : [];
-        const contextSourceMessage = hiddenCompanionHistory ? '' : originalMessage;
-        const worldInfoContextSourceMessage = hiddenCompanionHistory ? '' : worldInfoSourceMessage;
-        let message = contextSourceMessage;
-        let regexType = chatItem.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
-        let options = { isPrompt: true, depth: (coreChat.length - index - (isContinue ? 2 : 1)) };
-
-        // SillyBunny: apply in-chat agent regex scripts (e.g. CYOA "Trim Choices") in prompt mode
-        const agentRegexScripts = resolveRegexScriptsForSnapshot(chatItem?.extra?.inChatAgents);
-        if (agentRegexScripts.length > 0) {
-            const agentPlacement = chatItem.is_user ? AGENT_REGEX_PLACEMENT.USER_INPUT : AGENT_REGEX_PLACEMENT.AI_OUTPUT;
-            message = applyRegexScriptList(message, agentRegexScripts, agentPlacement, {
-                ...options,
-                characterOverride: name2,
-                substituteParamsFn: substituteParams,
-                substituteParamsExtendedFn: substituteParamsExtended,
-            });
-        }
-
-        let regexedMessage = getRegexedString(message, regexType, options);
-        let worldInfoRegexedMessage = message === worldInfoContextSourceMessage ? undefined : getRegexedString(worldInfoContextSourceMessage, regexType, options);
-        const fileContent = hiddenCompanionHistory ? '' : await appendFileContent(chatItem, '');
-        regexedMessage = fileContent + regexedMessage;
-        if (worldInfoRegexedMessage !== undefined) {
-            worldInfoRegexedMessage = fileContent + worldInfoRegexedMessage;
-        }
-
-        const titles = [];
-        if (!hiddenCompanionHistory && chatItem?.extra?.append_title && chatItem?.extra?.title) {
-            titles.push(chatItem.extra.title);
-        }
-        if (!hiddenCompanionHistory && Array.isArray(chatItem?.extra?.media)) {
-            for (const mediaItem of chatItem.extra.media) {
-                if (mediaItem?.title && mediaItem?.append_title) {
-                    titles.push(mediaItem.title);
-                }
-            }
-        }
-        if (titles.length > 0) {
-            const appendedTitles = `\n\n${titles.join('\n\n')}`;
-            regexedMessage += appendedTitles;
-            if (worldInfoRegexedMessage !== undefined) {
-                worldInfoRegexedMessage += appendedTitles;
+            if (!pingResult) {
+                unblockGeneration(type);
+                toastr.error(t`Verify that the server is running and accessible.`, t`ST Server cannot be reached`);
+                throw new Error('Server unreachable');
             }
         }
 
-        const contextDepth = Math.max(0, coreChat.length - index - 1);
-        const retainOoc = shouldRetainContextAtDepth(contextDepth, power_user.ooc_context_depth);
-        const retainHtml = shouldRetainContextAtDepth(contextDepth, power_user.html_context_depth);
-        const contextMessage = stripHtmlTagsFromContext(
-            stripOocBlocksFromContext(regexedMessage, retainOoc),
-            retainHtml,
-        );
-        const consolidatedContextMessage = [contextMessage, ...retainedContributions.map(contribution => contribution.content)]
-            .filter(Boolean)
-            .join('\n\n');
-        const agentContributions = retainedContributions
-            .filter(contribution => contribution.content && consolidatedContextMessage.includes(contribution.content));
-
-        let worldInfoContextMessage = contextMessage;
-        if (worldInfoRegexedMessage !== undefined) {
-            worldInfoContextMessage = stripHtmlTagsFromContext(
-                stripOocBlocksFromContext(worldInfoRegexedMessage, retainOoc),
-                retainHtml,
-            );
-        }
-        if (isConsolidatedCompanionHost) {
-            const worldInfoRetainedContent = consolidatedRetainedContributions
-                .map(item => item.worldInfoContent ?? item.contribution.content)
-                .filter(Boolean);
-            worldInfoContextMessage = [worldInfoContextMessage, ...worldInfoRetainedContent]
-                .filter(Boolean)
-                .join('\n\n');
-        }
-        if (worldInfoContextMessage !== consolidatedContextMessage) {
-            worldInfoMessageVariants.set(index, { prompt: consolidatedContextMessage, worldInfo: worldInfoContextMessage });
-        }
-
-        return {
-            ...chatItem,
-            mes: consolidatedContextMessage,
-            extra: hiddenCompanionHistory ? {} : chatItem.extra,
-            is_system: hiddenCompanionHistory ? false : chatItem.is_system,
-            ...(agentContributions.length > 0 && { agentContributions }),
-            index,
-        };
-    }));
-    // SillyBunny: ICA prompt-only regexes must not remove stored chat text from World Info scans.
-    const worldInfoOnlyChat = coreChat.filter(chatItem => {
-        const variant = worldInfoMessageVariants.get(chatItem.index);
-        return variant && !hasPromptPayload(chatItem) && hasPromptPayload({ ...chatItem, mes: variant.worldInfo });
-    });
-    // SillyBunny: preserve an interrupted reasoning-only prefix when continuing.
-    coreChat = coreChat.filter((chatItem, index) => hasPromptPayload(
-        chatItem,
-        isContinue && index === coreChat.length - 1,
-    ));
-
-    const promptReasoning = new PromptReasoning();
-    for (let i = coreChat.length - 1; i >= 0; i--) {
-        const depth = coreChat.length - i - (isContinue ? 2 : 1);
-        const isPrefix = isContinue && i === coreChat.length - 1;
-
-        // In group chats, only include reasoning from the currently generating character
-        const isOtherGroupMember = selected_group && coreChat[i].name !== name2;
-
-        const promptMessage = coreChat[i].mes;
-        const messageWithReasoning = isOtherGroupMember
-            ? promptMessage
-            : promptReasoning.addToMessage(
-                promptMessage,
-                getRegexedString(
-                    String(coreChat[i].extra?.reasoning ?? ''),
-                    regex_placement.REASONING,
-                    { isPrompt: true, depth: depth },
-                ),
-                isPrefix,
-                coreChat[i].extra?.reasoning_duration,
-            );
-
-        coreChat[i] = {
-            ...coreChat[i],
-            mes: messageWithReasoning,
-        };
-
-        const worldInfoVariant = worldInfoMessageVariants.get(coreChat[i].index);
-        if (worldInfoVariant?.prompt === promptMessage && messageWithReasoning.endsWith(promptMessage)) {
-            const reasoningPrefix = messageWithReasoning.slice(0, messageWithReasoning.length - promptMessage.length);
-            worldInfoVariant.prompt = messageWithReasoning;
-            worldInfoVariant.worldInfo = reasoningPrefix + worldInfoVariant.worldInfo;
-        }
-        if (promptReasoning.isLimitReached()) {
-            break;
-        }
-    }
-
-    // Determine token limit
-    let this_max_context = getMaxPromptTokens();
-
-    if (!dryRun) {
-        console.debug('Running extension interceptors');
-        const aborted = await runGenerationInterceptors(coreChat, this_max_context, type);
-
-        if (aborted) {
-            console.debug('Generation aborted by extension interceptors');
-            unblockGeneration(type);
-            return Promise.resolve();
-        }
-    } else {
-        console.debug('Skipping extension interceptors for dry run');
-    }
-
-    // Adjust token limit for Horde
-    let adjustedParams;
-    if (main_api == 'koboldhorde' && (horde_settings.auto_adjust_context_length || horde_settings.auto_adjust_response_length)) {
-        try {
-            adjustedParams = await adjustHordeGenerationParams(max_context, amount_gen);
-        } catch {
-            unblockGeneration(type);
-            return Promise.resolve();
-        }
-        if (horde_settings.auto_adjust_context_length) {
-            this_max_context = (adjustedParams.maxContextLength - adjustedParams.maxLength);
-        }
-    }
-
-    // Fetches the combined prompt for both negative and positive prompts
-    const cfgGuidanceScale = getGuidanceScale();
-    const useCfgPrompt = cfgGuidanceScale && cfgGuidanceScale.value !== 1;
-
-    // Adjust max context based on CFG prompt to prevent overfitting
-    if (useCfgPrompt) {
-        const negativePrompt = getCfgPrompt(cfgGuidanceScale, true, true)?.value || '';
-        const positivePrompt = getCfgPrompt(cfgGuidanceScale, false, true)?.value || '';
-        if (negativePrompt || positivePrompt) {
-            const previousMaxContext = this_max_context;
-            const [negativePromptTokenCount, positivePromptTokenCount] = await Promise.all([getTokenCountAsync(negativePrompt), getTokenCountAsync(positivePrompt)]);
-            const decrement = Math.max(negativePromptTokenCount, positivePromptTokenCount);
-            this_max_context -= decrement;
-            console.log(`Max context reduced by ${decrement} tokens of CFG prompt (${previousMaxContext} -> ${this_max_context})`);
-        }
-    }
-
-    console.log(`Core/all messages: ${coreChat.length}/${chat.length}`);
-
-    if ((promptBias && !isUserPromptBias) || power_user.always_force_name2 || main_api == 'novel') {
-        force_name2 = true;
-    }
-
-    if (isImpersonate) {
-        force_name2 = false;
-    }
-
-    let mesExamplesArray = parseMesExamples(mesExamples, isInstruct);
-
-    // Set non-WI AN
-    setFloatingPrompt();
-
-    // Add WI to prompt (and also inject WI to AN value via hijack)
-    // Make quiet prompt available for WIAN
-    setExtensionPrompt(inject_ids.QUIET_PROMPT, quiet_prompt || '', extension_prompt_types.IN_PROMPT, 0, true);
-    const chatForWI = buildWorldInfoScanChat(coreChat, worldInfoOnlyChat, worldInfoMessageVariants, world_info_include_names);
-    /** @type {import('./scripts/world-info.js').WIGlobalScanData} */
-    const globalScanData = {
-        personaDescription: persona,
-        characterDescription: description,
-        characterPersonality: personality,
-        characterDepthPrompt: charDepthPrompt,
-        scenario: scenario,
-        creatorNotes: creatorNotes,
-        trigger: GENERATION_TYPE_TRIGGERS.includes(type) ? type : 'normal',
-    };
-    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth, outletEntries } = await getWorldInfoPrompt(chatForWI, this_max_context, dryRun, globalScanData);
-    setExtensionPrompt(inject_ids.QUIET_PROMPT, '', extension_prompt_types.IN_PROMPT, 0, true);
-
-    // Add message example WI
-    for (const example of worldInfoExamples) {
-        const exampleMessage = example.content;
-
-        if (exampleMessage.length === 0) {
-            continue;
-        }
-
-        const formattedExample = baseChatReplace(exampleMessage);
-        const cleanedExample = parseMesExamples(formattedExample, isInstruct);
-
-        // Insert depending on before or after position
-        if (example.position === wi_anchor_position.before) {
-            mesExamplesArray.unshift(...cleanedExample);
-        } else {
-            mesExamplesArray.push(...cleanedExample);
-        }
-    }
-
-    // At this point, the raw message examples can be created
-    const mesExamplesRawArray = [...mesExamplesArray];
-
-    if (mesExamplesArray && isInstruct) {
-        mesExamplesArray = formatInstructModeExamples(mesExamplesArray, name1, name2);
-    }
-
-    if (skipWIAN !== true) {
-        console.log('skipWIAN not active, adding WIAN');
-        // Add all depth WI entries to prompt
-        flushWIInjections();
-        if (Array.isArray(worldInfoDepth)) {
-            worldInfoDepth.forEach((e) => {
-                const joinedEntries = e.entries.join('\n');
-                setExtensionPrompt(inject_ids.CUSTOM_WI_DEPTH_ROLE(e.depth, e.role), joinedEntries, extension_prompt_types.IN_CHAT, e.depth, false, e.role);
-            });
-        }
-        if (outletEntries && typeof outletEntries === 'object' && Object.keys(outletEntries).length > 0) {
-            Object.entries(outletEntries).forEach(([key, value]) => {
-                setExtensionPrompt(inject_ids.CUSTOM_WI_OUTLET(key), value.join('\n'), extension_prompt_types.NONE, 0);
-            });
-        }
-    } else {
-        console.log('skipping WIAN');
-    }
-
-    // Add persona description to prompt
-    addPersonaDescriptionExtensionPrompt();
-
-    // Prepare the system prompt for Text Completion APIs
-    if (main_api !== 'openai') {
-        if (power_user.sysprompt.enabled) {
-            system = power_user.prefer_character_prompt && system
-                ? substituteParams(system, { original: power_user.sysprompt.content ?? '' })
-                : baseChatReplace(power_user.sysprompt.content);
-            system = isInstruct ? substituteParams(system, { original: power_user.sysprompt.content ?? '' }) : system;
-        } else {
-            // Nullify if it's not enabled
-            system = '';
-        }
-    }
-
-    // Collect before / after story string injections
-    const beforeScenarioAnchor = await getExtensionPrompt(extension_prompt_types.BEFORE_PROMPT);
-    const afterScenarioAnchor = await getExtensionPrompt(extension_prompt_types.IN_PROMPT);
-
-    const storyStringParams = {
-        description: description,
-        personality: personality,
-        persona: power_user.persona_description_position == persona_description_positions.IN_PROMPT ? persona : '',
-        scenario: scenario,
-        system: system,
-        char: name2,
-        user: name1,
-        wiBefore: worldInfoBefore,
-        wiAfter: worldInfoAfter,
-        loreBefore: worldInfoBefore,
-        loreAfter: worldInfoAfter,
-        anchorBefore: beforeScenarioAnchor.trim(),
-        anchorAfter: afterScenarioAnchor.trim(),
-        mesExamples: mesExamplesArray.join(''),
-        mesExamplesRaw: mesExamplesRawArray.join(''),
-    };
-
-    // Render the story string and combine with injections
-    const storyString = renderStoryString(storyStringParams);
-    let combinedStoryString = isInstruct ? formatInstructModeStoryString(storyString) : storyString;
-
-    // Inject the story string as in-chat prompt (if needed)
-    const applyStoryStringInject = main_api !== 'openai' && power_user.context.story_string_position === extension_prompt_types.IN_CHAT;
-    if (applyStoryStringInject) {
-        const depth = power_user.context.story_string_depth ?? 1;
-        const role = power_user.context.story_string_role ?? extension_prompt_roles.SYSTEM;
-        setExtensionPrompt(inject_ids.STORY_STRING, combinedStoryString, extension_prompt_types.IN_CHAT, depth, false, role);
-        // Remove to prevent duplication
-        combinedStoryString = '';
-    } else {
-        setExtensionPrompt(inject_ids.STORY_STRING, '', extension_prompt_types.IN_CHAT, 0);
-    }
-
-    // Story string rendered, safe to remove
-    if (power_user.strip_examples) {
-        mesExamplesArray = [];
-    }
-
-    const generationExtensionPrompts = extension_prompts;
-
-    // Inject all Depth prompts. Chat Completion does it separately
-    let injectedIndices = [];
-    if (main_api !== 'openai') {
-        injectedIndices = await doChatInject(coreChat, isContinue);
-    }
-
-    if (main_api !== 'openai' && power_user.sysprompt.enabled) {
-        jailbreak = power_user.prefer_character_jailbreak && jailbreak
-            ? substituteParams(jailbreak, { original: power_user.sysprompt.post_history ?? '' })
-            : baseChatReplace(power_user.sysprompt.post_history);
-
-        // Only inject the jb if there is one
-        if (jailbreak) {
-            // When continuing generation of previous output, last user message precedes the message to continue
-            if (isContinue) {
-                coreChat.splice(coreChat.length - 1, 0, { mes: jailbreak, is_user: true });
-            } else {
-                // This operation will result in the injectedIndices indexes being off by one
-                coreChat.push({ mes: jailbreak, is_user: true });
-                // Add +1 to the elements to correct for the new PHI/Jailbreak message.
-                injectedIndices.forEach(shiftUpByOne);
-            }
-        }
-    }
-
-    let chat2 = [];
-    let chat2AgentContributions = [];
-    let continue_mag = '';
-    let userMessageIndices = [];
-    const lastUserMessageIndex = coreChat.findLastIndex(x => x.is_user);
-
-    for (let i = coreChat.length - 1, j = 0; i >= 0; i--, j++) {
-        if (main_api == 'openai') {
-            chat2[i] = coreChat[j].mes;
-            if (i === 0 && isContinue) {
-                chat2[i] = chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
-                continue_mag = coreChat[j].mes;
-            }
-            continue;
-        }
-
-        chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, false);
-        chat2AgentContributions[i] = Array.isArray(coreChat[j].agentContributions)
-            ? structuredClone(coreChat[j].agentContributions)
-            : [];
-
-        if (j === 0 && isInstruct) {
-            // Reformat with the first output sequence (if any)
-            chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.FIRST);
-        }
-
-        if (lastUserMessageIndex >= 0 && j === lastUserMessageIndex && isInstruct && !isImpersonate) {
-            // Reformat with the last input sequence (if any)
-            chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
-        }
-
-        // Do not suffix the message for continuation
-        if (i === 0 && isContinue) {
-            // Pick something that's very unlikely to be in a message
-            const FORMAT_TOKEN = '\u0000\ufffc\u0000\ufffd';
-
-            if (isInstruct) {
-                const originalMessage = String(coreChat[j].mes ?? '');
-                coreChat[j].mes = originalMessage.replaceAll(FORMAT_TOKEN, '') + FORMAT_TOKEN;
-                // Reformat with the last output sequence (if any)
-                chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
-                coreChat[j].mes = originalMessage;
-            }
-
-            chat2[i] = chat2[i].includes(FORMAT_TOKEN)
-                ? chat2[i].slice(0, chat2[i].lastIndexOf(FORMAT_TOKEN))
-                : chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
-            continue_mag = coreChat[j].mes;
-        }
-
-        if (coreChat[j].is_user) {
-            userMessageIndices.push(i);
-        }
-    }
-
-    let addUserAlignment = isInstruct && power_user.instruct.user_alignment_message;
-    let userAlignmentMessage = '';
-
-    if (addUserAlignment) {
-        const alignmentMessage = {
-            name: name1,
-            mes: substituteParams(power_user.instruct.user_alignment_message),
-            is_user: true,
-        };
-        userAlignmentMessage = formatMessageHistoryItem(alignmentMessage, isInstruct, force_output_sequence.FIRST);
-    }
-
-    let oaiMessages = [];
-    let oaiMessageExamples = [];
-
-    if (main_api === 'openai') {
-        oaiMessages = setOpenAIMessages(coreChat);
-        oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray);
-    }
-
-    // hack for regeneration of the first message
-    if (chat2.length == 0) {
-        chat2.push('');
-    }
-
-    let examplesString = '';
-    let chatString = addChatsPreamble(addChatsSeparator(''));
-    let cyclePrompt = '';
-
-    async function getMessagesTokenCount() {
-        const encodeString = [
-            combinedStoryString,
-            examplesString,
-            userAlignmentMessage,
-            chatString,
-            modifyLastPromptLine(''),
-            cyclePrompt,
-        ].join('').replace(/\r/gm, '');
-        return getTokenCountAsync(encodeString, power_user.token_padding);
-    }
-
-    // Force pinned examples into the context
-    let pinExmString;
-    if (power_user.pin_examples) {
-        pinExmString = examplesString = mesExamplesArray.join('');
-    }
-
-    // Only add the chat in context if past the greeting message
-    if (isContinue && (chat2.length > 1 || main_api === 'openai')) {
-        cyclePrompt = chat2.shift();
-        chat2AgentContributions.shift();
-        // Adjust indices to account for the shift
-        injectedIndices = injectedIndices.map(shiftDownByOne).filter(x => x >= 0);
-        userMessageIndices = userMessageIndices.map(shiftDownByOne).filter(x => x >= 0);
-    }
-
-    // Collect enough messages to fill the context
-    let arrMes = new Array(chat2.length);
-    let tokenCount = await getMessagesTokenCount();
-    let lastAddedIndex = 0;
-
-    // Pre-allocate all injections first.
-    // If it doesn't fit - user shot himself in the foot
-    for (const index of injectedIndices) {
-        // not needed for OAI prompting
-        if (main_api == 'openai') {
-            break;
-        }
-
-        const item = chat2[index];
-
-        if (typeof item !== 'string') {
-            continue;
-        }
-
-        tokenCount += await getTokenCountAsync(item.replace(/\r/gm, ''));
-        if (tokenCount < this_max_context) {
-            chatString = chatString + item;
-            arrMes[index] = item;
-            lastAddedIndex = Math.max(lastAddedIndex, index);
-        } else {
-            break;
-        }
-    }
-
-    for (let i = 0; i < chat2.length; i++) {
-        // not needed for OAI prompting
-        if (main_api == 'openai') {
-            break;
-        }
-
-        // Skip already injected messages
-        if (arrMes[i] !== undefined) {
-            continue;
-        }
-
-        let item = chat2[i];
-
-        if (typeof item !== 'string') {
-            continue;
-        }
-
-        let itemTokens = await getTokenCountAsync(item.replace(/\r/gm, ''));
-        while (tokenCount + itemTokens >= this_max_context && chat2AgentContributions[i].length > 0) {
-            const trimmed = trimOldestRetainedContribution(item, chat2AgentContributions[i]);
-            if (!trimmed.changed) break;
-            item = trimmed.content;
-            chat2[i] = item;
-            chat2AgentContributions[i] = trimmed.contributions;
-            itemTokens = await getTokenCountAsync(item.replace(/\r/gm, ''));
-        }
-        tokenCount += itemTokens;
-        if (tokenCount < this_max_context) {
-            chatString = chatString + item;
-            arrMes[i] = item;
-            lastAddedIndex = Math.max(lastAddedIndex, i);
-        } else {
-            break;
-        }
-    }
-
-    // Add user alignment message if last message is not a user message
-    const stoppedAtUser = userMessageIndices.includes(lastAddedIndex);
-    if (addUserAlignment && !stoppedAtUser) {
-        tokenCount += await getTokenCountAsync(userAlignmentMessage.replace(/\r/gm, ''));
-        chatString = userAlignmentMessage + chatString;
-        arrMes.push(userAlignmentMessage);
-        injectedIndices.push(arrMes.length - 1);
-    }
-
-    // Unsparse the array. Adjust injected indices
-    const newArrMes = [];
-    const newInjectedIndices = [];
-    for (let i = 0; i < arrMes.length; i++) {
-        if (arrMes[i] !== undefined) {
-            newArrMes.push(arrMes[i]);
-            if (injectedIndices.includes(i)) {
-                newInjectedIndices.push(newArrMes.length - 1);
-            }
-        }
-    }
-
-    arrMes = newArrMes;
-    injectedIndices = newInjectedIndices;
-
-    if (main_api !== 'openai') {
-        setInContextMessages(arrMes.length - injectedIndices.length, type, preserveLastMessage);
-    }
-
-    // Estimate how many unpinned example messages fit in the context
-    tokenCount = await getMessagesTokenCount();
-    let count_exm_add = 0;
-    if (!power_user.pin_examples) {
-        for (let example of mesExamplesArray) {
-            tokenCount += await getTokenCountAsync(example.replace(/\r/gm, ''));
-            examplesString += example;
-            if (tokenCount < this_max_context) {
-                count_exm_add++;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mesSend = [];
-    console.debug('calling runGenerate');
-
-    if (isContinue) {
-        // Coping mechanism for OAI spacing
-        if (main_api === 'openai' && !cyclePrompt.endsWith(' ')) {
-            cyclePrompt += oai_settings.continue_postfix;
-            continue_mag += oai_settings.continue_postfix;
-        }
-    }
-
-    const originalType = type;
-
-    if (!dryRun) {
-        is_send_press = true;
-    }
-
-    let generatedPromptCache = cyclePrompt || '';
-    if (generatedPromptCache.length == 0 || type === 'continue') {
-        console.debug('generating prompt');
-        chatString = '';
-        arrMes = arrMes.reverse();
-        arrMes.forEach(function (item, i, arr) {
-            // OAI doesn't need all of this
-            if (main_api === 'openai') {
-                return;
-            }
-
-            // Cohee: This removes a newline from the end of the last message in the context
-            // Last prompt line will add a newline if it's not a continuation
-            // In instruct mode it only removes it if wrap is enabled and it's not a quiet generation
-            if (i === arrMes.length - 1 && type !== 'continue') {
-                if (!isInstruct || (power_user.instruct.wrap && type !== 'quiet')) {
-                    item = item.replace(/\n?$/, '');
-                }
-            }
-
-            mesSend[mesSend.length] = { message: item, extensionPrompts: [] };
-        });
-    }
-
-    let mesExmString = '';
-
-    function setPromptString() {
-        if (main_api == 'openai') {
-            return;
-        }
-
-        console.debug('--setting Prompt string');
-        mesExmString = pinExmString ?? mesExamplesArray.slice(0, count_exm_add).join('');
-
-        if (mesSend.length) {
-            mesSend[mesSend.length - 1].message = modifyLastPromptLine(mesSend[mesSend.length - 1].message);
-        }
-    }
-
-    function modifyLastPromptLine(lastMesString) {
-        //#########QUIET PROMPT STUFF PT2##############
-
-        // Add quiet generation prompt at depth 0
-        if (quiet_prompt && quiet_prompt.length) {
-            // here name1 is forced for all quiet prompts..why?
-            const name = name1;
-            //checks if we are in instruct, if so, formats the chat as such, otherwise just adds the quiet prompt
-            const quietAppend = isInstruct ? formatInstructModeChat(name, quiet_prompt, false, true, '', name1, name2, false) : `\n${quiet_prompt}`;
-
-            //This begins to fix quietPrompts (particularly /sysgen) for instruct
-            //previously instruct input sequence was being appended to the last chat message w/o '\n'
-            //and no output sequence was added after the input's content.
-            //TODO: respect output_sequence vs last_output_sequence settings
-            //TODO: decide how to prompt this to clarify who is talking 'Narrator', 'System', etc.
-            if (isInstruct) {
-                lastMesString += quietAppend; // + power_user.instruct.output_sequence + '\n';
-            } else {
-                lastMesString += quietAppend;
-            }
-
-
-            // Ross: bailing out early prevents quiet prompts from respecting other instruct prompt toggles
-            // for sysgen, SD, and summary this is desireable as it prevents the AI from responding as char..
-            // but for idle prompting, we want the flexibility of the other prompt toggles, and to respect them as per settings in the extension
-            // need a detection for what the quiet prompt is being asked for...
-
-            // Bail out early?
-            if (!isInstruct && !quietToLoud) {
-                return lastMesString;
-            }
-        }
-
-
-        // Get instruct mode line
-        if (isInstruct && !isContinue) {
-            const name = (quiet_prompt && !quietToLoud && !isImpersonate) ? (quietName ?? 'System') : (isImpersonate ? name1 : name2);
-            const isQuiet = quiet_prompt && type == 'quiet';
-            lastMesString += formatInstructModePrompt(name, isImpersonate, promptBias, name1, name2, isQuiet, quietToLoud);
-        }
-
-        // Get non-instruct impersonation line
-        if (!isInstruct && isImpersonate && !isContinue) {
-            const name = name1;
-            if (!lastMesString.endsWith('\n')) {
-                lastMesString += '\n';
-            }
-            lastMesString += name + ':';
-        }
-
-        // Add character's name
-        // Force name append on continue (if not continuing on user message or first message)
-        const isContinuingOnFirstMessage = chat.length === 1 && isContinue;
-        if (!isInstruct && force_name2 && !isContinuingOnFirstMessage) {
-            if (!lastMesString.endsWith('\n')) {
-                lastMesString += '\n';
-            }
-            if (!isContinue || !(chat[chat.length - 1]?.is_user)) {
-                lastMesString += `${name2}:`;
-            }
-        }
-
-        return lastMesString;
-    }
-
-    async function checkPromptSize() {
-        console.debug('---checking Prompt size');
-        setPromptString();
-        const jointMessages = mesSend.map((e) => `${e.extensionPrompts.join('')}${e.message}`).join('');
-        const prompt = [
-            combinedStoryString,
-            mesExmString,
-            addChatsPreamble(addChatsSeparator(jointMessages)),
-            '\n',
-            modifyLastPromptLine(''),
-            generatedPromptCache,
-        ].join('').replace(/\r/gm, '');
-        let thisPromptContextSize = await getTokenCountAsync(prompt, power_user.token_padding);
-
-        if (thisPromptContextSize > this_max_context) {        //if the prepared prompt is larger than the max context size...
-            if (count_exm_add > 0) {                            // ..and we have example messages..
-                count_exm_add--;                            // remove the example messages...
-                await checkPromptSize();                            // and try agin...
-            } else if (mesSend.length > 0) {                    // if the chat history is longer than 0
-                mesSend.shift();                            // remove the first (oldest) chat entry..
-                await checkPromptSize();                            // and check size again..
-            } else {
-                //end
-                console.debug(`---mesSend.length = ${mesSend.length}`);
-            }
-        }
-    }
-
-    if (generatedPromptCache.length > 0 && main_api !== 'openai') {
-        console.debug('---Generated Prompt Cache length: ' + generatedPromptCache.length);
-        await checkPromptSize();
-    } else {
-        console.debug('---calling setPromptString ' + generatedPromptCache.length);
-        setPromptString();
-    }
-
-    // For prompt bit itemization
-    let mesSendString = '';
-
-    async function getCombinedPrompt(isNegative) {
-        // Only return if the guidance scale doesn't exist or the value is 1
-        // Also don't return if constructing the neutral prompt
-        if (isNegative && !useCfgPrompt) {
-            return;
-        }
-
-        // OAI has its own prompt manager. No need to do anything here
-        if (main_api === 'openai') {
-            return '';
-        }
-
-        // Deep clone
-        let finalMesSend = structuredClone(mesSend);
-
-        if (useCfgPrompt) {
-            const cfgPrompt = getCfgPrompt(cfgGuidanceScale, isNegative);
-            if (cfgPrompt.value) {
-                if (cfgPrompt.depth === 0) {
-                    finalMesSend[finalMesSend.length - 1].message +=
-                        /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
-                            ? cfgPrompt.value
-                            : ` ${cfgPrompt.value}`;
-                } else {
-                    // TODO: Make all extension prompts use an array/splice method
-                    const lengthDiff = mesSend.length - cfgPrompt.depth;
-                    const cfgDepth = lengthDiff >= 0 ? lengthDiff : 0;
-                    const cfgMessage = finalMesSend[cfgDepth];
-                    if (cfgMessage) {
-                        if (!Array.isArray(finalMesSend[cfgDepth].extensionPrompts)) {
-                            finalMesSend[cfgDepth].extensionPrompts = [];
-                        }
-                        finalMesSend[cfgDepth].extensionPrompts.push(`${cfgPrompt.value}\n`);
-                    }
-                }
-            }
-        }
-
-        // Add prompt bias after everything else
-        // Always run with continue
-        if (!isInstruct && !isImpersonate) {
-            if (promptBias.trim().length !== 0) {
-                finalMesSend[finalMesSend.length - 1].message +=
-                    /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
-                        ? promptBias.trimStart()
-                        : ` ${promptBias.trimStart()}`;
-            }
-        }
-
-        // Flattens the multiple prompt objects to a string.
-        const combine = () => {
-            // Right now, everything is suffixed with a newline
-            mesSendString = finalMesSend.map((e) => `${e.extensionPrompts.join('')}${e.message}`).join('');
-
-            // add a custom dingus (if defined)
-            mesSendString = addChatsSeparator(mesSendString);
-
-            // add chat preamble
-            mesSendString = addChatsPreamble(mesSendString);
-
-            let combinedPrompt = [
-                combinedStoryString,
-                mesExmString,
-                mesSendString,
-                generatedPromptCache,
-            ].join('').replace(/\r/gm, '');
-
-            if (power_user.collapse_newlines) {
-                combinedPrompt = collapseNewlines(combinedPrompt);
-            }
-
-            return combinedPrompt;
-        };
-
-        finalMesSend.forEach((item, i) => {
-            item.injected = injectedIndices.includes(finalMesSend.length - i - 1);
-        });
-
-        let data = {
-            api: main_api,
-            combinedPrompt: null,
+        let {
             description,
             personality,
             persona,
             scenario,
-            char: name2,
-            user: name1,
-            worldInfoBefore,
-            worldInfoAfter,
-            beforeScenarioAnchor,
-            afterScenarioAnchor,
-            storyString,
-            mesExmString,
-            mesSendString,
-            finalMesSend,
-            generatedPromptCache,
-            main: system,
+            mesExamples,
+            system,
             jailbreak,
-            naiPreamble: nai_settings.preamble,
-        };
+            charDepthPrompt,
+            creatorNotes,
+        } = getCharacterCardFields();
 
-        // Before returning the combined prompt, give available context related information to all subscribers.
-        await eventSource.emit(event_types.GENERATE_BEFORE_COMBINE_PROMPTS, data);
+        // Depth prompt (character-specific A/N)
+        removeDepthPrompts();
+        const groupDepthPrompts = getGroupDepthPrompts(selected_group, Number(this_chid));
 
-        // If one or multiple subscribers return a value, forfeit the responsibillity of flattening the context.
-        return !data.combinedPrompt ? combine() : data.combinedPrompt;
-    }
+        if (selected_group && Array.isArray(groupDepthPrompts) && groupDepthPrompts.length > 0) {
+            groupDepthPrompts.forEach((value, index) => {
+                const role = getExtensionPromptRoleByName(value.role);
+                setExtensionPrompt(inject_ids.DEPTH_PROMPT_INDEX(index), value.text, extension_prompt_types.IN_CHAT, value.depth, extension_settings.note.allowWIScan, role);
+            });
+        } else {
+            const depthPromptText = charDepthPrompt || '';
+            const depthPromptDepth = characters[this_chid]?.data?.extensions?.depth_prompt?.depth ?? depth_prompt_depth_default;
+            const depthPromptRole = getExtensionPromptRoleByName(characters[this_chid]?.data?.extensions?.depth_prompt?.role ?? depth_prompt_role_default);
+            setExtensionPrompt(inject_ids.DEPTH_PROMPT, depthPromptText, extension_prompt_types.IN_CHAT, depthPromptDepth, extension_settings.note.allowWIScan, depthPromptRole);
+        }
 
-    let finalPrompt = await getCombinedPrompt(false);
+        // First message in fresh 1-on-1 chat reacts to user/character settings changes
+        const firstChatMessage = chat[0];
+        const firstMessageVariants = !world_info_include_names && firstChatMessage
+            ? substituteWorldInfoGreeting(firstChatMessage.mes, substituteParams, { char: name2, user: name1 })
+            : undefined;
+        const firstPromptMessage = firstChatMessage
+            ? (firstMessageVariants?.prompt ?? substituteParams(firstChatMessage.mes))
+            : undefined;
 
-    const eventData = { prompt: finalPrompt, dryRun: dryRun };
-    await eventSource.emit(event_types.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
-    finalPrompt = eventData.prompt;
+        // Collect messages with usable content
+        const canUseTools = ToolManager.isToolCallingSupported();
+        const canPerformToolCalls = !dryRun && ToolManager.canPerformToolCalls(type) && depth < ToolManager.RECURSE_LIMIT;
+        let coreChat = chat.filter(x => !x.is_system
+        || (canUseTools && Array.isArray(x.extra?.tool_invocations))
+        || hasCompanionChatHistoryForHiddenHost(x));
+        if (generationChatFilter) {
+            coreChat = coreChat.filter((message, index) => generationChatFilter(message, index, coreChat));
+        }
+        if (type === 'swipe') {
+            coreChat.pop();
+        }
+        const companionRewriteTarget = companionHistoryTarget
+        ?? (isContinue || type === 'swipe' || type === 'regenerate' ? lastMessage : null);
+        const companionCandidateMessages = coreChat.filter(message =>
+            message !== companionRewriteTarget
+        && !message.extra?.[IGNORE_SYMBOL],
+        );
+        const companionPolicyMessages = (companionRewriteTarget && !chat.includes(companionRewriteTarget)
+            ? [...chat, companionRewriteTarget]
+            : chat
+        ).filter(message => !message.extra?.[IGNORE_SYMBOL]);
+        const companionChatHistory = selectCompanionChatHistory(companionCandidateMessages, {
+            policyMessages: companionPolicyMessages,
+        });
+        const {
+            host: consolidatedCompanionHistoryHost,
+            entries: consolidatedRetainedEntries,
+        } = consolidateCompanionChatHistory(companionCandidateMessages, companionChatHistory, sourceMessage => content => substituteParams(content, {
+            name2Override: String(sourceMessage.name ?? '').trim() || undefined,
+            original: sourceMessage.is_system ? '' : sourceMessage.mes,
+        }), message => !Array.isArray(message?.extra?.tool_invocations));
+        const consolidatedRetainedContributions = consolidatedRetainedEntries.map(({ message: sourceMessage, contribution }) => {
+            const sourceIndex = coreChat.indexOf(sourceMessage);
+            const regexType = sourceMessage.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
+            const options = { isPrompt: true, depth: (coreChat.length - sourceIndex - (isContinue ? 2 : 1)) };
+            const agentRegexScripts = resolveRegexScriptsForSnapshot(sourceMessage?.extra?.inChatAgents);
+            let promptContent = contribution.content;
+            if (agentRegexScripts.length > 0) {
+                const agentPlacement = sourceMessage.is_user ? AGENT_REGEX_PLACEMENT.USER_INPUT : AGENT_REGEX_PLACEMENT.AI_OUTPUT;
+                promptContent = applyRegexScriptList(promptContent, agentRegexScripts, agentPlacement, {
+                    ...options,
+                    characterOverride: name2,
+                    substituteParamsFn: substituteParams,
+                    substituteParamsExtendedFn: substituteParamsExtended,
+                });
+            }
+            const worldInfoContent = promptContent === contribution.content
+                ? undefined
+                : getRegexedString(contribution.content, regexType, options);
+            promptContent = getRegexedString(promptContent, regexType, options);
+            const contextDepth = Math.max(0, coreChat.length - sourceIndex - 1);
+            const retainOoc = shouldRetainContextAtDepth(contextDepth, power_user.ooc_context_depth);
+            const retainHtml = shouldRetainContextAtDepth(contextDepth, power_user.html_context_depth);
 
-    let maxLength = Number(amount_gen); // how many tokens the AI will be requested to generate
-    let thisPromptBits = [];
+            return {
+                contribution: {
+                    ...contribution,
+                    content: stripHtmlTagsFromContext(stripOocBlocksFromContext(promptContent, retainOoc), retainHtml),
+                },
+                worldInfoContent: worldInfoContent === undefined
+                    ? undefined
+                    : stripHtmlTagsFromContext(stripOocBlocksFromContext(worldInfoContent, retainOoc), retainHtml),
+            };
+        });
+        coreChat = coreChat.filter(chatItem => !chatItem.is_system
+        || (canUseTools && Array.isArray(chatItem.extra?.tool_invocations))
+        || chatItem === consolidatedCompanionHistoryHost);
 
-    let generate_data;
-    switch (main_api) {
-        case 'koboldhorde':
-        case 'kobold':
-            if (main_api == 'koboldhorde' && horde_settings.auto_adjust_response_length) {
-                maxLength = Math.min(maxLength, adjustedParams.maxLength);
-                maxLength = Math.max(maxLength, MIN_LENGTH); // prevent validation errors
+        const worldInfoMessageVariants = new Map();
+        coreChat = await Promise.all(coreChat.map(async (/** @type {ChatMessage} */ chatItem, index) => {
+            const originalMessage = chatItem === firstChatMessage ? firstPromptMessage : chatItem.mes;
+            const worldInfoSourceMessage = chatItem === firstChatMessage && firstMessageVariants !== undefined
+                ? firstMessageVariants.worldInfo
+                : originalMessage;
+            const isConsolidatedCompanionHost = chatItem === consolidatedCompanionHistoryHost;
+            const hiddenCompanionHistory = chatItem.is_system && isConsolidatedCompanionHost;
+            // SillyBunny: project opted-in companion notes into prompt history without changing stored chat text.
+            const retainedContributions = isConsolidatedCompanionHost
+                ? consolidatedRetainedContributions.map(item => item.contribution).filter(contribution => contribution.content)
+                : [];
+            const contextSourceMessage = hiddenCompanionHistory ? '' : originalMessage;
+            const worldInfoContextSourceMessage = hiddenCompanionHistory ? '' : worldInfoSourceMessage;
+            let message = contextSourceMessage;
+            let regexType = chatItem.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
+            let options = { isPrompt: true, depth: (coreChat.length - index - (isContinue ? 2 : 1)) };
+
+            // SillyBunny: apply in-chat agent regex scripts (e.g. CYOA "Trim Choices") in prompt mode
+            const agentRegexScripts = resolveRegexScriptsForSnapshot(chatItem?.extra?.inChatAgents);
+            if (agentRegexScripts.length > 0) {
+                const agentPlacement = chatItem.is_user ? AGENT_REGEX_PLACEMENT.USER_INPUT : AGENT_REGEX_PLACEMENT.AI_OUTPUT;
+                message = applyRegexScriptList(message, agentRegexScripts, agentPlacement, {
+                    ...options,
+                    characterOverride: name2,
+                    substituteParamsFn: substituteParams,
+                    substituteParamsExtendedFn: substituteParamsExtended,
+                });
             }
 
-            generate_data = {
-                prompt: finalPrompt,
-                gui_settings: true,
-                max_length: maxLength,
-                max_context_length: max_context,
-                api_server: kai_settings.api_server,
+            let regexedMessage = getRegexedString(message, regexType, options);
+            let worldInfoRegexedMessage = message === worldInfoContextSourceMessage ? undefined : getRegexedString(worldInfoContextSourceMessage, regexType, options);
+            const fileContent = hiddenCompanionHistory ? '' : await appendFileContent(chatItem, '');
+            regexedMessage = fileContent + regexedMessage;
+            if (worldInfoRegexedMessage !== undefined) {
+                worldInfoRegexedMessage = fileContent + worldInfoRegexedMessage;
+            }
+
+            const titles = [];
+            if (!hiddenCompanionHistory && chatItem?.extra?.append_title && chatItem?.extra?.title) {
+                titles.push(chatItem.extra.title);
+            }
+            if (!hiddenCompanionHistory && Array.isArray(chatItem?.extra?.media)) {
+                for (const mediaItem of chatItem.extra.media) {
+                    if (mediaItem?.title && mediaItem?.append_title) {
+                        titles.push(mediaItem.title);
+                    }
+                }
+            }
+            if (titles.length > 0) {
+                const appendedTitles = `\n\n${titles.join('\n\n')}`;
+                regexedMessage += appendedTitles;
+                if (worldInfoRegexedMessage !== undefined) {
+                    worldInfoRegexedMessage += appendedTitles;
+                }
+            }
+
+            const contextDepth = Math.max(0, coreChat.length - index - 1);
+            const retainOoc = shouldRetainContextAtDepth(contextDepth, power_user.ooc_context_depth);
+            const retainHtml = shouldRetainContextAtDepth(contextDepth, power_user.html_context_depth);
+            const contextMessage = stripHtmlTagsFromContext(
+                stripOocBlocksFromContext(regexedMessage, retainOoc),
+                retainHtml,
+            );
+            const consolidatedContextMessage = [contextMessage, ...retainedContributions.map(contribution => contribution.content)]
+                .filter(Boolean)
+                .join('\n\n');
+            const agentContributions = retainedContributions
+                .filter(contribution => contribution.content && consolidatedContextMessage.includes(contribution.content));
+
+            let worldInfoContextMessage = contextMessage;
+            if (worldInfoRegexedMessage !== undefined) {
+                worldInfoContextMessage = stripHtmlTagsFromContext(
+                    stripOocBlocksFromContext(worldInfoRegexedMessage, retainOoc),
+                    retainHtml,
+                );
+            }
+            if (isConsolidatedCompanionHost) {
+                const worldInfoRetainedContent = consolidatedRetainedContributions
+                    .map(item => item.worldInfoContent ?? item.contribution.content)
+                    .filter(Boolean);
+                worldInfoContextMessage = [worldInfoContextMessage, ...worldInfoRetainedContent]
+                    .filter(Boolean)
+                    .join('\n\n');
+            }
+            if (worldInfoContextMessage !== consolidatedContextMessage) {
+                worldInfoMessageVariants.set(index, { prompt: consolidatedContextMessage, worldInfo: worldInfoContextMessage });
+            }
+
+            return {
+                ...chatItem,
+                mes: consolidatedContextMessage,
+                extra: hiddenCompanionHistory ? {} : chatItem.extra,
+                is_system: hiddenCompanionHistory ? false : chatItem.is_system,
+                ...(agentContributions.length > 0 && { agentContributions }),
+                index,
+            };
+        }));
+        if (!isCurrent()) return;
+        // SillyBunny: ICA prompt-only regexes must not remove stored chat text from World Info scans.
+        const worldInfoOnlyChat = coreChat.filter(chatItem => {
+            const variant = worldInfoMessageVariants.get(chatItem.index);
+            return variant && !hasPromptPayload(chatItem) && hasPromptPayload({ ...chatItem, mes: variant.worldInfo });
+        });
+        // SillyBunny: preserve an interrupted reasoning-only prefix when continuing.
+        coreChat = coreChat.filter((chatItem, index) => hasPromptPayload(
+            chatItem,
+            isContinue && index === coreChat.length - 1,
+        ));
+
+        const promptReasoning = new PromptReasoning();
+        for (let i = coreChat.length - 1; i >= 0; i--) {
+            const depth = coreChat.length - i - (isContinue ? 2 : 1);
+            const isPrefix = isContinue && i === coreChat.length - 1;
+
+            // In group chats, only include reasoning from the currently generating character
+            const isOtherGroupMember = selected_group && coreChat[i].name !== name2;
+
+            const promptMessage = coreChat[i].mes;
+            const messageWithReasoning = isOtherGroupMember
+                ? promptMessage
+                : promptReasoning.addToMessage(
+                    promptMessage,
+                    getRegexedString(
+                        String(coreChat[i].extra?.reasoning ?? ''),
+                        regex_placement.REASONING,
+                        { isPrompt: true, depth: depth },
+                    ),
+                    isPrefix,
+                    coreChat[i].extra?.reasoning_duration,
+                );
+
+            coreChat[i] = {
+                ...coreChat[i],
+                mes: messageWithReasoning,
             };
 
-            if (kai_settings.preset_settings != 'gui') {
-                const isHorde = main_api == 'koboldhorde';
-                const presetSettings = koboldai_settings[koboldai_setting_names[kai_settings.preset_settings]];
-                const maxContext = (adjustedParams && horde_settings.auto_adjust_context_length) ? adjustedParams.maxContextLength : max_context;
-                generate_data = getKoboldGenerationData(finalPrompt, presetSettings, maxLength, maxContext, isHorde, type);
+            const worldInfoVariant = worldInfoMessageVariants.get(coreChat[i].index);
+            if (worldInfoVariant?.prompt === promptMessage && messageWithReasoning.endsWith(promptMessage)) {
+                const reasoningPrefix = messageWithReasoning.slice(0, messageWithReasoning.length - promptMessage.length);
+                worldInfoVariant.prompt = messageWithReasoning;
+                worldInfoVariant.worldInfo = reasoningPrefix + worldInfoVariant.worldInfo;
             }
-            break;
-        case 'textgenerationwebui': {
-            const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: await getCombinedPrompt(true) } : null;
-            generate_data = await getTextGenGenerationData(finalPrompt, maxLength, isImpersonate, isContinue, cfgValues, type, { cacheScope: resolvedCacheScope });
-            break;
+            if (promptReasoning.isLimitReached()) {
+                break;
+            }
         }
-        case 'novel': {
-            const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale } : null;
-            const presetSettings = novelai_settings[novelai_setting_names[nai_settings.preset_settings_novel]];
-            generate_data = getNovelGenerationData(finalPrompt, presetSettings, maxLength, isImpersonate, isContinue, cfgValues, type);
-            break;
-        }
-        case 'openai': {
-            let [prompt, counts] = await prepareOpenAIMessages({
-                name2: name2,
-                charDescription: description,
-                charPersonality: personality,
-                scenario: scenario,
-                worldInfoBefore: worldInfoBefore,
-                worldInfoAfter: worldInfoAfter,
-                extensionPrompts: generationExtensionPrompts,
-                bias: promptBias,
-                type: type,
-                quietPrompt: quiet_prompt,
-                quietImage: quietImage,
-                cyclePrompt: cyclePrompt,
-                systemPromptOverride: system,
-                jailbreakPromptOverride: jailbreak,
-                messages: oaiMessages,
-                messageExamples: oaiMessageExamples,
-            }, dryRun);
-            generate_data = { prompt: prompt, cacheScope: resolvedCacheScope };
 
-            // TODO: move these side-effects somewhere else, so this switch-case solely sets generate_data
-            // counts will return false if the user has not enabled the token breakdown feature
-            if (counts) {
-                parseTokenCounts(counts, thisPromptBits);
+        // Determine token limit
+        let this_max_context = getMaxPromptTokens();
+
+        if (!dryRun) {
+            console.debug('Running extension interceptors');
+            const aborted = await runGenerationInterceptors(coreChat, this_max_context, type);
+            if (!isCurrent()) return;
+
+            if (aborted) {
+                console.debug('Generation aborted by extension interceptors');
+                unblockGeneration(type);
+                return Promise.resolve();
+            }
+        } else {
+            console.debug('Skipping extension interceptors for dry run');
+        }
+
+        // Adjust token limit for Horde
+        let adjustedParams;
+        if (main_api == 'koboldhorde' && (horde_settings.auto_adjust_context_length || horde_settings.auto_adjust_response_length)) {
+            try {
+                adjustedParams = await adjustHordeGenerationParams(max_context, amount_gen);
+            } catch {
+                if (isCurrent()) unblockGeneration(type);
+                return Promise.resolve();
+            }
+            if (!isCurrent()) return;
+            if (horde_settings.auto_adjust_context_length) {
+                this_max_context = (adjustedParams.maxContextLength - adjustedParams.maxLength);
+            }
+        }
+
+        // Fetches the combined prompt for both negative and positive prompts
+        const cfgGuidanceScale = getGuidanceScale();
+        const useCfgPrompt = cfgGuidanceScale && cfgGuidanceScale.value !== 1;
+
+        // Adjust max context based on CFG prompt to prevent overfitting
+        if (useCfgPrompt) {
+            const negativePrompt = getCfgPrompt(cfgGuidanceScale, true, true)?.value || '';
+            const positivePrompt = getCfgPrompt(cfgGuidanceScale, false, true)?.value || '';
+            if (negativePrompt || positivePrompt) {
+                const previousMaxContext = this_max_context;
+                const [negativePromptTokenCount, positivePromptTokenCount] = await Promise.all([getTokenCountAsync(negativePrompt), getTokenCountAsync(positivePrompt)]);
+                const decrement = Math.max(negativePromptTokenCount, positivePromptTokenCount);
+                this_max_context -= decrement;
+                console.log(`Max context reduced by ${decrement} tokens of CFG prompt (${previousMaxContext} -> ${this_max_context})`);
+            }
+        }
+
+        console.log(`Core/all messages: ${coreChat.length}/${chat.length}`);
+
+        if ((promptBias && !isUserPromptBias) || power_user.always_force_name2 || main_api == 'novel') {
+            force_name2 = true;
+        }
+
+        if (isImpersonate) {
+            force_name2 = false;
+        }
+
+        let mesExamplesArray = parseMesExamples(mesExamples, isInstruct);
+        if (!isCurrent()) return;
+
+        // Set non-WI AN
+        setFloatingPrompt();
+
+        // Add WI to prompt (and also inject WI to AN value via hijack)
+        // Make quiet prompt available for WIAN
+        setExtensionPrompt(inject_ids.QUIET_PROMPT, quiet_prompt || '', extension_prompt_types.IN_PROMPT, 0, true);
+        const chatForWI = buildWorldInfoScanChat(coreChat, worldInfoOnlyChat, worldInfoMessageVariants, world_info_include_names);
+        /** @type {import('./scripts/world-info.js').WIGlobalScanData} */
+        const globalScanData = {
+            personaDescription: persona,
+            characterDescription: description,
+            characterPersonality: personality,
+            characterDepthPrompt: charDepthPrompt,
+            scenario: scenario,
+            creatorNotes: creatorNotes,
+            trigger: GENERATION_TYPE_TRIGGERS.includes(type) ? type : 'normal',
+        };
+        const nativeGenerationContext = !dryRun && type !== 'quiet' ? getAgentGenerationContext() : null;
+        const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth, outletEntries } = await getWorldInfoPrompt(chatForWI, this_max_context, dryRun, globalScanData, nativeGenerationContext);
+        if (!isCurrent()) return;
+        setExtensionPrompt(inject_ids.QUIET_PROMPT, '', extension_prompt_types.IN_PROMPT, 0, true);
+
+        // Add message example WI
+        for (const example of worldInfoExamples) {
+            const exampleMessage = example.content;
+
+            if (exampleMessage.length === 0) {
+                continue;
             }
 
-            if (!dryRun) {
-                setInContextMessages(openai_messages_count, type, preserveLastMessage);
+            const formattedExample = baseChatReplace(exampleMessage);
+            const cleanedExample = parseMesExamples(formattedExample, isInstruct);
+
+            // Insert depending on before or after position
+            if (example.position === wi_anchor_position.before) {
+                mesExamplesArray.unshift(...cleanedExample);
+            } else {
+                mesExamplesArray.push(...cleanedExample);
             }
-            break;
         }
-    }
 
-    await eventSource.emit(event_types.GENERATE_AFTER_DATA, generate_data, dryRun);
+        // At this point, the raw message examples can be created
+        const mesExamplesRawArray = [...mesExamplesArray];
 
-    if (dryRun) {
-        return Promise.resolve();
-    }
+        if (mesExamplesArray && isInstruct) {
+            mesExamplesArray = formatInstructModeExamples(mesExamplesArray, name1, name2);
+        }
 
-    /**
+        if (skipWIAN !== true) {
+            console.log('skipWIAN not active, adding WIAN');
+            // Add all depth WI entries to prompt
+            flushWIInjections();
+            if (Array.isArray(worldInfoDepth)) {
+                worldInfoDepth.forEach((e) => {
+                    const joinedEntries = e.entries.join('\n');
+                    setExtensionPrompt(inject_ids.CUSTOM_WI_DEPTH_ROLE(e.depth, e.role), joinedEntries, extension_prompt_types.IN_CHAT, e.depth, false, e.role);
+                });
+            }
+            if (outletEntries && typeof outletEntries === 'object' && Object.keys(outletEntries).length > 0) {
+                Object.entries(outletEntries).forEach(([key, value]) => {
+                    setExtensionPrompt(inject_ids.CUSTOM_WI_OUTLET(key), value.join('\n'), extension_prompt_types.NONE, 0);
+                });
+            }
+        } else {
+            console.log('skipping WIAN');
+        }
+
+        // Add persona description to prompt
+        addPersonaDescriptionExtensionPrompt();
+
+        // Prepare the system prompt for Text Completion APIs
+        if (main_api !== 'openai') {
+            if (power_user.sysprompt.enabled) {
+                system = power_user.prefer_character_prompt && system
+                    ? substituteParams(system, { original: power_user.sysprompt.content ?? '' })
+                    : baseChatReplace(power_user.sysprompt.content);
+                system = isInstruct ? substituteParams(system, { original: power_user.sysprompt.content ?? '' }) : system;
+            } else {
+            // Nullify if it's not enabled
+                system = '';
+            }
+        }
+
+        // Collect before / after story string injections
+        const beforeScenarioAnchor = await getExtensionPrompt(extension_prompt_types.BEFORE_PROMPT);
+        const afterScenarioAnchor = await getExtensionPrompt(extension_prompt_types.IN_PROMPT);
+        if (!isCurrent()) return;
+
+        const storyStringParams = {
+            description: description,
+            personality: personality,
+            persona: power_user.persona_description_position == persona_description_positions.IN_PROMPT ? persona : '',
+            scenario: scenario,
+            system: system,
+            char: name2,
+            user: name1,
+            wiBefore: worldInfoBefore,
+            wiAfter: worldInfoAfter,
+            loreBefore: worldInfoBefore,
+            loreAfter: worldInfoAfter,
+            anchorBefore: beforeScenarioAnchor.trim(),
+            anchorAfter: afterScenarioAnchor.trim(),
+            mesExamples: mesExamplesArray.join(''),
+            mesExamplesRaw: mesExamplesRawArray.join(''),
+        };
+
+        // Render the story string and combine with injections
+        const storyString = renderStoryString(storyStringParams);
+        let combinedStoryString = isInstruct ? formatInstructModeStoryString(storyString) : storyString;
+
+        // Inject the story string as in-chat prompt (if needed)
+        const applyStoryStringInject = main_api !== 'openai' && power_user.context.story_string_position === extension_prompt_types.IN_CHAT;
+        if (applyStoryStringInject) {
+            const depth = power_user.context.story_string_depth ?? 1;
+            const role = power_user.context.story_string_role ?? extension_prompt_roles.SYSTEM;
+            setExtensionPrompt(inject_ids.STORY_STRING, combinedStoryString, extension_prompt_types.IN_CHAT, depth, false, role);
+            // Remove to prevent duplication
+            combinedStoryString = '';
+        } else {
+            setExtensionPrompt(inject_ids.STORY_STRING, '', extension_prompt_types.IN_CHAT, 0);
+        }
+
+        // Story string rendered, safe to remove
+        if (power_user.strip_examples) {
+            mesExamplesArray = [];
+        }
+
+        const generationExtensionPrompts = extension_prompts;
+
+        // Inject all Depth prompts. Chat Completion does it separately
+        let injectedIndices = [];
+        if (main_api !== 'openai') {
+            injectedIndices = await doChatInject(coreChat, isContinue);
+        }
+
+        if (main_api !== 'openai' && power_user.sysprompt.enabled) {
+            jailbreak = power_user.prefer_character_jailbreak && jailbreak
+                ? substituteParams(jailbreak, { original: power_user.sysprompt.post_history ?? '' })
+                : baseChatReplace(power_user.sysprompt.post_history);
+
+            // Only inject the jb if there is one
+            if (jailbreak) {
+            // When continuing generation of previous output, last user message precedes the message to continue
+                if (isContinue) {
+                    coreChat.splice(coreChat.length - 1, 0, { mes: jailbreak, is_user: true });
+                } else {
+                // This operation will result in the injectedIndices indexes being off by one
+                    coreChat.push({ mes: jailbreak, is_user: true });
+                    // Add +1 to the elements to correct for the new PHI/Jailbreak message.
+                    injectedIndices.forEach(shiftUpByOne);
+                }
+            }
+        }
+
+        let chat2 = [];
+        let chat2AgentContributions = [];
+        let continue_mag = '';
+        let userMessageIndices = [];
+        const lastUserMessageIndex = coreChat.findLastIndex(x => x.is_user);
+
+        for (let i = coreChat.length - 1, j = 0; i >= 0; i--, j++) {
+            if (main_api == 'openai') {
+                chat2[i] = coreChat[j].mes;
+                if (i === 0 && isContinue) {
+                    chat2[i] = chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
+                    continue_mag = coreChat[j].mes;
+                }
+                continue;
+            }
+
+            chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, false);
+            chat2AgentContributions[i] = Array.isArray(coreChat[j].agentContributions)
+                ? structuredClone(coreChat[j].agentContributions)
+                : [];
+
+            if (j === 0 && isInstruct) {
+            // Reformat with the first output sequence (if any)
+                chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.FIRST);
+            }
+
+            if (lastUserMessageIndex >= 0 && j === lastUserMessageIndex && isInstruct && !isImpersonate) {
+            // Reformat with the last input sequence (if any)
+                chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
+            }
+
+            // Do not suffix the message for continuation
+            if (i === 0 && isContinue) {
+            // Pick something that's very unlikely to be in a message
+                const FORMAT_TOKEN = '\u0000\ufffc\u0000\ufffd';
+
+                if (isInstruct) {
+                    const originalMessage = String(coreChat[j].mes ?? '');
+                    coreChat[j].mes = originalMessage.replaceAll(FORMAT_TOKEN, '') + FORMAT_TOKEN;
+                    // Reformat with the last output sequence (if any)
+                    chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
+                    coreChat[j].mes = originalMessage;
+                }
+
+                chat2[i] = chat2[i].includes(FORMAT_TOKEN)
+                    ? chat2[i].slice(0, chat2[i].lastIndexOf(FORMAT_TOKEN))
+                    : chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
+                continue_mag = coreChat[j].mes;
+            }
+
+            if (coreChat[j].is_user) {
+                userMessageIndices.push(i);
+            }
+        }
+
+        let addUserAlignment = isInstruct && power_user.instruct.user_alignment_message;
+        let userAlignmentMessage = '';
+
+        if (addUserAlignment) {
+            const alignmentMessage = {
+                name: name1,
+                mes: substituteParams(power_user.instruct.user_alignment_message),
+                is_user: true,
+            };
+            userAlignmentMessage = formatMessageHistoryItem(alignmentMessage, isInstruct, force_output_sequence.FIRST);
+        }
+
+        let oaiMessages = [];
+        let oaiMessageExamples = [];
+
+        if (main_api === 'openai') {
+            oaiMessages = setOpenAIMessages(coreChat);
+            oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray);
+        }
+
+        // hack for regeneration of the first message
+        if (chat2.length == 0) {
+            chat2.push('');
+        }
+
+        let examplesString = '';
+        let chatString = addChatsPreamble(addChatsSeparator(''));
+        let cyclePrompt = '';
+
+        async function getMessagesTokenCount() {
+            const encodeString = [
+                combinedStoryString,
+                examplesString,
+                userAlignmentMessage,
+                chatString,
+                modifyLastPromptLine(''),
+                cyclePrompt,
+            ].join('').replace(/\r/gm, '');
+            return getTokenCountAsync(encodeString, power_user.token_padding);
+        }
+
+        // Force pinned examples into the context
+        let pinExmString;
+        if (power_user.pin_examples) {
+            pinExmString = examplesString = mesExamplesArray.join('');
+        }
+
+        // Only add the chat in context if past the greeting message
+        if (isContinue && (chat2.length > 1 || main_api === 'openai')) {
+            cyclePrompt = chat2.shift();
+            chat2AgentContributions.shift();
+            // Adjust indices to account for the shift
+            injectedIndices = injectedIndices.map(shiftDownByOne).filter(x => x >= 0);
+            userMessageIndices = userMessageIndices.map(shiftDownByOne).filter(x => x >= 0);
+        }
+
+        // Collect enough messages to fill the context
+        let arrMes = new Array(chat2.length);
+        let tokenCount = await getMessagesTokenCount();
+        let lastAddedIndex = 0;
+
+        // Pre-allocate all injections first.
+        // If it doesn't fit - user shot himself in the foot
+        for (const index of injectedIndices) {
+        // not needed for OAI prompting
+            if (main_api == 'openai') {
+                break;
+            }
+
+            const item = chat2[index];
+
+            if (typeof item !== 'string') {
+                continue;
+            }
+
+            tokenCount += await getTokenCountAsync(item.replace(/\r/gm, ''));
+            if (tokenCount < this_max_context) {
+                chatString = chatString + item;
+                arrMes[index] = item;
+                lastAddedIndex = Math.max(lastAddedIndex, index);
+            } else {
+                break;
+            }
+        }
+
+        for (let i = 0; i < chat2.length; i++) {
+        // not needed for OAI prompting
+            if (main_api == 'openai') {
+                break;
+            }
+
+            // Skip already injected messages
+            if (arrMes[i] !== undefined) {
+                continue;
+            }
+
+            let item = chat2[i];
+
+            if (typeof item !== 'string') {
+                continue;
+            }
+
+            let itemTokens = await getTokenCountAsync(item.replace(/\r/gm, ''));
+            while (tokenCount + itemTokens >= this_max_context && chat2AgentContributions[i].length > 0) {
+                const trimmed = trimOldestRetainedContribution(item, chat2AgentContributions[i]);
+                if (!trimmed.changed) break;
+                item = trimmed.content;
+                chat2[i] = item;
+                chat2AgentContributions[i] = trimmed.contributions;
+                itemTokens = await getTokenCountAsync(item.replace(/\r/gm, ''));
+            }
+            tokenCount += itemTokens;
+            if (tokenCount < this_max_context) {
+                chatString = chatString + item;
+                arrMes[i] = item;
+                lastAddedIndex = Math.max(lastAddedIndex, i);
+            } else {
+                break;
+            }
+        }
+
+        // Add user alignment message if last message is not a user message
+        const stoppedAtUser = userMessageIndices.includes(lastAddedIndex);
+        if (addUserAlignment && !stoppedAtUser) {
+            tokenCount += await getTokenCountAsync(userAlignmentMessage.replace(/\r/gm, ''));
+            chatString = userAlignmentMessage + chatString;
+            arrMes.push(userAlignmentMessage);
+            injectedIndices.push(arrMes.length - 1);
+        }
+
+        // Unsparse the array. Adjust injected indices
+        const newArrMes = [];
+        const newInjectedIndices = [];
+        for (let i = 0; i < arrMes.length; i++) {
+            if (arrMes[i] !== undefined) {
+                newArrMes.push(arrMes[i]);
+                if (injectedIndices.includes(i)) {
+                    newInjectedIndices.push(newArrMes.length - 1);
+                }
+            }
+        }
+
+        arrMes = newArrMes;
+        injectedIndices = newInjectedIndices;
+
+        if (main_api !== 'openai') {
+            setInContextMessages(arrMes.length - injectedIndices.length, type, preserveLastMessage);
+        }
+
+        // Estimate how many unpinned example messages fit in the context
+        tokenCount = await getMessagesTokenCount();
+        let count_exm_add = 0;
+        if (!power_user.pin_examples) {
+            for (let example of mesExamplesArray) {
+                tokenCount += await getTokenCountAsync(example.replace(/\r/gm, ''));
+                examplesString += example;
+                if (tokenCount < this_max_context) {
+                    count_exm_add++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let mesSend = [];
+        console.debug('calling runGenerate');
+
+        if (isContinue) {
+        // Coping mechanism for OAI spacing
+            if (main_api === 'openai' && !cyclePrompt.endsWith(' ')) {
+                cyclePrompt += oai_settings.continue_postfix;
+                continue_mag += oai_settings.continue_postfix;
+            }
+        }
+
+        const originalType = type;
+
+        if (!isCurrent()) return;
+        if (!dryRun && !isAuxiliaryGeneration) {
+            is_send_press = true;
+        }
+
+        let generatedPromptCache = cyclePrompt || '';
+        if (generatedPromptCache.length == 0 || type === 'continue') {
+            console.debug('generating prompt');
+            chatString = '';
+            arrMes = arrMes.reverse();
+            arrMes.forEach(function (item, i, arr) {
+            // OAI doesn't need all of this
+                if (main_api === 'openai') {
+                    return;
+                }
+
+                // Cohee: This removes a newline from the end of the last message in the context
+                // Last prompt line will add a newline if it's not a continuation
+                // In instruct mode it only removes it if wrap is enabled and it's not a quiet generation
+                if (i === arrMes.length - 1 && type !== 'continue') {
+                    if (!isInstruct || (power_user.instruct.wrap && type !== 'quiet')) {
+                        item = item.replace(/\n?$/, '');
+                    }
+                }
+
+                mesSend[mesSend.length] = { message: item, extensionPrompts: [] };
+            });
+        }
+
+        let mesExmString = '';
+
+        function setPromptString() {
+            if (main_api == 'openai') {
+                return;
+            }
+
+            console.debug('--setting Prompt string');
+            mesExmString = pinExmString ?? mesExamplesArray.slice(0, count_exm_add).join('');
+
+            if (mesSend.length) {
+                mesSend[mesSend.length - 1].message = modifyLastPromptLine(mesSend[mesSend.length - 1].message);
+            }
+        }
+
+        function modifyLastPromptLine(lastMesString) {
+        //#########QUIET PROMPT STUFF PT2##############
+
+            // Add quiet generation prompt at depth 0
+            if (quiet_prompt && quiet_prompt.length) {
+            // here name1 is forced for all quiet prompts..why?
+                const name = name1;
+                //checks if we are in instruct, if so, formats the chat as such, otherwise just adds the quiet prompt
+                const quietAppend = isInstruct ? formatInstructModeChat(name, quiet_prompt, false, true, '', name1, name2, false) : `\n${quiet_prompt}`;
+
+                //This begins to fix quietPrompts (particularly /sysgen) for instruct
+                //previously instruct input sequence was being appended to the last chat message w/o '\n'
+                //and no output sequence was added after the input's content.
+                //TODO: respect output_sequence vs last_output_sequence settings
+                //TODO: decide how to prompt this to clarify who is talking 'Narrator', 'System', etc.
+                if (isInstruct) {
+                    lastMesString += quietAppend; // + power_user.instruct.output_sequence + '\n';
+                } else {
+                    lastMesString += quietAppend;
+                }
+
+
+                // Ross: bailing out early prevents quiet prompts from respecting other instruct prompt toggles
+                // for sysgen, SD, and summary this is desireable as it prevents the AI from responding as char..
+                // but for idle prompting, we want the flexibility of the other prompt toggles, and to respect them as per settings in the extension
+                // need a detection for what the quiet prompt is being asked for...
+
+                // Bail out early?
+                if (!isInstruct && !quietToLoud) {
+                    return lastMesString;
+                }
+            }
+
+
+            // Get instruct mode line
+            if (isInstruct && !isContinue) {
+                const name = (quiet_prompt && !quietToLoud && !isImpersonate) ? (quietName ?? 'System') : (isImpersonate ? name1 : name2);
+                const isQuiet = quiet_prompt && type == 'quiet';
+                lastMesString += formatInstructModePrompt(name, isImpersonate, promptBias, name1, name2, isQuiet, quietToLoud);
+            }
+
+            // Get non-instruct impersonation line
+            if (!isInstruct && isImpersonate && !isContinue) {
+                const name = name1;
+                if (!lastMesString.endsWith('\n')) {
+                    lastMesString += '\n';
+                }
+                lastMesString += name + ':';
+            }
+
+            // Add character's name
+            // Force name append on continue (if not continuing on user message or first message)
+            const isContinuingOnFirstMessage = chat.length === 1 && isContinue;
+            if (!isInstruct && force_name2 && !isContinuingOnFirstMessage) {
+                if (!lastMesString.endsWith('\n')) {
+                    lastMesString += '\n';
+                }
+                if (!isContinue || !(chat[chat.length - 1]?.is_user)) {
+                    lastMesString += `${name2}:`;
+                }
+            }
+
+            return lastMesString;
+        }
+
+        async function checkPromptSize() {
+            console.debug('---checking Prompt size');
+            setPromptString();
+            const jointMessages = mesSend.map((e) => `${e.extensionPrompts.join('')}${e.message}`).join('');
+            const prompt = [
+                combinedStoryString,
+                mesExmString,
+                addChatsPreamble(addChatsSeparator(jointMessages)),
+                '\n',
+                modifyLastPromptLine(''),
+                generatedPromptCache,
+            ].join('').replace(/\r/gm, '');
+            let thisPromptContextSize = await getTokenCountAsync(prompt, power_user.token_padding);
+
+            if (thisPromptContextSize > this_max_context) {        //if the prepared prompt is larger than the max context size...
+                if (count_exm_add > 0) {                            // ..and we have example messages..
+                    count_exm_add--;                            // remove the example messages...
+                    await checkPromptSize();                            // and try agin...
+                } else if (mesSend.length > 0) {                    // if the chat history is longer than 0
+                    mesSend.shift();                            // remove the first (oldest) chat entry..
+                    await checkPromptSize();                            // and check size again..
+                } else {
+                //end
+                    console.debug(`---mesSend.length = ${mesSend.length}`);
+                }
+            }
+        }
+
+        if (generatedPromptCache.length > 0 && main_api !== 'openai') {
+            console.debug('---Generated Prompt Cache length: ' + generatedPromptCache.length);
+            await checkPromptSize();
+        } else {
+            console.debug('---calling setPromptString ' + generatedPromptCache.length);
+            setPromptString();
+        }
+
+        // For prompt bit itemization
+        let mesSendString = '';
+
+        async function getCombinedPrompt(isNegative) {
+        // Only return if the guidance scale doesn't exist or the value is 1
+        // Also don't return if constructing the neutral prompt
+            if (isNegative && !useCfgPrompt) {
+                return;
+            }
+
+            // OAI has its own prompt manager. No need to do anything here
+            if (main_api === 'openai') {
+                return '';
+            }
+
+            // Deep clone
+            let finalMesSend = structuredClone(mesSend);
+
+            if (useCfgPrompt) {
+                const cfgPrompt = getCfgPrompt(cfgGuidanceScale, isNegative);
+                if (cfgPrompt.value) {
+                    if (cfgPrompt.depth === 0) {
+                        finalMesSend[finalMesSend.length - 1].message +=
+                        /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
+                            ? cfgPrompt.value
+                            : ` ${cfgPrompt.value}`;
+                    } else {
+                    // TODO: Make all extension prompts use an array/splice method
+                        const lengthDiff = mesSend.length - cfgPrompt.depth;
+                        const cfgDepth = lengthDiff >= 0 ? lengthDiff : 0;
+                        const cfgMessage = finalMesSend[cfgDepth];
+                        if (cfgMessage) {
+                            if (!Array.isArray(finalMesSend[cfgDepth].extensionPrompts)) {
+                                finalMesSend[cfgDepth].extensionPrompts = [];
+                            }
+                            finalMesSend[cfgDepth].extensionPrompts.push(`${cfgPrompt.value}\n`);
+                        }
+                    }
+                }
+            }
+
+            // Add prompt bias after everything else
+            // Always run with continue
+            if (!isInstruct && !isImpersonate) {
+                if (promptBias.trim().length !== 0) {
+                    finalMesSend[finalMesSend.length - 1].message +=
+                    /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
+                        ? promptBias.trimStart()
+                        : ` ${promptBias.trimStart()}`;
+                }
+            }
+
+            // Flattens the multiple prompt objects to a string.
+            const combine = () => {
+            // Right now, everything is suffixed with a newline
+                mesSendString = finalMesSend.map((e) => `${e.extensionPrompts.join('')}${e.message}`).join('');
+
+                // add a custom dingus (if defined)
+                mesSendString = addChatsSeparator(mesSendString);
+
+                // add chat preamble
+                mesSendString = addChatsPreamble(mesSendString);
+
+                let combinedPrompt = [
+                    combinedStoryString,
+                    mesExmString,
+                    mesSendString,
+                    generatedPromptCache,
+                ].join('').replace(/\r/gm, '');
+
+                if (power_user.collapse_newlines) {
+                    combinedPrompt = collapseNewlines(combinedPrompt);
+                }
+
+                return combinedPrompt;
+            };
+
+            finalMesSend.forEach((item, i) => {
+                item.injected = injectedIndices.includes(finalMesSend.length - i - 1);
+            });
+
+            let data = {
+                api: main_api,
+                combinedPrompt: null,
+                description,
+                personality,
+                persona,
+                scenario,
+                char: name2,
+                user: name1,
+                worldInfoBefore,
+                worldInfoAfter,
+                beforeScenarioAnchor,
+                afterScenarioAnchor,
+                storyString,
+                mesExmString,
+                mesSendString,
+                finalMesSend,
+                generatedPromptCache,
+                main: system,
+                jailbreak,
+                naiPreamble: nai_settings.preamble,
+            };
+
+            // Before returning the combined prompt, give available context related information to all subscribers.
+            await eventSource.emit(event_types.GENERATE_BEFORE_COMBINE_PROMPTS, data);
+
+            // If one or multiple subscribers return a value, forfeit the responsibillity of flattening the context.
+            return !data.combinedPrompt ? combine() : data.combinedPrompt;
+        }
+
+        let finalPrompt = await getCombinedPrompt(false);
+
+        const eventData = { prompt: finalPrompt, dryRun: dryRun };
+        await eventSource.emit(event_types.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
+        if (!isCurrent()) return;
+        finalPrompt = eventData.prompt;
+
+        let maxLength = Number(amount_gen); // how many tokens the AI will be requested to generate
+        let thisPromptBits = [];
+
+        let generate_data;
+        switch (main_api) {
+            case 'koboldhorde':
+            case 'kobold':
+                if (main_api == 'koboldhorde' && horde_settings.auto_adjust_response_length) {
+                    maxLength = Math.min(maxLength, adjustedParams.maxLength);
+                    maxLength = Math.max(maxLength, MIN_LENGTH); // prevent validation errors
+                }
+
+                generate_data = {
+                    prompt: finalPrompt,
+                    gui_settings: true,
+                    max_length: maxLength,
+                    max_context_length: max_context,
+                    api_server: kai_settings.api_server,
+                };
+
+                if (kai_settings.preset_settings != 'gui') {
+                    const isHorde = main_api == 'koboldhorde';
+                    const presetSettings = koboldai_settings[koboldai_setting_names[kai_settings.preset_settings]];
+                    const maxContext = (adjustedParams && horde_settings.auto_adjust_context_length) ? adjustedParams.maxContextLength : max_context;
+                    generate_data = getKoboldGenerationData(finalPrompt, presetSettings, maxLength, maxContext, isHorde, type);
+                }
+                break;
+            case 'textgenerationwebui': {
+                const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: await getCombinedPrompt(true) } : null;
+                generate_data = await getTextGenGenerationData(finalPrompt, maxLength, isImpersonate, isContinue, cfgValues, type, { cacheScope: resolvedCacheScope });
+                break;
+            }
+            case 'novel': {
+                const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale } : null;
+                const presetSettings = novelai_settings[novelai_setting_names[nai_settings.preset_settings_novel]];
+                generate_data = getNovelGenerationData(finalPrompt, presetSettings, maxLength, isImpersonate, isContinue, cfgValues, type);
+                break;
+            }
+            case 'openai': {
+                let [prompt, counts] = await prepareOpenAIMessages({
+                    name2: name2,
+                    charDescription: description,
+                    charPersonality: personality,
+                    scenario: scenario,
+                    worldInfoBefore: worldInfoBefore,
+                    worldInfoAfter: worldInfoAfter,
+                    extensionPrompts: generationExtensionPrompts,
+                    bias: promptBias,
+                    type: type,
+                    quietPrompt: quiet_prompt,
+                    quietImage: quietImage,
+                    cyclePrompt: cyclePrompt,
+                    systemPromptOverride: system,
+                    jailbreakPromptOverride: jailbreak,
+                    messages: oaiMessages,
+                    messageExamples: oaiMessageExamples,
+                }, dryRun);
+                if (!isCurrent()) return;
+                generate_data = { prompt: prompt, cacheScope: resolvedCacheScope };
+
+                // TODO: move these side-effects somewhere else, so this switch-case solely sets generate_data
+                // counts will return false if the user has not enabled the token breakdown feature
+                if (counts) {
+                    parseTokenCounts(counts, thisPromptBits);
+                }
+
+                if (!dryRun) {
+                    setInContextMessages(openai_messages_count, type, preserveLastMessage);
+                }
+                break;
+            }
+        }
+
+        await eventSource.emit(event_types.GENERATE_AFTER_DATA, generate_data, dryRun);
+        if (!isCurrent()) return;
+
+        if (dryRun) {
+            return Promise.resolve();
+        }
+
+        /**
      * Saves itemized prompt bits and calls streaming or non-streaming generation API.
      * @returns {Promise<void|*|Awaited<*>|String|{fromStream}|string|undefined|Object>}
      * @throws {Error|object} Error with message text, or Error with response JSON (OAI/Horde), or the actual response JSON (novel|textgenerationwebui|kobold)
      */
-    async function finishGenerating() {
-        if (power_user.console_log_prompts) {
-            console.log(typeof generate_data.prompt === 'string' ? generate_data.prompt : JSON.stringify(generate_data.prompt));
-        }
+        async function finishGenerating() {
+            if (!isCurrent()) return;
+            if (power_user.console_log_prompts) {
+                console.log(typeof generate_data.prompt === 'string' ? generate_data.prompt : JSON.stringify(generate_data.prompt));
+            }
 
-        console.log(`[rungenerate] calling API: main_api=${main_api}${main_api === 'openai' ? ` source=${oai_settings.chat_completion_source} model=${getChatCompletionModel(oai_settings)}` : ''}`);
+            console.log(`[rungenerate] calling API: main_api=${main_api}${main_api === 'openai' ? ` source=${oai_settings.chat_completion_source} model=${getChatCompletionModel(oai_settings)}` : ''}`);
 
-        showStopButton();
+            if (!isAuxiliaryGeneration) showStopButton();
 
-        //set array object for prompt token itemization of this message
-        let currentArrayEntry = Number(thisPromptBits.length - 1);
-        let additionalPromptStuff = {
-            ...thisPromptBits[currentArrayEntry],
-            rawPrompt: generate_data.prompt || generate_data.input,
-            mesId: getNextMessageId(type, preserveLastMessage),
-            allAnchors: await getAllExtensionPrompts(),
-            chatInjects: injectedIndices?.map(index => arrMes[arrMes.length - index - 1])?.join('') || '',
-            summarizeString: (extension_prompts['1_memory']?.value || ''),
-            authorsNoteString: (extension_prompts['2_floating_prompt']?.value || ''),
-            smartContextString: (extension_prompts.chromadb?.value || ''),
-            chatVectorsString: (extension_prompts['3_vectors']?.value || ''),
-            dataBankVectorsString: (extension_prompts['4_vectors_data_bank']?.value || ''),
-            worldInfoString: worldInfoString,
-            storyString: storyString,
-            beforeScenarioAnchor: beforeScenarioAnchor,
-            afterScenarioAnchor: afterScenarioAnchor,
-            examplesString: examplesString,
-            mesSendString: mesSendString,
-            generatedPromptCache: generatedPromptCache,
-            promptBias: promptBias,
-            finalPrompt: finalPrompt,
-            charDescription: description,
-            charPersonality: personality,
-            scenarioText: scenario,
-            this_max_context: this_max_context,
-            padding: power_user.token_padding,
-            main_api: main_api,
-            instruction: main_api !== 'openai' && power_user.sysprompt.enabled ? substituteParams(power_user.prefer_character_prompt && system ? system : power_user.sysprompt.content) : '',
-            userPersona: (power_user.persona_description_position == persona_description_positions.IN_PROMPT ? (persona || '') : ''),
-            tokenizer: getFriendlyTokenizerName(main_api).tokenizerName || '',
-            presetName: getPresetManager()?.getSelectedPresetName() || '',
-            messagesCount: main_api !== 'openai' ? mesSend.length : oaiMessages.length,
-            examplesCount: main_api !== 'openai' ? (pinExmString ? mesExamplesArray.length : count_exm_add) : oaiMessageExamples.length,
-        };
+            //set array object for prompt token itemization of this message
+            let currentArrayEntry = Number(thisPromptBits.length - 1);
+            let additionalPromptStuff = {
+                ...thisPromptBits[currentArrayEntry],
+                rawPrompt: generate_data.prompt || generate_data.input,
+                mesId: getNextMessageId(type, preserveLastMessage),
+                allAnchors: await getAllExtensionPrompts(),
+                chatInjects: injectedIndices?.map(index => arrMes[arrMes.length - index - 1])?.join('') || '',
+                summarizeString: (extension_prompts['1_memory']?.value || ''),
+                authorsNoteString: (extension_prompts['2_floating_prompt']?.value || ''),
+                smartContextString: (extension_prompts.chromadb?.value || ''),
+                chatVectorsString: (extension_prompts['3_vectors']?.value || ''),
+                dataBankVectorsString: (extension_prompts['4_vectors_data_bank']?.value || ''),
+                worldInfoString: worldInfoString,
+                storyString: storyString,
+                beforeScenarioAnchor: beforeScenarioAnchor,
+                afterScenarioAnchor: afterScenarioAnchor,
+                examplesString: examplesString,
+                mesSendString: mesSendString,
+                generatedPromptCache: generatedPromptCache,
+                promptBias: promptBias,
+                finalPrompt: finalPrompt,
+                charDescription: description,
+                charPersonality: personality,
+                scenarioText: scenario,
+                this_max_context: this_max_context,
+                padding: power_user.token_padding,
+                main_api: main_api,
+                instruction: main_api !== 'openai' && power_user.sysprompt.enabled ? substituteParams(power_user.prefer_character_prompt && system ? system : power_user.sysprompt.content) : '',
+                userPersona: (power_user.persona_description_position == persona_description_positions.IN_PROMPT ? (persona || '') : ''),
+                tokenizer: getFriendlyTokenizerName(main_api).tokenizerName || '',
+                presetName: getPresetManager()?.getSelectedPresetName() || '',
+                messagesCount: main_api !== 'openai' ? mesSend.length : oaiMessages.length,
+                examplesCount: main_api !== 'openai' ? (pinExmString ? mesExamplesArray.length : count_exm_add) : oaiMessageExamples.length,
+            };
+            if (!isCurrent()) return;
 
-        //console.log(additionalPromptStuff);
-        const itemizedIndex = itemizedPrompts.findIndex((item) => item.mesId === additionalPromptStuff.mesId);
+            //console.log(additionalPromptStuff);
+            const itemizedIndex = itemizedPrompts.findIndex((item) => item.mesId === additionalPromptStuff.mesId);
 
-        if (itemizedIndex !== -1) {
-            itemizedPrompts[itemizedIndex] = additionalPromptStuff;
-        } else {
-            itemizedPrompts.push(additionalPromptStuff);
-        }
+            if (itemizedIndex !== -1) {
+                itemizedPrompts[itemizedIndex] = additionalPromptStuff;
+            } else {
+                itemizedPrompts.push(additionalPromptStuff);
+            }
 
-        console.debug(`pushed prompt bits to itemizedPrompts array. Length is now: ${itemizedPrompts.length}`);
+            console.debug(`pushed prompt bits to itemizedPrompts array. Length is now: ${itemizedPrompts.length}`);
 
-        if (isStreamingEnabled() && type !== 'quiet') {
-            let startedSuccessorGeneration = false;
-            try {
-                continue_mag = promptReasoning.removePrefix(continue_mag);
-                const activeStreamingProcessor = streamingProcessor = new StreamingProcessor(type, force_name2, generation_started, continue_mag, promptReasoning);
-                if (isContinue) {
+            if (isStreamingEnabled() && type !== 'quiet') {
+                let startedSuccessorGeneration = false;
+                try {
+                    continue_mag = promptReasoning.removePrefix(continue_mag);
+                    const activeStreamingProcessor = streamingProcessor = new StreamingProcessor(type, force_name2, generation_started, continue_mag, promptReasoning);
+                    activeStreamingProcessor.isCurrentGeneration = isCurrent;
+                    activeStreamingProcessor.agentGenerationContext = agentGenerationContext;
+                    activeStream = activeStreamingProcessor;
+                    if (isContinue) {
                     // Save reply does add cycle text to the prompt, so it's not needed here
-                    activeStreamingProcessor.firstMessageText = '';
-                }
+                        activeStreamingProcessor.firstMessageText = '';
+                    }
 
-                const shouldBufferOutput = await shouldBufferMainGenerationOutput({ type, isStreaming: true });
-                activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
+                    const shouldBufferOutput = await shouldBufferMainGenerationOutput({ type, isStreaming: true });
+                    if (!isCurrent()) return;
+                    activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope, signal });
+                    if (!isCurrent()) return;
 
-                hideSwipeButtons();
-                let getMessage = shouldBufferOutput
-                    ? await activeStreamingProcessor.generateBuffered()
-                    : await activeStreamingProcessor.generate();
-                let messageChunk = cleanUpMessage({
-                    getMessage: getMessage,
-                    isImpersonate: isImpersonate,
-                    isContinue: isContinue,
-                    displayIncompleteSentences: false,
-                });
+                    hideSwipeButtons();
+                    let getMessage = shouldBufferOutput
+                        ? await activeStreamingProcessor.generateBuffered()
+                        : await activeStreamingProcessor.generate();
+                    if (!isCurrent()) return;
+                    let messageChunk = cleanUpMessage({
+                        getMessage: getMessage,
+                        isImpersonate: isImpersonate,
+                        isContinue: isContinue,
+                        displayIncompleteSentences: false,
+                    });
 
-                const isReasoningOnlyStream = !getMessage.trim() && !!(activeStreamingProcessor.reasoningHandler.reasoning || activeStreamingProcessor.pendingReasoning);
+                    const isReasoningOnlyStream = !getMessage.trim() && !!(activeStreamingProcessor.reasoningHandler.reasoning || activeStreamingProcessor.pendingReasoning);
 
-                if (isContinue) {
-                    getMessage = continue_mag + getMessage;
-                }
+                    if (isContinue) {
+                        getMessage = continue_mag + getMessage;
+                    }
 
-                const isStreamCancelled = activeStreamingProcessor.isStopped
+                    const isStreamCancelled = activeStreamingProcessor.isStopped
                     || activeStreamingProcessor.isCancelled
                     || activeStreamingProcessor.abortController.signal.aborted;
-                const isStreamFinished = !isStreamCancelled && activeStreamingProcessor.isFinished;
-                const isStreamWithToolCalls = Array.isArray(activeStreamingProcessor.toolCalls) && activeStreamingProcessor.toolCalls.length;
+                    const isStreamFinished = !isStreamCancelled && activeStreamingProcessor.isFinished;
+                    const isStreamWithToolCalls = Array.isArray(activeStreamingProcessor.toolCalls) && activeStreamingProcessor.toolCalls.length;
 
-                if (isStreamFinished && !isStreamWithToolCalls && isReasoningOnlyStream) {
-                    toastr.warning(t`The model finished reasoning but returned no reply text.`);
-                }
-                if (canPerformToolCalls && isStreamFinished && isStreamWithToolCalls) {
-                    const hasToolCalls = ToolManager.hasToolCalls(activeStreamingProcessor.toolCalls);
-                    const lastMessage = chat[chat.length - 1];
-                    const shouldDeleteMessage = !shouldBufferOutput && type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(activeStreamingProcessor.result);
-                    hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
-                    if (!shouldBufferOutput && hasToolCalls && !shouldDeleteMessage) {
-                        await activeStreamingProcessor.finalizeIntermediaryMessage(activeStreamingProcessor.messageId, getMessage, { unlockUI: false });
+                    if (isStreamFinished && !isStreamWithToolCalls && isReasoningOnlyStream) {
+                        toastr.warning(t`The model finished reasoning but returned no reply text.`);
                     }
-                    const invocationResult = await ToolManager.invokeFunctionTools(activeStreamingProcessor.toolCalls, {
-                        reasoningText: activeStreamingProcessor.reasoningHandler.reasoning,
-                    });
-                    const shouldStopGeneration = (!invocationResult.invocations.length && shouldDeleteMessage) || invocationResult.stealthCalls.length;
-                    if (hasToolCalls) {
-                        if (shouldStopGeneration) {
-                            if (Array.isArray(invocationResult.errors) && invocationResult.errors.length) {
-                                ToolManager.showToolCallError(invocationResult.errors);
+                    if (canPerformToolCalls && isStreamFinished && isStreamWithToolCalls) {
+                        const hasToolCalls = ToolManager.hasToolCalls(activeStreamingProcessor.toolCalls);
+                        const lastMessage = chat[chat.length - 1];
+                        const shouldDeleteMessage = !shouldBufferOutput && type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(activeStreamingProcessor.result);
+                        hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
+                        if (!shouldBufferOutput && hasToolCalls && !shouldDeleteMessage) {
+                            await activeStreamingProcessor.finalizeIntermediaryMessage(activeStreamingProcessor.messageId, getMessage, { unlockUI: false });
+                        }
+                        const invocationResult = await ToolManager.invokeFunctionTools(activeStreamingProcessor.toolCalls, {
+                            reasoningText: activeStreamingProcessor.reasoningHandler.reasoning,
+                            isCurrent,
+                            signal,
+                        });
+                        if (!isCurrent()) return;
+                        const shouldStopGeneration = (!invocationResult.invocations.length && shouldDeleteMessage) || invocationResult.stealthCalls.length;
+                        if (hasToolCalls) {
+                            if (shouldStopGeneration) {
+                                if (Array.isArray(invocationResult.errors) && invocationResult.errors.length) {
+                                    ToolManager.showToolCallError(invocationResult.errors);
+                                }
+                                unblockGeneration(type);
+                                clearStreamingProcessorIfCurrent(activeStreamingProcessor);
+                                return;
                             }
+
+                            clearStreamingProcessorIfCurrent(activeStreamingProcessor);
+                            depth = depth + 1;
+                            await ToolManager.saveFunctionToolInvocations(invocationResult.invocations);
+                            if (!isCurrent()) return;
+                            startedSuccessorGeneration = true;
+                            delegatedGeneration = true;
+                            return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, companionHistoryTarget: companionRewriteTarget }, dryRun);
+                        }
+                    }
+
+                    if (isStreamFinished) {
+                        if (shouldBufferOutput) {
+                            const interceptResult = await applyMainGenerationOutputInterceptors({
+                                type,
+                                text: getMessage,
+                                isStreaming: true,
+                            });
+
+                            if (interceptResult.cancelled || !isCurrent() || activeStreamingProcessor.abortController.signal.aborted) {
+                                if (isCurrent()) unblockGeneration(type, { emitGenerationEnded: false });
+                                clearStreamingProcessorIfCurrent(activeStreamingProcessor);
+                                return;
+                            }
+
+                            getMessage = interceptResult.text;
+                            messageChunk = cleanUpMessage({
+                                getMessage: getMessage,
+                                isImpersonate: isImpersonate,
+                                isContinue: isContinue,
+                                displayIncompleteSentences: false,
+                            });
+
+                            const saveReplyType = originalType !== 'continue' ? type : 'appendFinal';
+                            ({ type, getMessage } = await saveReply({
+                                type: saveReplyType,
+                                isCurrent,
+                                getMessage,
+                                swipes: activeStreamingProcessor.swipes,
+                                reasoning: activeStreamingProcessor.reasoningHandler.reasoning,
+                                imageUrls: activeStreamingProcessor.images,
+                                reasoningSignature: activeStreamingProcessor.reasoningSignature,
+                                reasoningTokens: activeStreamingProcessor.reasoningTokens,
+                            }));
+                            if (!isCurrent()) return;
+                            saveLogprobsForActiveMessage(activeStreamingProcessor.messageLogprobs.filter(Boolean), continue_mag);
                             unblockGeneration(type);
                             clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-                            return;
+
+                            const isAborted = activeStreamingProcessor.abortController.signal.aborted;
+                            if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
+                                return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
+                            }
+
+                            await saveChatConditional();
+                            if (!isCurrent()) return;
+                            playMessageSound();
+                            triggerAutoContinue(messageChunk, isImpersonate);
+                            return Object.defineProperties(new String(getMessage), {
+                                'messageChunk': { value: messageChunk },
+                                'fromStream': { value: true },
+                            });
                         }
 
+                        await activeStreamingProcessor.onFinishStreaming(activeStreamingProcessor.messageId, getMessage);
+                        if (!isCurrent()) return;
                         clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-                        depth = depth + 1;
-                        await ToolManager.saveFunctionToolInvocations(invocationResult.invocations);
-                        startedSuccessorGeneration = true;
-                        return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, companionHistoryTarget: companionRewriteTarget }, dryRun);
-                    }
-                }
-
-                if (isStreamFinished) {
-                    if (shouldBufferOutput) {
-                        const interceptResult = await applyMainGenerationOutputInterceptors({
-                            type,
-                            text: getMessage,
-                            isStreaming: true,
-                        });
-
-                        if (interceptResult.cancelled || activeStreamingProcessor.abortController.signal.aborted) {
-                            unblockGeneration(type, { emitGenerationEnded: false });
-                            clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-                            return;
-                        }
-
-                        getMessage = interceptResult.text;
-                        messageChunk = cleanUpMessage({
-                            getMessage: getMessage,
-                            isImpersonate: isImpersonate,
-                            isContinue: isContinue,
-                            displayIncompleteSentences: false,
-                        });
-
-                        const saveReplyType = originalType !== 'continue' ? type : 'appendFinal';
-                        ({ type, getMessage } = await saveReply({
-                            type: saveReplyType,
-                            getMessage,
-                            swipes: activeStreamingProcessor.swipes,
-                            reasoning: activeStreamingProcessor.reasoningHandler.reasoning,
-                            imageUrls: activeStreamingProcessor.images,
-                            reasoningSignature: activeStreamingProcessor.reasoningSignature,
-                            reasoningTokens: activeStreamingProcessor.reasoningTokens,
-                        }));
-                        saveLogprobsForActiveMessage(activeStreamingProcessor.messageLogprobs.filter(Boolean), continue_mag);
-                        unblockGeneration(type);
-                        clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-
-                        const isAborted = activeStreamingProcessor.abortController.signal.aborted;
-                        if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
-                            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
-                        }
-
-                        await saveChatConditional();
-                        playMessageSound();
                         triggerAutoContinue(messageChunk, isImpersonate);
                         return Object.defineProperties(new String(getMessage), {
                             'messageChunk': { value: messageChunk },
@@ -8375,206 +8541,225 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                         });
                     }
 
-                    await activeStreamingProcessor.onFinishStreaming(activeStreamingProcessor.messageId, getMessage);
                     clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-                    triggerAutoContinue(messageChunk, isImpersonate);
-                    return Object.defineProperties(new String(getMessage), {
-                        'messageChunk': { value: messageChunk },
-                        'fromStream': { value: true },
-                    });
-                }
-
-                clearStreamingProcessorIfCurrent(activeStreamingProcessor);
-                return;
-            } finally {
+                    return;
+                } finally {
                 // SillyBunny: Safety net - every streaming exit path must leave the UI idle.
                 // Cancelled streams used to skip unblockGeneration(), leaving is_send_press stuck.
-                if (is_send_press && streamingProcessor === null && !startedSuccessorGeneration) {
-                    unblockGeneration(type);
+                    if (isCurrent() && is_send_press && streamingProcessor === null && !startedSuccessorGeneration) {
+                        unblockGeneration(type);
+                    }
                 }
+            } else {
+                return await sendGenerationRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope, signal });
             }
-        } else {
-            return await sendGenerationRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
         }
-    }
 
-    return finishGenerating().then(onSuccess, onError);
+        return await finishGenerating().then(onSuccess, onError);
 
-    /**
+        /**
      * Handles the successful response from the generation API.
      * @param data
      * @returns {Promise<String|{fromStream}|*|string|string|void|Awaited<*>|undefined>}
      * @throws {Error} Throws an error if the response data contains an error message
      */
-    async function onSuccess(data) {
-        if (!data) {
+        async function onSuccess(data) {
+            if (delegatedGeneration) return data;
+            if (!isCurrent()) return;
+            if (!data) {
             // SillyBunny: unblock generation on null/falsy data so the send
             // buttons are not left locked. (#527)
-            unblockGeneration(type, { force: true });
-            return;
-        }
-
-        if (data?.fromStream) {
-            return data;
-        }
-
-        let messageChunk = '';
-
-        // if an error was returned in data (textgenwebui), show it and throw it
-        if (data.error) {
-            unblockGeneration(type);
-
-            if (data?.response) {
-                toastr.error(data.response, t`API Error`, { preventDuplicates: true });
-            }
-            throw new Error(data?.response);
-        }
-
-        if (jsonSchema) {
-            unblockGeneration(type);
-            return extractJsonFromData(data, { returnInvalidJson: jsonSchema.returnInvalid ?? false });
-        }
-
-        //const getData = await response.json();
-        let getMessage = extractMessageFromData(data);
-        let title = extractTitleFromData(data);
-        let reasoning = extractReasoningFromData(data);
-        let imageUrls = extractImagesFromData(data);
-        const reasoningSignature = extractReasoningSignatureFromData(data);
-        kobold_horde_model = title;
-
-        const swipes = extractMultiSwipes(data, type);
-
-        messageChunk = cleanUpMessage({
-            getMessage: getMessage,
-            isImpersonate: isImpersonate,
-            isContinue: isContinue,
-            displayIncompleteSentences: false,
-        });
-
-
-        reasoning = getRegexedString(reasoning, regex_placement.REASONING);
-
-        if (power_user.trim_spaces) {
-            reasoning = reasoning.trim();
-        }
-
-        if (!getMessage.trim() && reasoning && type !== 'quiet') {
-            toastr.warning(t`The model finished reasoning but returned no reply text.`);
-        }
-
-        if (isContinue) {
-            continue_mag = promptReasoning.removePrefix(continue_mag);
-            getMessage = continue_mag + getMessage;
-        }
-
-        //Formating
-        const displayIncomplete = type === 'quiet' && !quietToLoud;
-        getMessage = cleanUpMessage({
-            getMessage: getMessage,
-            isImpersonate: isImpersonate,
-            isContinue: isContinue,
-            displayIncompleteSentences: displayIncomplete,
-        });
-
-        const interceptResult = await applyMainGenerationOutputInterceptors({
-            type,
-            text: getMessage,
-            isStreaming: false,
-        });
-
-        if (interceptResult.cancelled || (abortController && abortController.signal.aborted)) {
-            unblockGeneration(type, { emitGenerationEnded: false });
-            streamingProcessor = null;
-            return;
-        }
-
-        getMessage = interceptResult.text;
-        messageChunk = cleanUpMessage({
-            getMessage: getMessage,
-            isImpersonate: isImpersonate,
-            isContinue: isContinue,
-            displayIncompleteSentences: false,
-        });
-
-        if (isImpersonate) {
-            $('#send_textarea').val(getMessage)[0].dispatchEvent(new Event('input', { bubbles: true }));
-            await eventSource.emit(event_types.IMPERSONATE_READY, getMessage);
-        } else if (type == 'quiet') {
-            unblockGeneration(type);
-            return getMessage;
-        } else {
-            // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
-            if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens }));
-            } else {
-                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens }));
+                if (!isAuxiliaryGeneration) unblockGeneration(type, { force: true });
+                return;
             }
 
-            // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
-            parseAndSaveLogprobs(data, continue_mag);
-        }
+            if (data?.fromStream) {
+                return data;
+            }
 
-        if (canPerformToolCalls) {
-            const hasToolCalls = ToolManager.hasToolCalls(data);
-            const shouldDeleteMessage = type !== 'swipe' && ['', '...'].includes(getMessage) && !reasoning;
-            hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
-            const invocationResult = await ToolManager.invokeFunctionTools(data, { reasoningText: reasoning });
-            const shouldStopGeneration = (!invocationResult.invocations.length && shouldDeleteMessage) || invocationResult.stealthCalls.length;
-            if (hasToolCalls) {
-                if (shouldStopGeneration) {
-                    if (Array.isArray(invocationResult.errors) && invocationResult.errors.length) {
-                        ToolManager.showToolCallError(invocationResult.errors);
-                    }
-                    unblockGeneration(type);
-                    return;
+            let messageChunk = '';
+
+            // if an error was returned in data (textgenwebui), show it and throw it
+            if (data.error) {
+                unblockGeneration(type);
+
+                if (data?.response) {
+                    toastr.error(data.response, t`API Error`, { preventDuplicates: true });
                 }
-
-                depth = depth + 1;
-                await ToolManager.saveFunctionToolInvocations(invocationResult.invocations);
-                return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, companionHistoryTarget: companionRewriteTarget }, dryRun);
+                throw new Error(data?.response);
             }
+
+            if (jsonSchema) {
+                unblockGeneration(type);
+                return extractJsonFromData(data, { returnInvalidJson: jsonSchema.returnInvalid ?? false });
+            }
+
+            //const getData = await response.json();
+            let getMessage = extractMessageFromData(data);
+            let title = extractTitleFromData(data);
+            let reasoning = extractReasoningFromData(data);
+            let imageUrls = extractImagesFromData(data);
+            const reasoningSignature = extractReasoningSignatureFromData(data);
+            kobold_horde_model = title;
+
+            const swipes = extractMultiSwipes(data, type);
+
+            messageChunk = cleanUpMessage({
+                getMessage: getMessage,
+                isImpersonate: isImpersonate,
+                isContinue: isContinue,
+                displayIncompleteSentences: false,
+            });
+
+
+            reasoning = getRegexedString(reasoning, regex_placement.REASONING);
+
+            if (power_user.trim_spaces) {
+                reasoning = reasoning.trim();
+            }
+
+            if (!getMessage.trim() && reasoning && type !== 'quiet') {
+                toastr.warning(t`The model finished reasoning but returned no reply text.`);
+            }
+
+            if (isContinue) {
+                continue_mag = promptReasoning.removePrefix(continue_mag);
+                getMessage = continue_mag + getMessage;
+            }
+
+            //Formating
+            const displayIncomplete = type === 'quiet' && !quietToLoud;
+            getMessage = cleanUpMessage({
+                getMessage: getMessage,
+                isImpersonate: isImpersonate,
+                isContinue: isContinue,
+                displayIncompleteSentences: displayIncomplete,
+            });
+
+            const interceptResult = await applyMainGenerationOutputInterceptors({
+                type,
+                text: getMessage,
+                isStreaming: false,
+            });
+
+            if (interceptResult.cancelled || !isCurrent()) {
+                if (isCurrent() && !isAuxiliaryGeneration) {
+                    unblockGeneration(type, { emitGenerationEnded: false });
+                    streamingProcessor = null;
+                }
+                return;
+            }
+
+            getMessage = interceptResult.text;
+            messageChunk = cleanUpMessage({
+                getMessage: getMessage,
+                isImpersonate: isImpersonate,
+                isContinue: isContinue,
+                displayIncompleteSentences: false,
+            });
+
+            if (isImpersonate) {
+                $('#send_textarea').val(getMessage)[0].dispatchEvent(new Event('input', { bubbles: true }));
+                await eventSource.emit(event_types.IMPERSONATE_READY, getMessage);
+            } else if (type == 'quiet') {
+                unblockGeneration(type);
+                return getMessage;
+            } else {
+            // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
+                if (originalType !== 'continue') {
+                    ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens, isCurrent }));
+                } else {
+                    ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens, isCurrent }));
+                }
+                if (!isCurrent()) return;
+
+                // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
+                parseAndSaveLogprobs(data, continue_mag);
+            }
+
+            if (canPerformToolCalls) {
+                const hasToolCalls = ToolManager.hasToolCalls(data);
+                const shouldDeleteMessage = type !== 'swipe' && ['', '...'].includes(getMessage) && !reasoning;
+                hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
+                const invocationResult = await ToolManager.invokeFunctionTools(data, { reasoningText: reasoning, isCurrent, signal });
+                if (!isCurrent()) return;
+                const shouldStopGeneration = (!invocationResult.invocations.length && shouldDeleteMessage) || invocationResult.stealthCalls.length;
+                if (hasToolCalls) {
+                    if (shouldStopGeneration) {
+                        if (Array.isArray(invocationResult.errors) && invocationResult.errors.length) {
+                            ToolManager.showToolCallError(invocationResult.errors);
+                        }
+                        unblockGeneration(type);
+                        return;
+                    }
+
+                    depth = depth + 1;
+                    await ToolManager.saveFunctionToolInvocations(invocationResult.invocations);
+                    if (!isCurrent()) return;
+                    return Generate('normal', { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth, suppressUserMessage, companionHistoryTarget: companionRewriteTarget }, dryRun);
+                }
+            }
+
+            if (type !== 'quiet') {
+                playMessageSound();
+            }
+
+            const isAborted = abortController && abortController.signal.aborted;
+            if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
+                is_send_press = false;
+                return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
+            }
+
+            console.debug('/api/chats/save called by /Generate');
+            await saveChatConditional();
+            if (!isCurrent()) return;
+            unblockGeneration(type);
+            streamingProcessor = null;
+
+            if (type !== 'quiet') {
+                triggerAutoContinue(messageChunk, isImpersonate);
+            }
+
+            // Don't break the API chain that expects a single string in return
+            return Object.defineProperty(new String(getMessage), 'messageChunk', { value: messageChunk });
         }
 
-        if (type !== 'quiet') {
-            playMessageSound();
-        }
-
-        const isAborted = abortController && abortController.signal.aborted;
-        if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
-            is_send_press = false;
-            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
-        }
-
-        console.debug('/api/chats/save called by /Generate');
-        await saveChatConditional();
-        unblockGeneration(type);
-        streamingProcessor = null;
-
-        if (type !== 'quiet') {
-            triggerAutoContinue(messageChunk, isImpersonate);
-        }
-
-        // Don't break the API chain that expects a single string in return
-        return Object.defineProperty(new String(getMessage), 'messageChunk', { value: messageChunk });
-    }
-
-    /**
+        /**
      * Exception handler for finishGenerating
      * @param {Error|object} exception Error or response JSON
      * @throws {Error|object} Re-throws the exception
      */
-    function onError(exception) {
-        // if the response JSON was thrown (novel|textgenerationwebui|kobold), show the error message
-        if (typeof exception?.error?.message === 'string') {
-            toastr.error(exception.error.message, t`Text generation error`, { timeOut: 10000, extendedTimeOut: 20000 });
-        }
+        function onError(exception) {
+            if (!isCurrent()) throw exception;
+            // if the response JSON was thrown (novel|textgenerationwebui|kobold), show the error message
+            if (typeof exception?.error?.message === 'string') {
+                toastr.error(exception.error.message, t`Text generation error`, { timeOut: 10000, extendedTimeOut: 20000 });
+            }
 
-        eventSource.emit(event_types.GENERATION_STOPPED);
-        unblockGeneration(type, { emitGenerationEnded: false });
-        console.log(exception);
-        streamingProcessor = null;
-        throw exception;
+            if (!isAuxiliaryGeneration) {
+                eventSource.emit(event_types.GENERATION_STOPPED, ...(agentGenerationContext ? [agentGenerationContext] : []));
+                unblockGeneration(type, { emitGenerationEnded: false });
+                streamingProcessor = null;
+            }
+            console.log(exception);
+            throw exception;
+        }
+    } finally {
+        externalSignal?.removeEventListener('abort', onAbort);
+        requestController?.signal.removeEventListener('abort', stopStream);
+        eventSource.removeListener(event_types.GENERATION_ENDED, onEnded);
+        eventSource.removeListener(event_types.GENERATION_STOPPED, onStopped);
+        eventSource.removeListener(event_types.CHAT_CHANGED, onChatChanged);
+        if (run && activeGenerationRun === run) {
+            activeGenerationRun = null;
+            if (!run.terminal && getCurrentChatId() === originChatId && chatGeneration === originChatGeneration) {
+                unblockGeneration(type, { emitGenerationEnded: false, force: true });
+                await eventSource.emit(event_types.GENERATION_ENDED, chat.length, agentGenerationContext);
+            }
+        }
+        if (isAuxiliaryGeneration && abortController === requestController) {
+            abortController = activeGenerationRun?.controller ?? previousAbortController;
+        }
     }
 }
 //MARK: Generate() ends
@@ -8585,7 +8770,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 export function stopGeneration() {
     const activeStreamingProcessor = streamingProcessor;
     const stopState = resolveStopGenerationState({
-        isSendPressed: is_send_press,
+        isSendPressed: is_send_press || Boolean(activeGenerationRun),
         isGroupGenerating: is_group_generating,
         hasStreamingProcessor: Boolean(activeStreamingProcessor),
         streamingType: activeStreamingProcessor?.type,
@@ -8597,10 +8782,12 @@ export function stopGeneration() {
 
     if (stopState.shouldAbortRequest && abortController) {
         abortController.abort(stopState.abortReason);
+        activeGenerationRun?.controller.abort(stopState.abortReason);
     }
 
     if (stopState.shouldEmitStopped) {
-        eventSource.emitAndWait(event_types.GENERATION_STOPPED);
+        const generationContext = agentGenerationContextProvider?.();
+        eventSource.emitAndWait(event_types.GENERATION_STOPPED, ...(generationContext ? [generationContext] : []));
     }
 
     if (stopState.shouldClearStreamingProcessor) {
@@ -8689,6 +8876,9 @@ function flushWIInjections() {
  * @param {boolean} [options.force=false] Whether to bypass stream-wait guards.
  */
 function unblockGeneration(type, { emitGenerationEnded = true, force = false } = {}) {
+    // SillyBunny: a nested quiet helper must not end its owning main generation.
+    if (type === 'quiet' && activeGenerationRun && !force
+        && (activeGenerationRun.type !== 'quiet' || abortController !== activeGenerationRun.controller)) return;
     const unblockState = resolveGenerationUnblockState({
         type,
         hasStreamingProcessor: Boolean(streamingProcessor),
@@ -9125,6 +9315,7 @@ function setInContextMessages(msgInContextCount, type, preserveLastMessage = fal
 
 /**
  * @typedef {object} AdditionalRequestOptions
+ * @property {AbortSignal} [signal] Originating request's cancellation signal
  * @property {JsonSchema} [jsonSchema]
  * @property {'main'|'auxiliary'|'none'} [cacheScope]
  */
@@ -9138,12 +9329,13 @@ function setInContextMessages(msgInContextCount, type, preserveLastMessage = fal
  * @throws {Error|object}
  */
 export async function sendGenerationRequest(type, data, options = {}) {
+    const signal = options.signal ?? abortController.signal;
     if (main_api === 'openai') {
-        return await sendOpenAIRequest(type, data.prompt, abortController.signal, options);
+        return await sendOpenAIRequest(type, data.prompt, signal, options);
     }
 
     if (main_api === 'koboldhorde') {
-        return await generateHorde(data.prompt, data, abortController.signal, true);
+        return await generateHorde(data.prompt, data, signal, true);
     }
 
     const response = await fetchResumable(getGenerateUrl(main_api), {
@@ -9151,7 +9343,7 @@ export async function sendGenerationRequest(type, data, options = {}) {
         headers: getRequestHeaders(),
         cache: 'no-cache',
         body: JSON.stringify(data),
-        signal: abortController.signal,
+        signal,
     });
 
     if (!response.ok) {
@@ -9169,7 +9361,7 @@ export async function sendGenerationRequest(type, data, options = {}) {
  * @returns {Promise<any>} Streaming generator
  */
 export async function sendStreamingRequest(type, data, options = {}) {
-    if (abortController?.signal?.aborted) {
+    if ((options.signal ?? abortController?.signal)?.aborted) {
         throw new Error('Generation was aborted.');
     }
 
@@ -9781,12 +9973,13 @@ async function processImageAttachment(message, { imageUrls }) {
  * @property {string} type Type of generation
  * @property {string} getMessage Generated message
  */
-export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null, reasoningTokens = 0 }) {
+export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null, reasoningTokens = 0, isCurrent = () => true }) {
     // Backward compatibility
     if (arguments.length > 1 && typeof arguments[0] !== 'object') {
         console.trace('saveReply called with positional arguments. Please use an object instead.');
         [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens] = arguments;
     }
+    if (!isCurrent()) return { type, getMessage };
 
     const lastMessage = chat[chat.length - 1];
 
@@ -9794,6 +9987,10 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.is_user)) {
         type = 'normal';
     }
+    // SillyBunny: asynchronous attachment/token work must retain its message, not the new chat tail.
+    const replyIndex = ['swipe', 'append', 'continue', 'appendFinal'].includes(type) ? chat.length - 1 : chat.length;
+    let replyMessage = lastMessage;
+    const isReplyCurrent = () => isCurrent() && chat[replyIndex] === replyMessage;
 
     if (chat.length && (!lastMessage.extra || typeof lastMessage.extra !== 'object')) {
         lastMessage.extra = {};
@@ -9828,10 +10025,13 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             delete lastMessage.extra[IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY];
             delete lastMessage.extra[IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY];
             await processImageAttachment(lastMessage, { imageUrls });
+            if (!isReplyCurrent()) return { type, getMessage };
             await updateMessageTokenAccounting(lastMessage, { reasoning, reasoningTokens });
-            const chat_id = (chat.length - 1);
+            if (!isReplyCurrent()) return { type, getMessage };
+            const chat_id = replyIndex;
             !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
-            addOneMessage(chat[chat_id], { type: 'swipe' });
+            if (!isReplyCurrent()) return { type, getMessage };
+            addOneMessage(replyMessage, { type: 'swipe' });
             !fromStreaming && await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, chat_id, type);
         } else {
             lastMessage.mes = getMessage;
@@ -9851,10 +10051,13 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.reasoning_duration = null;
         lastMessage.extra.reasoning_signature = reasoningSignature;
         await processImageAttachment(lastMessage, { imageUrls });
+        if (!isReplyCurrent()) return { type, getMessage };
         await updateMessageTokenAccounting(lastMessage, { reasoning, reasoningTokens });
-        const chat_id = (chat.length - 1);
+        if (!isReplyCurrent()) return { type, getMessage };
+        const chat_id = replyIndex;
         !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
-        addOneMessage(chat[chat_id], { type: 'swipe' });
+        if (!isReplyCurrent()) return { type, getMessage };
+        addOneMessage(replyMessage, { type: 'swipe' });
         !fromStreaming && await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, chat_id, type);
     } else if (type === 'appendFinal') {
         oldMessage = lastMessage.mes;
@@ -9870,18 +10073,22 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.reasoning += reasoning;
         lastMessage.extra.reasoning_signature = reasoningSignature;
         await processImageAttachment(lastMessage, { imageUrls });
+        if (!isReplyCurrent()) return { type, getMessage };
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         await updateMessageTokenAccounting(lastMessage, {
             reasoning: lastMessage.extra.reasoning,
             reasoningTokens: Math.max(getPositiveTokenCount(lastMessage.extra.reasoning_tokens), getPositiveTokenCount(reasoningTokens)),
         });
-        const chat_id = (chat.length - 1);
+        if (!isReplyCurrent()) return { type, getMessage };
+        const chat_id = replyIndex;
         !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
-        addOneMessage(chat[chat_id], { type: 'swipe' });
+        if (!isReplyCurrent()) return { type, getMessage };
+        addOneMessage(replyMessage, { type: 'swipe' });
         !fromStreaming && await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, chat_id, type);
     } else {
         console.debug('entering chat update routine for non-swipe post');
         const newMessage = {};
+        replyMessage = newMessage;
         chat.push(newMessage);
         newMessage.extra = {};
         newMessage.name = name2;
@@ -9902,6 +10109,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         newMessage.gen_finished = generationFinished;
 
         await updateMessageTokenAccounting(newMessage, { reasoning, reasoningTokens });
+        if (!isReplyCurrent()) return { type, getMessage };
 
         if (selected_group) {
             consumePendingGeneratedMessageExtra(newMessage);
@@ -9916,14 +10124,17 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         }
 
         await processImageAttachment(newMessage, { imageUrls });
-        const chat_id = (chat.length - 1);
+        if (!isReplyCurrent()) return { type, getMessage };
+        const chat_id = replyIndex;
 
         !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
-        addOneMessage(chat[chat_id]);
+        if (!isReplyCurrent()) return { type, getMessage };
+        addOneMessage(replyMessage);
         !fromStreaming && await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, chat_id, type);
     }
 
-    const item = chat[chat.length - 1];
+    if (!isReplyCurrent()) return { type, getMessage };
+    const item = replyMessage;
     if (item.swipe_info === undefined) {
         item.swipe_info = [];
     }

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -41,6 +41,9 @@ export const event_types = {
     OAI_PRESET_IMPORT_READY: 'oai_preset_import_ready',
     WORLDINFO_SETTINGS_UPDATED: 'worldinfo_settings_updated',
     WORLDINFO_UPDATED: 'worldinfo_updated',
+    // SillyBunny: distinguish file lifecycle changes from ordinary entry edits.
+    WORLDINFO_RENAMED: 'worldinfo_renamed',
+    WORLDINFO_DELETED: 'worldinfo_deleted',
     CHARACTER_EDITOR_OPENED: 'character_editor_opened',
     CHARACTER_EDITED: 'character_edited',
     CHARACTER_PAGE_LOADED: 'character_page_loaded',

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -58,6 +58,7 @@ import {
 import {
     getSettings as getPathfinderRuntimeSettings,
     replaceSettings as replacePathfinderRuntimeSettings,
+    isPathfinderSelfWrite,
 } from './pathfinder/tree-store.js';
 import { onPathfinderWorldInfoUpdated, onPathfinderWorldInfoRenamed, onPathfinderWorldInfoDeleted } from './pathfinder/entry-manager.js';
 import { initializePromptStore, setPromptStorePersistHook } from './pathfinder/prompts/prompt-store.js';
@@ -154,6 +155,7 @@ const activeToolApprovals = new Map();
 const pathfinderRetrievalCacheSession = uuidv4();
 // ponytail: invalidate all retrieval caches on book changes; use per-book revisions only if this becomes costly.
 let pathfinderRetrievalCacheRevision = 0;
+let pathfinderToolRevision = 0;
 let pathfinderRetrievalRun = null;
 let pathfinderChatSyncRevision = 0;
 let activePathfinderRetrievalToast = null;
@@ -752,13 +754,13 @@ export function syncToolAgentRegistrations() {
                 parameters: toolDef.parameters,
                 action: async (args) => {
                     const { cancelRevision, runId, chatId } = getAgentGenerationContext();
-                    const lorebookRevision = pathfinderRetrievalCacheRevision;
+                    const lorebookRevision = pathfinderToolRevision;
                     const controller = new AbortController();
                     const isCurrent = () => {
                         const liveAgent = getEnabledToolAgents().find(item => item.id === agent.id);
                         return !controller.signal.aborted && !generationStopRequested && areAgentsGloballyEnabled()
                             && cancelRevision === agentGenerationCancelRevision && runId === postProcessingGenerationRunId
-                            && lorebookRevision === pathfinderRetrievalCacheRevision
+                            && lorebookRevision === pathfinderToolRevision
                             && chatId === getCurrentSnapshotChatId() && liveAgent
                             && (!isPathfinderToolAgent(liveAgent) || getPathfinderRuntimeAgent()?.id === agent.id)
                             && getRegisterableAgentTools(liveAgent).some(tool => tool.name === toolDef.name && tool.actionKey === toolDef.actionKey)
@@ -774,7 +776,7 @@ export function syncToolAgentRegistrations() {
                             if (!approved) return declined;
                         }
                         if (!isCurrent()) return declined;
-                        return action(args);
+                        return await action(args, { signal: controller.signal, isCurrent });
                     } finally {
                         activeToolApprovals.delete(controller);
                     }
@@ -5204,6 +5206,8 @@ function invalidatePathfinderRetrieval() {
 
 function onWorldInfoUpdatedToolSync(name, data, options) {
     if (typeof name === 'string' && name) {
+        // Other queued tools remain valid when a sibling tool commits its save.
+        if (options?.replaced || !isPathfinderSelfWrite(name)) pathfinderToolRevision++;
         onPathfinderWorldInfoUpdated(name, data, options);
         invalidatePathfinderRetrieval();
     }
@@ -5212,6 +5216,7 @@ function onWorldInfoUpdatedToolSync(name, data, options) {
 
 async function onWorldInfoRenamedOrDeleted(oldName, newName = '') {
     if (typeof oldName !== 'string' || !oldName) return;
+    pathfinderToolRevision++;
     if (newName) onPathfinderWorldInfoRenamed(oldName, newName);
     else onPathfinderWorldInfoDeleted(oldName);
     invalidatePathfinderRetrieval();

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -6,6 +6,7 @@ import {
     extension_prompt_types,
     extension_prompts,
     setExtensionPrompt,
+    setAgentGenerationContextProvider,
     substituteParams,
     substituteParamsExtended,
     generateQuietPrompt,
@@ -20,11 +21,13 @@ import {
 } from '../../../script.js';
 import { getContext } from '../../extensions.js';
 import { eventSource, event_types } from '../../events.js';
+import { is_group_generating } from '../../group-chats.js';
 import { POPUP_RESULT, POPUP_TYPE, callGenericPopup } from '../../popup.js';
 import { ToolManager } from '../../tool-calling.js';
 import {
     areAgentsGloballyEnabled,
     getAgentById,
+    getAgents,
     getAgentRegexScripts,
     getEnabledAgents,
     getEnabledToolAgents,
@@ -40,7 +43,7 @@ import {
     resolveCompanionConnectionProfile,
     resolveConnectionProfile,
 } from './agent-store.js';
-import { regexFromString } from '../../utils.js';
+import { regexFromString, uuidv4 } from '../../utils.js';
 import { isKimiK3Model } from '../../openai-model-capabilities.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
 import { getConnectionProfileDisplayName, getConnectionProfileModelName } from './profile-utils.js';
@@ -55,17 +58,14 @@ import {
 import {
     getSettings as getPathfinderRuntimeSettings,
     replaceSettings as replacePathfinderRuntimeSettings,
-    setSettings as setPathfinderRuntimeSettings,
-    deleteTree as deletePathfinderTree,
-    syncTrackerUidsForLorebook,
-    isPathfinderSelfWrite,
 } from './pathfinder/tree-store.js';
+import { onPathfinderWorldInfoUpdated, onPathfinderWorldInfoRenamed, onPathfinderWorldInfoDeleted } from './pathfinder/entry-manager.js';
 import { initializePromptStore, setPromptStorePersistHook } from './pathfinder/prompts/prompt-store.js';
 import { getDefaultPrompts, getDefaultPipelines } from './pathfinder/prompts/default-prompts.js';
 import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { getContextualLorebooks, getForcedToolChoice } from './pathfinder/pathfinder-tool-bridge.js';
 import { confirmToolCall, shouldConfirmToolCall } from './pathfinder/tool-confirmation.js';
-import { PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
+import { injectPathfinderRetrieval, PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
 import { resetAutoSummaryCount, shouldAutoSummarize } from './pathfinder/auto-summary.js';
 import { buildRegexScriptRefsForAgent, cacheAgentRegexScripts, migrateLegacyRegexSnapshotsInMessages } from './regex-snapshot-store.js';
 import { AGENT_REGEX_PLACEMENT, applyRegexScriptList } from './regex-scripts.js';
@@ -150,6 +150,12 @@ let postProcessingGenerationRunId = 0;
 let swipeNavigationPending = false;
 const activeAgentRequestAbortControllers = new Set();
 const activePathfinderRetrievalAbortControllers = new Set();
+const activeToolApprovals = new Map();
+const pathfinderRetrievalCacheSession = uuidv4();
+// ponytail: invalidate all retrieval caches on book changes; use per-book revisions only if this becomes costly.
+let pathfinderRetrievalCacheRevision = 0;
+let pathfinderRetrievalRun = null;
+let pathfinderChatSyncRevision = 0;
 let activePathfinderRetrievalToast = null;
 let activeInitialGenerationToast = null;
 let companionRuntime = null;
@@ -160,6 +166,18 @@ export function registerCompanionRuntime(runtime = null) {
 
 export function getAgentGenerationCancelRevision() {
     return agentGenerationCancelRevision;
+}
+
+export function isAgentGenerationStopped() {
+    return generationStopRequested;
+}
+
+export function getAgentGenerationContext() {
+    return {
+        chatId: getCurrentSnapshotChatId(),
+        runId: postProcessingGenerationRunId,
+        cancelRevision: agentGenerationCancelRevision,
+    };
 }
 
 function shouldDeferAgentRegularBackup() {
@@ -231,6 +249,7 @@ const agentRegisteredToolNames = new Set();
 
 /** Guard to prevent re-registration during generation when WORLDINFO_UPDATED fires. */
 let toolSyncDuringGeneration = false;
+let pendingToolSync = false;
 
 /** Recursion depth tracker for tool-call passes. */
 let toolRecursionDepth = 0;
@@ -252,7 +271,7 @@ function escapeToastHtml(value) {
 }
 
 export function isAgentGenerationActive() {
-    return internalPromptTransformDepth > 0 || manualAgentRunQueueProcessing || manualAgentRunQueue.length > 0 || parallelManualRunCount > 0;
+    return internalPromptTransformDepth > 0 || manualAgentRunQueueProcessing || manualAgentRunQueue.length > 0 || parallelManualRunCount > 0 || activePathfinderRetrievalAbortControllers.size > 0;
 }
 
 export function onAgentGenerationStateChanged(listener) {
@@ -315,9 +334,9 @@ export function cancelAgentGeneration() {
     manualAgentRunCancelRequested = true;
     agentGenerationCancelRevision++;
 
-    if (internalPromptTransformDepth > 0) {
-        generationStopRequested = true;
-    }
+    generationStopRequested = true;
+    invalidateToolApprovals();
+    releaseToolAgentRegistrations();
 
     clearLatestAssistantPostProcessingFallback();
     clearDeferredPostProcessing();
@@ -327,8 +346,9 @@ export function cancelAgentGeneration() {
     clearPathfinderRetrievalToast();
     abortActiveAgentRequests('Agent generation cancelled by user.');
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled by user.');
+    clearPathfinderExtensionPrompts();
 
-    const stopped = internalPromptTransformDepth > 0 || activeManualAgentRun ? stopGeneration() : false;
+    const stopped = wasActive || activeManualAgentRun ? stopGeneration() : false;
     notifyAgentGenerationStateChanged();
 
     if (stopped || wasActive || queuedCount > 0) {
@@ -356,12 +376,26 @@ function isAbortSignalTriggered(error, signal = null) {
 
 function abortActivePathfinderRetrieval(reason = 'Pathfinder retrieval cancelled.') {
     const error = reason instanceof Error ? reason : new Error(String(reason));
+    pathfinderRetrievalRun?.controller.abort(error);
+    pathfinderRetrievalRun = null;
 
     for (const controller of activePathfinderRetrievalAbortControllers) {
         controller.abort(error);
     }
 
     activePathfinderRetrievalAbortControllers.clear();
+    notifyAgentGenerationStateChanged();
+}
+
+function invalidateToolApprovals(force = false) {
+    for (const [controller, isCurrent] of activeToolApprovals) {
+        if (force || !isCurrent()) controller.abort();
+    }
+}
+
+function releaseToolAgentRegistrations() {
+    toolSyncDuringGeneration = false;
+    if (pendingToolSync) syncToolAgentRegistrations();
 }
 
 function showPathfinderRetrievalToast() {
@@ -621,9 +655,6 @@ export function getToolRecursionState() {
     };
 }
 
-// Counterpart of syncAutoAttachedLorebooks (pathfinder-settings-ui.js), which
-// handles the panel-open trigger from the same contextual-lorebook source;
-// keep the two in sync.
 export async function syncPathfinderAgentLorebooksForCurrentChat(agent = getPathfinderRuntimeAgent(), { persist = false } = {}) {
     if (!isPathfinderSubmoduleEnabled()) {
         return false;
@@ -633,40 +664,35 @@ export async function syncPathfinderAgentLorebooksForCurrentChat(agent = getPath
         return false;
     }
 
-    const existingSettings = {
-        ...getPathfinderRuntimeSettings(),
-        ...(agent.settings || {}),
+    const chatId = getCurrentSnapshotChatId();
+    const revision = pathfinderChatSyncRevision;
+    const books = [...new Set(getContextualLorebooks().filter(Boolean))];
+    const isCurrent = () => revision === pathfinderChatSyncRevision && chatId === getCurrentSnapshotChatId()
+        && getPathfinderRuntimeAgent()?.id === agent.id;
+    const update = current => {
+        if (!current || !isCurrent() || current.settings?.autoSyncLorebooksOnChatChange === false) return null;
+        const settings = current.settings ?? {};
+        const contextualBooks = books.filter(book => settings.bookPermissions?.[book]?.enabled !== false);
+        const selectedLorebook = contextualBooks[0] ?? '';
+        const currentBooks = settings.enabledLorebooks ?? [];
+        if (currentBooks.length === contextualBooks.length && currentBooks.every((book, index) => book === contextualBooks[index])
+            && (settings.selectedLorebook ?? '') === selectedLorebook) return null;
+        return { ...current, settings: { ...settings, enabledLorebooks: contextualBooks, selectedLorebook } };
     };
-    if (existingSettings.autoSyncLorebooksOnChatChange === false) {
-        return false;
-    }
-
-    const contextualBooks = Array.from(new Set(getContextualLorebooks().filter(Boolean)));
-    const currentBooks = Array.isArray(existingSettings.enabledLorebooks) ? existingSettings.enabledLorebooks : [];
-    const sameBooks = currentBooks.length === contextualBooks.length && currentBooks.every((book, index) => book === contextualBooks[index]);
-    const selectedLorebook = contextualBooks[0] ?? '';
-
-    if (sameBooks && (existingSettings.selectedLorebook ?? '') === selectedLorebook) {
-        return false;
-    }
-
-    const nextSettings = {
-        ...existingSettings,
-        enabledLorebooks: contextualBooks,
-        selectedLorebook,
-    };
-    agent.settings = {
-        ...(agent.settings || {}),
-        ...nextSettings,
-    };
-    setPathfinderRuntimeSettings(nextSettings);
-
+    let saved;
     if (persist) {
-        await saveAgent(agent);
+        saved = await saveAgent(agent.id, { update });
+    } else {
+        const current = getAgentById(agent.id) ?? agent;
+        saved = update(current);
+        if (saved) current.settings = saved.settings;
     }
+    if (!saved || !isCurrent()) return false;
+    syncToolAgentRegistrations();
+    notifyAgentGenerationStateChanged();
 
     console.info('[Pathfinder] Synced enabled lorebooks to the current chat context.', {
-        lorebooks: contextualBooks,
+        lorebooks: saved.settings.enabledLorebooks,
     });
     return true;
 }
@@ -676,13 +702,23 @@ export async function syncPathfinderAgentLorebooksForCurrentChat(agent = getPath
  * Unregisters tools from disabled agents, registers tools from enabled ones.
  */
 export function syncToolAgentRegistrations() {
+    invalidateToolApprovals();
+    if (pathfinderRetrievalRun && !pathfinderRetrievalRun.isCurrent()) {
+        abortActivePathfinderRetrieval();
+        clearPathfinderRetrievalToast();
+        clearPathfinderExtensionPrompts();
+    }
     if (toolSyncDuringGeneration) {
+        pendingToolSync = true;
         return;
     }
+    pendingToolSync = false;
 
     const desiredTools = new Set();
-    const enabledToolAgents = areAgentsGloballyEnabled() ? getEnabledToolAgents() : [];
-    syncPathfinderRuntimeSettings(getPathfinderRuntimeAgent(enabledToolAgents));
+    const allEnabledToolAgents = areAgentsGloballyEnabled() ? getEnabledToolAgents() : [];
+    const pathfinderAgent = getPathfinderRuntimeAgent(allEnabledToolAgents);
+    const enabledToolAgents = allEnabledToolAgents.filter(agent => !isPathfinderToolAgent(agent) || agent.id === pathfinderAgent?.id);
+    syncPathfinderRuntimeSettings(pathfinderAgent);
 
     for (const agent of enabledToolAgents) {
         const enabledTools = getRegisterableAgentTools(agent);
@@ -715,13 +751,33 @@ export function syncToolAgentRegistrations() {
                 description: toolDef.description,
                 parameters: toolDef.parameters,
                 action: async (args) => {
-                    if (shouldConfirmToolCall(toolDef.name)) {
-                        const approved = await confirmToolCall(toolDef.displayName ?? toolDef.name, args);
-                        if (!approved) {
-                            return 'The user declined this tool call. Continue the response without it and do not retry.';
+                    const { cancelRevision, runId, chatId } = getAgentGenerationContext();
+                    const lorebookRevision = pathfinderRetrievalCacheRevision;
+                    const controller = new AbortController();
+                    const isCurrent = () => {
+                        const liveAgent = getEnabledToolAgents().find(item => item.id === agent.id);
+                        return !controller.signal.aborted && !generationStopRequested && areAgentsGloballyEnabled()
+                            && cancelRevision === agentGenerationCancelRevision && runId === postProcessingGenerationRunId
+                            && lorebookRevision === pathfinderRetrievalCacheRevision
+                            && chatId === getCurrentSnapshotChatId() && liveAgent
+                            && (!isPathfinderToolAgent(liveAgent) || getPathfinderRuntimeAgent()?.id === agent.id)
+                            && getRegisterableAgentTools(liveAgent).some(tool => tool.name === toolDef.name && tool.actionKey === toolDef.actionKey)
+                            && getToolAction(toolDef.actionKey) === action;
+                    };
+                    const declined = 'The user declined this tool call. Continue the response without it and do not retry.';
+                    if (!isCurrent()) return declined;
+
+                    activeToolApprovals.set(controller, isCurrent);
+                    try {
+                        if (shouldConfirmToolCall(toolDef.name, getEnabledToolAgents().find(item => item.id === agent.id)?.settings)) {
+                            const approved = await confirmToolCall(toolDef.displayName ?? toolDef.name, args, controller.signal);
+                            if (!approved) return declined;
                         }
+                        if (!isCurrent()) return declined;
+                        return action(args);
+                    } finally {
+                        activeToolApprovals.delete(controller);
                     }
-                    return action(args);
                 },
                 formatMessage,
                 shouldRegister: async () => true,
@@ -945,7 +1001,13 @@ function clearPendingPostProcessingForChatChange() {
     }
 
     isGenerationInProgress = false;
-    toolSyncDuringGeneration = false;
+    agentGenerationCancelRevision++;
+    invalidateToolApprovals();
+    abortActiveAgentRequests();
+    abortActivePathfinderRetrieval();
+    clearPathfinderRetrievalToast();
+    clearInChatAgentExtensionPrompts();
+    releaseToolAgentRegistrations();
     generationStopRequested = false;
     generationStartChatId = getCurrentSnapshotChatId();
     pendingGenerationSnapshot = null;
@@ -954,6 +1016,7 @@ function clearPendingPostProcessingForChatChange() {
     clearLatestAssistantPostProcessingFallback();
     clearPostGenerationRecoveryCheck();
     clearMissedGenerationEndRecoveryCheck();
+    notifyAgentGenerationStateChanged();
 }
 
 function clearStalePendingGenerationSnapshot() {
@@ -1235,7 +1298,9 @@ function buildPathfinderRetrievalCacheSignature(pathfinderAgent, activationSnaps
     }
 
     const signaturePayload = normalizePathfinderCacheValue({
-        version: 1,
+        version: 2,
+        cacheSession: pathfinderRetrievalCacheSession,
+        lorebookRevision: pathfinderRetrievalCacheRevision,
         chatId: normalizeSnapshotChatId(activationSnapshot?.chatId ?? getCurrentSnapshotChatId()),
         generationType: normalizeGenerationType(generationType),
         targetMessageIndex: cacheTarget.messageIndex,
@@ -1330,7 +1395,7 @@ function restorePathfinderRetrievalPromptSnapshot(cache) {
     return true;
 }
 
-function storePathfinderRetrievalCache(message, signature) {
+function storePathfinderRetrievalCache(message, signature, retrieval) {
     if (!message || !signature) {
         return;
     }
@@ -1338,6 +1403,7 @@ function storePathfinderRetrievalCache(message, signature) {
     const cacheEntry = {
         signature,
         prompts: capturePathfinderRetrievalPromptSnapshot(),
+        retrieval: { ...retrieval, stageResults: [], metadata: {} },
         savedAt: Date.now(),
     };
     const caches = getStoredPathfinderRetrievalCaches(message).filter(cache => cache.signature !== signature);
@@ -1699,7 +1765,7 @@ function recoverMissedGenerationEnd(reason = 'fallback') {
     console.warn(`[InChatAgents] Recovering missed generation end via ${reason}; flushing queued post-processing.`);
     isGenerationInProgress = false;
     lastMainGenerationEndedAt = Date.now() - BODY_GENERATING_FLAG_GRACE_MS;
-    toolSyncDuringGeneration = false;
+    releaseToolAgentRegistrations();
     generationStopRequested = false;
     clearMissedGenerationEndRecoveryCheck();
     clearInitialGenerationToast();
@@ -3113,24 +3179,33 @@ async function requestProfilePromptTransform(CMRS, profileId, promptMessages, ma
     };
 }
 
+export async function runAsInternalPromptTransform(requestFn, signal = null) {
+    signal?.throwIfAborted();
+    internalPromptTransformDepth++;
+    notifyAgentGenerationStateChanged();
+    let active = true;
+    const finish = () => {
+        if (!active) return;
+        active = false;
+        internalPromptTransformDepth = Math.max(0, internalPromptTransformDepth - 1);
+        notifyPromptTransformIdle();
+        notifyAgentGenerationStateChanged();
+    };
+    signal?.addEventListener('abort', finish, { once: true });
+    try {
+        return await requestFn();
+    } finally {
+        signal?.removeEventListener('abort', finish);
+        finish();
+    }
+}
+
 export async function requestPromptTransform(agent, promptMessages, maxTokens, options = {}) {
     const profileId = resolveAgentConnectionProfile(agent);
     const modelOverride = typeof agent.modelOverride === 'string' ? agent.modelOverride.trim() : '';
     const context = getContext();
     const CMRS = context?.ConnectionManagerRequestService;
     const requestAbortController = new AbortController();
-    const runAsInternalPromptTransform = async (requestFn) => {
-        internalPromptTransformDepth++;
-        notifyAgentGenerationStateChanged();
-        try {
-            return await requestFn();
-        } finally {
-            internalPromptTransformDepth = Math.max(0, internalPromptTransformDepth - 1);
-            notifyPromptTransformIdle();
-            notifyAgentGenerationStateChanged();
-        }
-    };
-
     activeAgentRequestAbortControllers.add(requestAbortController);
 
     try {
@@ -3139,14 +3214,16 @@ export async function requestPromptTransform(agent, promptMessages, maxTokens, o
                 throw new Error(`${describePromptTransformTarget(profileId, 'profile')} is set, but Connection Manager is unavailable.`);
             }
 
-            return await runAsInternalPromptTransform(async () =>
-                await requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride, requestAbortController.signal),
+            return await runAsInternalPromptTransform(
+                () => requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride, requestAbortController.signal),
+                requestAbortController.signal,
             );
         }
 
         if (canUseMainChatCompletionHelper(context)) {
-            return await runAsInternalPromptTransform(async () =>
-                await requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options, requestAbortController.signal),
+            return await runAsInternalPromptTransform(
+                () => requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options, requestAbortController.signal),
+                requestAbortController.signal,
             );
         }
 
@@ -3155,6 +3232,7 @@ export async function requestPromptTransform(agent, promptMessages, maxTokens, o
             .join('\n\n');
         const preservedPrompts = Object.entries(extension_prompts)
             .filter(([key]) => key.startsWith(PROMPT_KEY_PREFIX));
+        const origin = getAgentGenerationContext();
 
         for (const [key] of preservedPrompts) {
             delete extension_prompts[key];
@@ -3172,10 +3250,13 @@ export async function requestPromptTransform(agent, promptMessages, maxTokens, o
                 }),
                 runner: 'main',
                 profileId: '',
-            }));
+            }), requestAbortController.signal);
         } finally {
-            for (const [key, value] of preservedPrompts) {
-                extension_prompts[key] = value;
+            if (!requestAbortController.signal.aborted && origin.chatId === getCurrentSnapshotChatId()
+                && origin.runId === postProcessingGenerationRunId && origin.cancelRevision === agentGenerationCancelRevision) {
+                for (const [key, value] of preservedPrompts) {
+                    if (!Object.hasOwn(extension_prompts, key)) extension_prompts[key] = value;
+                }
             }
         }
     } finally {
@@ -3583,11 +3664,14 @@ function clearPathfinderExtensionPrompts() {
 }
 
 export function deactivatePathfinderRuntime() {
+    invalidateToolApprovals();
     clearPathfinderRetrievalToast();
     abortActivePathfinderRetrieval('Pathfinder disabled.');
     clearPathfinderExtensionPrompts();
     toolRecursionDepth = 0;
-    syncToolAgentRegistrations();
+    pendingToolSync = true;
+    releaseToolAgentRegistrations();
+    notifyAgentGenerationStateChanged();
 }
 
 function injectPreGenerationAgentPrompts(activeAgents, generationType) {
@@ -3626,12 +3710,18 @@ function injectPreGenerationAgentPrompts(activeAgents, generationType) {
 /**
  * Cleans up all in-chat agent extension prompts before a new generation.
  */
-function onGenerationStarted(generationType, _options, dryRun) {
+function onGenerationStarted(generationType, options, dryRun) {
     swipeNavigationPending = false;
 
-    if (dryRun || internalPromptTransformDepth > 0) {
+    if (dryRun || options?.isAuxiliaryGeneration || (internalPromptTransformDepth > 0 && normalizeGenerationType(generationType) === 'quiet')) {
         return;
     }
+
+    // Generate dispatches a group wrapper before any member has started.
+    if (getContext()?.groupId && !is_group_generating) return;
+
+    abortActivePathfinderRetrieval();
+    releaseToolAgentRegistrations();
 
     currentMainGenerationType = normalizeGenerationType(generationType);
     isGenerationInProgress = true;
@@ -3642,6 +3732,7 @@ function onGenerationStarted(generationType, _options, dryRun) {
     generationStartedAt = Date.now();
     lastMainGenerationEndedAt = 0;
     postProcessingGenerationRunId++;
+    invalidateToolApprovals();
     stoppedGenerationRunId = -1;
     stoppedStreamingMessageIndexes.clear();
     clearLatestAssistantPostProcessingFallback();
@@ -3669,17 +3760,25 @@ function onGenerationStarted(generationType, _options, dryRun) {
     clearInChatAgentExtensionPrompts();
 }
 
-function onGenerationEnded() {
-    if (internalPromptTransformDepth > 0) {
+function onGenerationEnded(_chatLength, generationContext) {
+    if (generationContext && (generationContext.runId !== postProcessingGenerationRunId
+        || generationContext.chatId !== getCurrentSnapshotChatId()
+        || generationContext.cancelRevision !== agentGenerationCancelRevision)) {
+        return;
+    }
+    if (internalPromptTransformDepth > 0 && activePathfinderRetrievalAbortControllers.size === 0) {
         return;
     }
 
     clearInitialGenerationToast();
+    invalidateToolApprovals(true);
+    abortActivePathfinderRetrieval();
+    clearPathfinderRetrievalToast();
+    releaseToolAgentRegistrations();
 
     if (stoppedGenerationRunId === postProcessingGenerationRunId) {
         isGenerationInProgress = false;
         lastMainGenerationEndedAt = Date.now();
-        toolSyncDuringGeneration = false;
         clearLatestAssistantPostProcessingFallback();
         clearPostGenerationRecoveryCheck();
         clearMissedGenerationEndRecoveryCheck();
@@ -3690,7 +3789,6 @@ function onGenerationEnded() {
 
     if (postProcessingInvalidatedByChatChange || isCurrentGenerationChatStale()) {
         isGenerationInProgress = false;
-        toolSyncDuringGeneration = false;
         generationStopRequested = false;
         clearPendingPostProcessingForChatChange();
         return;
@@ -3699,7 +3797,6 @@ function onGenerationEnded() {
     pendingGenerationSnapshot ??= buildActivationSnapshot(currentMainGenerationType);
     isGenerationInProgress = false;
     lastMainGenerationEndedAt = Date.now();
-    toolSyncDuringGeneration = false;
     generationStopRequested = false;
     clearMissedGenerationEndRecoveryCheck();
     clearAllPromptTransformRunningToasts();
@@ -3710,12 +3807,17 @@ function onGenerationEnded() {
     scheduleLatestAssistantPostProcessingFallback();
 }
 
-function onGenerationStopped() {
-    if (internalPromptTransformDepth > 0) {
+function onGenerationStopped(generationContext) {
+    if (generationContext && (generationContext.runId !== postProcessingGenerationRunId
+        || generationContext.chatId !== getCurrentSnapshotChatId()
+        || generationContext.cancelRevision !== agentGenerationCancelRevision)) {
         return;
     }
-
     generationStopRequested = true;
+    agentGenerationCancelRevision++;
+    invalidateToolApprovals();
+    abortActiveAgentRequests();
+    releaseToolAgentRegistrations();
     stoppedGenerationRunId = postProcessingGenerationRunId;
     const stoppedMessageIndex = Number(streamingProcessor?.messageId);
     if (Number.isInteger(stoppedMessageIndex) && stoppedMessageIndex >= 0) {
@@ -3732,6 +3834,8 @@ function onGenerationStopped() {
     clearInitialGenerationToast();
     takePendingPreGenerationInterceptRuns();
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled because generation stopped.');
+    clearPathfinderExtensionPrompts();
+    notifyAgentGenerationStateChanged();
 }
 
 /**
@@ -3741,9 +3845,11 @@ function onGenerationStopped() {
  * @param {boolean} dryRun
  */
 async function onGenerationAfterCommands(generationType, options, dryRun) {
-    if (internalPromptTransformDepth > 0) {
+    if (options?.isAuxiliaryGeneration || (internalPromptTransformDepth > 0 && (dryRun || normalizeGenerationType(generationType) === 'quiet'))) {
         return;
     }
+
+    if (!dryRun && getContext()?.groupId && !is_group_generating) return;
 
     const normalizedGenerationType = normalizeGenerationType(generationType);
 
@@ -3773,35 +3879,60 @@ async function onGenerationAfterCommands(generationType, options, dryRun) {
     const pathfinderAgent = getPathfinderRuntimeAgent(activeAgents);
 
     if (!dryRun && pathfinderAgent) {
-        const retrievalCancelRevision = agentGenerationCancelRevision;
+        abortActivePathfinderRetrieval();
+        const run = {
+            controller: new AbortController(),
+            ...getAgentGenerationContext(),
+            cacheRevision: pathfinderRetrievalCacheRevision,
+            result: null,
+            nativeApplied: false,
+            skipWIAN: options?.skipWIAN,
+        };
+        run.isCurrent = () => pathfinderRetrievalRun === run && !run.controller.signal.aborted && !options?.signal?.aborted
+            && !generationStopRequested && run.cancelRevision === agentGenerationCancelRevision
+            && run.runId === postProcessingGenerationRunId && run.chatId === getCurrentSnapshotChatId()
+            && run.cacheRevision === pathfinderRetrievalCacheRevision && areAgentsGloballyEnabled()
+            && getPathfinderRuntimeAgent(getEnabledAgents())?.id === pathfinderAgent.id
+            && JSON.stringify(getPathfinderRetrievalSettingsSnapshot(getAgentById(pathfinderAgent.id))) === run.settingsSignature;
+        run.writePrompt = (...args) => run.isCurrent() ? setExtensionPrompt(...args) : false;
+        pathfinderRetrievalRun = run;
         syncPathfinderRuntimeSettings(pathfinderAgent);
+        run.settingsSignature = JSON.stringify(getPathfinderRetrievalSettingsSnapshot(pathfinderAgent));
         const retrievalCacheTarget = getPathfinderRetrievalCacheTarget(normalizedGenerationType);
         const retrievalCacheSignature = buildPathfinderRetrievalCacheSignature(pathfinderAgent, activationSnapshot, normalizedGenerationType, retrievalCacheTarget);
         const cachedRetrieval = findPathfinderRetrievalCache(retrievalCacheTarget?.message, retrievalCacheSignature);
-        let retrievalAbortController = null;
 
         if (cachedRetrieval) {
+            if (!run.isCurrent()) return;
+            run.result = cachedRetrieval.retrieval;
             restorePathfinderRetrievalPromptSnapshot(cachedRetrieval);
         } else {
-            retrievalAbortController = new AbortController();
-            activePathfinderRetrievalAbortControllers.add(retrievalAbortController);
+            const onAbort = () => run.controller.abort(options.signal.reason);
+            options?.signal?.addEventListener('abort', onAbort, { once: true });
+            if (options?.signal?.aborted) onAbort();
+            activePathfinderRetrievalAbortControllers.add(run.controller);
+            notifyAgentGenerationStateChanged();
 
             try {
                 if (shouldShowPathfinderRetrievalToast(pathfinderAgent)) {
                     showPathfinderRetrievalToast();
                 }
-                await runSidecarRetrieval(setExtensionPrompt, extension_prompt_types, extension_prompt_roles, retrievalAbortController.signal);
+                run.result = await runSidecarRetrieval(run.writePrompt, extension_prompt_types, extension_prompt_roles, run.controller.signal, {
+                    chatMessages: getPathfinderRetrievalContextSnapshot(retrievalCacheTarget?.messageIndex ?? chat.length),
+                });
             } finally {
-                clearPathfinderRetrievalToast();
-                activePathfinderRetrievalAbortControllers.delete(retrievalAbortController);
+                if (pathfinderRetrievalRun === run) clearPathfinderRetrievalToast();
+                activePathfinderRetrievalAbortControllers.delete(run.controller);
+                options?.signal?.removeEventListener('abort', onAbort);
+                notifyAgentGenerationStateChanged();
             }
 
-            if (!generationStopRequested && agentGenerationCancelRevision === retrievalCancelRevision && !retrievalAbortController.signal.aborted) {
-                storePathfinderRetrievalCache(retrievalCacheTarget?.message, retrievalCacheSignature);
+            if (run.isCurrent() && run.result?.success && run.result.cacheable !== false) {
+                storePathfinderRetrievalCache(retrievalCacheTarget?.message, retrievalCacheSignature, run.result);
             }
         }
 
-        if (generationStopRequested || agentGenerationCancelRevision !== retrievalCancelRevision || retrievalAbortController?.signal.aborted) {
+        if (!run.isCurrent()) {
             return;
         }
 
@@ -4982,7 +5113,7 @@ function onMessageSwipeDeleted(data) {
  * @param {object} data Generation data being prepared for the API call
  */
 function onChatCompletionSettingsReady(data) {
-    if (!areAgentsGloballyEnabled() || agentRegisteredToolNames.size === 0) {
+    if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled() || agentRegisteredToolNames.size === 0) {
         return;
     }
 
@@ -5014,10 +5145,26 @@ function onWorldInfoEntriesLoaded(data) {
     void data;
 }
 
+function onWorldInfoActivated(entries, generationContext) {
+    const run = pathfinderRetrievalRun;
+    // Native activation is emitted after retrieval, before either prompt builder
+    // reads extension prompts. Untagged events cannot identify overlapping scans.
+    if (internalPromptTransformDepth > 0 || !isGenerationInProgress || !run?.isCurrent()
+        || !run.result?.success || run.nativeApplied || run.skipWIAN || !Array.isArray(entries)
+        || generationContext?.runId !== run.runId || generationContext?.chatId !== run.chatId
+        || generationContext?.cancelRevision !== run.cancelRevision) {
+        return;
+    }
+    run.nativeApplied = true;
+    injectPathfinderRetrieval(run.result, run.writePrompt, extension_prompt_types, extension_prompt_roles, entries);
+}
+
 let _onChatChangedToolSync = false;
 
 function onChatChangedToolSync() {
+    pathfinderChatSyncRevision++;
     clearPendingPostProcessingForChatChange();
+    resetAutoSummaryCount();
 
     if (!areAgentsGloballyEnabled()) {
         syncToolAgentRegistrations();
@@ -5032,34 +5179,68 @@ function onChatChangedToolSync() {
     requestAnimationFrame(() => {
         _onChatChangedToolSync = false;
         toolRecursionDepth = 0;
-        // The counter is per-chat: messages from the previous chat must not
-        // trigger a summary in the new one.
-        resetAutoSummaryCount();
+        const revision = pathfinderChatSyncRevision;
         void (async () => {
-            const pathfinderAgent = getPathfinderRuntimeAgent();
-            if (pathfinderAgent) {
-                await syncPathfinderAgentLorebooksForCurrentChat(pathfinderAgent, { persist: true });
+            try {
+                const pathfinderAgent = getPathfinderRuntimeAgent();
+                if (pathfinderAgent) {
+                    await syncPathfinderAgentLorebooksForCurrentChat(pathfinderAgent, { persist: true });
+                }
+            } catch (error) {
+                console.warn('[Pathfinder] Failed to save agent', error);
+            } finally {
+                if (revision === pathfinderChatSyncRevision) syncToolAgentRegistrations();
             }
-            syncToolAgentRegistrations();
         })();
     });
 }
 
-function onWorldInfoUpdatedToolSync(name, data) {
-    // External lorebook edits invalidate the cached waypoint tree; it is
-    // rebuilt on demand. Pathfinder's own saves maintain the tree in place.
-    if (typeof name === 'string' && name && !isPathfinderSelfWrite()) {
-        deletePathfinderTree(name);
-        syncTrackerUidsForLorebook(name, data);
-    }
+function invalidatePathfinderRetrieval() {
+    pathfinderRetrievalCacheRevision++;
+    abortActivePathfinderRetrieval();
+    clearPathfinderRetrievalToast();
+    clearPathfinderExtensionPrompts();
+}
 
-    if (!areAgentsGloballyEnabled()) {
+function onWorldInfoUpdatedToolSync(name, data, options) {
+    if (typeof name === 'string' && name) {
+        onPathfinderWorldInfoUpdated(name, data, options);
+        invalidatePathfinderRetrieval();
+    }
+    syncToolAgentRegistrations();
+}
+
+async function onWorldInfoRenamedOrDeleted(oldName, newName = '') {
+    if (typeof oldName !== 'string' || !oldName) return;
+    if (newName) onPathfinderWorldInfoRenamed(oldName, newName);
+    else onPathfinderWorldInfoDeleted(oldName);
+    invalidatePathfinderRetrieval();
+
+    const retarget = settings => {
+        if (!settings || !(settings.enabledLorebooks?.includes(oldName) || settings.selectedLorebook === oldName
+            || Object.hasOwn(settings.bookPermissions ?? {}, oldName))) return null;
+        const enabledLorebooks = [...new Set((settings.enabledLorebooks ?? []).map(name => name === oldName ? newName : name).filter(Boolean))];
+        const bookPermissions = { ...(settings.bookPermissions ?? {}) };
+        if (newName && Object.hasOwn(bookPermissions, oldName)) {
+            bookPermissions[newName] ??= bookPermissions[oldName];
+        }
+        delete bookPermissions[oldName];
+        return {
+            ...settings,
+            enabledLorebooks,
+            selectedLorebook: settings.selectedLorebook === oldName ? (newName || enabledLorebooks[0] || '') : settings.selectedLorebook,
+            bookPermissions,
+        };
+    };
+
+    for (const agent of getAgents().filter(isPathfinderToolAgent)) {
+        const saved = await saveAgent(agent.id, { update: current => {
+            const settings = retarget(current?.settings);
+            return settings ? { ...current, settings } : null;
+        } });
+        if (!saved) continue;
         syncToolAgentRegistrations();
-        return;
-    }
-
-    if (toolSyncDuringGeneration || isGenerationInProgress) {
-        return;
+        notifyAgentGenerationStateChanged();
     }
     syncToolAgentRegistrations();
 }
@@ -5113,11 +5294,10 @@ async function persistPathfinderRuntimeSettingsToAgent() {
         return;
     }
 
-    agent.settings = {
-        ...(agent.settings || {}),
-        ...getPathfinderRuntimeSettings(),
-    };
-    await saveAgent(agent);
+    const { pipelinePrompts, pipelines } = structuredClone(getPathfinderRuntimeSettings());
+    await saveAgent(agent.id, { update: current => current
+        ? { ...current, settings: { ...current.settings, pipelinePrompts, pipelines } }
+        : null });
 }
 
 export function initAgentRunner() {
@@ -5126,6 +5306,7 @@ export function initAgentRunner() {
     }
 
     agentRunnerInitialized = true;
+    setAgentGenerationContextProvider(getAgentGenerationContext);
     initPostGenerationRecoveryHooks();
     setPromptStorePersistHook(() => { void persistPathfinderRuntimeSettingsToAgent(); });
 
@@ -5180,6 +5361,10 @@ export function initAgentRunner() {
         eventSource.on(event_types.WORLDINFO_ENTRIES_LOADED, onWorldInfoEntriesLoaded);
     }
 
+    if (event_types.WORLD_INFO_ACTIVATED) {
+        eventSource.on(event_types.WORLD_INFO_ACTIVATED, onWorldInfoActivated);
+    }
+
     if (event_types.CHAT_CHANGED) {
         eventSource.on(event_types.CHAT_CHANGED, migrateLegacyRegexSnapshotsForCurrentChat);
         eventSource.on(event_types.CHAT_CHANGED, onChatChangedToolSync);
@@ -5187,6 +5372,13 @@ export function initAgentRunner() {
 
     if (event_types.WORLDINFO_UPDATED) {
         eventSource.on(event_types.WORLDINFO_UPDATED, onWorldInfoUpdatedToolSync);
+    }
+
+    if (event_types.WORLDINFO_RENAMED) {
+        eventSource.on(event_types.WORLDINFO_RENAMED, onWorldInfoRenamedOrDeleted);
+    }
+    if (event_types.WORLDINFO_DELETED) {
+        eventSource.on(event_types.WORLDINFO_DELETED, name => onWorldInfoRenamedOrDeleted(name));
     }
 
     migrateLegacyRegexSnapshotsForCurrentChat();

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -1624,30 +1624,43 @@ export function loadAgents(data) {
     }
 }
 
+let agentSaveChain = Promise.resolve();
+
 /**
  * Saves an agent to the server. Updates local array.
- * @param {InChatAgent} agent
+ * @param {InChatAgent|string} agent Agent snapshot, or ID when updating the latest saved state
+ * @param {{update?: function}} options A synchronous updater; null skips an obsolete save
  */
-export async function saveAgent(agent) {
-    const normalizedAgent = normalizeAgent(agent);
-    const index = agents.findIndex(existingAgent => existingAgent.id === normalizedAgent.id);
+export async function saveAgent(agent, { update = null } = {}) {
+    const id = typeof agent === 'string' ? agent : agent.id;
+    const snapshot = update ? null : normalizeAgent(structuredClone(agent));
+    // Panel and background updates must merge only after earlier saves have committed.
+    const save = agentSaveChain.then(async () => {
+        const next = update ? update(structuredClone(getAgentById(id))) : snapshot;
+        if (!next) return null;
+        const normalizedAgent = update ? normalizeAgent(next) : next;
+        const response = await fetch('/api/in-chat-agents/save', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify(normalizedAgent),
+        });
 
-    if (index >= 0) {
-        agents[index] = normalizedAgent;
-    } else {
-        agents.push(normalizedAgent);
-    }
-    cacheAgentRegexScriptsForAgent(normalizedAgent);
+        if (!response.ok) {
+            throw new Error('Failed to save agent');
+        }
 
-    const response = await fetch('/api/in-chat-agents/save', {
-        method: 'POST',
-        headers: getRequestHeaders(),
-        body: JSON.stringify(normalizedAgent),
+        // Publish the saved snapshot only after the server accepts it.
+        const index = agents.findIndex(existingAgent => existingAgent.id === normalizedAgent.id);
+        if (index >= 0) {
+            agents[index] = normalizedAgent;
+        } else {
+            agents.push(normalizedAgent);
+        }
+        cacheAgentRegexScriptsForAgent(normalizedAgent);
+        return normalizedAgent;
     });
-
-    if (!response.ok) {
-        throw new Error('Failed to save agent');
-    }
+    agentSaveChain = save.catch(() => {});
+    return save;
 }
 
 /**

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -1721,23 +1721,27 @@ export async function reorderAgentsIntoOrderSlots(orderedSubsetIds) {
  * @param {string} id
  */
 export async function deleteAgent(id) {
-    agents = agents.filter(agent => agent.id !== id);
-    deleteCachedAgentRegexScripts(id);
-    const scopedStateChanged = removeAgentIdFromScopedEnabledAgentIds(id);
+    const deletion = agentSaveChain.then(async () => {
+        agents = agents.filter(agent => agent.id !== id);
+        deleteCachedAgentRegexScripts(id);
+        const scopedStateChanged = removeAgentIdFromScopedEnabledAgentIds(id);
 
-    const response = await fetch('/api/in-chat-agents/delete', {
-        method: 'POST',
-        headers: getRequestHeaders(),
-        body: JSON.stringify({ id }),
+        const response = await fetch('/api/in-chat-agents/delete', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ id }),
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to delete agent');
+        }
+
+        if (scopedStateChanged) {
+            persistAgentGlobalSettings();
+        }
     });
-
-    if (!response.ok) {
-        throw new Error('Failed to delete agent');
-    }
-
-    if (scopedStateChanged) {
-        persistAgentGlobalSettings();
-    }
+    agentSaveChain = deletion.catch(() => {});
+    return deletion;
 }
 
 /**

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -83,7 +83,7 @@ import {
     normalizeRegexScript,
 } from './regex-scripts.js';
 import { initPathfinder, teardownPathfinder } from './pathfinder-init.js';
-import { openPathfinderSettings, isPathfinderAgent } from './pathfinder-settings-ui.js';
+import { openPathfinderSettings, closePathfinderSettings, canClosePathfinderSettings, cancelPathfinderSummary, refreshPathfinderSettings, isPathfinderAgent } from './pathfinder-settings-ui.js';
 import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
 import { appendHelperPrefillMessages } from '../helper-prefill.js';
@@ -130,6 +130,7 @@ let selectModeActive = false;
 const selectedAgentIds = new Set();
 let suppressCardClickUntil = 0;
 let pathfinderExtensionsMountPromise = null;
+let pathfinderExtensionsMountRevision = 0;
 let fixTrackersRunning = false;
 
 const REMOVED_BUNDLED_TEMPLATE_IDS = new Set([
@@ -710,6 +711,7 @@ function sortAgentsByOrder(agentList = []) {
 
 async function toggleAgentEnabled(agent) {
     setAgentEnabledForCurrentScope(agent, !isAgentEnabledForCurrentScope(agent));
+    if (isPathfinderAgent(agent) && !isAgentEnabledForCurrentScope(agent)) cancelPathfinderSummary();
     await saveAgent(agent);
     refreshRegexSnapshotsForAgent(agent.id);
     persistExtensionState();
@@ -5085,6 +5087,8 @@ function getPathfinderSettingsAgent() {
 }
 
 function removePathfinderExtensionsHost() {
+    pathfinderExtensionsMountRevision++;
+    closePathfinderSettings();
     document.getElementById(PATHFINDER_EXTENSIONS_HOST_ID)?.remove();
     pathfinderExtensionsMountPromise = null;
 }
@@ -5115,7 +5119,7 @@ function ensurePathfinderExtensionsHost() {
     return host;
 }
 
-async function mountPathfinderSettingsInExtensions() {
+async function mountPathfinderSettingsInExtensions(agent = getPathfinderSettingsAgent()) {
     if (!isPathfinderSubmoduleEnabled()) {
         removePathfinderExtensionsHost();
         return null;
@@ -5132,7 +5136,9 @@ async function mountPathfinderSettingsInExtensions() {
         return null;
     }
 
-    const agent = getPathfinderSettingsAgent();
+    const mountRevision = ++pathfinderExtensionsMountRevision;
+    closePathfinderSettings();
+    delete host.dataset.pathfinderAgentId;
     body.innerHTML = '';
 
     if (!agent) {
@@ -5140,11 +5146,19 @@ async function mountPathfinderSettingsInExtensions() {
         return host;
     }
 
-    const settingsPanel = await openPathfinderSettings(agent);
-    if (!isPathfinderSubmoduleEnabled()) {
-        removePathfinderExtensionsHost();
+    body.setAttribute('aria-busy', 'true');
+    const settingsPanel = await openPathfinderSettings(agent).catch(error => {
+        if (mountRevision === pathfinderExtensionsMountRevision) {
+            body.setAttribute('aria-busy', 'false');
+            body.innerHTML = '<div class="pf--extensions-empty">Could not load Pathfinder settings.</div>';
+        }
+        throw error;
+    });
+    if (mountRevision !== pathfinderExtensionsMountRevision || !host.isConnected || !isPathfinderSubmoduleEnabled()) {
+        if (settingsPanel) closePathfinderSettings(settingsPanel);
         return null;
     }
+    body.setAttribute('aria-busy', 'false');
 
     if (!settingsPanel) {
         body.innerHTML = '<div class="pf--extensions-empty">Could not load Pathfinder settings.</div>';
@@ -5155,16 +5169,17 @@ async function mountPathfinderSettingsInExtensions() {
     for (const node of settingsPanel.toArray()) {
         body.append(node);
     }
+    host.dataset.pathfinderAgentId = agent.id;
     return host;
 }
 
-function schedulePathfinderExtensionsMount() {
+function schedulePathfinderExtensionsMount(agent) {
     if (!isPathfinderSubmoduleEnabled()) {
         removePathfinderExtensionsHost();
         return Promise.resolve(null);
     }
 
-    pathfinderExtensionsMountPromise = mountPathfinderSettingsInExtensions()
+    pathfinderExtensionsMountPromise = mountPathfinderSettingsInExtensions(agent)
         .catch(error => {
             console.warn('[Pathfinder] Failed to mount settings in Extensions drawer:', error);
             return null;
@@ -5179,8 +5194,9 @@ function scrollElementIntoNearestPanelScroller(element, { block = 'nearest' } = 
     }
 
     const scroller = element.closest('.sb-shell-panel-scroller, .scrollableInner, .scrollableInnerFull');
+    const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
     if (!(scroller instanceof HTMLElement) || scroller.clientHeight <= 0) {
-        element.scrollIntoView({ block, inline: 'nearest', behavior: 'smooth' });
+        element.scrollIntoView({ block, inline: 'nearest', behavior });
         return;
     }
 
@@ -5203,12 +5219,13 @@ function scrollElementIntoNearestPanelScroller(element, { block = 'nearest' } = 
     if (Math.abs(delta) > 1) {
         scroller.scrollTo({
             top: Math.min(Math.max(scroller.scrollTop + delta, 0), Math.max(0, scroller.scrollHeight - scroller.clientHeight)),
-            behavior: 'smooth',
+            behavior,
         });
     }
 }
 
 function openPathfinderExtensionsDrawer(host) {
+    refreshPathfinderSettings();
     const clickEvent = () => new (globalThis.MouseEvent ?? Event)('click', { bubbles: true });
     const drawer = document.getElementById('extensions-settings-button');
     const drawerContent = drawer?.querySelector(':scope > .drawer-content');
@@ -5224,6 +5241,7 @@ function openPathfinderExtensionsDrawer(host) {
     }
 
     globalThis.setTimeout(() => {
+        if (!host?.isConnected) return;
         scrollElementIntoNearestPanelScroller(host, { block: 'start' });
         host?.querySelector('input, button, select, textarea')?.focus?.({ preventScroll: true });
     }, 100);
@@ -5241,38 +5259,28 @@ async function openPathfinderEditor(agent) {
 
     const existingHost = document.getElementById(PATHFINDER_EXTENSIONS_HOST_ID);
     if (existingHost) {
-        const host = await (pathfinderExtensionsMountPromise ?? schedulePathfinderExtensionsMount());
+        const host = await (existingHost.dataset.pathfinderAgentId === agent.id
+            ? (pathfinderExtensionsMountPromise ?? schedulePathfinderExtensionsMount(agent))
+            : schedulePathfinderExtensionsMount(agent));
         openPathfinderExtensionsDrawer(host ?? existingHost);
         toastr.info('Pathfinder settings are in the Extensions drawer.');
         return;
     }
 
-    const originalAgentState = JSON.stringify(agent);
-    const template = findTemplateForAgent(agent);
-    const settingsPanel = await openPathfinderSettings(agent, async (updatedAgent) => {
-        await saveAgent(updatedAgent);
-        renderAgentList();
-    });
+    const settingsPanel = await openPathfinderSettings(agent);
 
     if (!settingsPanel) return;
 
-    const result = await new Popup(settingsPanel, POPUP_TYPE.CONFIRM, '', {
-        okButton: 'Save & Close',
-        cancelButton: 'Cancel',
-        wide: true,
-        large: true,
-    }).show();
-
-    if (result === POPUP_RESULT.AFFIRMATIVE) {
-        if (JSON.stringify(agent) !== originalAgentState || agent.phaseLocked) {
-            lockBundledAgentCustomization(agent, template);
-        }
-
-        // Settings are already saved via the UI callbacks
-        await saveAgent(agent);
+    try {
+        await new Popup(settingsPanel, POPUP_TYPE.TEXT, '', {
+            okButton: 'Close',
+            wide: true,
+            large: true,
+            onClosing: () => canClosePathfinderSettings(settingsPanel),
+        }).show();
+    } finally {
+        closePathfinderSettings(settingsPanel);
         renderAgentList();
-        syncToolAgentRegistrations();
-        toastr.success('Pathfinder settings saved');
     }
 }
 
@@ -5777,6 +5785,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     $('#ica--globalEnabled').on('click', () => {
         const enabled = !areAgentsGloballyEnabled();
         setGlobalSettings({ enabled });
+        if (!enabled) cancelPathfinderSummary();
         persistExtensionState();
         updateGlobalAgentToggle();
         syncToolAgentRegistrations();
@@ -5912,6 +5921,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
             const agent = getAgentById(id);
             if (agent && isAgentEnabledForCurrentScope(agent)) {
                 setAgentEnabledForCurrentScope(agent, false);
+                if (isPathfinderAgent(agent)) cancelPathfinderSummary();
                 await saveAgent(agent);
                 changed = true;
             }

--- a/public/scripts/extensions/in-chat-agents/pathfinder-init.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-init.js
@@ -1,5 +1,6 @@
 import { getSettings, setSettings, isLorebookEnabled, setLorebookEnabled, clearAllTrees } from './pathfinder/tree-store.js';
-import { initEntryManagerAPIs } from './pathfinder/entry-manager.js';
+import { initEntryManagerAPIs, onPathfinderWorldInfoUpdated } from './pathfinder/entry-manager.js';
+import { getSummaryMemoryState } from './pathfinder/summary-memory-store.js';
 import { initActivityFeed } from './pathfinder/activity-feed.js';
 import { isPathfinderSubmoduleEnabled } from './agent-store.js';
 import { unregisterToolAction, unregisterToolFormatter } from './tool-action-registry.js';
@@ -24,6 +25,7 @@ import { initializePromptStore } from './pathfinder/prompts/prompt-store.js';
 import { getDefaultPrompts, getDefaultPipelines } from './pathfinder/prompts/default-prompts.js';
 
 let initialized = false;
+let initializationRevision = 0;
 
 function registerPathfinderToolActions() {
     registerSearchActions();
@@ -55,6 +57,7 @@ export function initPathfinder(context) {
 
     if (initialized) return;
     initialized = true;
+    const revision = ++initializationRevision;
 
     registerPathfinderToolActions();
 
@@ -67,6 +70,16 @@ export function initPathfinder(context) {
     const missingEntryManagerAPIs = entryManagerAPIs.filter(api => !context?.[api]);
     if (missingEntryManagerAPIs.length === 0) {
         initEntryManagerAPIs(context.loadWorldInfo, context.createWorldInfoEntry, context.saveWorldInfo);
+        const summary = getSummaryMemoryState();
+        if (summary.bookName && summary.uid !== null) {
+            // Changes made while disabled or offline may not have delivered a book event.
+            void Promise.resolve().then(() => context.loadWorldInfo(summary.bookName)).then(data => {
+                if (initialized && revision === initializationRevision
+                    && JSON.stringify(getSummaryMemoryState()) === JSON.stringify(summary)) {
+                    onPathfinderWorldInfoUpdated(summary.bookName, data);
+                }
+            }).catch(error => console.warn(error));
+        }
     } else {
         console.error(`[Pathfinder] Missing context APIs for lorebook writes: ${missingEntryManagerAPIs.join(', ')}`);
     }
@@ -94,6 +107,7 @@ export function teardownPathfinder() {
     // lorebook edits made while Pathfinder was off.
     clearAllTrees();
     initialized = false;
+    initializationRevision++;
     console.info('[Pathfinder] Disabled and unregistered.');
 }
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -3,33 +3,27 @@
  */
 
 import { renderExtensionTemplateAsync, getContext } from '../../extensions.js';
-import { saveSettingsDebounced } from '../../../script.js';
+import { eventSource, event_types, online_status } from '../../../script.js';
 import { accountStorage } from '../../util/AccountStorage.js';
 import { escapeHtml } from '../../utils.js';
 import { attachTextareaFullscreen } from './textarea-fullscreen.js';
-import { world_names, loadWorldInfo } from '../../world-info.js';
-import { isAgentEnabledForCurrentScope, isPathfinderSubmoduleEnabled, persistAgentGlobalSettings, saveAgent, setAgentEnabledForCurrentScope } from './agent-store.js';
+import { world_names } from '../../world-info.js';
+import { areAgentsGloballyEnabled, getActiveAgentChatScope, getAgentById, getGlobalSettings, isAgentEnabledForCurrentScope, isPathfinderSubmoduleEnabled, persistAgentGlobalSettings, saveAgent, setAgentEnabledForScope } from './agent-store.js';
+import { runDiagnostics } from './pathfinder-init.js';
 import {
-    getPathfinderSettings,
-    setPathfinderSettings,
-    runDiagnostics,
-} from './pathfinder-init.js';
-import {
-    setLorebookEnabled,
+    SETTING_DEFAULTS,
+    replaceSettings,
     listConnectionProfiles,
     normalizeAutoSummaryInterval,
-    isPathfinderToolEnabled as isRuntimePathfinderToolEnabled,
-    setPathfinderToolEnabled as setRuntimePathfinderToolEnabled,
-    setBookPermission,
     canReadBook,
     canWriteBook,
     canDeleteBook,
 } from './pathfinder/tree-store.js';
-import { buildTreeFromMetadata } from './pathfinder/tree-builder.js';
-import { syncToolAgentRegistrations } from './agent-runner.js';
-import { ALL_TOOL_NAMES, CONFIRMABLE_TOOLS, getContextualLorebookDetails } from './pathfinder/pathfinder-tool-bridge.js';
-import { getPrompt, savePrompt } from './pathfinder/prompts/prompt-store.js';
-import { getDefaultPrompts } from './pathfinder/prompts/default-prompts.js';
+import { getAgentGenerationContext, getAgentGenerationCancelRevision, getPathfinderRuntimeAgent, isAgentGenerationStopped, isPathfinderToolEnabledForAgent, onAgentGenerationStateChanged, syncToolAgentRegistrations } from './agent-runner.js';
+import { ALL_TOOL_NAMES, CONFIRMABLE_TOOLS, getActiveTunnelVisionBooks, getReadableBooks, getWritableBooks, getContextualLorebookDetails, resolveTargetBook } from './pathfinder/pathfinder-tool-bridge.js';
+import { initializePromptStore } from './pathfinder/prompts/prompt-store.js';
+import { getDefaultPrompts, getDefaultPipelines } from './pathfinder/prompts/default-prompts.js';
+import { populateConnectionProfileSelect } from './profile-utils.js';
 import { clearFeed, getFeedItems } from './pathfinder/activity-feed.js';
 import { getSummaryMemoryState, onSummaryMemoryChanged, saveSummaryMemoryContent } from './pathfinder/summary-memory-store.js';
 import { sidecarGenerate } from './pathfinder/llm-sidecar.js';
@@ -44,9 +38,48 @@ const DEFAULT_PIPELINE_MAX_TOKENS = 64000;
 
 let settingsEl = null;
 let currentAgent = null;
+let settingsSession = null;
+let settingsOpenRevision = 0;
 let retrievalLogMode = safeGetAccountStorageItem(PATHFINDER_LOG_MODE_KEY) === 'detailed' ? 'detailed' : 'summary';
-let summaryMemoryUnsubscribe = null;
-let summaryMemoryPanelSeenConnected = false;
+
+export function cancelPathfinderSummary() {
+    settingsSession?.summaryController?.abort();
+}
+
+export function closePathfinderSettings(panel = settingsEl) {
+    if (panel !== settingsEl) return;
+    settingsOpenRevision++;
+    settingsSession?.summaryController?.abort();
+    settingsSession?.cleanup.forEach(dispose => dispose());
+    settingsEl?.off().find('*').off();
+    settingsEl?.find('input, button, select, textarea').prop('disabled', true);
+    settingsSession = null;
+    settingsEl = null;
+    currentAgent = null;
+}
+
+export async function canClosePathfinderSettings(panel) {
+    const session = settingsSession;
+    if (session?.element !== panel) return true;
+    const hadPendingSave = session.pending > 0;
+    cancelPathfinderSummary();
+    await agentSettingsSaveChain;
+    // A newly failed save stays visible for retry; a subsequent Close must still work offline.
+    return settingsSession !== session || (session.pending === 0
+        && (!hadPendingSave || (session.dirtySettings.size === 0 && session.enabledChange === undefined)));
+}
+
+export function refreshPathfinderSettings() {
+    if (!settingsSession) return;
+    const saved = getAgentById(currentAgent.id);
+    if (!saved) return;
+    const edits = Object.fromEntries([...settingsSession.dirtySettings].map(key => [key, currentAgent.settings[key]]));
+    currentAgent.settings = structuredClone({ ...SETTING_DEFAULTS, ...saved.settings, ...edits });
+    if (!settingsSession.dirtySettings.has('toolStates')) currentAgent.tools = structuredClone(saved.tools ?? []);
+    refreshLorebookList();
+    updateModeCardStates();
+    updateStatusBanner();
+}
 
 function safeGetAccountStorageItem(key) {
     try {
@@ -109,7 +142,9 @@ function setSectionCollapsedPreference(sectionKey, collapsed) {
 }
 
 function setSectionChevronState(section, collapsed) {
-    const chevron = section.children('.pf--collapsible-header').first().find('.pf--chevron').first();
+    const header = section.children('.pf--collapsible-header').first();
+    const chevron = header.find('.pf--chevron').first();
+    header.attr('aria-expanded', String(!collapsed));
     chevron.toggleClass('fa-chevron-down', !collapsed);
     chevron.toggleClass('fa-chevron-right', collapsed);
 }
@@ -120,11 +155,9 @@ function applyPersistedCollapseStates() {
     settingsEl.find('.pf--section-collapsible').each(function () {
         const section = $(this);
         const sectionKey = getCollapseSectionKey(section);
-        if (!sectionKey || !Object.prototype.hasOwnProperty.call(states, sectionKey)) {
-            return;
-        }
-
-        const collapsed = states[sectionKey] === true;
+        const collapsed = Object.hasOwn(states, sectionKey)
+            ? states[sectionKey] === true
+            : section.children('.pf--collapsible-header').attr('aria-expanded') === 'false';
         section.children('.pf--section-body').first().toggle(!collapsed);
         setSectionChevronState(section, collapsed);
     });
@@ -136,33 +169,6 @@ function ensureEnabledLorebooks(settings) {
     }
 
     return settings.enabledLorebooks;
-}
-
-function addUniqueLorebookName(names, name) {
-    const bookName = String(name ?? '').trim();
-    if (bookName && !names.includes(bookName)) {
-        names.push(bookName);
-    }
-}
-
-function getActiveLorebookNames(settings, lorebooks = []) {
-    const names = [...ensureEnabledLorebooks(settings)];
-
-    if (settings.autoUseAttachedLorebook || settings.autoSyncLorebooksOnChatChange !== false) {
-        for (const book of lorebooks) {
-            if (book.attached) {
-                addUniqueLorebookName(names, book.name);
-            }
-        }
-    }
-
-    if (settings.includeContextualLorebooks !== false) {
-        for (const source of getContextualLorebookDetails()) {
-            addUniqueLorebookName(names, source.name);
-        }
-    }
-
-    return names;
 }
 
 function getEffectiveLorebooks(lorebooks, settings) {
@@ -177,15 +183,14 @@ function getEffectiveLorebooks(lorebooks, settings) {
         const sourceTypes = Array.isArray(source.types) ? new Set(source.types) : new Set([source.type || 'attached']);
         booksByName.set(source.name, {
             name: source.name,
-            entries: '?',
             attached: true,
             sourceTypes,
             type: formatLorebookSourceLabel(sourceTypes),
         });
     }
 
-    return getActiveLorebookNames(settings, allBooks)
-        .map(name => booksByName.get(name) ?? { name, entries: '?', attached: false, type: 'lorebook' })
+    return getActiveTunnelVisionBooks(settings)
+        .map(name => booksByName.get(name) ?? { name, attached: false, type: 'lorebook' })
         .filter(book => book?.name);
 }
 
@@ -206,14 +211,9 @@ function upsertLorebook(lorebooksByName, name, data = {}) {
 
     const book = lorebooksByName.get(name) ?? {
         name,
-        entries: '?',
         attached: false,
         sourceTypes: new Set(),
     };
-
-    if (data.entries !== undefined) {
-        book.entries = data.entries;
-    }
 
     if (data.type) {
         book.sourceTypes.add(data.type);
@@ -223,76 +223,6 @@ function upsertLorebook(lorebooksByName, name, data = {}) {
     }
 
     lorebooksByName.set(name, book);
-}
-
-async function ensureLorebookTree(bookName) {
-    try {
-        const bookData = await loadWorldInfo(bookName);
-        if (!bookData?.entries) {
-            console.warn(`${PATHFINDER_LOG_PREFIX} Lorebook "${bookName}" could not be loaded for tree building.`);
-            return false;
-        }
-
-        await buildTreeFromMetadata(bookName, bookData);
-        return true;
-    } catch (err) {
-        console.warn(`${PATHFINDER_LOG_PREFIX} Failed to build tree for lorebook "${bookName}".`, err);
-        return false;
-    }
-}
-
-// Counterpart of syncPathfinderAgentLorebooksForCurrentChat (agent-runner.js),
-// which handles the CHAT_CHANGED trigger; both derive the book set from
-// getContextualLorebookDetails, so keep the two in sync.
-async function syncAutoAttachedLorebooks(lorebooks, settings) {
-    if (!settings.autoUseAttachedLorebook && !settings.autoSyncLorebooksOnChatChange) {
-        return [];
-    }
-
-    const enabledLorebooks = [...ensureEnabledLorebooks(settings)];
-    const attachedLorebooks = lorebooks.filter(book => book.attached).map(book => book.name);
-    const syncedLorebooks = Array.from(new Set(attachedLorebooks));
-    const selectedLorebook = syncedLorebooks[0] ?? '';
-    const autoSyncChanged = settings.autoSyncLorebooksOnChatChange
-        && (enabledLorebooks.length !== syncedLorebooks.length
-            || enabledLorebooks.some((name, index) => name !== syncedLorebooks[index])
-            || (settings.selectedLorebook ?? '') !== selectedLorebook);
-    if (settings.autoSyncLorebooksOnChatChange) {
-        settings.enabledLorebooks = syncedLorebooks;
-        settings.selectedLorebook = selectedLorebook;
-        setPathfinderSettings(settings);
-    }
-
-    const newLorebooks = attachedLorebooks.filter(name => !enabledLorebooks.includes(name));
-
-    if (attachedLorebooks.length === 0) {
-        if (autoSyncChanged) {
-            return enabledLorebooks;
-        }
-        return [];
-    }
-
-    if (!settings.autoSyncLorebooksOnChatChange) {
-        settings.enabledLorebooks = Array.from(new Set([...enabledLorebooks, ...attachedLorebooks]));
-        if (!settings.selectedLorebook || !settings.enabledLorebooks.includes(settings.selectedLorebook)) {
-            settings.selectedLorebook = settings.enabledLorebooks[0] ?? '';
-        }
-    }
-    attachedLorebooks.forEach(bookName => setLorebookEnabled(bookName, true));
-    setPathfinderSettings(settings);
-
-    if (newLorebooks.length > 0) {
-        for (const bookName of newLorebooks) {
-            await ensureLorebookTree(bookName);
-        }
-    }
-
-    if (autoSyncChanged) {
-        const removedLorebooks = enabledLorebooks.filter(name => !syncedLorebooks.includes(name));
-        return Array.from(new Set([...newLorebooks, ...removedLorebooks]));
-    }
-
-    return newLorebooks;
 }
 
 /**
@@ -305,29 +235,71 @@ export async function openPathfinderSettings(agent) {
         return null;
     }
 
-    currentAgent = agent;
-    const existingSettings = getPathfinderSettings();
-    setPathfinderSettings({
-        pipelinePrompts: existingSettings.pipelinePrompts,
-        pipelines: existingSettings.pipelines,
-        ...(agent?.settings || {}),
-    });
-
+    closePathfinderSettings();
+    const openRevision = settingsOpenRevision;
     const html = await renderExtensionTemplateAsync(MODULE_NAME, 'pathfinder-settings');
+    if (openRevision !== settingsOpenRevision || !isPathfinderSubmoduleEnabled()) return null;
     if (!html) {
         toastr.error('Could not load Pathfinder settings.');
         return null;
     }
 
     settingsEl = $(html);
-    if (summaryMemoryUnsubscribe) {
-        summaryMemoryUnsubscribe();
+    currentAgent = structuredClone(getAgentById(agent.id) ?? agent);
+    currentAgent.settings = structuredClone({ ...SETTING_DEFAULTS, ...currentAgent.settings });
+    const session = settingsSession = {
+        element: settingsEl,
+        agent: currentAgent,
+        revision: 0,
+        contextRevision: 0,
+        pending: 0,
+        dirtySettings: new Set(),
+        cleanup: [],
+        summaryDraft: null,
+        summaryBusy: false,
+        summaryController: null,
+    };
+    session.cleanup.push(onSummaryMemoryChanged(() => {
+        if (settingsSession === session) renderSummaryMemoryEditor();
+    }));
+    session.cleanup.push(onAgentGenerationStateChanged(refreshPathfinderSettings));
+    const refreshContext = () => {
+        session.summaryController?.abort();
+        // A chat switch invalidates queued edits; the runner owns auto-sync.
+        session.contextRevision++;
+        session.dirtySettings.clear();
+        session.enabledChange = undefined;
+        session.element.find('#pf--settings-save-status').text('');
+        session.element.find('#pf--settings-retry').hide();
+        refreshPathfinderSettings();
+        loadSettingsIntoUI();
+    };
+    eventSource.on(event_types.CHAT_CHANGED, refreshContext);
+    session.cleanup.push(() => eventSource.removeListener(event_types.CHAT_CHANGED, refreshContext));
+    const refreshStatus = () => {
+        updateStatusBanner();
+        populateConnectionProfiles();
+    };
+    for (const event of [
+        event_types.SETTINGS_UPDATED,
+        event_types.MAIN_API_CHANGED,
+        event_types.ONLINE_STATUS_CHANGED,
+        event_types.CHATCOMPLETION_SOURCE_CHANGED,
+        event_types.CHATCOMPLETION_MODEL_CHANGED,
+        event_types.OAI_PRESET_CHANGED_AFTER,
+        event_types.GENERATION_ENDED,
+        event_types.GENERATION_STOPPED,
+        event_types.CONNECTION_PROFILE_LOADED,
+        event_types.CONNECTION_PROFILE_CREATED,
+        event_types.CONNECTION_PROFILE_UPDATED,
+        event_types.CONNECTION_PROFILE_DELETED,
+    ].filter(Boolean)) {
+        eventSource.on(event, refreshStatus);
+        session.cleanup.push(() => eventSource.removeListener(event, refreshStatus));
     }
-    summaryMemoryPanelSeenConnected = false;
-    summaryMemoryUnsubscribe = onSummaryMemoryChanged(renderSummaryMemoryEditor);
 
     // Initialize UI
-    await refreshLorebookList();
+    refreshLorebookList();
     applyQuickstartDismissalState();
     loadSettingsIntoUI();
     applyPersistedCollapseStates();
@@ -345,7 +317,7 @@ export async function openPathfinderSettings(agent) {
 /**
  * Get available lorebooks from current context
  */
-async function getAvailableLorebooks() {
+function getAvailableLorebooks() {
     const ctx = getContext();
     if (!ctx && !globalThis.window?.SillyTavern?.getContext?.() && (!Array.isArray(world_names) || world_names.length === 0)) {
         console.warn(`${PATHFINDER_LOG_PREFIX} Could not resolve the current context while gathering lorebooks.`);
@@ -354,26 +326,9 @@ async function getAvailableLorebooks() {
 
     const lorebooksByName = new Map();
 
-    // Use the global world_names array from world-info.js
-    if (Array.isArray(world_names) && world_names.length > 0) {
-        for (const name of world_names) {
-            try {
-                // Try to load the world info to get entry count
-                const bookData = await loadWorldInfo(name);
-                const entryCount = bookData?.entries ? Object.keys(bookData.entries).length : '?';
-                upsertLorebook(lorebooksByName, name, {
-                    entries: entryCount,
-                    type: 'global',
-                });
-            } catch (err) {
-                // If we can't load it, just add with unknown count
-                console.warn(`${PATHFINDER_LOG_PREFIX} Failed to load lorebook metadata for "${name}".`, err);
-                upsertLorebook(lorebooksByName, name, {
-                    entries: '?',
-                    type: 'global',
-                });
-            }
-        }
+    // Counts and waypoint builds belong to retrieval, not opening settings.
+    for (const name of world_names ?? []) {
+        upsertLorebook(lorebooksByName, name, { type: 'global' });
     }
 
     for (const source of getContextualLorebookDetails()) {
@@ -384,15 +339,10 @@ async function getAvailableLorebooks() {
                 book.sourceTypes.add(type);
             }
         }
+    }
 
-        if (book?.entries === '?') {
-            try {
-                const bookData = await loadWorldInfo(source.name);
-                book.entries = bookData?.entries ? Object.keys(bookData.entries).length : '?';
-            } catch {
-                // Keep unknown count for contextual books that are not importable as standalone lorebooks.
-            }
-        }
+    for (const name of ensureEnabledLorebooks(currentAgent.settings)) {
+        upsertLorebook(lorebooksByName, name);
     }
 
     const lorebooks = Array.from(lorebooksByName.values()).map(book => ({
@@ -406,21 +356,14 @@ async function getAvailableLorebooks() {
 /**
  * Refresh the lorebook list in the UI
  */
-async function refreshLorebookList() {
+function refreshLorebookList() {
     const listEl = settingsEl.find('#pf--lorebook-list');
     listEl.empty();
 
-    const lorebooks = await getAvailableLorebooks();
-    const settings = getPathfinderSettings();
+    const lorebooks = getAvailableLorebooks();
+    const settings = currentAgent.settings;
     ensureEnabledLorebooks(settings);
-
-    settingsEl.find('#pf--auto-use-attached').prop('checked', Boolean(settings.autoUseAttachedLorebook));
-    const autoEnabledLorebooks = await syncAutoAttachedLorebooks(lorebooks, settings);
-    if (autoEnabledLorebooks.length > 0) {
-        await updateAgentSettings();
-        updateStatusBanner();
-    }
-    const enabledBooks = getActiveLorebookNames(getPathfinderSettings(), lorebooks);
+    const enabledBooks = getActiveTunnelVisionBooks(settings);
 
     if (lorebooks.length === 0) {
         listEl.html(`
@@ -433,52 +376,17 @@ async function refreshLorebookList() {
         return;
     }
 
-    for (const book of lorebooks) {
+    for (const [index, book] of lorebooks.entries()) {
         const isEnabled = enabledBooks.includes(book.name);
         const item = $(`
-            <div class="pf--lorebook-item ${isEnabled ? 'selected' : ''}" data-book="${escapeHtml(book.name)}">
-                <input type="checkbox" ${isEnabled ? 'checked' : ''} />
-                <div class="pf--lorebook-info">
-                    <span class="pf--lorebook-name">${escapeHtml(book.name)}</span>
-                    <span class="pf--lorebook-meta">${book.entries} entries · ${book.type}</span>
-                </div>
-            </div>
+            <label class="pf--lorebook-item ${isEnabled ? 'selected' : ''}" data-book="${escapeHtml(book.name)}">
+                <input type="checkbox" aria-labelledby="pf--lorebook-name-${index}" ${isEnabled ? 'checked' : ''} />
+                <span class="pf--lorebook-info">
+                    <span class="pf--lorebook-name" id="pf--lorebook-name-${index}">${escapeHtml(book.name)}</span>
+                    <span class="pf--lorebook-meta">${escapeHtml(book.type)}</span>
+                </span>
+            </label>
         `);
-
-        item.on('click', async function (e) {
-            if (e.target.tagName === 'INPUT') return;
-            const checkbox = $(this).find('input[type="checkbox"]');
-            checkbox.prop('checked', !checkbox.prop('checked')).trigger('change');
-        });
-
-        item.find('input').on('change', async function () {
-            const bookName = item.data('book');
-            const checked = $(this).prop('checked');
-
-            item.toggleClass('selected', checked);
-
-            // Update settings
-            const s = getPathfinderSettings();
-            ensureEnabledLorebooks(s);
-
-            if (checked && !s.enabledLorebooks.includes(bookName)) {
-                s.enabledLorebooks.push(bookName);
-                s.selectedLorebook = s.selectedLorebook || bookName;
-                setLorebookEnabled(bookName, true);
-                await ensureLorebookTree(bookName);
-            } else if (!checked) {
-                s.enabledLorebooks = s.enabledLorebooks.filter(b => b !== bookName);
-                if (s.selectedLorebook === bookName) {
-                    s.selectedLorebook = s.enabledLorebooks[0] ?? '';
-                }
-                setLorebookEnabled(bookName, false);
-            }
-
-            setPathfinderSettings(s);
-            updateAgentSettings();
-            updateStatusBanner();
-            renderPermissionMatrix(lorebooks);
-        });
 
         listEl.append(item);
     }
@@ -488,7 +396,6 @@ async function refreshLorebookList() {
 
 
 function setPathfinderToolEnabled(toolName, enabled) {
-    setRuntimePathfinderToolEnabled(toolName, enabled);
     if (!currentAgent) {
         return;
     }
@@ -512,15 +419,7 @@ function setPathfinderToolEnabled(toolName, enabled) {
 }
 
 function isPathfinderToolEnabled(toolName) {
-    const fallbackTool = Array.isArray(currentAgent?.tools)
-        ? currentAgent.tools.find(t => t.name === toolName)
-        : null;
-
-    if (currentAgent?.settings?.toolStates && Object.hasOwn(currentAgent.settings.toolStates, toolName)) {
-        return currentAgent.settings.toolStates[toolName] !== false;
-    }
-
-    return isRuntimePathfinderToolEnabled(toolName, fallbackTool?.enabled !== false);
+    return isPathfinderToolEnabledForAgent(currentAgent, toolName);
 }
 
 function getToolLabel(toolName) {
@@ -566,7 +465,7 @@ function renderConfirmToggles() {
         return;
     }
 
-    const confirmTools = getPathfinderSettings().confirmTools ?? {};
+    const confirmTools = currentAgent.settings.confirmTools ?? {};
     confirmList.empty();
     for (const toolName of ALL_TOOL_NAMES) {
         if (!CONFIRMABLE_TOOLS.has(toolName)) {
@@ -590,22 +489,23 @@ function renderPermissionMatrix(lorebooks = null) {
         return;
     }
 
-    const books = getEffectiveLorebooks(lorebooks, getPathfinderSettings());
+    const settings = currentAgent.settings;
+    const books = getEffectiveLorebooks(lorebooks, settings);
 
     if (books.length === 0) {
         matrix.html('<div class="pf--empty-state pf--permission-empty"><i class="fa-solid fa-lock-open"></i><span>Select a lorebook above, or attach one to the current character/chat with auto-select enabled.</span></div>');
         return;
     }
 
-    const rows = books.map(book => `
-        <div class="pf--permission-row" data-book="${escapeHtml(book.name)}">
+    const rows = books.map((book, index) => `
+        <div class="pf--permission-row" data-book="${escapeHtml(book.name)}" role="group" aria-labelledby="pf--permission-book-${index}">
             <div class="pf--permission-book">
-                <strong>${escapeHtml(book.name)}</strong>
+                <strong id="pf--permission-book-${index}">${escapeHtml(book.name)}</strong>
                 <span>${escapeHtml(book.type || 'lorebook')}</span>
             </div>
-            <label class="checkbox_label"><input type="checkbox" data-permission="read" ${canReadBook(book.name) ? 'checked' : ''} /><span>Read</span></label>
-            <label class="checkbox_label"><input type="checkbox" data-permission="write" ${canWriteBook(book.name) ? 'checked' : ''} /><span>Write</span></label>
-            <label class="checkbox_label"><input type="checkbox" data-permission="delete" ${canDeleteBook(book.name) ? 'checked' : ''} /><span>Delete</span></label>
+            <label class="checkbox_label"><input type="checkbox" data-permission="read" aria-labelledby="pf--permission-book-${index} pf--permission-read-${index}" ${canReadBook(book.name, settings) ? 'checked' : ''} /><span id="pf--permission-read-${index}">Read</span></label>
+            <label class="checkbox_label"><input type="checkbox" data-permission="write" aria-labelledby="pf--permission-book-${index} pf--permission-write-${index}" ${canWriteBook(book.name, settings) ? 'checked' : ''} /><span id="pf--permission-write-${index}">Write</span></label>
+            <label class="checkbox_label"><input type="checkbox" data-permission="delete" aria-labelledby="pf--permission-book-${index} pf--permission-delete-${index}" ${canDeleteBook(book.name, settings) ? 'checked' : ''} /><span id="pf--permission-delete-${index}">Delete</span></label>
         </div>
     `).join('');
 
@@ -621,9 +521,9 @@ function readPromptMaxTokens() {
  * Load current settings into UI elements
  */
 function loadSettingsIntoUI() {
-    const s = getPathfinderSettings();
+    const s = currentAgent.settings;
 
-    settingsEl.find('#pf--master-enable').prop('checked', currentAgent ? isAgentEnabledForCurrentScope(currentAgent) : false);
+    settingsEl.find('#pf--master-enable').prop('checked', settingsSession.enabledChange ?? isAgentEnabledForCurrentScope(getAgentById(currentAgent.id) ?? currentAgent));
 
     // Pipeline settings
     settingsEl.find('#pf--enable-pipeline').prop('checked', s.pipelineEnabled || false);
@@ -638,6 +538,7 @@ function loadSettingsIntoUI() {
     settingsEl.find('#pf--mandatory-tools').prop('checked', s.mandatoryTools || false);
     settingsEl.find('#pf--auto-use-attached').prop('checked', s.autoUseAttachedLorebook || false);
     settingsEl.find('#pf--auto-sync-lorebooks').prop('checked', s.autoSyncLorebooksOnChatChange !== false);
+    settingsEl.find('#pf--include-contextual-lorebooks').prop('checked', s.includeContextualLorebooks !== false);
     settingsEl.find('#pf--dedupe-natural-activation').prop('checked', s.dedupeNaturalActivation !== false);
     settingsEl.find('#pf--auto-summary').prop('checked', s.autoSummary || false);
     settingsEl.find('#pf--auto-summary-interval').val(s.autoSummaryInterval ?? 20);
@@ -660,19 +561,10 @@ function loadSettingsIntoUI() {
  * Populate connection profile dropdowns
  */
 function populateConnectionProfiles() {
-    const profiles = listConnectionProfiles();
-    const select = settingsEl.find('#pf--pipeline-profile');
-
-    select.find('option:not(:first)').remove();
-
-    for (const profile of profiles) {
-        select.append(`<option value="${escapeHtml(profile.id)}">${escapeHtml(profile.name || profile.id)}</option>`);
-    }
-
-    const s = getPathfinderSettings();
-    if (s.connectionProfile) {
-        select.val(s.connectionProfile);
-    }
+    populateConnectionProfileSelect(settingsEl.find('#pf--pipeline-profile')[0], {
+        emptyLabel: 'Use main model',
+        selectedValue: currentAgent.settings.connectionProfile ?? '',
+    });
 }
 
 
@@ -689,35 +581,23 @@ function renderSummaryMemoryEditor() {
         return;
     }
 
-    // The panel is created detached and mounted by the caller; nothing fires
-    // on close. Track the first time it is seen in the DOM, and once it is
-    // gone again drop the listener so it stops holding the detached panel.
-    if (settingsEl[0]?.isConnected) {
-        summaryMemoryPanelSeenConnected = true;
-    } else if (summaryMemoryPanelSeenConnected) {
-        if (summaryMemoryUnsubscribe) {
-            summaryMemoryUnsubscribe();
-            summaryMemoryUnsubscribe = null;
-        }
-        settingsEl = null;
-        return;
-    }
-
     const summary = getSummaryMemoryState();
     const textarea = settingsEl.find('#pf--summary-content');
     const indicator = settingsEl.find('#pf--summary-injection-indicator');
     const meta = settingsEl.find('#pf--summary-meta');
-    const hasSummary = Boolean(summary.content || summary.uid);
-    const currentContent = String(textarea.val() || summary.content || '').trim();
+    const hasSummary = Boolean(summary.content || summary.uid !== null || settingsSession.summaryDraft);
+    const draft = settingsSession.summaryDraft;
+    const currentContent = String(draft?.content ?? summary.content ?? '').trim();
 
-    if (document.activeElement !== textarea[0]) {
-        textarea.val(summary.content || '');
+    if (!draft) {
+        textarea.val(summary.content ?? '');
     }
 
     textarea.prop('disabled', !hasSummary);
-    settingsEl.find('#pf--summary-save').prop('disabled', !hasSummary);
-    settingsEl.find('#pf--summary-save-entry').prop('disabled', !currentContent);
-    settingsEl.find('#pf--summary-create').toggle(!hasSummary).prop('disabled', hasSummary);
+    const busy = settingsSession.summaryBusy || settingsSession.pending > 0;
+    settingsEl.find('#pf--summary-save').prop('disabled', !hasSummary || busy);
+    settingsEl.find('#pf--summary-save-entry').prop('disabled', !currentContent || busy);
+    settingsEl.find('#pf--summary-create').toggle(!hasSummary).prop('disabled', hasSummary || busy);
 
     indicator.removeClass('pf--summary-indicator-missing pf--summary-indicator-not-injected pf--summary-indicator-injected');
     if (!hasSummary) {
@@ -737,12 +617,12 @@ function renderSummaryMemoryEditor() {
     const location = summary.bookName && summary.uid !== null ? `${summary.bookName} / UID ${summary.uid}` : 'not linked to a lorebook entry';
     const updated = summary.updatedAt ? `Updated ${formatSummaryTimestamp(summary.updatedAt)}` : 'Not saved yet';
     const injected = summary.injectedAt ? `Last injected ${formatSummaryTimestamp(summary.injectedAt)}${summary.injectedMode ? ` via ${summary.injectedMode}` : ''}` : 'Not injected by retrieval yet';
-    meta.text(`${title} — ${location}. ${updated}. ${injected}.`);
+    meta.text(`${title} - ${location}. ${updated}. ${injected}.`);
 }
 
 function getSummaryEditorDraft() {
-    const summary = getSummaryMemoryState();
-    const content = String(settingsEl.find('#pf--summary-content').val() || summary.content || '').trim();
+    const summary = settingsSession.summaryDraft?.source ?? getSummaryMemoryState();
+    const content = String(settingsEl.find('#pf--summary-content').val() ?? '').trim();
     return {
         title: deriveSummaryLorebookTitle({
             title: summary.title,
@@ -752,8 +632,16 @@ function getSummaryEditorDraft() {
         content,
         significance: summary.significance || 'medium',
         arc: summary.arc || '',
-        book: summary.bookName || getPathfinderSettings().selectedLorebook || '',
+        book: summary.bookName || currentAgent.settings.selectedLorebook || '',
     };
+}
+
+function assertSummarySource(expected) {
+    const current = getSummaryMemoryState();
+    if (['bookName', 'uid', 'title', 'content'].some(key => expected[key] !== current[key])) {
+        throw new Error('The summary or its linked entry changed while the user was editing. Saves are blocked to prevent overwriting.');
+    }
+    return current;
 }
 
 function getRecentChatForSummary(maxMessages = 24) {
@@ -812,6 +700,13 @@ function parseGeneratedSummary(rawSummary) {
 }
 
 async function createManualSummaryMemory() {
+    const session = settingsSession;
+    const generation = getAgentGenerationContext();
+    const alreadyStopped = isAgentGenerationStopped();
+    const agentId = currentAgent.id;
+    const agent = getAgentById(agentId) ?? currentAgent;
+    const targetBook = resolveTargetBook(agent.settings?.selectedLorebook, getWritableBooks());
+    if (!targetBook) throw new Error('No Pathfinder-enabled lorebooks available for writing.');
     const recentChat = getRecentChatForSummary();
     if (!recentChat) {
         throw new Error('No recent chat messages are available to summarize.');
@@ -825,270 +720,209 @@ Return only a compact JSON object with this shape:
 Recent chat:
 ${recentChat}`;
 
-    const rawSummary = await sidecarGenerate(
-        prompt,
-        'You create concise long-term memory summaries for creative roleplay. Preserve names, changed state, unresolved threads, and why the scene matters. Return valid JSON only.',
-    );
-    const summary = parseGeneratedSummary(rawSummary);
+    const controller = session.summaryController = new AbortController();
+    const isCurrent = () => {
+        const liveAgent = getAgentById(agentId);
+        const context = getAgentGenerationContext();
+        return settingsSession === session && !controller.signal.aborted
+            && generation.chatId === context.chatId && generation.runId === context.runId
+            && generation.cancelRevision === getAgentGenerationCancelRevision()
+            && (alreadyStopped || !isAgentGenerationStopped())
+            && areAgentsGloballyEnabled() && isPathfinderSubmoduleEnabled()
+            && liveAgent && isAgentEnabledForCurrentScope(liveAgent)
+            && getPathfinderRuntimeAgent()?.id === agentId
+            && getWritableBooks().includes(targetBook);
+    };
+    const checkCurrent = () => {
+        if (!isCurrent()) controller.abort();
+    };
+    const unsubscribe = onAgentGenerationStateChanged(checkCurrent);
+    session.cleanup.push(unsubscribe);
+    try {
+        checkCurrent();
+        controller.signal.throwIfAborted();
+        const rawSummary = await sidecarGenerate(
+            prompt,
+            'You create concise long-term memory summaries for creative roleplay. Preserve names, changed state, unresolved threads, and why the scene matters. Return valid JSON only.',
+            controller.signal,
+        );
+        checkCurrent();
+        controller.signal.throwIfAborted();
+        const summary = parseGeneratedSummary(rawSummary);
+        if (!summary.content) throw new Error('The sidecar model returned an empty summary.');
 
-    if (!summary.content) {
-        throw new Error('The sidecar model returned an empty summary.');
+        return await createSummaryMemoryEntry({ ...summary, book: targetBook }, { signal: controller.signal, isCurrent });
+    } finally {
+        unsubscribe();
+        session.cleanup = session.cleanup.filter(dispose => dispose !== unsubscribe);
+        if (session.summaryController === controller) session.summaryController = null;
     }
-
-    return await createSummaryMemoryEntry(summary);
 }
 
 /**
  * Bind all event handlers
  */
 function bindEvents() {
+    const session = settingsSession;
+    const panel = settingsEl;
+    // Autosave failures remain visible and retryable; explicit saves await rejection.
+    const save = keys => updateAgentSettings(keys).catch(() => {});
+
     settingsEl.find('#pf--quickstart-dismiss').on('click', () => {
         safeSetAccountStorageItem(PATHFINDER_QUICKSTART_DISMISSED_KEY, 'true');
-        settingsEl.find('#pf--quickstart').slideUp(180);
+        settingsEl.find('#pf--quickstart').stop(true, true).slideUp(window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 180);
     });
 
-    settingsEl.find('#pf--master-enable').on('change', async function () {
-        if (!currentAgent) {
-            return;
-        }
-
-        const enabled = $(this).prop('checked');
-        setAgentEnabledForCurrentScope(currentAgent, enabled);
-        await saveAgent(currentAgent);
-        persistAgentGlobalSettings();
-        saveSettingsDebounced();
-        updateStatusBanner();
+    settingsEl.find('#pf--master-enable').on('change', function () {
+        session.enabledChange = this.checked;
+        if (!this.checked) cancelPathfinderSummary();
+        return save();
     });
 
-    // Refresh lorebooks
-    settingsEl.find('#pf--refresh-lorebooks').on('click', async () => {
-        await refreshLorebookList();
+    settingsEl.find('#pf--settings-retry').on('click', () => save());
+
+    settingsEl.find('#pf--refresh-lorebooks').on('click', () => {
+        refreshPathfinderSettings();
         toastr.info('Lorebook list refreshed');
     });
 
-    settingsEl.find('#pf--auto-use-attached').on('change', async function () {
-        const enabled = $(this).prop('checked');
-        const s = getPathfinderSettings();
-        s.autoUseAttachedLorebook = enabled;
-        setPathfinderSettings(s);
-
-        if (enabled) {
-            await refreshLorebookList();
+    settingsEl.on('change', '[data-pf-setting]', function () {
+        const key = this.dataset.pfSetting;
+        let value = this.type === 'checkbox' ? this.checked : this.value;
+        if (this.type === 'number') {
+            value = key === 'autoSummaryInterval'
+                ? normalizeSummaryIntervalInput(value)
+                : Math.max(Number(this.min), Math.min(Number(this.max), parseInt(value, 10) || SETTING_DEFAULTS[key]));
+            this.value = String(value);
         }
-
-        updateAgentSettings();
-        updateStatusBanner();
-    });
-
-    settingsEl.find('#pf--auto-sync-lorebooks').on('change', async function () {
-        const enabled = $(this).prop('checked');
-        const s = getPathfinderSettings();
-        s.autoSyncLorebooksOnChatChange = enabled;
-        setPathfinderSettings(s);
-
-        if (enabled) {
-            await refreshLorebookList();
-        }
-
-        await updateAgentSettings();
-        updateStatusBanner();
-    });
-
-    // Mode toggles
-    settingsEl.find('#pf--enable-tools').on('change', function () {
-        const enabled = $(this).prop('checked');
-        const s = getPathfinderSettings();
-        s.sidecarEnabled = enabled;
-        setPathfinderSettings(s);
-        updateModeCardStates();
-        updateDualModeWarning();
-        updateStatusBanner();
-        updateAgentSettings();
-        syncToolAgentRegistrations();
-    });
-
-    settingsEl.find('#pf--enable-pipeline').on('change', function () {
-        const enabled = $(this).prop('checked');
-        const s = getPathfinderSettings();
-        s.pipelineEnabled = enabled;
-        // Don't force sidecarEnabled - let user choose both independently
-        setPathfinderSettings(s);
-        updateModeCardStates();
-        updateStatusBanner();
-        updateAgentSettings();
-    });
-
-    // Pipeline settings
-    settingsEl.find('#pf--pipeline-type').on('change', function () {
-        const s = getPathfinderSettings();
-        s.pipelineId = $(this).val();
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    settingsEl.find('#pf--content-mode').on('change', function () {
-        const s = getPathfinderSettings();
-        s.entryContentMode = $(this).val();
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    settingsEl.find('#pf--truncate-length').on('change', function () {
-        const s = getPathfinderSettings();
-        s.truncateLength = parseInt($(this).val()) || 500;
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    settingsEl.find('#pf--max-candidates').on('change', function () {
-        const s = getPathfinderSettings();
-        s.maxCandidates = parseInt($(this).val()) || 20;
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    settingsEl.find('#pf--retrieval-timeout').on('change', function () {
-        const s = getPathfinderSettings();
-        s.retrievalTimeoutSeconds = Math.max(1, Math.min(60, parseInt($(this).val()) || 8));
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    settingsEl.find('#pf--pipeline-profile').on('change', function () {
-        const s = getPathfinderSettings();
-        s.connectionProfile = $(this).val();
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    settingsEl.find('#pf--dedupe-natural-activation').on('change', function () {
-        const s = getPathfinderSettings();
-        s.dedupeNaturalActivation = $(this).prop('checked');
-        setPathfinderSettings(s);
-        updateAgentSettings();
-    });
-
-    // Memory summary settings
-    settingsEl.find('#pf--enable-summarize-tool').on('change', async function () {
-        const enabled = $(this).prop('checked');
-        setPathfinderToolEnabled('Pathfinder_Summarize', enabled);
-        await updateAgentSettings();
-        syncToolAgentRegistrations();
-    });
-
-    settingsEl.find('#pf--auto-summary').on('change', function () {
-        const s = getPathfinderSettings();
-        s.autoSummary = $(this).prop('checked');
-        if (s.autoSummary) {
+        currentAgent.settings[key] = value;
+        const keys = [key];
+        if (key === 'autoSummary' && value) {
             setPathfinderToolEnabled('Pathfinder_Summarize', true);
             settingsEl.find('#pf--enable-summarize-tool').prop('checked', true);
+            keys.push('toolStates');
         }
-        setPathfinderSettings(s);
-        updateAgentSettings();
-        syncToolAgentRegistrations();
+        if (['autoUseAttachedLorebook', 'autoSyncLorebooksOnChatChange', 'includeContextualLorebooks'].includes(key)) {
+            refreshLorebookList();
+        }
+        updateModeCardStates();
+        return save(keys);
     });
 
-    settingsEl.find('#pf--auto-summary-interval').on('change', function () {
-        const s = getPathfinderSettings();
-        s.autoSummaryInterval = normalizeSummaryIntervalInput($(this).val());
-        setPathfinderSettings(s);
-        updateAgentSettings();
+    settingsEl.on('change', '#pf--lorebook-list input', function () {
+        const item = $(this).closest('.pf--lorebook-item');
+        const bookName = item.attr('data-book');
+        const checked = this.checked;
+        const s = currentAgent.settings;
+        s.enabledLorebooks = ensureEnabledLorebooks(s).filter(name => name !== bookName);
+        if (checked) s.enabledLorebooks.push(bookName);
+        // Selection must not erase the user's independent permission choices.
+        s.bookPermissions = { ...s.bookPermissions, [bookName]: { ...s.bookPermissions?.[bookName], enabled: checked } };
+        if (!s.selectedLorebook || (!checked && s.selectedLorebook === bookName)) {
+            s.selectedLorebook = getActiveTunnelVisionBooks(s)[0] ?? '';
+        }
+        item.toggleClass('selected', checked);
+        renderPermissionMatrix(getAvailableLorebooks());
+        return save(['enabledLorebooks', 'selectedLorebook', 'bookPermissions']);
     });
 
     settingsEl.find('#pf--summary-save').on('click', async () => {
-        const status = settingsEl.find('#pf--summary-save-status');
+        if (session.summaryBusy) return;
+        const status = panel.find('#pf--summary-save-status');
+        const draft = session.summaryDraft ?? { source: getSummaryMemoryState(), content: String(panel.find('#pf--summary-content').val() ?? '') };
+        session.summaryDraft = draft;
+        session.summaryBusy = true;
+        renderSummaryMemoryEditor();
         try {
-            await saveSummaryMemoryContent(settingsEl.find('#pf--summary-content').val());
-            renderSummaryMemoryEditor();
+            const current = assertSummarySource(draft.source);
+            if (current.bookName && !getWritableBooks().includes(current.bookName)) {
+                throw new Error('No Pathfinder-enabled lorebooks available for writing.');
+            }
+            await saveSummaryMemoryContent(draft.content);
+            if (settingsSession !== session) return;
+            const committed = assertSummarySource({ ...draft.source, content: draft.content.trim() });
+            if (session.summaryDraft === draft) session.summaryDraft = null;
+            else session.summaryDraft.source = committed;
             status.text('Saved!').removeClass('error').addClass('success');
-            setTimeout(() => status.text(''), 3000);
         } catch (err) {
+            if (settingsSession !== session) return;
             status.text(`Save failed: ${err.message}`).removeClass('success').addClass('error');
+        } finally {
+            session.summaryBusy = false;
+            if (settingsSession === session) renderSummaryMemoryEditor();
         }
     });
 
-    settingsEl.find('#pf--summary-content').on('input', renderSummaryMemoryEditor);
+    settingsEl.find('#pf--summary-content').on('input', function () {
+        session.summaryDraft = {
+            source: session.summaryDraft?.source ?? getSummaryMemoryState(),
+            content: this.value,
+        };
+        panel.find('#pf--summary-save-status').text('');
+        renderSummaryMemoryEditor();
+    });
 
     settingsEl.find('#pf--summary-save-entry').on('click', async () => {
-        const status = settingsEl.find('#pf--summary-save-status');
-        const button = settingsEl.find('#pf--summary-save-entry');
+        if (session.summaryBusy) return;
+        const status = panel.find('#pf--summary-save-status');
         const draft = getSummaryEditorDraft();
         if (!draft.content) {
             status.text('Write or create a summary first.').removeClass('success').addClass('error');
             return;
         }
 
-        button.prop('disabled', true);
+        session.summaryBusy = true;
+        renderSummaryMemoryEditor();
         status.text('Saving entry...').removeClass('success error');
 
         try {
             const result = await createSeparateSummaryMemoryEntry(draft);
-            setPathfinderToolEnabled('Pathfinder_Summarize', true);
-            settingsEl.find('#pf--enable-summarize-tool').prop('checked', true);
-            await updateAgentSettings();
-            syncToolAgentRegistrations();
+            if (settingsSession !== session) return;
             status.text(`Saved "${result.summaryTitle}"`).removeClass('error').addClass('success');
-            setTimeout(() => status.text(''), 4000);
         } catch (err) {
+            if (settingsSession !== session) return;
             status.text(`Entry save failed: ${err.message}`).removeClass('success').addClass('error');
         } finally {
-            renderSummaryMemoryEditor();
+            session.summaryBusy = false;
+            if (settingsSession === session) renderSummaryMemoryEditor();
         }
     });
 
     settingsEl.find('#pf--summary-create').on('click', async () => {
-        const status = settingsEl.find('#pf--summary-save-status');
-        const button = settingsEl.find('#pf--summary-create');
-        button.prop('disabled', true);
+        if (session.summaryBusy) return;
+        const status = panel.find('#pf--summary-save-status');
+        session.summaryBusy = true;
+        renderSummaryMemoryEditor();
         status.text('Creating summary...').removeClass('success error');
 
         try {
             const result = await createManualSummaryMemory();
-            setPathfinderToolEnabled('Pathfinder_Summarize', true);
-            settingsEl.find('#pf--enable-summarize-tool').prop('checked', true);
-            await updateAgentSettings();
-            syncToolAgentRegistrations();
-            renderSummaryMemoryEditor();
+            if (settingsSession !== session) return;
             status.text(`Created UID ${result.uid}`).removeClass('error').addClass('success');
-            setTimeout(() => status.text(''), 3000);
         } catch (err) {
-            button.prop('disabled', false);
-            status.text(`Create failed: ${err.message}`).removeClass('success').addClass('error');
+            if (settingsSession !== session) return;
+            status.text(err.name === 'AbortError' ? 'Cancelled' : `Create failed: ${err.message}`).removeClass('success').addClass('error');
+        } finally {
+            session.summaryBusy = false;
+            if (settingsSession === session) renderSummaryMemoryEditor();
         }
-    });
-
-    // Tool settings
-    settingsEl.find('#pf--mandatory-tools').on('change', function () {
-        const s = getPathfinderSettings();
-        s.mandatoryTools = $(this).prop('checked');
-        setPathfinderSettings(s);
-        updateAgentSettings();
     });
 
     settingsEl.on('change', '#pf--confirm-tool-list input[data-confirm-tool]', function () {
         const toolName = $(this).data('confirmTool');
-        const s = getPathfinderSettings();
-        if (!s.confirmTools || typeof s.confirmTools !== 'object') {
-            s.confirmTools = {};
-        }
-        s.confirmTools[toolName] = $(this).prop('checked');
-        setPathfinderSettings(s);
-        updateAgentSettings();
+        currentAgent.settings.confirmTools = { ...currentAgent.settings.confirmTools, [toolName]: this.checked };
+        return save(['confirmTools']);
     });
 
-    settingsEl.on('change', '.pf--tool-list input[data-tool]', async function () {
-        const toolName = $(this).data('tool');
-        const enabled = $(this).prop('checked');
-
-        setPathfinderToolEnabled(toolName, enabled);
-
-        await updateAgentSettings();
-        syncToolAgentRegistrations();
+    settingsEl.on('change', 'input[data-tool]', function () {
+        setPathfinderToolEnabled($(this).data('tool'), this.checked);
+        updateModeCardStates();
+        return save(['toolStates']);
     });
 
-    settingsEl.on('change', '#pf--permission-matrix input[data-permission]', async function () {
+    settingsEl.on('change', '#pf--permission-matrix input[data-permission]', function () {
         const row = $(this).closest('.pf--permission-row');
-        const bookName = row.data('book');
+        const bookName = row.attr('data-book');
         const permission = $(this).data('permission');
         const enabled = $(this).prop('checked');
 
@@ -1096,17 +930,18 @@ function bindEvents() {
             return;
         }
 
-        setBookPermission(bookName, permission, enabled ? 'readwrite' : 'none');
-        await updateAgentSettings();
+        const permissions = currentAgent.settings.bookPermissions;
+        currentAgent.settings.bookPermissions = { ...permissions, [bookName]: { ...permissions?.[bookName], [permission]: enabled ? 'readwrite' : 'none' } };
+        return save(['bookPermissions']);
     });
 
     // Collapsible sections
     settingsEl.find('.pf--collapsible-header').on('click', function () {
         const section = $(this).closest('.pf--section-collapsible');
         const body = section.children('.pf--section-body').first();
-        const willOpen = !body.is(':visible');
+        const willOpen = $(this).attr('aria-expanded') !== 'true';
 
-        body.slideToggle(200);
+        body.stop(true, true).toggle(willOpen);
         setSectionChevronState(section, !willOpen);
         setSectionCollapsedPreference(getCollapseSectionKey(section), !willOpen);
     });
@@ -1132,6 +967,7 @@ function bindEvents() {
 
         try {
             const results = await runDiagnostics();
+            if (settingsSession !== session) return;
             let text = '';
 
             for (const [key, value] of Object.entries(results)) {
@@ -1141,6 +977,7 @@ function bindEvents() {
 
             output.text(text || 'All checks passed!');
         } catch (err) {
+            if (settingsSession !== session) return;
             output.text('Error running diagnostics: ' + err.message);
             console.warn(`${PATHFINDER_LOG_PREFIX} Pathfinder diagnostics failed.`, err);
         }
@@ -1181,34 +1018,58 @@ function bindEvents() {
  * Update status banner based on current configuration
  */
 function updateStatusBanner() {
+    if (!settingsEl) return;
     const banner = settingsEl.find('#pf--status-banner');
-    const s = getPathfinderSettings();
-    const activeBooks = getActiveLorebookNames(s);
-    const hasBooks = activeBooks.length > 0;
-    const hasMode = s.sidecarEnabled || s.pipelineEnabled;
-    const masterEnabled = currentAgent ? isAgentEnabledForCurrentScope(currentAgent) : false;
+    const agent = getAgentById(currentAgent.id) ?? currentAgent;
+    settingsEl.find('#pf--master-enable').prop('checked', settingsSession.enabledChange ?? isAgentEnabledForCurrentScope(agent));
+    const s = agent.settings ?? {};
+    const books = getActiveTunnelVisionBooks(s);
+    const readableBooks = getReadableBooks(s);
+    const ToolManager = getContext()?.ToolManager;
+    const usesTools = s.sidecarEnabled || isPathfinderToolEnabledForAgent(agent, 'Pathfinder_Summarize');
+    const enabledTools = ALL_TOOL_NAMES.filter(name => (s.sidecarEnabled || name === 'Pathfinder_Summarize') && isPathfinderToolEnabledForAgent(agent, name));
+    const registered = (ToolManager?.tools ?? []).map(tool => tool.toFunctionOpenAI?.()?.function?.name);
+    let title = 'Pathfinder is not configured';
+    let message = 'Select at least one lorebook below to get started';
+    let ready = false;
 
-    if (hasBooks && hasMode && !masterEnabled) {
-        banner.removeClass('pf--status-ready').addClass('pf--status-disabled');
-        banner.find('.pf--status-icon i').removeClass('fa-circle-check').addClass('fa-circle-xmark');
-        banner.find('.pf--status-text strong').text('Pathfinder is disabled');
-        banner.find('.pf--status-text span').text('Enable Pathfinder above to use the current setup');
-    } else if (hasBooks && hasMode) {
-        banner.removeClass('pf--status-disabled').addClass('pf--status-ready');
-        banner.find('.pf--status-icon i').removeClass('fa-circle-xmark').addClass('fa-circle-check');
-        banner.find('.pf--status-text strong').text('Pathfinder is ready');
-        banner.find('.pf--status-text span').text(`${activeBooks.length} lorebook(s) available`);
-    } else if (hasBooks) {
-        banner.removeClass('pf--status-disabled').addClass('pf--status-ready');
-        banner.find('.pf--status-icon i').removeClass('fa-circle-xmark').addClass('fa-circle-check');
-        banner.find('.pf--status-text strong').text('Lorebooks selected');
-        banner.find('.pf--status-text span').text('Enable Tool Mode or Pipeline Mode above');
-    } else {
-        banner.removeClass('pf--status-ready').addClass('pf--status-disabled');
-        banner.find('.pf--status-icon i').removeClass('fa-circle-check').addClass('fa-circle-xmark');
-        banner.find('.pf--status-text strong').text('Pathfinder is not configured');
-        banner.find('.pf--status-text span').text('Select at least one lorebook below to get started');
+    if (!areAgentsGloballyEnabled() || !isPathfinderSubmoduleEnabled() || !isAgentEnabledForCurrentScope(agent)) {
+        title = 'Pathfinder is disabled';
+        message = !areAgentsGloballyEnabled()
+            ? 'In-Chat Agents disabled.'
+            : !isPathfinderSubmoduleEnabled()
+                ? 'Pathfinder is disabled in In-Chat Agents settings.'
+                : 'Enable Pathfinder above to use the current setup';
+    } else if (books.length > 0) {
+        title = 'Lorebooks selected';
+        message = 'Enable Tool Mode or Pipeline Mode above';
+        if (readableBooks.length === 0) {
+            title = 'Lorebook Permissions';
+            message = 'No readable lorebooks';
+        } else if (usesTools || s.pipelineEnabled) {
+            if (getPathfinderRuntimeAgent()?.id !== agent.id) {
+                message = 'Tool mode is enabled, but the Pathfinder tool agent is not active right now. Enable Pathfinder as a tool agent, then reopen settings or reload agents.';
+            } else if (s.pipelineEnabled && s.connectionProfile && !listConnectionProfiles().some(profile => profile.id === s.connectionProfile)) {
+                message = `Missing profile (${s.connectionProfile})`;
+            } else if (online_status === 'no_connection' && (usesTools || !s.connectionProfile)) {
+                message = 'Not connected to API!';
+            } else if (usesTools && !ToolManager?.isToolCallingSupported?.()) {
+                message = 'Tool calling is not supported for the current API/settings. Enable "Function Calling" in OpenAI settings and ensure the current model supports tools.';
+            } else if (usesTools && enabledTools.length === 0) {
+                message = 'Tool mode is enabled, but every Pathfinder tool toggle is off. Re-enable at least one Pathfinder tool in Tool Settings.';
+            } else if (usesTools && enabledTools.some(name => !registered.includes(name))) {
+                message = 'Tools are configured but not registered with ToolManager. Try reloading the extension or switching API sources.';
+            } else {
+                ready = true;
+                title = 'Pathfinder is ready';
+                message = `${readableBooks.length} lorebook(s) available`;
+            }
+        }
     }
+    banner.toggleClass('pf--status-ready', ready).toggleClass('pf--status-disabled', !ready);
+    banner.find('.pf--status-icon i').toggleClass('fa-circle-check', ready).toggleClass('fa-circle-xmark', !ready);
+    banner.find('.pf--status-text strong').text(title);
+    banner.find('.pf--status-text span').text(message);
 }
 
 function renderRetrievalLog() {
@@ -1532,7 +1393,7 @@ function formatRetrievalLogItem(item) {
  * Update mode card visual states
  */
 function updateModeCardStates() {
-    const s = getPathfinderSettings();
+    const s = currentAgent.settings;
 
     const toolEnabled = Boolean(s.sidecarEnabled);
     const pipelineEnabled = Boolean(s.pipelineEnabled);
@@ -1546,7 +1407,8 @@ function updateModeCardStates() {
     pipelineCard.toggleClass('active', pipelineEnabled);
 
     // Show/hide settings sections
-    settingsEl.find('#pf--tool-settings').toggle(toolEnabled);
+    settingsEl.find('#pf--tool-settings').show();
+    settingsEl.find('.pf--tool-mode-only').toggle(toolEnabled);
     settingsEl.find('#pf--pipeline-settings').toggle(pipelineEnabled);
     settingsEl.find('#pf--prompt-editor-section').toggle(pipelineEnabled);
 
@@ -1558,40 +1420,96 @@ function updateModeCardStates() {
  * Show/hide warning when both modes are enabled
  */
 function updateDualModeWarning() {
-    const s = getPathfinderSettings();
+    const s = currentAgent.settings;
     const bothEnabled = s.sidecarEnabled && s.pipelineEnabled;
     settingsEl.find('#pf--dual-mode-warning').toggle(bothEnabled);
 }
 
 /**
- * Update agent settings object and trigger save.
- * Serialized: many toggle handlers call this without awaiting, and
- * overlapping saveAgent calls on the same agent have no ordering guarantee.
+ * Queue private edits, preserving unrelated changes made outside this panel.
  */
 let agentSettingsSaveChain = Promise.resolve();
 
-function updateAgentSettings() {
-    agentSettingsSaveChain = agentSettingsSaveChain
-        .then(async () => {
-            if (!currentAgent) return;
+function updateAgentSettings(keys = []) {
+    const session = settingsSession;
+    const agentId = currentAgent.id;
+    keys.forEach(key => session.dirtySettings.add(key));
+    const changes = structuredClone(Object.fromEntries([...session.dirtySettings].map(key => [key, currentAgent.settings[key]])));
+    const enabled = session.enabledChange;
+    const scope = getActiveAgentChatScope();
+    const contextRevision = session.contextRevision;
+    const revision = ++session.revision;
+    const status = session.element.find('#pf--settings-save-status');
+    session.pending++;
+    status.text('Not saved yet').removeClass('success error').attr('aria-busy', 'true');
+    session.element.find('#pf--settings-retry').hide();
+    renderSummaryMemoryEditor();
 
-            const s = getPathfinderSettings();
-            currentAgent.settings = { ...s };
-
-            await saveAgent(currentAgent);
+    const run = saveAgent(agentId, { update: agent => {
+        if (settingsSession !== session || session.contextRevision !== contextRevision) return null;
+        if (!agent) throw new Error('Pathfinder agent is not available. Reload In-Chat Agents or restore the bundled Pathfinder template.');
+        agent.settings = { ...agent.settings, ...changes };
+        if (changes.toolStates) {
+            agent.tools = (agent.tools ?? []).map(tool => Object.hasOwn(changes.toolStates, tool.name)
+                ? { ...tool, enabled: changes.toolStates[tool.name] !== false } : tool);
+        }
+        if (enabled !== undefined) {
+            const global = getGlobalSettings();
+            agent.enabled = enabled || (global.separateRecentChats && Object.entries(global.enabledAgentIdsByChatType ?? {})
+                .some(([otherScope, ids]) => otherScope !== scope && ids.includes(agentId)));
+        }
+        return agent;
+    } }).then(agent => {
+        if (!agent) return;
+        if (enabled !== undefined) {
+            setAgentEnabledForScope(getAgentById(agentId) ?? agent, enabled, scope);
             persistAgentGlobalSettings();
-            saveSettingsDebounced();
-        })
-        .catch(err => console.warn('[Pathfinder] Failed to save agent settings:', err));
+        }
+        if (session.contextRevision !== contextRevision) return;
 
-    return agentSettingsSaveChain;
+        try {
+            if (getPathfinderRuntimeAgent()?.id === agentId) {
+                replaceSettings(structuredClone(agent.settings));
+                initializePromptStore(getDefaultPrompts(), getDefaultPipelines());
+            }
+            syncToolAgentRegistrations();
+        } catch (err) {
+            console.warn('[Pathfinder] Could not refresh tool registrations after saving.', err);
+        }
+        if (settingsSession !== session) return;
+        if (revision === session.revision) {
+            session.dirtySettings.clear();
+            session.enabledChange = undefined;
+            session.agent.settings = structuredClone({ ...SETTING_DEFAULTS, ...agent.settings });
+            session.agent.tools = structuredClone(agent.tools ?? []);
+            status.text('Saved!').removeClass('error').addClass('success');
+            session.element.find('#pf--prompt-status.error').text('');
+            updateModeCardStates();
+        }
+        updateStatusBanner();
+    }).catch(err => {
+        if (settingsSession === session && revision === session.revision && session.contextRevision === contextRevision) {
+            status.text(`Save failed: ${err.message}`).removeClass('success').addClass('error');
+            session.element.find('#pf--settings-retry').show();
+        }
+        throw err;
+    }).finally(() => {
+        session.pending--;
+        if (settingsSession === session) {
+            status.attr('aria-busy', String(session.pending > 0));
+            session.element.find('#pf--settings-retry').prop('disabled', session.pending > 0);
+            renderSummaryMemoryEditor();
+        }
+    });
+    agentSettingsSaveChain = run.catch(() => {});
+    return run;
 }
 
 /**
  * Load a prompt into the editor
  */
 function loadPromptIntoEditor(promptId) {
-    const prompt = getPrompt(promptId);
+    const prompt = currentAgent.settings.pipelinePrompts?.[promptId] ?? getDefaultPrompts()[promptId];
     if (!prompt) return;
 
     settingsEl.find('#pf--prompt-system').val(prompt.systemPrompt || '');
@@ -1604,10 +1522,12 @@ function loadPromptIntoEditor(promptId) {
  * Save the current prompt
  */
 async function saveCurrentPrompt() {
+    const session = settingsSession;
+    const contextRevision = session.contextRevision;
     const promptId = settingsEl.find('#pf--prompt-selector').val();
     if (!promptId) return;
 
-    const prompt = getPrompt(promptId);
+    const prompt = structuredClone(currentAgent.settings.pipelinePrompts?.[promptId] ?? getDefaultPrompts()[promptId]);
     if (!prompt) return;
 
     prompt.systemPrompt = settingsEl.find('#pf--prompt-system').val();
@@ -1617,15 +1537,26 @@ async function saveCurrentPrompt() {
         maxTokens: readPromptMaxTokens(),
     };
 
-    savePrompt(prompt);
-    await updateAgentSettings();
-    showPromptStatus('Saved!', 'success');
+    currentAgent.settings.pipelinePrompts = { ...currentAgent.settings.pipelinePrompts, [promptId]: prompt };
+    try {
+        await updateAgentSettings(['pipelinePrompts']);
+        if (settingsSession === session && session.contextRevision === contextRevision && settingsEl.find('#pf--prompt-selector').val() === promptId) {
+            const unchanged = settingsEl.find('#pf--prompt-system').val() === prompt.systemPrompt
+                && settingsEl.find('#pf--prompt-user').val() === prompt.userPromptTemplate
+                && readPromptMaxTokens() === prompt.settings.maxTokens;
+            showPromptStatus(unchanged ? 'Saved!' : 'Not saved yet', unchanged ? 'success' : '');
+        }
+    } catch (err) {
+        if (settingsSession === session && session.contextRevision === contextRevision) showPromptStatus(`Save failed: ${err.message}`, 'error');
+    }
 }
 
 /**
  * Reset the current prompt to default
  */
 async function resetCurrentPrompt() {
+    const session = settingsSession;
+    const contextRevision = session.contextRevision;
     const promptId = settingsEl.find('#pf--prompt-selector').val();
     if (!promptId) return;
 
@@ -1637,16 +1568,23 @@ async function resetCurrentPrompt() {
         return;
     }
 
-    savePrompt({ ...defaultPrompt, isDefault: true });
-    await updateAgentSettings();
-    loadPromptIntoEditor(promptId);
-    showPromptStatus('Reset to default', 'success');
+    const fields = ['#pf--prompt-system', '#pf--prompt-user', '#pf--prompt-max-tokens'];
+    const originalValues = fields.map(selector => settingsEl.find(selector).val());
+    currentAgent.settings.pipelinePrompts = { ...currentAgent.settings.pipelinePrompts, [promptId]: structuredClone({ ...defaultPrompt, isDefault: true }) };
+    try {
+        await updateAgentSettings(['pipelinePrompts']);
+        if (settingsSession !== session || session.contextRevision !== contextRevision || settingsEl.find('#pf--prompt-selector').val() !== promptId) return;
+        const unchanged = fields.every((selector, index) => settingsEl.find(selector).val() === originalValues[index]);
+        if (unchanged) loadPromptIntoEditor(promptId);
+        showPromptStatus(unchanged ? 'Reset to default' : 'Not saved yet', unchanged ? 'success' : '');
+    } catch (err) {
+        if (settingsSession === session && session.contextRevision === contextRevision) showPromptStatus(`Save failed: ${err.message}`, 'error');
+    }
 }
 
 function showPromptStatus(message, type) {
     const status = settingsEl.find('#pf--prompt-status');
     status.text(message).removeClass('success error').addClass(type);
-    setTimeout(() => status.text(''), 3000);
 }
 
 function clearPromptStatus() {

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -1,11 +1,16 @@
 <div id="pf--settings" class="pf--settings">
     <!-- Status Banner -->
-    <div id="pf--status-banner" class="pf--status-banner pf--status-disabled">
-        <div class="pf--status-icon"><i class="fa-solid fa-circle-xmark"></i></div>
+    <div id="pf--status-banner" class="pf--status-banner pf--status-disabled" role="status" aria-live="polite">
+        <div class="pf--status-icon" aria-hidden="true"><i class="fa-solid fa-circle-xmark"></i></div>
         <div class="pf--status-text">
             <strong>Pathfinder is not configured</strong>
             <span>Select at least one lorebook below to get started</span>
         </div>
+    </div>
+
+    <div class="pf--save-state">
+        <span id="pf--settings-save-status" class="pf--prompt-status" role="status" aria-live="polite"></span>
+        <button type="button" id="pf--settings-retry" class="menu_button" style="display: none;">Retry</button>
     </div>
 
     <div class="pf--section pf--master-section">
@@ -41,15 +46,15 @@
 
     <!-- Step 1: Select Lorebooks -->
     <div id="pf--lorebook-section" class="pf--section pf--section-primary pf--section-collapsible">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="true" aria-controls="pf--lorebook-body">
             <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <span class="pf--step-badge">1</span>
             <strong>Select Lorebooks</strong>
             <span class="pf--required">(Required)</span>
-        </div>
-        <div class="pf--section-body">
+        </button>
+        <div class="pf--section-body" id="pf--lorebook-body">
             <div class="pf--section-desc">
-                Choose which lorebooks Pathfinder can access. These must be lorebooks attached to your current character or chat.
+                Choose which lorebooks Pathfinder can access.
             </div>
             <div id="pf--lorebook-list" class="pf--lorebook-list">
                 <div class="pf--empty-state">
@@ -65,32 +70,38 @@
             </div>
             <div class="pf--setting-group pf--lorebook-toggle">
                 <label class="checkbox_label">
-                    <input type="checkbox" id="pf--auto-use-attached" />
+                    <input type="checkbox" id="pf--auto-use-attached" data-pf-setting="autoUseAttachedLorebook" />
                     <span>Automatically use attached character/chat lorebooks</span>
                 </label>
                 <div class="pf--setting-help">When enabled, Pathfinder auto-selects lorebooks attached to the active character card or chat.</div>
             </div>
             <div class="pf--setting-group pf--lorebook-toggle">
                 <label class="checkbox_label">
-                    <input type="checkbox" id="pf--auto-sync-lorebooks" />
+                    <input type="checkbox" id="pf--auto-sync-lorebooks" data-pf-setting="autoSyncLorebooksOnChatChange" />
                     <span>Reset selections to the current chat/character lorebooks on chat change</span>
                 </label>
                 <div class="pf--setting-help">Prevents a previous chat's lorebook from staying selected when the new chat has no attached lorebook.</div>
+            </div>
+            <div class="pf--setting-group pf--lorebook-toggle">
+                <label class="checkbox_label">
+                    <input type="checkbox" id="pf--include-contextual-lorebooks" data-pf-setting="includeContextualLorebooks" />
+                    <span>Automatically include attached lorebooks, aside from excluded lorebooks</span>
+                </label>
             </div>
         </div>
     </div>
 
     <!-- Step 2: Choose Mode -->
     <div id="pf--mode-section" class="pf--section pf--section-collapsible">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="true" aria-controls="pf--mode-body">
             <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <span class="pf--step-badge">2</span>
             <strong>Choose How Pathfinder Works</strong>
-        </div>
+        </button>
 
-        <div class="pf--section-body">
+        <div class="pf--section-body" id="pf--mode-body">
             <!-- Warning banner when both modes enabled -->
-            <div id="pf--dual-mode-warning" class="pf--dual-mode-warning" style="display: none;">
+            <div id="pf--dual-mode-warning" class="pf--dual-mode-warning" role="status" aria-live="polite" style="display: none;">
                 <i class="fa-solid fa-triangle-exclamation"></i>
                 <span>Both modes enabled — this uses more tokens but gives the AI both automatic context and active lorebook control.</span>
             </div>
@@ -100,7 +111,7 @@
                 <div class="pf--mode-card" data-mode="tools">
                     <div class="pf--mode-card-header">
                         <label class="checkbox_label">
-                            <input type="checkbox" id="pf--enable-tools" />
+                            <input type="checkbox" id="pf--enable-tools" data-pf-setting="sidecarEnabled" />
                             <span><i class="fa-solid fa-wrench"></i> Tool Mode</span>
                         </label>
                     </div>
@@ -123,7 +134,7 @@
                 <div class="pf--mode-card" data-mode="pipeline">
                     <div class="pf--mode-card-header">
                         <label class="checkbox_label">
-                            <input type="checkbox" id="pf--enable-pipeline" />
+                            <input type="checkbox" id="pf--enable-pipeline" data-pf-setting="pipelineEnabled" />
                             <span><i class="fa-solid fa-wand-magic-sparkles"></i> Predictive Pipeline</span>
                         </label>
                     </div>
@@ -147,14 +158,14 @@
 
     <!-- Pipeline Settings (shown when pipeline enabled) -->
     <div id="pf--pipeline-settings" class="pf--section pf--section-collapsible" style="display: none;">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="true" aria-controls="pf--pipeline-body">
             <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <strong>Pipeline Settings</strong>
-        </div>
-        <div class="pf--section-body">
+        </button>
+        <div class="pf--section-body" id="pf--pipeline-body">
             <div class="pf--setting-group">
-                <label class="pf--setting-label">Pipeline Type</label>
-                <select id="pf--pipeline-type" class="text_pole">
+                <label class="pf--setting-label" for="pf--pipeline-type">Pipeline Type</label>
+                <select id="pf--pipeline-type" class="text_pole" data-pf-setting="pipelineId">
                     <option value="default">Two-Stage (Recommended) - Select candidates, then filter</option>
                     <option value="single-pass">Single-Pass (Faster) - Select only, no filtering</option>
                 </select>
@@ -163,30 +174,30 @@
 
             <div class="pf--setting-row">
                 <div class="pf--setting-group">
-                    <label class="pf--setting-label">Entry Content Mode</label>
-                    <select id="pf--content-mode" class="text_pole">
+                    <label class="pf--setting-label" for="pf--content-mode">Entry Content Mode</label>
+                    <select id="pf--content-mode" class="text_pole" data-pf-setting="entryContentMode">
                         <option value="full">Full Content</option>
                         <option value="truncated">Truncated (saves tokens)</option>
                     </select>
                 </div>
                 <div class="pf--setting-group">
-                    <label class="pf--setting-label">Truncate Length</label>
-                    <input type="number" id="pf--truncate-length" class="text_pole" min="100" max="2000" value="500" />
+                    <label class="pf--setting-label" for="pf--truncate-length">Truncate Length</label>
+                    <input type="number" id="pf--truncate-length" class="text_pole" min="100" max="2000" value="500" data-pf-setting="truncateLength" />
                 </div>
                 <div class="pf--setting-group">
-                    <label class="pf--setting-label">Max Candidates</label>
-                    <input type="number" id="pf--max-candidates" class="text_pole" min="5" max="50" value="20" />
+                    <label class="pf--setting-label" for="pf--max-candidates">Max Candidates</label>
+                    <input type="number" id="pf--max-candidates" class="text_pole" min="5" max="50" value="20" data-pf-setting="maxCandidates" />
                 </div>
                 <div class="pf--setting-group">
-                    <label class="pf--setting-label">Retrieval Timeout</label>
-                    <input type="number" id="pf--retrieval-timeout" class="text_pole" min="1" max="60" value="8" />
+                    <label class="pf--setting-label" for="pf--retrieval-timeout">Retrieval Timeout</label>
+                    <input type="number" id="pf--retrieval-timeout" class="text_pole" min="1" max="60" value="8" data-pf-setting="retrievalTimeoutSeconds" />
                     <div class="pf--setting-help">Seconds before Pathfinder shows a slow-retrieval warning. Generation still waits unless cancelled.</div>
                 </div>
             </div>
 
             <div class="pf--setting-group">
-                <label class="pf--setting-label">Connection Profile for Pipeline</label>
-                <select id="pf--pipeline-profile" class="text_pole">
+                <label class="pf--setting-label" for="pf--pipeline-profile">Connection Profile for Pipeline</label>
+                <select id="pf--pipeline-profile" class="text_pole" data-pf-setting="connectionProfile">
                     <option value="">Use main model</option>
                 </select>
                 <div class="pf--setting-help">Use a faster/cheaper model for the pipeline (e.g., Haiku, GPT-4o-mini)</div>
@@ -194,7 +205,7 @@
 
             <div class="pf--setting-group">
                 <label class="checkbox_label">
-                    <input type="checkbox" id="pf--dedupe-natural-activation" />
+                    <input type="checkbox" id="pf--dedupe-natural-activation" data-pf-setting="dedupeNaturalActivation" />
                     <span>Skip entries already activated by World Info</span>
                 </label>
                 <div class="pf--setting-help">Keeps keyword/constant lore active naturally, then removes those entries from Pathfinder's injected context.</div>
@@ -204,14 +215,14 @@
 
     <!-- Advanced: Prompt Editor -->
     <div id="pf--prompt-editor-section" class="pf--section pf--section-collapsible" style="display: none;">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="false" aria-controls="pf--prompt-editor-body">
             <i class="fa-solid fa-chevron-right pf--chevron"></i>
             <strong>Edit Pipeline Prompts</strong>
             <span class="pf--badge">Advanced</span>
-        </div>
-        <div class="pf--section-body" style="display: none;">
+        </button>
+        <div class="pf--section-body" id="pf--prompt-editor-body" style="display: none;">
             <div class="pf--setting-group">
-                <label class="pf--setting-label">Select Prompt to Edit</label>
+                <label class="pf--setting-label" for="pf--prompt-selector">Select Prompt to Edit</label>
                 <select id="pf--prompt-selector" class="text_pole">
                     <option value="">Choose a prompt...</option>
                     <option value="candidate-selector">Stage 1: Candidate Selector</option>
@@ -221,7 +232,7 @@
 
             <div id="pf--prompt-fields" style="display: none;">
                 <div class="pf--setting-group">
-                    <label class="pf--setting-label">System Prompt</label>
+                    <label class="pf--setting-label" for="pf--prompt-system">System Prompt</label>
                     <textarea id="pf--prompt-system" class="text_pole" rows="6" placeholder="Instructions for the AI..."></textarea>
                 </div>
                 <div class="pf--setting-group">
@@ -230,7 +241,7 @@
                     <div class="pf--setting-help">Maximum tokens Pathfinder can receive from this pipeline stage.</div>
                 </div>
                 <div class="pf--setting-group">
-                    <label class="pf--setting-label">User Prompt Template</label>
+                    <label class="pf--setting-label" for="pf--prompt-user">User Prompt Template</label>
                     <textarea id="pf--prompt-user" class="text_pole" rows="4" placeholder="Template with {{variables}}..."></textarea>
                     <div class="pf--setting-help">
                         Variables: <code>{{chat_history}}</code>, <code>{{entry_list}}</code>, <code>{{candidate_entries}}</code>
@@ -243,7 +254,7 @@
                     <button type="button" id="pf--prompt-reset" class="menu_button">
                         <i class="fa-solid fa-rotate-left"></i> <span>Reset to Default</span>
                     </button>
-                    <span id="pf--prompt-status" class="pf--prompt-status"></span>
+                    <span id="pf--prompt-status" class="pf--prompt-status" role="status" aria-live="polite"></span>
                 </div>
             </div>
         </div>
@@ -251,15 +262,15 @@
 
     <!-- Memory Summary Settings -->
     <div id="pf--memory-summary-settings" class="pf--section pf--section-collapsible">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="true" aria-controls="pf--memory-summary-body">
             <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <strong>Memory Summaries</strong>
             <span class="pf--badge">Lorebook</span>
-        </div>
-        <div class="pf--section-body">
+        </button>
+        <div class="pf--section-body" id="pf--memory-summary-body">
             <div class="pf--setting-group">
                 <label class="checkbox_label">
-                    <input type="checkbox" id="pf--enable-summarize-tool" />
+                    <input type="checkbox" id="pf--enable-summarize-tool" data-tool="Pathfinder_Summarize" />
                     <span>Allow summary memory tool</span>
                 </label>
                 <div class="pf--setting-help">Lets Pathfinder write scene/event summaries into enabled lorebooks with the Summarize tool.</div>
@@ -267,24 +278,24 @@
             <div class="pf--setting-row">
                 <div class="pf--setting-group">
                     <label class="checkbox_label">
-                        <input type="checkbox" id="pf--auto-summary" />
+                        <input type="checkbox" id="pf--auto-summary" data-pf-setting="autoSummary" />
                         <span>Auto-track summary interval</span>
                     </label>
                     <div class="pf--setting-help">Counts sent/received messages toward automatic summary prompts.</div>
                 </div>
                 <div class="pf--setting-group">
                     <label class="pf--setting-label" for="pf--auto-summary-interval">Summary Interval</label>
-                    <input type="number" id="pf--auto-summary-interval" class="text_pole" min="2" max="200" value="20" />
+                    <input type="number" id="pf--auto-summary-interval" class="text_pole" min="2" max="200" value="20" data-pf-setting="autoSummaryInterval" />
                     <div class="pf--setting-help">Messages before Pathfinder should consider writing a memory summary.</div>
                 </div>
             </div>
             <div class="pf--setting-group pf--summary-editor">
                 <div class="pf--summary-editor-header">
                     <label class="pf--setting-label" for="pf--summary-content">Latest memory summary</label>
-                    <span id="pf--summary-injection-indicator" class="pf--summary-indicator pf--summary-indicator-missing">No summary</span>
+                    <span id="pf--summary-injection-indicator" class="pf--summary-indicator pf--summary-indicator-missing" role="status" aria-live="polite">No summary</span>
                 </div>
                 <textarea id="pf--summary-content" class="text_pole" rows="7" placeholder="When Pathfinder creates a memory summary, it will appear here for review and editing."></textarea>
-                <div class="pf--summary-meta" id="pf--summary-meta">No Pathfinder summary has been created yet.</div>
+                <div class="pf--summary-meta" id="pf--summary-meta" aria-live="polite">No Pathfinder summary has been created yet.</div>
                 <div class="pf--summary-actions">
                     <button type="button" id="pf--summary-create" class="menu_button menu_button_icon">
                         <i class="fa-solid fa-wand-magic-sparkles"></i>
@@ -298,42 +309,42 @@
                         <i class="fa-solid fa-book-medical"></i>
                         <span>Save as Entry</span>
                     </button>
-                    <span id="pf--summary-save-status" class="pf--prompt-status"></span>
+                    <span id="pf--summary-save-status" class="pf--prompt-status" role="status" aria-live="polite"></span>
                 </div>
                 <div class="pf--setting-help">Save Summary updates the tracked memory summary. Save as Entry creates a separate lorebook entry with a title derived from the summary text.</div>
             </div>
         </div>
     </div>
 
-    <!-- Tool Settings (shown when tools enabled) -->
-    <div id="pf--tool-settings" class="pf--section pf--section-collapsible" style="display: none;">
-        <div class="pf--section-header pf--collapsible-header">
+    <!-- Permissions also apply to pipeline retrieval and summary writes. -->
+    <div id="pf--tool-settings" class="pf--section pf--section-collapsible">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="true" aria-controls="pf--tool-body">
             <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <strong>Tool Settings</strong>
-        </div>
-        <div class="pf--section-body">
-            <div class="pf--setting-group">
-                <label class="pf--setting-label">Enabled Tools</label>
-                <div class="pf--tool-list">
+        </button>
+        <div class="pf--section-body" id="pf--tool-body">
+            <div class="pf--setting-group pf--tool-mode-only">
+                <div class="pf--setting-label" id="pf--enabled-tools-label">Enabled Tools</div>
+                <div class="pf--tool-list" role="group" aria-labelledby="pf--enabled-tools-label">
                     <div class="pf--empty-state pf--tool-loading"><i class="fa-solid fa-wrench"></i><span>Loading tool toggles...</span></div>
                 </div>
             </div>
 
             <div class="pf--setting-group">
-                <label class="pf--setting-label">Lorebook Permissions</label>
-                <div class="pf--setting-help">Limit what Tool Mode can read, edit, or delete per selected lorebook. Write permission allows creating, updating, disabling, and reorganizing entries. Delete permission is only needed for hard deletes.</div>
-                <div id="pf--permission-matrix" class="pf--permission-matrix"></div>
+                <div class="pf--setting-label" id="pf--permissions-label">Lorebook Permissions</div>
+                <div class="pf--setting-help">Write permission allows creating, updating, disabling, and reorganizing entries. Delete permission is only needed for hard deletes.</div>
+                <div id="pf--permission-matrix" class="pf--permission-matrix" role="group" aria-labelledby="pf--permissions-label"></div>
             </div>
 
             <div class="pf--setting-group">
-                <label class="pf--setting-label">Ask Before Executing</label>
+                <div class="pf--setting-label" id="pf--confirm-tools-label">Ask Before Executing</div>
                 <div class="pf--setting-help">Show a confirmation dialog before the checked tools change lorebook data. Denying a call tells the AI to continue without it.</div>
-                <div class="pf--tool-list" id="pf--confirm-tool-list"></div>
+                <div class="pf--tool-list" id="pf--confirm-tool-list" role="group" aria-labelledby="pf--confirm-tools-label"></div>
             </div>
 
-            <div class="pf--setting-group">
+            <div class="pf--setting-group pf--tool-mode-only">
                 <label class="checkbox_label">
-                    <input type="checkbox" id="pf--mandatory-tools" />
+                    <input type="checkbox" id="pf--mandatory-tools" data-pf-setting="mandatoryTools" />
                     <span>Require tool use on every response</span>
                 </label>
                 <div class="pf--setting-help">Forces the AI to call at least one tool at the start of each response. The follow-up pass that writes the reply is not forced.</div>
@@ -343,12 +354,12 @@
 
     <!-- Diagnostics -->
     <div class="pf--section pf--section-collapsible">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="false" aria-controls="pf--diagnostics-body">
             <i class="fa-solid fa-chevron-right pf--chevron"></i>
             <strong>Diagnostics</strong>
-        </div>
-        <div class="pf--section-body pf--diagnostics-panel" style="display: none;">
-            <div id="pf--diagnostics-output" class="pf--diagnostics-output">Click "Run Diagnostics" to check your Pathfinder configuration.</div>
+        </button>
+        <div class="pf--section-body pf--diagnostics-panel" id="pf--diagnostics-body" style="display: none;">
+            <div id="pf--diagnostics-output" class="pf--diagnostics-output" role="status" aria-live="polite" tabindex="0">Click "Run Diagnostics" to check your Pathfinder configuration.</div>
             <div class="pf--diagnostics-actions">
                 <button type="button" id="pf--run-diagnostics" class="menu_button menu_button_icon">
                     <i class="fa-solid fa-stethoscope"></i>
@@ -363,12 +374,12 @@
     </div>
 
     <div class="pf--section pf--section-collapsible">
-        <div class="pf--section-header pf--collapsible-header">
+        <button type="button" class="pf--section-header pf--collapsible-header" aria-expanded="false" aria-controls="pf--retrieval-log-body">
             <i class="fa-solid fa-chevron-right pf--chevron"></i>
             <strong>Retrieval Log</strong>
             <span class="pf--badge">Detailed</span>
-        </div>
-        <div class="pf--section-body" style="display: none;">
+        </button>
+        <div class="pf--section-body" id="pf--retrieval-log-body" style="display: none;">
             <div class="pf--section-desc">Shows what Pathfinder actually selected or injected, including selected lore entries, stage results, and the prompt payload Pathfinder added before generation.</div>
             <div class="pf--log-mode-row">
                 <label class="pf--log-mode-control" for="pf--log-mode">
@@ -389,7 +400,7 @@
                     <span>Clear Log</span>
                 </button>
             </div>
-            <div id="pf--retrieval-log-output" class="pf--retrieval-log-output">No Pathfinder retrieval activity recorded yet.</div>
+            <div id="pf--retrieval-log-output" class="pf--retrieval-log-output" role="log" aria-live="polite" tabindex="0">No Pathfinder retrieval activity recorded yet.</div>
         </div>
     </div>
 </div>
@@ -418,8 +429,7 @@
     --pf-radius-sm: var(--sb-radius-sm, 10px);
     --pf-radius-md: var(--sb-radius-md, 14px);
     --pf-radius-lg: var(--sb-radius-lg, 18px);
-    --pf-shadow-card: 0 10px 26px color-mix(in srgb, var(--SmartThemeShadowColor, oklch(12% 0.01 260)) 14%, transparent);
-    --pf-shadow-raised: 0 16px 38px color-mix(in srgb, var(--SmartThemeShadowColor, oklch(12% 0.01 260)) 22%, transparent);
+    --pf-control-size: max(38px, var(--sb-control-min-height, 38px));
     --pf-ease: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -436,6 +446,10 @@
     -webkit-overflow-scrolling: touch;
     text-align: left;
     color: var(--pf-text);
+    font-size: var(--mainFontSize);
+    line-height: 1.5;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .pf--settings.pf--settings-embedded {
@@ -446,6 +460,36 @@
 
 .pf--settings * {
     text-align: left;
+}
+
+.pf--settings :is(button, select, input:not([type="checkbox"])) {
+    min-height: var(--pf-control-size);
+}
+
+.pf--settings :is(button, select, input, textarea) {
+    min-width: 0;
+    max-width: 100%;
+    font-size: inherit;
+}
+
+.pf--settings button {
+    white-space: normal;
+}
+
+.pf--settings :is(button, input, select, textarea, [tabindex]):focus-visible {
+    outline: 2px solid var(--sb-focus-ring, var(--pf-accent));
+    outline-offset: 2px;
+}
+
+.pf--save-state {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.pf--save-state .pf--prompt-status {
+    margin: 0;
 }
 
 .pf--extensions-host .inline-drawer-header b {
@@ -464,7 +508,7 @@
     border-radius: var(--pf-radius-md);
     background: var(--pf-surface-soft);
     color: var(--pf-text-muted);
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
 }
 
 /* Status Banner */
@@ -476,7 +520,6 @@
     border-radius: var(--pf-radius-md);
     border: 1px solid var(--pf-border);
     background: var(--pf-surface-strong);
-    box-shadow: var(--pf-shadow-card);
     text-align: left;
 }
 
@@ -501,7 +544,7 @@
 }
 
 .pf--status-icon {
-    font-size: 18px;
+    font-size: calc(var(--mainFontSize) * 1.2);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -515,15 +558,16 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    min-width: 0;
 }
 
 .pf--status-text strong {
-    font-size: 14px;
+    font-size: calc(var(--mainFontSize) * 0.92);
     line-height: 1.2;
 }
 
 .pf--status-text span {
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     color: var(--pf-text-muted);
 }
 
@@ -542,7 +586,8 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    min-height: var(--sb-control-min-height, 30px);
+    min-height: var(--pf-control-size);
+    min-width: 0;
     line-height: 1.35;
 }
 
@@ -567,7 +612,6 @@
     border: 1px solid color-mix(in srgb, var(--pf-border) 76%, var(--pf-accent) 18%);
     border-radius: var(--pf-radius-lg);
     overflow: hidden;
-    box-shadow: var(--pf-shadow-card);
 }
 
 .pf--quickstart-header {
@@ -578,7 +622,7 @@
     padding: 10px 14px;
     background: color-mix(in srgb, var(--pf-surface-strong) 92%, var(--pf-accent) 8%);
     border-bottom: 1px solid color-mix(in srgb, var(--pf-border) 70%, transparent);
-    font-size: 14px;
+    font-size: calc(var(--mainFontSize) * 0.92);
 }
 
 .pf--quickstart-title {
@@ -597,9 +641,9 @@
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
-    width: 30px;
-    height: 30px;
-    margin: -4px -6px -4px 8px;
+    width: var(--pf-control-size);
+    height: var(--pf-control-size);
+    margin: 0;
     border: 1px solid color-mix(in srgb, var(--pf-border) 72%, transparent);
     border-radius: var(--pf-radius-sm);
     background: color-mix(in srgb, var(--pf-surface-strong) 88%, var(--pf-text) 4%);
@@ -617,7 +661,7 @@
 
 .pf--quickstart-body {
     padding: 12px 14px;
-    font-size: 13px;
+    font-size: var(--mainFontSize);
     line-height: 1.5;
     color: var(--pf-text-muted);
 }
@@ -641,7 +685,8 @@
     border: 1px solid var(--pf-border);
     border-radius: var(--pf-radius-lg);
     padding: 14px;
-    box-shadow: var(--pf-shadow-card);
+    min-width: 0;
+    flex-shrink: 0;
 }
 
 .pf--section-primary {
@@ -653,16 +698,24 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 10px;
-    font-size: 14px;
+    font-size: calc(var(--mainFontSize) * 0.92);
     line-height: 1.25;
     text-align: left;
 }
 
 .pf--collapsible-header {
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
+    width: 100%;
+    padding: 4px 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font-family: inherit;
 }
 
 .pf--collapsible-header:hover {
@@ -671,8 +724,9 @@
 
 .pf--chevron {
     transition: transform 0.2s;
-    font-size: 12px;
-    width: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
+    width: 1em;
+    flex: 0 0 auto;
 }
 
 .pf--section-collapsible .pf--section-body {
@@ -688,14 +742,14 @@
     background: var(--pf-accent);
     color: var(--pf-on-accent);
     border-radius: 50%;
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     font-weight: bold;
-    box-shadow: 0 4px 12px color-mix(in srgb, var(--pf-accent) 26%, transparent);
+    flex: 0 0 auto;
 }
 
 .pf--required {
     color: var(--pf-danger);
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
 }
 
 .pf--badge {
@@ -703,13 +757,13 @@
     color: var(--pf-on-accent);
     padding: 1px 6px;
     border-radius: 8px;
-    font-size: 9px;
+    font-size: calc(var(--mainFontSize) * 0.72);
     text-transform: uppercase;
     letter-spacing: 0.03em;
 }
 
 .pf--section-desc {
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.92);
     color: var(--pf-text-muted);
     margin-bottom: 12px;
     line-height: 1.4;
@@ -731,20 +785,21 @@
 }
 
 .pf--log-mode-control {
-    display: grid;
-    grid-template-columns: max-content minmax(128px, 160px);
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 8px;
     max-width: 100%;
-    min-height: var(--sb-control-min-height, 30px);
+    min-height: var(--pf-control-size);
 }
 
 .pf--log-mode-control span {
-    white-space: nowrap;
+    overflow-wrap: anywhere;
 }
 
 #pf--log-mode {
-    width: 100%;
+    width: auto;
+    flex: 1 1 8em;
     min-width: 0;
 }
 
@@ -752,7 +807,7 @@
 .pf--diagnostics-output {
     white-space: pre-wrap;
     line-height: 1.55;
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     padding: 12px;
     border-radius: var(--pf-radius-md);
     background: color-mix(in srgb, var(--pf-surface-strong) 88%, var(--pf-text) 3%);
@@ -786,6 +841,9 @@
     border: 1px solid color-mix(in srgb, var(--pf-border) 74%, transparent);
     border-radius: var(--pf-radius-md);
     cursor: pointer;
+    min-height: var(--pf-control-size);
+    min-width: 0;
+    flex-shrink: 0;
     transition: background 0.18s var(--pf-ease), border-color 0.18s var(--pf-ease), transform 0.18s var(--pf-ease);
 }
 
@@ -802,6 +860,7 @@
 
 .pf--lorebook-item input[type="checkbox"] {
     margin: 0;
+    flex: 0 0 auto;
 }
 
 .pf--lorebook-info {
@@ -809,15 +868,17 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .pf--lorebook-name {
     font-weight: 500;
-    font-size: 13px;
+    font-size: calc(var(--mainFontSize) * 0.92);
 }
 
 .pf--lorebook-meta {
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     color: var(--pf-text-muted);
 }
 
@@ -836,13 +897,13 @@
 }
 
 .pf--empty-state i {
-    font-size: 24px;
+    font-size: calc(var(--mainFontSize) * 1.6);
 }
 
 /* Mode Cards */
 .pf--mode-cards {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16em), 1fr));
     gap: 12px;
 }
 
@@ -851,8 +912,8 @@
     border: 1px solid color-mix(in srgb, var(--pf-border) 72%, transparent);
     border-radius: var(--pf-radius-lg);
     overflow: hidden;
-    box-shadow: var(--pf-shadow-card);
-    transition: background 0.18s var(--pf-ease), border-color 0.18s var(--pf-ease), box-shadow 0.18s var(--pf-ease), transform 0.18s var(--pf-ease);
+    min-width: 0;
+    transition: background 0.18s var(--pf-ease), border-color 0.18s var(--pf-ease);
 }
 
 .pf--mode-card:hover {
@@ -863,7 +924,6 @@
 .pf--mode-card.active {
     background: linear-gradient(180deg, color-mix(in srgb, var(--pf-accent) 30%, var(--pf-surface-strong)), color-mix(in srgb, var(--pf-accent) 16%, var(--pf-surface)));
     border-color: color-mix(in srgb, var(--pf-accent) 72%, var(--pf-border));
-    box-shadow: var(--pf-shadow-raised), inset 0 0 0 1px color-mix(in srgb, var(--pf-accent) 18%, transparent);
 }
 
 .pf--mode-card-header {
@@ -879,7 +939,7 @@
 
 .pf--mode-card-header .checkbox_label {
     font-weight: 600;
-    font-size: 13px;
+    font-size: calc(var(--mainFontSize) * 0.92);
 }
 
 .pf--mode-card-header i {
@@ -893,7 +953,7 @@
 
 .pf--mode-card-body {
     padding: 12px;
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.92);
 }
 
 .pf--mode-card-body p {
@@ -923,7 +983,7 @@
     margin-top: 10px;
     padding: 8px 10px;
     border-radius: var(--pf-radius-sm);
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     display: flex;
     align-items: flex-start;
     gap: 6px;
@@ -949,7 +1009,7 @@
     border: 1px solid color-mix(in srgb, var(--pf-warning) 34%, var(--pf-border));
     border-radius: var(--pf-radius-md);
     color: var(--pf-warning);
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     margin-bottom: 12px;
 }
 
@@ -968,13 +1028,13 @@
 
 .pf--setting-label {
     display: block;
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.92);
     font-weight: 500;
     margin-bottom: 6px;
 }
 
 .pf--setting-help {
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     color: var(--pf-text-muted);
     margin-top: 4px;
 }
@@ -984,7 +1044,7 @@
     border: 1px solid color-mix(in srgb, var(--pf-border) 80%, transparent);
     padding: 1px 5px;
     border-radius: 5px;
-    font-size: 10px;
+    font-size: inherit;
 }
 
 .pf--setting-row {
@@ -1002,6 +1062,7 @@
 
 .pf--summary-editor-header {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     gap: 10px;
@@ -1009,9 +1070,9 @@
 
 .pf--summary-indicator {
     border-radius: 999px;
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     padding: 3px 8px;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .pf--summary-indicator-injected {
@@ -1033,7 +1094,7 @@
 }
 
 .pf--summary-meta {
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     color: var(--pf-text-muted);
     margin-top: 5px;
 }
@@ -1082,7 +1143,7 @@
 
 .pf--permission-row {
     display: grid;
-    grid-template-columns: minmax(150px, 1fr) repeat(3, minmax(78px, max-content));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     align-items: center;
     gap: 10px;
     padding: 10px;
@@ -1096,36 +1157,36 @@
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    grid-column: 1 / -1;
 }
 
 .pf--permission-book strong,
 .pf--permission-book span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
 }
 
 .pf--permission-book span {
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     color: var(--pf-text-muted);
 }
 
 .pf--permission-row .checkbox_label {
     margin: 0;
-    padding: 0;
-    min-height: 0;
+    padding: 6px;
+    min-height: var(--pf-control-size);
 }
 
 /* Prompt Editor */
 .pf--prompt-actions {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 10px;
     margin-top: 10px;
 }
 
 .pf--prompt-status {
-    font-size: 12px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     margin-left: auto;
     min-width: 0;
     overflow-wrap: anywhere;
@@ -1145,7 +1206,7 @@
     border-radius: var(--pf-radius-md);
     padding: 12px;
     font-family: monospace;
-    font-size: 11px;
+    font-size: calc(var(--mainFontSize) * 0.84);
     white-space: pre-wrap;
     max-height: 200px;
     overflow-y: auto;
@@ -1176,7 +1237,7 @@
     width: fit-content;
     inline-size: fit-content;
     max-inline-size: 100%;
-    min-inline-size: var(--sb-control-min-height, 30px);
+    min-inline-size: var(--pf-control-size);
     white-space: normal;
     margin-left: 0;
     margin-right: auto;
@@ -1198,6 +1259,13 @@
 }
 
 /* Responsive */
+@media (max-width: 768px), (pointer: coarse) {
+    .pf--extensions-host,
+    .pf--settings {
+        --pf-control-size: max(44px, var(--sb-control-min-height, 44px));
+    }
+}
+
 @media (max-width: 600px) {
     .pf--settings {
         max-height: calc(100dvh - 120px);

--- a/public/scripts/extensions/in-chat-agents/pathfinder/commands.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/commands.js
@@ -3,9 +3,10 @@ import { ARGUMENT_TYPE, SlashCommandArgument } from '../../../slash-commands/Sla
 import { SlashCommandParser } from '../../../slash-commands/SlashCommandParser.js';
 
 import { isPathfinderSubmoduleEnabled } from '../agent-store.js';
-import { getTree, findNodeById } from './tree-store.js';
+import { findNodeById } from './tree-store.js';
+import { getTreeWithAutoBuild } from './tree-builder.js';
 import { createEntry } from './entry-manager.js';
-import { getActiveTunnelVisionBooks, getWritableBooks } from './pathfinder-tool-bridge.js';
+import { getReadableBooks, getWritableBooks } from './pathfinder-tool-bridge.js';
 
 const registeredCommands = [];
 
@@ -73,8 +74,8 @@ export function initCommands(registerSlashCommand) {
             if (books.length === 0) return 'No writable Pathfinder-enabled lorebooks.';
             const bookName = books[0];
             try {
-                await createEntry(bookName, content.slice(0, 50), content);
-                return `Remembered in "${bookName}".`;
+                const result = await createEntry(bookName, content.slice(0, 50), content);
+                return `Remembered in "${result.bookName}".`;
             } catch (err) {
                 return `Error: ${err.message}`;
             }
@@ -93,8 +94,8 @@ export function initCommands(registerSlashCommand) {
             if (!query) return 'No search query.';
             const q = query.toLowerCase();
             const results = [];
-            for (const bookName of getActiveTunnelVisionBooks()) {
-                const tree = getTree(bookName);
+            for (const bookName of getReadableBooks()) {
+                const tree = await getTreeWithAutoBuild(bookName);
                 if (!tree) continue;
                 const exact = findNodeById(tree, query);
                 const matches = exact ? [exact] : findNodesByName(tree, q);

--- a/public/scripts/extensions/in-chat-agents/pathfinder/diagnostics.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/diagnostics.js
@@ -12,7 +12,7 @@ function getRegisteredPathfinderTools(ToolManager) {
             : [];
 
     return ALL_TOOL_NAMES.filter(name =>
-        tools.find(t => t?.name === name),
+        tools.some(tool => tool?.toFunctionOpenAI?.()?.function?.name === name),
     );
 }
 
@@ -20,7 +20,7 @@ function formatNameList(names, fallback = 'none') {
     return names.length > 0 ? names.join(', ') : fallback;
 }
 
-function getEnabledPathfinderTools(pathfinderAgent, registeredTools = [], settings = getSettings()) {
+function getEnabledPathfinderTools(pathfinderAgent, settings = getSettings()) {
     if (!pathfinderAgent) {
         return [];
     }
@@ -104,13 +104,13 @@ function getPipelineStageSummary(stageResults = []) {
 
 export async function runDiagnostics() {
     const results = {};
-    const s = getSettings();
 
     try {
         syncToolAgentRegistrations();
     } catch (error) {
         console.warn('[Pathfinder] Diagnostics could not refresh tool registrations before checks.', error);
     }
+    const s = getSettings();
 
     // Check enabled lorebooks
     const manualBooks = (s.enabledLorebooks || []);
@@ -167,7 +167,7 @@ export async function runDiagnostics() {
         const enabledAgents = getEnabledToolAgents();
         const pathfinderAgent = getPathfinderRuntimeAgent(enabledAgents);
         const registeredTools = getRegisteredPathfinderTools(ToolManager);
-        const enabledPathfinderToolNames = getEnabledPathfinderTools(pathfinderAgent, registeredTools, s);
+        const enabledPathfinderToolNames = getEnabledPathfinderTools(pathfinderAgent, s);
         const registrationDetail = getToolRegistrationDetail(enabledPathfinderToolNames, registeredTools);
 
         if (enabledPathfinderToolNames.length > 0 && enabledPathfinderToolNames.every(name => registeredTools.includes(name))) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js
@@ -131,7 +131,7 @@ export function createEntry(bookName, title, content, keys = [], { arc = '', sig
     }, { signal, isCurrent });
 }
 
-export function updateEntry(bookName, uid, newContent, newTitle, expectedEntry = null) {
+export function updateEntry(bookName, uid, newContent, newTitle, expectedEntry = null, options = {}) {
     return writeBook(bookName, bookData => {
         const entry = findEntryByUid(bookData.entries, uid);
         if (expectedEntry && (!isEntryEligible(entry) || entry.comment !== expectedEntry.title || String(entry.content || '').trim() !== expectedEntry.content)) {
@@ -144,10 +144,10 @@ export function updateEntry(bookName, uid, newContent, newTitle, expectedEntry =
         if (typeof newTitle === 'string') entry.comment = newTitle;
         syncWIOriginalDataEntry(bookData, entry.uid);
         return { uid: entry.uid };
-    });
+    }, options);
 }
 
-export function forgetEntry(bookName, uid, hardDelete = false) {
+export function forgetEntry(bookName, uid, hardDelete = false, options = {}) {
     return writeBook(bookName, bookData => {
         if (typeof hardDelete !== 'boolean') throw new Error('Permanent deletion request refused; the tool supplied an invalid permanent deletion choice.');
         const entry = requireEntry(bookName, bookData, uid);
@@ -160,10 +160,10 @@ export function forgetEntry(bookName, uid, hardDelete = false) {
             syncWIOriginalDataEntry(bookData, entry.uid);
         }
         return { uid: entry.uid, deleted: hardDelete, disabled: !hardDelete };
-    });
+    }, options);
 }
 
-export function moveEntry(bookName, uid, targetNodeId) {
+export function moveEntry(bookName, uid, targetNodeId, options = {}) {
     return writeBook(bookName, bookData => {
         const entry = requireEntry(bookName, bookData, uid, true);
         const tree = getEditableTree(bookName, bookData);
@@ -173,10 +173,10 @@ export function moveEntry(bookName, uid, targetNodeId) {
         writeTreeLayout(bookData, tree);
         syncWIOriginalDataEntry(bookData, entry.uid);
         return { uid: entry.uid, targetNodeId };
-    });
+    }, options);
 }
 
-export function createCategory(bookName, parentNodeId, name, description = '') {
+export function createCategory(bookName, parentNodeId, name, description = '', options = {}) {
     return writeBook(bookName, bookData => {
         const tree = getEditableTree(bookName, bookData);
         const newNode = createLayoutNode(bookName, name, description);
@@ -185,7 +185,7 @@ export function createCategory(bookName, parentNodeId, name, description = '') {
         parent.children.push(newNode);
         writeTreeLayout(bookData, tree);
         return { nodeId: newNode.id, name };
-    });
+    }, options);
 }
 
 export function findEntry(entries, uid) {
@@ -214,7 +214,7 @@ export async function listNodeEntries(bookName, nodeId) {
         .map(e => ({ uid: e.uid, title: e.comment || e.key?.[0] || '', content: e.content || '' }));
 }
 
-export function mergeEntries(bookName, uid1, uid2, mergedTitle) {
+export function mergeEntries(bookName, uid1, uid2, mergedTitle, options = {}) {
     return writeBook(bookName, bookData => {
         const e1 = requireEntry(bookName, bookData, uid1, true);
         const e2 = requireEntry(bookName, bookData, uid2, true);
@@ -232,10 +232,10 @@ export function mergeEntries(bookName, uid1, uid2, mergedTitle) {
         delete bookData.entries[key2];
         syncWIOriginalDataEntry(bookData, uid1);
         return { mergedUid: uid1, removedUid: uid2 };
-    });
+    }, options);
 }
 
-export function splitEntry(bookName, uid, splitTitle1, content1, splitTitle2, content2) {
+export function splitEntry(bookName, uid, splitTitle1, content1, splitTitle2, content2, options = {}) {
     return writeBook(bookName, async bookData => {
         const original = requireEntry(bookName, bookData, uid, true);
         uid = original.uid;
@@ -257,7 +257,7 @@ export function splitEntry(bookName, uid, splitTitle1, content1, splitTitle2, co
         syncWIOriginalDataEntry(bookData, uid);
         syncWIOriginalDataEntry(bookData, newEntry.uid);
         return { originalUid: uid, newUid: newEntry.uid };
-    });
+    }, options);
 }
 
 function findParentOfEntry(tree, uid) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js
@@ -1,5 +1,8 @@
-import { createWorldInfoEntry as createWorldInfoEntryFallback } from '../../../world-info.js';
-import { getTree, saveTree, findNodeById, addEntryToNode, removeEntryFromTree, createTreeNode, isTrackerTitle, setTrackerUid, beginPathfinderSelfWrite, endPathfinderSelfWrite } from './tree-store.js';
+import { createWorldInfoEntry as createWorldInfoEntryFallback, syncWIOriginalDataEntry, deleteWIOriginalDataValue, reloadEditor } from '../../../world-info.js';
+import { getTree, saveTree, deleteTree, renameTree, findNodeById, isEntryEligible, parseEntryUid, syncTrackerUidsForLorebook, beginPathfinderSelfWrite, endPathfinderSelfWrite, isPathfinderSelfWrite } from './tree-store.js';
+import { deriveTreeFromMetadata } from './tree-builder.js';
+import { createLayoutNode, readTreeLayout, setEntryPlacement, syncBookLayoutMetadata, writeTreeLayout } from './tree-layout.js';
+import { getSummaryMemoryState, renameSummaryMemoryBook, detachSummaryMemoryBook, syncSummaryMemoryForBook } from './summary-memory-store.js';
 
 let _loadWorldInfo = null;
 let _createWorldInfoEntry = null;
@@ -25,13 +28,13 @@ async function createWIE(name, data) {
 }
 
 function assertCreatedEntry(newEntry, bookName) {
-    if (!newEntry || newEntry.uid === undefined) {
+    if (!newEntry || parseEntryUid(newEntry.uid) === null) {
         throw new Error(`Could not create a new entry in "${bookName}". Lorebook may be missing or unwritable.`);
     }
 }
 
 async function saveWI(name, data, immediate) {
-    beginPathfinderSelfWrite();
+    beginPathfinderSelfWrite(name);
     try {
         if (_saveWorldInfo) return await _saveWorldInfo(name, data, immediate);
         const ctx = window?.SillyTavern?.getContext?.();
@@ -41,127 +44,153 @@ async function saveWI(name, data, immediate) {
     }
 }
 
-// Serializes all lorebook writes: each operation does an independent
-// load → mutate → save, so two concurrent tool calls in one round would
-// clobber each other's snapshot without this.
+// Each queued operation loads its own private snapshot before mutating it.
 // ponytail: global lock; per-book locks if tool-call throughput ever matters
 let writeChain = Promise.resolve();
-function withWriteLock(fn) {
-    const run = writeChain.then(fn, fn);
+
+function writeBook(bookName, mutate, { signal, isCurrent } = {}) {
+    const assertCurrent = () => {
+        signal?.throwIfAborted();
+        if (isCurrent && !isCurrent()) throw new DOMException('Cancelled', 'AbortError');
+    };
+    const run = writeChain.then(async () => {
+        // The host returns a private copy and tracks its identity for stale-editor merges.
+        const bookData = await loadWI(bookName);
+        assertCurrent();
+        if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
+        const summary = getSummaryMemoryState();
+        const previousSummaryEntry = summary.bookName === bookName
+            ? structuredClone(findEntryByUid(bookData.entries, summary.uid)) : null;
+        const result = await mutate(bookData);
+        syncBookLayoutMetadata(bookData);
+        assertCurrent();
+        // Cancellation cannot undo a save once the request has been sent.
+        const committedName = await saveWI(bookName, bookData, true);
+        if (typeof committedName !== 'string' || !committedName) throw new Error('The lorebook save did not complete.');
+        if (committedName !== bookName) onPathfinderWorldInfoRenamed(bookName, committedName);
+        let committedData;
+        try {
+            committedData = await loadWI(committedName);
+        } catch (error) {
+            console.warn(error);
+        }
+        // A failed refresh must not retry an already committed entry creation.
+        deleteTree(committedName);
+        if (committedData) saveTree(committedName, deriveTreeFromMetadata(committedName, committedData));
+        syncTrackerUidsForLorebook(committedName, committedData);
+        const currentSummary = getSummaryMemoryState();
+        if (currentSummary.uid === summary.uid && currentSummary.title === summary.title && currentSummary.content === summary.content) {
+            syncSummaryMemoryForBook(committedName, committedData, previousSummaryEntry);
+        }
+        try {
+            reloadEditor(committedName);
+        } catch (error) {
+            // An editor refresh failure must not report an already committed write as failed.
+            console.warn(error);
+        }
+        return { ...result, bookName: committedName };
+    });
     writeChain = run.then(() => {}, () => {});
     return run;
 }
 
-export function createEntry(bookName, title, content, keys = []) {
-    return withWriteLock(() => createEntryUnlocked(bookName, title, content, keys));
+function getEditableTree(bookName, bookData) {
+    if (readTreeLayout(bookData) === null) throw new Error('The saved waypoint layout is damaged or uses an unsupported format and will not be overwritten.');
+    return deriveTreeFromMetadata(bookName, bookData, getTree(bookName));
 }
 
-async function createEntryUnlocked(bookName, title, content, keys = []) {
-    const bookData = await loadWI(bookName);
-    if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
-    const newEntry = await createWIE(bookName, bookData);
-    assertCreatedEntry(newEntry, bookName);
-    newEntry.content = content;
-    newEntry.comment = title;
-    newEntry.key = keys.length > 0 ? keys : [title.replace(/^\[.*?\]\s*/, '').split(/[:|]/)[0].trim().toLowerCase()];
-    newEntry.selective = false;
-    newEntry.constant = false;
-    newEntry.disable = false;
-    await saveWI(bookName, bookData, true);
-
-    const tree = getTree(bookName);
-    if (tree && newEntry.uid !== undefined) {
-        const targetNodeId = findBestNodeForTitle(tree, title);
-        const targetNode = targetNodeId ? findNodeById(tree, targetNodeId) : tree;
-        if (targetNode) addEntryToNode(targetNode, newEntry.uid);
-        if (isTrackerTitle(title)) setTrackerUid(bookName, newEntry.uid);
-        saveTree(bookName, tree);
-    }
-
-    return { uid: newEntry.uid, title, bookName };
+function requireEntry(bookName, bookData, uid, eligibleOnly = false) {
+    const entry = findEntryByUid(bookData.entries, uid);
+    if (!entry || entry.agentBlacklisted || (eligibleOnly && !isEntryEligible(entry))) throw new Error(`Entry UID ${uid} not found in "${bookName}".`);
+    return entry;
 }
 
-function findBestNodeForTitle(tree, title) {
-    if (!tree) return null;
-    const lower = (title || '').toLowerCase();
-    const waypointKeywords = {
-        character: ['character', 'npc', 'person', 'protagonist', 'antagonist'],
-        location: ['location', 'place', 'city', 'town', 'room', 'area', 'dungeon'],
-        tracker: ['tracker', 'status', 'inventory', 'mood', 'state'],
-        summary: ['summary', 'recap', 'event', 'scene', 'arc'],
-        rule: ['rule', 'mechanic', 'system', 'magic', 'combat', 'skill'],
-    };
-    for (const child of tree.children || []) {
-        const childLower = child.name.toLowerCase();
-        for (const [prefix, keywords] of Object.entries(waypointKeywords)) {
-            if (keywords.some(kw => lower.includes(kw)) && childLower.includes(prefix)) {
-                return child.id;
+export function createEntry(bookName, title, content, keys = [], { arc = '', signal, isCurrent } = {}) {
+    return writeBook(bookName, async bookData => {
+        const newEntry = await createWIE(bookName, bookData);
+        assertCreatedEntry(newEntry, bookName);
+        newEntry.content = content;
+        newEntry.comment = title;
+        newEntry.key = keys.length > 0 ? [...keys] : [title.replace(/^\[.*?\]\s*/, '').split(/[:|]/)[0].trim().toLowerCase()];
+        newEntry.selective = false;
+        newEntry.constant = false;
+        newEntry.disable = false;
+        if (arc) {
+            const tree = getEditableTree(bookName, bookData);
+            const summaryWaypoint = findParentOfEntry(tree, newEntry.uid);
+            let arcNode = summaryWaypoint.children.find(node => node.name.replace(/^Arc:\s*/i, '').toLowerCase() === arc.toLowerCase());
+            if (!arcNode) {
+                arcNode = createLayoutNode(bookName, `Arc: ${arc}`, `Narrative arc: ${arc}`);
+                summaryWaypoint.children.push(arcNode);
             }
+            setEntryPlacement(newEntry, arcNode);
+            writeTreeLayout(bookData, tree);
         }
-    }
-    return null;
+        syncWIOriginalDataEntry(bookData, newEntry.uid);
+        return { uid: newEntry.uid, title };
+    }, { signal, isCurrent });
 }
 
-export function updateEntry(bookName, uid, newContent, newTitle) {
-    return withWriteLock(async () => {
-        const bookData = await loadWI(bookName);
-        if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
+export function updateEntry(bookName, uid, newContent, newTitle, expectedEntry = null) {
+    return writeBook(bookName, bookData => {
         const entry = findEntryByUid(bookData.entries, uid);
-        if (!entry) throw new Error(`Entry UID ${uid} not found in "${bookName}".`);
+        if (expectedEntry && (!isEntryEligible(entry) || entry.comment !== expectedEntry.title || String(entry.content || '').trim() !== expectedEntry.content)) {
+            const error = new Error('The summary or its linked entry changed while the user was editing. Saves are blocked to prevent overwriting.');
+            error.code = 'PATHFINDER_ENTRY_CHANGED';
+            throw error;
+        }
+        requireEntry(bookName, bookData, uid);
         if (typeof newContent === 'string') entry.content = newContent;
         if (typeof newTitle === 'string') entry.comment = newTitle;
-        await saveWI(bookName, bookData, true);
-        return { uid, bookName };
+        syncWIOriginalDataEntry(bookData, entry.uid);
+        return { uid: entry.uid };
     });
 }
 
 export function forgetEntry(bookName, uid, hardDelete = false) {
-    return withWriteLock(async () => {
-        const bookData = await loadWI(bookName);
-        if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
-        const entry = findEntryByUid(bookData.entries, uid);
-        if (!entry) throw new Error(`Entry UID ${uid} not found in "${bookName}".`);
+    return writeBook(bookName, bookData => {
+        if (typeof hardDelete !== 'boolean') throw new Error('Permanent deletion request refused; the tool supplied an invalid permanent deletion choice.');
+        const entry = requireEntry(bookName, bookData, uid);
         if (hardDelete) {
             const key = Object.keys(bookData.entries).find(k => bookData.entries[k] === entry);
-            if (key) delete bookData.entries[key];
+            deleteWIOriginalDataValue(bookData, entry.uid);
+            delete bookData.entries[key];
         } else {
             entry.disable = true;
+            syncWIOriginalDataEntry(bookData, entry.uid);
         }
-        await saveWI(bookName, bookData, true);
-        const tree = getTree(bookName);
-        if (tree) {
-            removeEntryFromTree(tree, uid);
-            saveTree(bookName, tree);
-        }
-        return { uid, bookName, deleted: hardDelete, disabled: !hardDelete };
+        return { uid: entry.uid, deleted: hardDelete, disabled: !hardDelete };
     });
 }
 
-export async function moveEntry(bookName, uid, targetNodeId) {
-    const tree = getTree(bookName);
-    if (!tree) throw new Error(`No tree for "${bookName}".`);
-    const targetNode = findNodeById(tree, targetNodeId);
-    if (!targetNode) throw new Error(`Waypoint ${targetNodeId} not found in "${bookName}". Use Search to list valid waypoint IDs.`);
-    removeEntryFromTree(tree, uid);
-    addEntryToNode(targetNode, uid);
-    saveTree(bookName, tree);
-    return { uid, targetNodeId, bookName };
+export function moveEntry(bookName, uid, targetNodeId) {
+    return writeBook(bookName, bookData => {
+        const entry = requireEntry(bookName, bookData, uid, true);
+        const tree = getEditableTree(bookName, bookData);
+        const targetNode = findNodeById(tree, targetNodeId);
+        if (!targetNode) throw new Error(`Waypoint ${targetNodeId} not found in "${bookName}". Use Search to list valid waypoint IDs.`);
+        setEntryPlacement(entry, targetNode);
+        writeTreeLayout(bookData, tree);
+        syncWIOriginalDataEntry(bookData, entry.uid);
+        return { uid: entry.uid, targetNodeId };
+    });
 }
 
-export async function createCategory(bookName, parentNodeId, name, description = '') {
-    const tree = getTree(bookName);
-    if (!tree) throw new Error(`No tree for "${bookName}".`);
-    const newNode = createTreeNode(name, description);
-    const parent = parentNodeId ? findNodeById(tree, parentNodeId) : tree;
-    if (!parent) throw new Error(`Parent node ${parentNodeId} not found.`);
-    if (!Array.isArray(parent.children)) parent.children = [];
-    parent.children.push(newNode);
-    saveTree(bookName, tree);
-    return { nodeId: newNode.id, name, bookName };
+export function createCategory(bookName, parentNodeId, name, description = '') {
+    return writeBook(bookName, bookData => {
+        const tree = getEditableTree(bookName, bookData);
+        const newNode = createLayoutNode(bookName, name, description);
+        const parent = parentNodeId ? findNodeById(tree, parentNodeId) : tree;
+        if (!parent) throw new Error(`Parent node ${parentNodeId} not found.`);
+        parent.children.push(newNode);
+        writeTreeLayout(bookData, tree);
+        return { nodeId: newNode.id, name };
+    });
 }
 
 export function findEntry(entries, uid) {
-    if (!entries) return null;
+    uid = parseEntryUid(uid);
+    if (!entries || uid === null) return null;
     for (const [, entry] of Object.entries(entries)) {
         if (entry && entry.uid === uid) return entry;
     }
@@ -181,57 +210,53 @@ export async function listNodeEntries(bookName, nodeId) {
     if (!bookData) return [];
     return (node.entries || [])
         .map(uid => findEntryByUid(bookData.entries, uid))
-        .filter(Boolean)
+        .filter(isEntryEligible)
         .map(e => ({ uid: e.uid, title: e.comment || e.key?.[0] || '', content: e.content || '' }));
 }
 
 export function mergeEntries(bookName, uid1, uid2, mergedTitle) {
-    return withWriteLock(async () => {
+    return writeBook(bookName, bookData => {
+        const e1 = requireEntry(bookName, bookData, uid1, true);
+        const e2 = requireEntry(bookName, bookData, uid2, true);
+        uid1 = e1.uid;
+        uid2 = e2.uid;
         if (uid1 === uid2) throw new Error('Cannot merge an entry with itself: "uid1" and "uid2" must differ.');
-        const bookData = await loadWI(bookName);
-        if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
-        const e1 = findEntryByUid(bookData.entries, uid1);
-        const e2 = findEntryByUid(bookData.entries, uid2);
-        if (!e1 || !e2) throw new Error('One or both entries not found.');
+        const tree = getEditableTree(bookName, bookData);
+        setEntryPlacement(e1, findParentOfEntry(tree, uid1));
+        writeTreeLayout(bookData, tree);
         e1.content = `${e1.content}\n\n---\n\n${e2.content}`;
         if (mergedTitle) e1.comment = mergedTitle;
         else e1.comment = (e1.comment || '') + ' + ' + (e2.comment || '');
         const key2 = Object.keys(bookData.entries).find(k => bookData.entries[k] === e2);
-        if (key2) delete bookData.entries[key2];
-        await saveWI(bookName, bookData, true);
-        const tree = getTree(bookName);
-        if (tree) {
-            removeEntryFromTree(tree, uid2);
-            saveTree(bookName, tree);
-        }
-        return { mergedUid: uid1, removedUid: uid2, bookName };
+        deleteWIOriginalDataValue(bookData, uid2);
+        delete bookData.entries[key2];
+        syncWIOriginalDataEntry(bookData, uid1);
+        return { mergedUid: uid1, removedUid: uid2 };
     });
 }
 
 export function splitEntry(bookName, uid, splitTitle1, content1, splitTitle2, content2) {
-    return withWriteLock(async () => {
-        const bookData = await loadWI(bookName);
-        if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
-        const original = findEntryByUid(bookData.entries, uid);
-        if (!original) throw new Error(`Entry UID ${uid} not found.`);
-        original.content = content1;
-        original.comment = splitTitle1 || original.comment;
+    return writeBook(bookName, async bookData => {
+        const original = requireEntry(bookName, bookData, uid, true);
+        uid = original.uid;
+        const tree = getEditableTree(bookName, bookData);
+        setEntryPlacement(original, findParentOfEntry(tree, uid));
+        writeTreeLayout(bookData, tree);
         const newEntry = await createWIE(bookName, bookData);
         assertCreatedEntry(newEntry, bookName);
-        newEntry.content = content2;
-        newEntry.comment = splitTitle2 || 'Split entry';
-        newEntry.key = original.key ? [...original.key] : [splitTitle2?.toLowerCase() || 'split'];
-        newEntry.selective = false;
-        newEntry.constant = false;
-        newEntry.disable = false;
-        await saveWI(bookName, bookData, true);
-        const tree = getTree(bookName);
-        if (tree) {
-            const parent = findParentOfEntry(tree, uid);
-            if (parent) addEntryToNode(parent, newEntry.uid);
-            saveTree(bookName, tree);
+        Object.assign(newEntry, structuredClone(original), { uid: newEntry.uid, content: content2, comment: splitTitle2 || 'Split entry' });
+        const originals = bookData.originalData?.entries;
+        const sourceIndex = bookData.originalDataUidMap?.[uid] ?? originals?.findIndex(entry => String(entry.id ?? entry.uid) === String(uid));
+        const targetIndex = bookData.originalDataUidMap?.[newEntry.uid];
+        if (originals?.[sourceIndex] && Number.isInteger(targetIndex)) {
+            // Copy card-only metadata without replacing the newly allocated card ID.
+            originals[targetIndex] = { ...structuredClone(originals[sourceIndex]), id: originals[targetIndex].id };
         }
-        return { originalUid: uid, newUid: newEntry.uid, bookName };
+        original.content = content1;
+        original.comment = splitTitle1 || original.comment;
+        syncWIOriginalDataEntry(bookData, uid);
+        syncWIOriginalDataEntry(bookData, newEntry.uid);
+        return { originalUid: uid, newUid: newEntry.uid };
     });
 }
 
@@ -243,4 +268,22 @@ function findParentOfEntry(tree, uid) {
         if (found) return found;
     }
     return null;
+}
+
+export function onPathfinderWorldInfoUpdated(bookName, bookData, { replaced = false } = {}) {
+    if (!replaced && isPathfinderSelfWrite(bookName)) return;
+    deleteTree(bookName, replaced);
+    syncTrackerUidsForLorebook(bookName, bookData);
+    if (replaced) detachSummaryMemoryBook(bookName);
+    else syncSummaryMemoryForBook(bookName, bookData);
+}
+
+export function onPathfinderWorldInfoRenamed(oldName, newName) {
+    renameTree(oldName, newName);
+    renameSummaryMemoryBook(oldName, newName);
+}
+
+export function onPathfinderWorldInfoDeleted(bookName) {
+    deleteTree(bookName, true);
+    detachSummaryMemoryBook(bookName);
 }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js
@@ -1,6 +1,7 @@
 import { generateRaw } from '../../../../script.js';
 import { isAbortLikeError } from '../../../util/abort-error.js';
 import { extractProfileResponseText } from '../llm-utils.js';
+import { runAsInternalPromptTransform } from '../agent-runner.js';
 import { getSettings } from './tree-store.js';
 
 // Throttled so a multi-stage pipeline failure doesn't stack toasts
@@ -36,6 +37,7 @@ export async function sidecarGenerate(prompt, systemPrompt = '', signal = null) 
  * @returns {Promise<string>}
  */
 export async function sidecarGenerateWithProfile(prompt, systemPrompt = '', profileId = '', maxTokens = 2048, signal = null) {
+    signal?.throwIfAborted();
     const ctx = window?.SillyTavern?.getContext?.();
 
     const messages = [];
@@ -46,13 +48,16 @@ export async function sidecarGenerateWithProfile(prompt, systemPrompt = '', prof
     if (ctx?.ConnectionManagerRequestService && profileId) {
         const CMRS = ctx.ConnectionManagerRequestService;
         try {
-            const result = await CMRS.sendRequest(profileId, messages, maxTokens, {
+            const result = await runAsInternalPromptTransform(() => CMRS.sendRequest(profileId, messages, maxTokens, {
                 extractData: true,
                 includePreset: true,
                 stream: false,
                 signal,
-            });
-            return typeof result === 'string' ? result : extractProfileResponseText(result);
+            }), signal);
+            signal?.throwIfAborted();
+            const text = typeof result === 'string' ? result : extractProfileResponseText(result);
+            if (!text.trim()) throw new Error('Sidecar generation failed; Pathfinder retrieval was skipped.');
+            return text;
         } catch (err) {
             if (isAbortLikeError(err, signal)) {
                 throw err;
@@ -63,20 +68,22 @@ export async function sidecarGenerateWithProfile(prompt, systemPrompt = '', prof
     }
 
     try {
-        return await generateRaw({
+        const result = await runAsInternalPromptTransform(() => generateRaw({
             prompt: messages,
             responseLength: maxTokens,
             trimNames: false,
             signal,
-        });
+            cacheScope: 'auxiliary',
+        }), signal);
+        signal?.throwIfAborted();
+        if (!result.trim()) throw new Error('Sidecar generation failed; Pathfinder retrieval was skipped.');
+        return result;
     } catch (err) {
         if (isAbortLikeError(err, signal)) {
             throw err;
         }
         console.warn('[Pathfinder] Sidecar via main model failed:', err);
         notifySidecarIssue('Sidecar generation failed; Pathfinder retrieval was skipped.', 'error');
+        throw err;
     }
-
-    return '';
 }
-

--- a/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
@@ -173,6 +173,14 @@ export function getDeletableBooks(s = getSettings()) {
     return getActiveTunnelVisionBooks(s).filter(b => canDeleteBook(b, s));
 }
 
+export function getToolWriteOptions(bookName, options = {}, getAllowedBooks = getWritableBooks) {
+    // Queued writes must recheck permissions after loading, not only when invoked.
+    return {
+        signal: options.signal,
+        isCurrent: () => (!options.isCurrent || options.isCurrent()) && getAllowedBooks().includes(bookName),
+    };
+}
+
 export function resolveTargetBook(requestedBook, writableBooks = null) {
     const books = writableBooks ?? getWritableBooks();
     if (books.length === 0) return null;

--- a/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
@@ -1,6 +1,6 @@
 import { isPathfinderSubmoduleEnabled } from '../agent-store.js';
 import { getLinkApiRequestFormat } from '../../../linkapi-utils.js';
-import { getSettings, getTree, isLorebookEnabled, canReadBook, canWriteBook, canDeleteBook } from './tree-store.js';
+import { getSettings, getTree, getAllEntryUids, isEntryEligible, isLorebookEnabled, canReadBook, canWriteBook, canDeleteBook } from './tree-store.js';
 
 const CHAT_LOREBOOK_METADATA_KEY = 'world_info';
 
@@ -56,21 +56,20 @@ export function getForcedToolChoice(chatCompletionSource, model) {
     return usesAnthropicFormat ? 'any' : 'required';
 }
 
-export function getActiveTunnelVisionBooks() {
+export function getActiveTunnelVisionBooks(s = getSettings()) {
     if (!isPathfinderSubmoduleEnabled()) {
         return [];
     }
 
-    const s = getSettings();
     const books = Array.isArray(s.enabledLorebooks)
-        ? s.enabledLorebooks.filter(b => isLorebookEnabled(b))
+        ? s.enabledLorebooks.filter(b => isLorebookEnabled(b, s))
         : [];
 
-    if (s.includeContextualLorebooks !== false) {
+    if (s.includeContextualLorebooks !== false || s.autoUseAttachedLorebook) {
         books.push(...getContextualLorebooks());
     }
 
-    return Array.from(new Set(books.filter(Boolean)));
+    return Array.from(new Set(books.filter(book => book && s.bookPermissions?.[book]?.enabled !== false)));
 }
 
 function addBookSource(sources, name, type) {
@@ -162,16 +161,16 @@ function getCharacterFileName(character) {
     return avatar.replace(/\.[^.]+$/, '');
 }
 
-export function getReadableBooks() {
-    return getActiveTunnelVisionBooks().filter(b => canReadBook(b));
+export function getReadableBooks(s = getSettings()) {
+    return getActiveTunnelVisionBooks(s).filter(b => canReadBook(b, s));
 }
 
-export function getWritableBooks() {
-    return getActiveTunnelVisionBooks().filter(b => canWriteBook(b));
+export function getWritableBooks(s = getSettings()) {
+    return getActiveTunnelVisionBooks(s).filter(b => canWriteBook(b, s));
 }
 
-export function getDeletableBooks() {
-    return getActiveTunnelVisionBooks().filter(b => canDeleteBook(b));
+export function getDeletableBooks(s = getSettings()) {
+    return getActiveTunnelVisionBooks(s).filter(b => canDeleteBook(b, s));
 }
 
 export function resolveTargetBook(requestedBook, writableBooks = null) {
@@ -203,21 +202,12 @@ export function getUnknownBookError(requestedBook, allowedBooks) {
 }
 
 export function getBookListWithDescriptions() {
-    const books = getActiveTunnelVisionBooks();
+    const books = getReadableBooks();
     return books.map(b => {
         const tree = getTree(b);
-        const entryCount = tree ? countAllEntries(tree) : 0;
+        const entryCount = getAllEntryUids(tree).length;
         return `📚 ${b} (${entryCount} entries)`;
     }).join('\n');
-}
-
-function countAllEntries(tree) {
-    if (!tree) return 0;
-    let count = (tree.entries || []).length;
-    for (const child of tree.children || []) {
-        count += countAllEntries(child);
-    }
-    return count;
 }
 
 export function preflightToolRuntimeState() {
@@ -236,6 +226,7 @@ export function preflightToolRuntimeState() {
  * @returns {Promise<Object|null>} Entry object with uid, comment, content, etc.
  */
 export async function getEntryContent(bookName, uid) {
+    if (!canReadBook(bookName)) return null;
     const ctx = window?.SillyTavern?.getContext?.();
     if (!ctx?.loadWorldInfo) {
         console.warn(`${PATHFINDER_LOG_PREFIX} Cannot fetch lorebook entry because loadWorldInfo is unavailable.`, {
@@ -253,7 +244,7 @@ export async function getEntryContent(bookName, uid) {
         }
 
         for (const entry of Object.values(bookData.entries)) {
-            if (entry && entry.uid === uid) {
+            if (isEntryEligible(entry) && entry.uid === uid) {
                 return {
                     uid: entry.uid,
                     world: entry.world || bookName,
@@ -285,6 +276,7 @@ export async function getEntryContent(bookName, uid) {
  * @returns {Promise<Object[]>} Array of entry objects
  */
 export async function getAllEntriesWithContent(bookName) {
+    if (!canReadBook(bookName)) return [];
     const ctx = window?.SillyTavern?.getContext?.();
     if (!ctx?.loadWorldInfo) {
         console.warn(`${PATHFINDER_LOG_PREFIX} Cannot fetch lorebook contents because loadWorldInfo is unavailable.`, {
@@ -301,7 +293,7 @@ export async function getAllEntriesWithContent(bookName) {
         }
 
         return Object.values(bookData.entries)
-            .filter(entry => entry && !entry.disable)
+            .filter(isEntryEligible)
             .map(entry => ({
                 uid: entry.uid,
                 world: entry.world || bookName,

--- a/public/scripts/extensions/in-chat-agents/pathfinder/prompts/pipeline-runner.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/prompts/pipeline-runner.js
@@ -4,8 +4,8 @@
 
 import { getPrompt, getPipeline } from './prompt-store.js';
 import { sidecarGenerateWithProfile } from '../llm-sidecar.js';
-import { getSettings, getTree, getAllEntryUids } from '../tree-store.js';
-import { getReadableBooks, getAllEntriesWithContent } from '../pathfinder-tool-bridge.js';
+import { canReadBook, getSettings, getTree, getAllEntryUids, isEntryEligible } from '../tree-store.js';
+import { getReadableBooks } from '../pathfinder-tool-bridge.js';
 import { logPipelineStageStart, logPipelineStageComplete, logPipelineError } from '../activity-feed.js';
 import { isAbortLikeError } from '../../../../util/abort-error.js';
 
@@ -32,6 +32,7 @@ function throwIfAborted(signal) {
  * @typedef {Object} PipelineResult
  * @property {boolean} success
  * @property {string[]} selectedEntries - Entry names/UIDs to activate
+ * @property {Object[]} [selectedEntryData] - Selected entries with their originating book and UID
  * @property {Object[]} stageResults - Results from each stage
  * @property {string} [error] - Error message if failed
  */
@@ -43,7 +44,7 @@ function throwIfAborted(signal) {
  * @param {number} [maxMessages=10] - Max messages to include in context
  * @returns {Promise<PipelineResult>}
  */
-export async function runPipeline(pipelineId, chatMessages, maxMessages = 10, signal = null) {
+export async function runPipeline(pipelineId, chatMessages, maxMessages = 10, signal = null, books = getReadableBooks()) {
     throwIfAborted(signal);
     const pipeline = getPipeline(pipelineId);
     if (!pipeline) {
@@ -57,12 +58,14 @@ export async function runPipeline(pipelineId, chatMessages, maxMessages = 10, si
     }
 
     const settings = getSettings();
-    const context = await buildPipelineContext(chatMessages, maxMessages);
+    const context = await buildPipelineContext(chatMessages, maxMessages, books, signal);
+    throwIfAborted(signal);
 
     if (!context.entry_names.trim()) {
         return {
             success: true,
             selectedEntries: [],
+            selectedEntryData: [],
             stageResults: [],
             error: 'No lorebook entries available',
         };
@@ -174,9 +177,26 @@ export async function runPipeline(pipelineId, chatMessages, maxMessages = 10, si
 
     return {
         success: true,
-        selectedEntries: currentEntries,
+        selectedEntries: currentEntries.map(name => context.entriesByName.get(name).comment),
+        selectedEntryData: currentEntries.map(name => context.entriesByName.get(name)),
         stageResults,
     };
+}
+
+export async function loadRetrievalEntries(bookName, signal = null) {
+    throwIfAborted(signal);
+    if (!canReadBook(bookName)) return [];
+    const ctx = globalThis.window?.SillyTavern?.getContext?.();
+    const data = await ctx?.loadWorldInfo?.(bookName);
+    throwIfAborted(signal);
+    if (!canReadBook(bookName)) return [];
+    // A failed read must not become a cacheable empty selection.
+    if (!data?.entries || typeof data.entries !== 'object' || Array.isArray(data.entries)) {
+        throw new Error(`Lorebook "${bookName}" has no entries while fetching all content.`);
+    }
+    return Object.values(data.entries)
+        .filter(isEntryEligible)
+        .map(entry => ({ ...entry, bookName, comment: entry.comment || entry.key?.[0] || '' }));
 }
 
 /**
@@ -185,14 +205,12 @@ export async function runPipeline(pipelineId, chatMessages, maxMessages = 10, si
  * @param {number} maxMessages
  * @returns {Promise<PipelineContext>}
  */
-async function buildPipelineContext(chatMessages, maxMessages) {
-    const books = getReadableBooks();
-
+async function buildPipelineContext(chatMessages, maxMessages, books, signal) {
     // Format chat history
     const recentMessages = chatMessages.slice(-maxMessages);
     const chat_history = recentMessages
         .map(msg => {
-            const name = msg.is_user ? 'User' : (msg.name || 'Assistant');
+            const name = msg.is_user || msg.role === 'user' ? 'User' : (msg.name || 'Assistant');
             return `${name}: ${msg.mes}`;
         })
         .join('\n\n');
@@ -209,13 +227,14 @@ async function buildPipelineContext(chatMessages, maxMessages) {
         }
 
         const treeUids = new Set(getAllEntryUids(tree));
-        const entries = await getAllEntriesWithContent(bookName);
+        const entries = await loadRetrievalEntries(bookName, signal);
         for (const entry of entries) {
             if (!treeUids.has(entry.uid) || !entry.comment) {
                 continue;
             }
-            entriesByName.set(entry.comment, { ...entry, bookName });
-            entryNames.push(`- ${entry.comment}`);
+            const name = `${JSON.stringify([bookName, entry.uid])} ${entry.comment}`;
+            entriesByName.set(name, entry);
+            entryNames.push(`- ${name}`);
         }
     }
 
@@ -282,7 +301,7 @@ function formatCandidateEntries(candidates, context, settings) {
 
     for (const name of limited) {
         const entry = context.entriesByName.get(name);
-        if (!entry) continue;
+        if (!entry || !canReadBook(entry.bookName)) continue;
 
         let content = entry.content || '';
 
@@ -311,13 +330,10 @@ function resolveEntryName(name, entriesByName) {
     }
 
     const normalized = normalizeEntryName(trimmed);
-    for (const knownName of entriesByName.keys()) {
-        if (normalizeEntryName(knownName) === normalized) {
-            return knownName;
-        }
-    }
-
-    return null;
+    const matches = [...entriesByName].filter(([knownName, entry]) =>
+        normalizeEntryName(knownName) === normalized || normalizeEntryName(entry.comment) === normalized,
+    );
+    return matches.length === 1 ? matches[0][0] : null;
 }
 
 /**
@@ -374,7 +390,7 @@ function parseOutput(response, format, entriesByName) {
                 for (const name of entries) {
                     const resolvedName = resolveEntryName(name, entriesByName);
                     if (resolvedName) {
-                        validEntries.push(resolvedName);
+                        if (!validEntries.includes(resolvedName)) validEntries.push(resolvedName);
                     }
                 }
 
@@ -400,7 +416,8 @@ function parseOutput(response, format, entriesByName) {
     // Fallback: extract entry names line by line
     const lines = trimmed.split('\n')
         .map(line => line.replace(/^[-*]\s*/, '').trim())
-        .filter(line => line && entriesByName.has(line));
+        .map(line => resolveEntryName(line, entriesByName))
+        .filter(Boolean);
 
-    return { entries: lines };
+    return { entries: [...new Set(lines)] };
 }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js
@@ -1,13 +1,12 @@
-import { chat, substituteParams } from '../../../../script.js';
-import { parseRegexFromString, world_info_logic, world_info_match_whole_words } from '../../../world-info.js';
+import { chat, getCurrentChatId } from '../../../../script.js';
 import { isAbortLikeError } from '../../../util/abort-error.js';
 import { isPathfinderSubmoduleEnabled } from '../agent-store.js';
-import { getTree, findNodeById, getAllEntryUids, getSettings } from './tree-store.js';
-import { getReadableBooks, getAllEntriesWithContent } from './pathfinder-tool-bridge.js';
+import { getTree, findNodeById, getSettings } from './tree-store.js';
+import { getReadableBooks } from './pathfinder-tool-bridge.js';
 import { sidecarGenerate } from './llm-sidecar.js';
 import { logPathfinderRetrievalDetail, logSidecarRetrieval, logPipelineStart, logPipelineComplete } from './activity-feed.js';
 import { buildTreeFromMetadata } from './tree-builder.js';
-import { runPipeline } from './prompts/pipeline-runner.js';
+import { loadRetrievalEntries, runPipeline } from './prompts/pipeline-runner.js';
 import { isSummaryMemoryEntry, markSummaryMemoryInjected } from './summary-memory-store.js';
 
 const RETRIEVAL_PROMPT_KEY = 'pathfinder_sidecar_retrieval';
@@ -18,160 +17,16 @@ export const PATHFINDER_RETRIEVAL_PROMPT_KEYS = Object.freeze([
 ]);
 
 function clearRetrievalPrompt(setExtensionPrompt, key, extensionPromptTypes, extensionPromptRoles) {
-    setExtensionPrompt(
-        key,
-        '',
-        extensionPromptTypes?.IN_PROMPT ?? 0,
-        4,
-        false,
-        extensionPromptRoles?.SYSTEM ?? 0,
-    );
-}
-
-function getRecentChatText(limit = 10) {
-    const ctx = globalThis.window?.SillyTavern?.getContext?.();
-    const messages = Array.isArray(ctx?.chat) ? ctx.chat : chat;
-    return messages
-        .slice(-limit)
-        .map(message => String(message?.mes ?? message?.content ?? message ?? ''))
-        .join('\n');
-}
-
-function transformForEntry(value, entry) {
-    return entry?.caseSensitive ? String(value ?? '') : String(value ?? '').toLowerCase();
-}
-
-function escapeRegexLiteral(value) {
-    return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function matchesWorldInfoKey(haystack, key, entry) {
-    const substituted = substituteParams(String(key ?? '')).trim();
-    if (!substituted) {
-        return false;
-    }
-
-    const keyRegex = parseRegexFromString(substituted);
-    if (keyRegex) {
-        return keyRegex.test(haystack);
-    }
-
-    const transformedHaystack = transformForEntry(haystack, entry);
-    const transformedKey = transformForEntry(substituted, entry);
-    const matchWholeWords = entry?.matchWholeWords ?? world_info_match_whole_words;
-
-    if (!matchWholeWords) {
-        return transformedHaystack.includes(transformedKey);
-    }
-
-    const keyWords = transformedKey.split(/\s+/);
-    if (keyWords.length > 1) {
-        return transformedHaystack.includes(transformedKey);
-    }
-
-    return new RegExp(`(?:^|\\W)(${escapeRegexLiteral(transformedKey)})(?:$|\\W)`).test(transformedHaystack);
-}
-
-function hasSecondaryActivationMatch(textToScan, entry) {
-    if (!entry?.selective || !Array.isArray(entry.keysecondary) || entry.keysecondary.length === 0) {
-        return true;
-    }
-
-    const selectiveLogic = entry.selectiveLogic ?? world_info_logic.AND_ANY;
-    let hasAnyMatch = false;
-    let hasAllMatch = true;
-
-    for (const key of entry.keysecondary) {
-        const matched = matchesWorldInfoKey(textToScan, key, entry);
-        if (matched) hasAnyMatch = true;
-        if (!matched) hasAllMatch = false;
-
-        if (selectiveLogic === world_info_logic.AND_ANY && matched) return true;
-        if (selectiveLogic === world_info_logic.NOT_ALL && !matched) return true;
-    }
-
-    if (selectiveLogic === world_info_logic.NOT_ANY && !hasAnyMatch) return true;
-    if (selectiveLogic === world_info_logic.AND_ALL && hasAllMatch) return true;
-    return false;
-}
-
-function getNaturalActivationReason(entry, textToScan = getRecentChatText()) {
-    if (!entry || entry.disable) {
-        return '';
-    }
-
-    if (entry.decorators?.includes?.('@@activate')) {
-        return '@@activate decorator';
-    }
-
-    if (entry.constant) {
-        return 'constant entry';
-    }
-
-    const primaryKeyMatch = Array.isArray(entry.key)
-        ? entry.key.find(key => matchesWorldInfoKey(textToScan, key, entry))
-        : null;
-    if (!primaryKeyMatch) {
-        return '';
-    }
-
-    return hasSecondaryActivationMatch(textToScan, entry)
-        ? `keyword match: ${primaryKeyMatch}`
-        : '';
-}
-
-function shouldSkipNaturalActivation(entry, textToScan) {
-    const settings = getSettings();
-    if (settings.dedupeNaturalActivation === false) {
-        return '';
-    }
-
-    return getNaturalActivationReason(entry, textToScan);
-}
-
-function getRetrievalStatusTimeoutMs() {
-    const seconds = Number(getSettings().retrievalTimeoutSeconds ?? 8);
-    return Math.max(1, Math.min(60, Number.isFinite(seconds) ? seconds : 8)) * 1000;
+    setExtensionPrompt(key, '', extensionPromptTypes?.IN_PROMPT ?? 0, 4, false, extensionPromptRoles?.SYSTEM ?? 0);
 }
 
 function throwIfAborted(signal) {
-    if (!signal?.aborted) {
-        return;
-    }
-
-    throw signal.reason ?? new Error('Pathfinder retrieval cancelled.');
-}
-
-async function withRetrievalStatusGuard(task, mode = 'retrieval', signal = null) {
-    const timeoutMs = getRetrievalStatusTimeoutMs();
-    const controller = new AbortController();
-    const onOuterAbort = () => controller.abort(signal?.reason);
-    signal?.addEventListener('abort', onOuterAbort, { once: true });
-
-    let timedOut = false;
-    const timeoutId = setTimeout(() => {
-        timedOut = true;
-        controller.abort(new Error(`Pathfinder ${mode} timed out after ${timeoutMs / 1000}s.`));
-    }, timeoutMs);
-
-    try {
-        throwIfAborted(signal);
-        return await task(controller.signal);
-    } catch (err) {
-        if (timedOut && !signal?.aborted) {
-            const timeoutError = new Error(`Pathfinder ${mode} timed out after ${timeoutMs / 1000}s before entries could be injected.`);
-            timeoutError.isPathfinderRetrievalTimeout = true;
-            timeoutError.timeoutSeconds = timeoutMs / 1000;
-            throw timeoutError;
-        }
-        throw err;
-    } finally {
-        clearTimeout(timeoutId);
-        signal?.removeEventListener('abort', onOuterAbort);
+    if (signal?.aborted) {
+        throw signal.reason ?? new Error('Pathfinder retrieval cancelled.');
     }
 }
 
-function formatCollapsedGuide(tree, bookName) {
+function formatCollapsedGuide(tree) {
     if (!tree) return '';
     const lines = [];
     function walk(node, depth = 0) {
@@ -189,373 +44,179 @@ function formatCollapsedGuide(tree, bookName) {
     return lines.join('\n');
 }
 
-async function ensureLorebookTree(bookName, signal = null) {
-    throwIfAborted(signal);
+async function ensureReadableBookTrees(bookNames, signal) {
+    const books = [...new Set(bookNames.filter(Boolean))];
+    for (const bookName of books) {
+        throwIfAborted(signal);
+        if (getTree(bookName)) continue;
 
-    if (getTree(bookName)) {
-        return true;
-    }
-
-    const ctx = window?.SillyTavern?.getContext?.();
-    if (typeof ctx?.loadWorldInfo !== 'function') {
-        console.warn(`[Pathfinder] Could not build a tree for "${bookName}" because loadWorldInfo is unavailable.`);
-        return false;
-    }
-
-    try {
-        const bookData = await ctx.loadWorldInfo(bookName);
+        const ctx = globalThis.window?.SillyTavern?.getContext?.();
+        const bookData = await ctx?.loadWorldInfo?.(bookName);
         throwIfAborted(signal);
         if (!bookData?.entries) {
-            console.warn(`[Pathfinder] Could not build a tree for "${bookName}" because no lorebook entries were found.`);
-            return false;
+            throw new Error(`Could not build a tree for "${bookName}" because no lorebook entries were found.`);
         }
-
         await buildTreeFromMetadata(bookName, bookData);
-        return true;
-    } catch (err) {
-        console.warn(`[Pathfinder] Failed to build a tree for "${bookName}".`, err);
-        return false;
+        throwIfAborted(signal);
     }
+    return books;
 }
 
-async function ensureReadableBookTrees(bookNames, signal = null) {
-    const readableBooks = Array.from(new Set((bookNames ?? []).filter(Boolean)));
-
-    for (const bookName of readableBooks) {
-        await ensureLorebookTree(bookName, signal);
-    }
-
-    return readableBooks.filter(bookName => getTree(bookName));
-}
-
-/**
- * Run predictive pipeline retrieval
- * @param {Function} setExtensionPrompt
- * @param {Object} extensionPromptTypes
- * @param {Object} extensionPromptRoles
- * @returns {Promise<void>}
- */
-async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, signal = null) {
-    const s = getSettings();
-    const pipelineId = s.pipelineId || 'default';
-    const books = await ensureReadableBookTrees(getReadableBooks(), signal);
-
-    // Get chat messages from context
-    const ctx = window?.SillyTavern?.getContext?.();
-    const chatMessages = ctx?.chat ?? [];
-
-    if (books.length === 0) {
-        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
-        logPathfinderRetrievalDetail({
-            mode: 'pipeline',
-            books,
+async function runPipelineRetrieval(books, chatMessages, signal) {
+    const pipelineId = getSettings().pipelineId || 'default';
+    if (books.length === 0 || chatMessages.length === 0) {
+        return {
+            success: true,
             selectedEntries: [],
             stageResults: [],
-            injectedPrompt: '',
-            metadata: { pipelineId, reason: 'no-readable-lorebooks' },
-        });
-        return;
+            metadata: { pipelineId, reason: books.length ? 'no-chat-messages' : 'no-readable-lorebooks' },
+        };
     }
 
-    if (chatMessages.length === 0) {
-        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
-        logPathfinderRetrievalDetail({
-            mode: 'pipeline',
-            books,
-            selectedEntries: [],
-            stageResults: [],
-            injectedPrompt: '',
-            metadata: { pipelineId, reason: 'no-chat-messages' },
-        });
-        return;
-    }
-
-    logPipelineStart(pipelineId, 2); // Assuming 2-stage pipeline
-
-    const result = await runPipeline(pipelineId, chatMessages, 10, signal);
-
+    logPipelineStart(pipelineId, 2);
+    const result = await runPipeline(pipelineId, chatMessages, 10, signal, books);
+    throwIfAborted(signal);
     logPipelineComplete(pipelineId, result.selectedEntries?.length ?? 0, result.stageResults);
 
     if (!result.success) {
-        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
         console.warn('[Pathfinder] Pipeline retrieval failed:', result.error);
-        logPathfinderRetrievalDetail({
-            mode: 'pipeline',
-            books,
-            selectedEntries: [],
-            stageResults: result.stageResults,
-            injectedPrompt: '',
-            metadata: { pipelineId, error: result.error },
-        });
-        return;
     }
 
-    if (result.selectedEntries.length === 0) {
-        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
-        logPathfinderRetrievalDetail({
-            mode: 'pipeline',
-            books,
-            selectedEntries: [],
-            stageResults: result.stageResults,
-            injectedPrompt: '',
-            metadata: { pipelineId, selectedEntryCount: 0 },
-        });
-        return;
+    return {
+        success: result.success,
+        cacheable: result.stageResults.every(stage => stage.success !== false),
+        selectedEntries: (result.selectedEntryData ?? []).map(entry => ({ name: entry.comment, bookName: entry.bookName, uid: entry.uid, content: entry.content || '' })),
+        stageResults: result.stageResults,
+        metadata: { pipelineId, ...(result.error && { error: result.error }) },
+    };
+}
+
+async function runLegacySidecarRetrieval(books, chatMessages, signal) {
+    const contextText = books.map(bookName => `\n### ${bookName}\n${formatCollapsedGuide(getTree(bookName))}\n`).join('');
+    if (!contextText.trim()) {
+        return { success: true, selectedEntries: [], stageResults: [], metadata: {} };
     }
 
-    // Build content for injection. Load each book once and index by title;
-    // the previous per-UID fetch re-loaded the whole book for every entry.
-    const entryContents = [];
-    const skippedNaturalEntries = [];
-    const textToScan = getRecentChatText();
-    const availableByName = await collectTreeEntriesByName(books);
+    const history = chatMessages.map(message => `${message.is_user || message.role === 'user' ? 'User' : (message.name || 'Assistant')}: ${message.mes}`).join('\n\n');
+    const prompt = `Given the current conversation context, which of these lorebook waypoints contain information relevant to what's happening right now? List the waypoint/node IDs (the "id: node_..." values) you'd retrieve.\n\n${history}\n\n${contextText}`;
+    const response = await sidecarGenerate(prompt, 'You are a lorebook retrieval assistant. Analyze the conversation and identify which waypoints are relevant. Respond with waypoint/node IDs (the "id: node_..." values), one per line.', signal);
+    throwIfAborted(signal);
+    const nodeIds = [...new Set(response.split('\n').map(line => line.match(/node_[a-z0-9]+/i)?.[0]).filter(Boolean))];
+    const selectedEntries = [];
 
-    for (const entryName of result.selectedEntries) {
-        const entry = availableByName.get(entryName);
-        if (!entry) continue;
+    for (const bookName of books) {
+        const tree = getTree(bookName);
+        const uids = new Set(nodeIds.flatMap(nodeId => findNodeById(tree, nodeId)?.entries ?? []));
+        if (uids.size === 0) continue;
 
-        const naturalActivationReason = shouldSkipNaturalActivation(entry, textToScan);
-        if (naturalActivationReason) {
-            skippedNaturalEntries.push({
-                name: entry.comment,
-                bookName: entry.bookName,
-                uid: entry.uid,
-                reason: naturalActivationReason,
-            });
-            continue;
+        const entries = await loadRetrievalEntries(bookName, signal);
+        for (const entry of entries) {
+            if (uids.has(entry.uid)) selectedEntries.push({ name: entry.comment, bookName, uid: entry.uid, content: entry.content || '' });
         }
+    }
 
-        entryContents.push({
-            name: entry.comment,
+    logSidecarRetrieval(nodeIds, selectedEntries.length);
+    return {
+        success: true,
+        selectedEntries,
+        stageResults: [{ stageIndex: 0, promptId: 'legacy-sidecar', success: true, entriesFound: selectedEntries.length, nodeIds }],
+        metadata: { nodeIds },
+    };
+}
+
+export function injectPathfinderRetrieval(result, setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, nativeEntries = []) {
+    if (!result?.success || !Array.isArray(result.selectedEntries)) return;
+
+    const selectedEntries = [];
+    const skippedNaturalEntries = [];
+    const readableBooks = new Set(getReadableBooks());
+    for (const entry of result.selectedEntries) {
+        if (!readableBooks.has(entry.bookName)) continue;
+        if (result.dedupeNaturalActivation !== false && nativeEntries.some(native =>
+            native.world === entry.bookName && String(native.uid) === String(entry.uid),
+        )) {
+            skippedNaturalEntries.push({ name: entry.name, bookName: entry.bookName, uid: entry.uid, reason: 'WORLD_INFO_ACTIVATED' });
+        } else {
+            selectedEntries.push(entry);
+        }
+    }
+
+    const injectedPrompt = selectedEntries.length
+        ? `<pathfinder_context>\n${selectedEntries.map(entry => `[${entry.name}]\n${entry.content}`).join('\n\n')}\n</pathfinder_context>`
+        : '';
+    if (setExtensionPrompt(result.promptKey, injectedPrompt, extensionPromptTypes?.IN_PROMPT ?? 0, 4, false, extensionPromptRoles?.SYSTEM ?? 0) === false) {
+        return;
+    }
+    if (selectedEntries.some(entry => isSummaryMemoryEntry(entry))) {
+        markSummaryMemoryInjected({ mode: result.mode });
+    }
+    logPathfinderRetrievalDetail({
+        mode: result.mode,
+        books: result.books,
+        selectedEntries: selectedEntries.map(entry => ({
+            name: entry.name,
             bookName: entry.bookName,
             uid: entry.uid,
-            content: entry.content,
-        });
-    }
-
-    if (entryContents.length > 0) {
-        const formattedContent = entryContents
-            .map(e => `[${e.name}]\n${e.content}`)
-            .join('\n\n');
-
-        const content = `<pathfinder_context>\n${formattedContent}\n</pathfinder_context>`;
-        if (entryContents.some(entry => isSummaryMemoryEntry(entry))) {
-            markSummaryMemoryInjected({ mode: 'pipeline' });
-        }
-
-        logPathfinderRetrievalDetail({
-            mode: 'pipeline',
-            books,
-            selectedEntries: entryContents.map(entry => ({
-                name: entry.name,
-                bookName: entry.bookName || '',
-                uid: entry.uid ?? null,
-                preview: entry.content ? String(entry.content).slice(0, 240) : '',
-            })),
-            stageResults: result.stageResults,
-            injectedPrompt: content,
-            metadata: {
-                pipelineId,
-                selectedEntryCount: entryContents.length,
-                candidateCount: result.selectedEntries?.length ?? 0,
-                skippedNaturalActivationCount: skippedNaturalEntries.length,
-                skippedNaturalEntries,
-            },
-        });
-        setExtensionPrompt(
-            PIPELINE_RETRIEVAL_KEY,
-            content,
-            extensionPromptTypes?.IN_PROMPT ?? 0,
-            4,
-            false,
-            extensionPromptRoles?.SYSTEM ?? 0,
-        );
-    } else {
-        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
-        logPathfinderRetrievalDetail({
-            mode: 'pipeline',
-            books,
-            selectedEntries: [],
-            stageResults: result.stageResults,
-            injectedPrompt: '',
-            metadata: {
-                pipelineId,
-                selectedEntryCount: 0,
-                candidateCount: result.selectedEntries?.length ?? 0,
-                skippedNaturalActivationCount: skippedNaturalEntries.length,
-                skippedNaturalEntries,
-            },
-        });
-    }
+            preview: entry.content ? String(entry.content).slice(0, 240) : '',
+        })),
+        stageResults: result.stageResults,
+        injectedPrompt,
+        metadata: {
+            ...result.metadata,
+            selectedEntryCount: selectedEntries.length,
+            candidateCount: result.selectedEntries.length,
+            skippedNaturalActivationCount: skippedNaturalEntries.length,
+            skippedNaturalEntries,
+        },
+    });
 }
 
-/**
- * Load every tree-listed entry once per book and index it by title.
- * @param {string[]} books
- * @returns {Promise<Map<string, Object>>} title -> entry (with bookName); first match wins
- */
-async function collectTreeEntriesByName(books) {
-    const byName = new Map();
-    for (const bookName of books) {
-        const tree = getTree(bookName);
-        if (!tree) continue;
-        const treeUids = new Set(getAllEntryUids(tree));
-        const entries = await getAllEntriesWithContent(bookName);
-        for (const entry of entries) {
-            if (!treeUids.has(entry.uid) || !entry.comment) continue;
-            if (!byName.has(entry.comment)) {
-                byName.set(entry.comment, { ...entry, bookName });
-            }
-        }
-    }
-    return byName;
-}
-
-/**
- * Run legacy waypoint-based sidecar retrieval
- * @param {Function} setExtensionPrompt
- * @param {Object} extensionPromptTypes
- * @param {Object} extensionPromptRoles
- * @returns {Promise<void>}
- */
-async function runLegacySidecarRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, signal = null) {
-    const books = await ensureReadableBookTrees(getReadableBooks(), signal);
-
-    let contextText = '';
-
-    for (const bookName of books) {
-        const tree = getTree(bookName);
-        if (!tree) continue;
-        contextText += `\n### ${bookName}\n${formatCollapsedGuide(tree, bookName)}\n`;
-    }
-
-    if (!contextText.trim()) {
-        clearRetrievalPrompt(setExtensionPrompt, RETRIEVAL_PROMPT_KEY, extensionPromptTypes, extensionPromptRoles);
-        return;
-    }
-
-    const prompt = `Given the current conversation context, which of these lorebook waypoints contain information relevant to what's happening right now? List the waypoint/node IDs (the "id: node_..." values) you'd retrieve.\n\n${contextText}`;
-
-    try {
-        const response = await sidecarGenerate(prompt, 'You are a lorebook retrieval assistant. Analyze the conversation and identify which waypoints are relevant. Respond with waypoint/node IDs (the "id: node_..." values), one per line.', signal);
-        const nodeIds = Array.from(new Set(
-            response.split('\n')
-                .map(line => line.match(/node_[a-z0-9]+/i)?.[0])
-                .filter(Boolean),
-        ));
-
-        const textToScan = getRecentChatText();
-        const selectedEntries = [];
-        const skippedNaturalEntries = [];
-
-        for (const bookName of books) {
-            const tree = getTree(bookName);
-            if (!tree) continue;
-            const uids = new Set();
-            for (const nodeId of nodeIds) {
-                const node = findNodeById(tree, nodeId);
-                for (const uid of node?.entries ?? []) {
-                    uids.add(uid);
-                }
-            }
-            if (uids.size === 0) continue;
-
-            const entries = await getAllEntriesWithContent(bookName);
-            for (const entry of entries) {
-                if (!uids.has(entry.uid)) continue;
-                const reason = shouldSkipNaturalActivation(entry, textToScan);
-                if (reason) {
-                    skippedNaturalEntries.push({ name: entry.comment, bookName, uid: entry.uid, reason });
-                    continue;
-                }
-                selectedEntries.push({ name: entry.comment, bookName, uid: entry.uid, content: entry.content });
-            }
-        }
-
-        const injectedPrompt = selectedEntries.length > 0
-            ? `<pathfinder_context>\n${selectedEntries.map(e => `[${e.name}]\n${e.content}`).join('\n\n')}\n</pathfinder_context>`
-            : '';
-
-        logSidecarRetrieval(nodeIds, selectedEntries.length);
-        logPathfinderRetrievalDetail({
-            mode: 'tool-retrieval',
-            books,
-            selectedEntries: selectedEntries.map(entry => ({
-                uid: entry.uid,
-                name: entry.name,
-                preview: entry.content ? String(entry.content).slice(0, 240) : '',
-            })),
-            stageResults: [{
-                stageIndex: 0,
-                promptId: 'legacy-sidecar',
-                success: true,
-                entriesFound: selectedEntries.length,
-                nodeIds,
-            }],
-            injectedPrompt,
-            metadata: {
-                nodeIds,
-                selectedEntryCount: selectedEntries.length,
-                skippedNaturalActivationCount: skippedNaturalEntries.length,
-                skippedNaturalEntries,
-            },
-        });
-
-        if (selectedEntries.some(entry => isSummaryMemoryEntry(entry))) {
-            markSummaryMemoryInjected({ mode: 'tool-retrieval' });
-        }
-
-        if (selectedEntries.length > 0) {
-            setExtensionPrompt(RETRIEVAL_PROMPT_KEY, injectedPrompt, extensionPromptTypes?.IN_PROMPT ?? 0, 4, false, extensionPromptRoles?.SYSTEM ?? 0);
-        } else {
-            clearRetrievalPrompt(setExtensionPrompt, RETRIEVAL_PROMPT_KEY, extensionPromptTypes, extensionPromptRoles);
-        }
-    } catch (err) {
-        if (isAbortLikeError(err, signal)) {
-            throw err;
-        }
-        console.warn('[Pathfinder] Sidecar retrieval failed:', err);
-        clearRetrievalPrompt(setExtensionPrompt, RETRIEVAL_PROMPT_KEY, extensionPromptTypes, extensionPromptRoles);
-    }
-}
-
-export async function runSidecarRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, signal = null) {
-    if (!isPathfinderSubmoduleEnabled()) {
-        return;
-    }
-
+export async function runSidecarRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, signal = null, { chatMessages = null } = {}) {
     const s = getSettings();
-    if (!(s.sidecarEnabled || s.pipelineEnabled)) return;
+    if (!isPathfinderSubmoduleEnabled() || !(s.sidecarEnabled || s.pipelineEnabled)) {
+        return { success: false };
+    }
 
-    const books = getReadableBooks();
-    if (books.length === 0) return;
-
+    const chatId = getCurrentChatId();
+    const isCurrent = () => !signal?.aborted && isPathfinderSubmoduleEnabled() && getCurrentChatId() === chatId;
+    const writePrompt = (...args) => isCurrent() ? setExtensionPrompt(...args) : false;
+    const ctx = globalThis.window?.SillyTavern?.getContext?.();
+    const messages = (chatMessages ?? ctx?.chat ?? chat).slice(-10).map(message => ({
+        name: message.name,
+        is_user: message.is_user || message.role === 'user',
+        mes: String(message.mes ?? message.content ?? ''),
+    }));
     const mode = s.pipelineEnabled ? 'pipeline' : 'tool-retrieval';
+    const promptKey = s.pipelineEnabled ? PIPELINE_RETRIEVAL_KEY : RETRIEVAL_PROMPT_KEY;
+    const seconds = Number(s.retrievalTimeoutSeconds ?? 8);
+    const timeoutMs = Math.max(1, Math.min(60, Number.isFinite(seconds) ? seconds : 8)) * 1000;
+    const timeoutId = setTimeout(() => {
+        if (isCurrent()) {
+            globalThis.toastr?.warning?.('Pathfinder is processing lore for this reply...', 'Please wait');
+        }
+    }, timeoutMs);
 
     try {
-        await withRetrievalStatusGuard(async (retrievalSignal) => {
-            if (s.pipelineEnabled) {
-                await runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, retrievalSignal);
-            } else {
-                await runLegacySidecarRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, retrievalSignal);
-            }
-        }, mode, signal);
+        throwIfAborted(signal);
+        for (const key of PATHFINDER_RETRIEVAL_PROMPT_KEYS) {
+            clearRetrievalPrompt(writePrompt, key, extensionPromptTypes, extensionPromptRoles);
+        }
+        const books = await ensureReadableBookTrees(getReadableBooks(), signal);
+        const selection = s.pipelineEnabled
+            ? await runPipelineRetrieval(books, messages, signal)
+            : await runLegacySidecarRetrieval(books, messages, signal);
+        throwIfAborted(signal);
+        if (!isCurrent()) return { success: false };
+
+        const result = { ...selection, books, mode, promptKey, dedupeNaturalActivation: s.dedupeNaturalActivation };
+        injectPathfinderRetrieval(result, writePrompt, extensionPromptTypes, extensionPromptRoles);
+        return result;
     } catch (err) {
-        if (err?.isPathfinderRetrievalTimeout) {
-            console.warn('[Pathfinder] Retrieval timed out; generating without injected entries.', err);
-            for (const key of PATHFINDER_RETRIEVAL_PROMPT_KEYS) {
-                clearRetrievalPrompt(setExtensionPrompt, key, extensionPromptTypes, extensionPromptRoles);
-            }
-            logPathfinderRetrievalDetail({
-                mode,
-                books,
-                selectedEntries: [],
-                stageResults: [],
-                injectedPrompt: '',
-                metadata: { timedOut: true, timeoutSeconds: err.timeoutSeconds },
-            });
-        } else if (!isAbortLikeError(err, signal)) {
+        if (!isAbortLikeError(err, signal)) {
             console.warn('[Pathfinder] Retrieval failed:', err);
         }
+        return { success: false };
+    } finally {
+        clearTimeout(timeoutId);
     }
 }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js
@@ -1,5 +1,6 @@
 import { updateEntry } from './entry-manager.js';
 import { accountStorage } from '../../../util/AccountStorage.js';
+import { isEntryEligible, parseEntryUid } from './tree-store.js';
 
 const STORAGE_KEY = 'pathfinder-summary-memory-state';
 const listeners = new Set();
@@ -8,14 +9,14 @@ let state = loadState();
 function loadState() {
     try {
         const parsed = JSON.parse(accountStorage.getItem(STORAGE_KEY) || '{}');
-        if (parsed && typeof parsed === 'object') {
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
             return {
                 title: String(parsed.title || ''),
                 content: String(parsed.content || ''),
                 significance: String(parsed.significance || ''),
                 arc: String(parsed.arc || ''),
                 bookName: String(parsed.bookName || ''),
-                uid: Number.isFinite(Number(parsed.uid)) ? Number(parsed.uid) : null,
+                uid: parseEntryUid(parsed.uid),
                 updatedAt: Number(parsed.updatedAt || 0),
                 injectedAt: Number(parsed.injectedAt || 0),
                 injectedMode: String(parsed.injectedMode || ''),
@@ -45,7 +46,11 @@ function persistState() {
         // Persistence failure leaves the current in-memory summary available.
     }
     for (const listener of listeners) {
-        listener(getSummaryMemoryState());
+        try {
+            listener(getSummaryMemoryState());
+        } catch (error) {
+            console.warn(error);
+        }
     }
 }
 
@@ -70,7 +75,7 @@ export function setSummaryMemoryCreated({ title, content, significance, arc, boo
         significance: String(significance || ''),
         arc: String(arc || ''),
         bookName: String(bookName || ''),
-        uid: Number.isFinite(Number(uid)) ? Number(uid) : null,
+        uid: parseEntryUid(uid),
         updatedAt: Date.now(),
         injectedAt: 0,
         injectedMode: '',
@@ -79,18 +84,57 @@ export function setSummaryMemoryCreated({ title, content, significance, arc, boo
 }
 
 export async function saveSummaryMemoryContent(content) {
+    const previous = state;
+    const nextContent = String(content || '').trim();
+    if (previous.bookName && previous.uid !== null) {
+        try {
+            await updateEntry(previous.bookName, previous.uid, formatSummaryContent(nextContent, previous.significance), previous.title || undefined, {
+                title: previous.title,
+                content: formatSummaryContent(previous.content, previous.significance),
+            });
+        } catch (error) {
+            if (error.code === 'PATHFINDER_ENTRY_CHANGED' && state === previous) detachSummaryMemoryBook(previous.bookName);
+            throw error;
+        }
+        return;
+    }
+    state = { ...previous, content: nextContent, updatedAt: Date.now(), injectedAt: 0, injectedMode: '' };
+    persistState();
+}
+
+export function detachSummaryMemoryBook(bookName) {
+    if (state.bookName !== bookName) return;
+    state = { ...state, bookName: '', uid: null, injectedAt: 0, injectedMode: '' };
+    persistState();
+}
+
+export function renameSummaryMemoryBook(oldName, newName) {
+    if (state.bookName !== oldName) return;
+    state = { ...state, bookName: newName };
+    persistState();
+}
+
+export function syncSummaryMemoryForBook(bookName, bookData, previousEntry = undefined) {
+    if (state.bookName !== bookName || state.uid === null) return;
+    const entry = Object.values(bookData?.entries || {}).find(item => item?.uid === state.uid);
+    const expected = previousEntry === undefined ? entry : previousEntry;
+    if (!isEntryEligible(entry) || !isSummaryMemoryEntry({ ...expected, bookName })) {
+        detachSummaryMemoryBook(bookName);
+        return;
+    }
+    if (isSummaryMemoryEntry({ ...entry, bookName })) return;
+    const significance = String(entry.content || '').match(/^Significance:\s*([^\n]*)\n\n/i)?.[1] || '';
+    const title = String(entry.comment || '');
     state = {
         ...state,
-        content: String(content || '').trim(),
+        title,
+        content: stripSummaryContent(entry.content),
+        significance,
+        arc: state.arc && title.endsWith(` \u2014 ${state.arc}`) ? state.arc : '',
         updatedAt: Date.now(),
         injectedAt: 0,
         injectedMode: '',
     };
-
-    if (state.bookName && state.uid !== null) {
-        await updateEntry(state.bookName, state.uid, formatSummaryContent(state.content, state.significance), state.title || undefined);
-    }
-
     persistState();
 }
 
@@ -108,11 +152,10 @@ export function markSummaryMemoryInjected({ mode = '' } = {}) {
 }
 
 export function isSummaryMemoryEntry(entry) {
-    if (!entry || state.uid === null) {
-        return false;
-    }
-
-    return Number(entry.uid) === Number(state.uid) && (!state.bookName || entry.bookName === state.bookName);
+    return isEntryEligible(entry) && state.uid !== null
+        && parseEntryUid(entry.uid) === state.uid && (entry.bookName ?? entry.world) === state.bookName
+        && (entry.comment ?? entry.name ?? entry.title) === state.title
+        && String(entry.content || '').trim() === formatSummaryContent(state.content, state.significance);
 }
 
 export function onSummaryMemoryChanged(listener) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tool-confirmation.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tool-confirmation.js
@@ -10,12 +10,12 @@ const MAX_ARG_PREVIEW_LENGTH = 300;
  * @param {string} toolName
  * @returns {boolean}
  */
-export function shouldConfirmToolCall(toolName) {
+export function shouldConfirmToolCall(toolName, settings = getSettings()) {
     if (!CONFIRMABLE_TOOLS.has(toolName)) {
         return false;
     }
 
-    const confirmTools = getSettings().confirmTools;
+    const confirmTools = settings.confirmTools;
     return confirmTools?.[toolName] === true;
 }
 
@@ -42,9 +42,12 @@ export function formatToolArgsPreview(args) {
  * so this module stays loadable in dependency-light environments.
  * @param {string} displayName - Human-readable tool name
  * @param {object} args - Tool call arguments from the model
+ * @param {AbortSignal?} signal
  * @returns {Promise<boolean>} true when the user approved the call
  */
-export async function confirmToolCall(displayName, args) {
+export async function confirmToolCall(displayName, args, signal = null) {
+    if (signal?.aborted) return false;
+
     const ctx = globalThis.window?.SillyTavern?.getContext?.();
     const Popup = ctx?.Popup;
     const popupType = ctx?.POPUP_TYPE;
@@ -59,11 +62,25 @@ export async function confirmToolCall(displayName, args) {
         ${preview ? `<pre class="justifyLeft">${escapeHtml(preview)}</pre>` : ''}
     `;
 
+    let onAbort;
     try {
-        const result = await new Popup(content, popupType.CONFIRM, '', { okButton: 'Allow', cancelButton: 'Deny' }).show();
-        return result === (ctx.POPUP_RESULT?.AFFIRMATIVE ?? 1);
+        const popup = new Popup(content, popupType.CONFIRM, '', { okButton: 'Allow', cancelButton: 'Deny' });
+        const cancelled = new Promise(resolve => {
+            onAbort = () => {
+                resolve(false);
+                Promise.resolve().then(() => popup.completeCancelled?.()).catch(() => {});
+            };
+        });
+        signal?.addEventListener('abort', onAbort, { once: true });
+        if (signal?.aborted) {
+            return false;
+        }
+        const result = await Promise.race([popup.show(), cancelled]);
+        return !signal?.aborted && result === (ctx.POPUP_RESULT?.AFFIRMATIVE ?? 1);
     } catch (err) {
         console.warn('[Pathfinder] Tool confirmation dialog failed; declining the call.', err);
         return false;
+    } finally {
+        signal?.removeEventListener('abort', onAbort);
     }
 }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js
@@ -1,4 +1,5 @@
 import { forgetEntry } from '../entry-manager.js';
+import { parseEntryUid } from '../tree-store.js';
 import { getDeletableBooks, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
@@ -6,22 +7,30 @@ import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../a
 const COMPACT_DESCRIPTION = 'Disable or delete a lorebook entry that is no longer relevant.';
 
 function toBooleanArg(value) {
+    if (value === undefined) return false;
+    if (typeof value === 'boolean') return value;
     if (typeof value === 'string') {
-        return ['true', '1', 'yes'].includes(value.trim().toLowerCase());
+        const normalized = value.trim().toLowerCase();
+        if (['true', '1', 'yes'].includes(normalized)) return true;
+        if (['false', '0', 'no'].includes(normalized)) return false;
     }
-    return Boolean(value);
+    return null;
 }
 
 async function forgetAction(args) {
-    const uid = Number(args.uid);
+    const uid = parseEntryUid(args.uid);
     const bookName = String(args.book || '').trim();
     const hardDelete = toBooleanArg(args.hard_delete);
 
     logToolCallStarted(TOOL_NAMES.FORGET, { uid, bookName, hardDelete });
 
-    if (!uid && uid !== 0) {
+    if (uid === null) {
         logToolCallError(TOOL_NAMES.FORGET, 'Missing UID');
         return 'Error: "uid" is required.';
+    }
+    if (hardDelete === null) {
+        logToolCallError(TOOL_NAMES.FORGET, 'Permanent deletion request refused; the tool supplied an invalid permanent deletion choice.');
+        return 'Permanent deletion request refused; the tool supplied an invalid permanent deletion choice.';
     }
 
     const allowedBooks = hardDelete ? getDeletableBooks() : getWritableBooks();
@@ -42,7 +51,7 @@ async function forgetAction(args) {
     try {
         const result = await forgetEntry(targetBook, uid, hardDelete);
         logToolCallCompleted(TOOL_NAMES.FORGET, `Forgot UID:${uid} (${result.disabled ? 'disabled' : 'deleted'})`);
-        return `🗑️ ${hardDelete ? 'Deleted' : 'Disabled'} entry UID:${uid} in "${targetBook}". ${hardDelete ? 'The entry has been permanently removed.' : 'The entry is disabled and can be re-enabled later.'}`;
+        return `🗑️ ${hardDelete ? 'Deleted' : 'Disabled'} entry UID:${uid} in "${result.bookName}". ${hardDelete ? 'The entry has been permanently removed.' : 'The entry is disabled and can be re-enabled later.'}`;
     } catch (err) {
         logToolCallError(TOOL_NAMES.FORGET, err.message);
         return `❌ Failed to forget: ${err.message}`;

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js
@@ -1,6 +1,6 @@
 import { forgetEntry } from '../entry-manager.js';
 import { parseEntryUid } from '../tree-store.js';
-import { getDeletableBooks, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getDeletableBooks, getToolWriteOptions, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -17,7 +17,7 @@ function toBooleanArg(value) {
     return null;
 }
 
-async function forgetAction(args) {
+async function forgetAction(args, options = {}) {
     const uid = parseEntryUid(args.uid);
     const bookName = String(args.book || '').trim();
     const hardDelete = toBooleanArg(args.hard_delete);
@@ -49,7 +49,7 @@ async function forgetAction(args) {
     }
 
     try {
-        const result = await forgetEntry(targetBook, uid, hardDelete);
+        const result = await forgetEntry(targetBook, uid, hardDelete, getToolWriteOptions(targetBook, options, hardDelete ? getDeletableBooks : getWritableBooks));
         logToolCallCompleted(TOOL_NAMES.FORGET, `Forgot UID:${uid} (${result.disabled ? 'disabled' : 'deleted'})`);
         return `🗑️ ${hardDelete ? 'Deleted' : 'Disabled'} entry UID:${uid} in "${result.bookName}". ${hardDelete ? 'The entry has been permanently removed.' : 'The entry is disabled and can be re-enabled later.'}`;
     } catch (err) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/merge-split.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/merge-split.js
@@ -1,12 +1,12 @@
 import { mergeEntries, splitEntry } from '../entry-manager.js';
 import { canDeleteBook, parseEntryUid } from '../tree-store.js';
-import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getToolWriteOptions, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
 const COMPACT_DESCRIPTION = 'Merge related entries together or split a long entry into two.';
 
-async function mergeSplitAction(args) {
+async function mergeSplitAction(args, options = {}) {
     const action = String(args.action || '').trim().toLowerCase();
     const bookName = String(args.book || '').trim();
 
@@ -38,7 +38,7 @@ async function mergeSplitAction(args) {
             if (uid1 === null || uid2 === null) {
                 return 'Error: "uid1" and "uid2" required for merge.';
             }
-            const result = await mergeEntries(targetBook, uid1, uid2, mergedTitle || undefined);
+            const result = await mergeEntries(targetBook, uid1, uid2, mergedTitle || undefined, getToolWriteOptions(targetBook, options, () => getWritableBooks().filter(book => canDeleteBook(book))));
             logToolCallCompleted(TOOL_NAMES.MERGE_SPLIT, `Merged UID:${uid1} + UID:${uid2}`);
             return `✂️ Merged UID:${uid1} and UID:${uid2} into "${result.mergedUid}" in "${result.bookName}". UID:${uid2} removed.`;
         }
@@ -51,7 +51,7 @@ async function mergeSplitAction(args) {
             const content2 = String(args.content2 || '').trim();
             if (uid === null) return 'Error: "uid" required for split.';
             if (!content1 || !content2) return 'Error: "content1" and "content2" required for split.';
-            const result = await splitEntry(targetBook, uid, title1, content1, title2, content2);
+            const result = await splitEntry(targetBook, uid, title1, content1, title2, content2, getToolWriteOptions(targetBook, options));
             logToolCallCompleted(TOOL_NAMES.MERGE_SPLIT, `Split UID:${uid}`);
             return `✂️ Split UID:${uid} into UID:${result.originalUid} and UID:${result.newUid} in "${result.bookName}".`;
         }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/merge-split.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/merge-split.js
@@ -1,4 +1,5 @@
 import { mergeEntries, splitEntry } from '../entry-manager.js';
+import { canDeleteBook, parseEntryUid } from '../tree-store.js';
 import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
@@ -16,7 +17,7 @@ async function mergeSplitAction(args) {
         return 'Error: "action" is required. Use "merge" or "split".';
     }
 
-    const writableBooks = getWritableBooks();
+    const writableBooks = getWritableBooks().filter(book => action !== 'merge' || canDeleteBook(book));
     const bookError = getUnknownBookError(bookName, writableBooks);
     if (bookError) {
         logToolCallError(TOOL_NAMES.MERGE_SPLIT, `Unknown book: ${bookName}`);
@@ -31,28 +32,28 @@ async function mergeSplitAction(args) {
 
     try {
         if (action === 'merge') {
-            const uid1 = Number(args.uid1);
-            const uid2 = Number(args.uid2);
+            const uid1 = parseEntryUid(args.uid1);
+            const uid2 = parseEntryUid(args.uid2);
             const mergedTitle = String(args.merged_title || '').trim();
-            if ((!uid1 && uid1 !== 0) || (!uid2 && uid2 !== 0)) {
+            if (uid1 === null || uid2 === null) {
                 return 'Error: "uid1" and "uid2" required for merge.';
             }
             const result = await mergeEntries(targetBook, uid1, uid2, mergedTitle || undefined);
             logToolCallCompleted(TOOL_NAMES.MERGE_SPLIT, `Merged UID:${uid1} + UID:${uid2}`);
-            return `✂️ Merged UID:${uid1} and UID:${uid2} into "${result.mergedUid}" in "${targetBook}". UID:${uid2} removed.`;
+            return `✂️ Merged UID:${uid1} and UID:${uid2} into "${result.mergedUid}" in "${result.bookName}". UID:${uid2} removed.`;
         }
 
         if (action === 'split') {
-            const uid = Number(args.uid);
+            const uid = parseEntryUid(args.uid);
             const title1 = String(args.title1 || '').trim();
             const content1 = String(args.content1 || '').trim();
             const title2 = String(args.title2 || '').trim();
             const content2 = String(args.content2 || '').trim();
-            if (!uid && uid !== 0) return 'Error: "uid" required for split.';
+            if (uid === null) return 'Error: "uid" required for split.';
             if (!content1 || !content2) return 'Error: "content1" and "content2" required for split.';
             const result = await splitEntry(targetBook, uid, title1, content1, title2, content2);
             logToolCallCompleted(TOOL_NAMES.MERGE_SPLIT, `Split UID:${uid}`);
-            return `✂️ Split UID:${uid} into UID:${result.originalUid} and UID:${result.newUid} in "${targetBook}".`;
+            return `✂️ Split UID:${uid} into UID:${result.originalUid} and UID:${result.newUid} in "${result.bookName}".`;
         }
 
         logToolCallError(TOOL_NAMES.MERGE_SPLIT, `Unknown action: ${action}`);

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js
@@ -1,6 +1,6 @@
 import { canReadBook, getSettings, isEntryEligible } from '../tree-store.js';
 import { createEntry } from '../entry-manager.js';
-import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getToolWriteOptions, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -21,7 +21,7 @@ function trigramSimilarity(a, b) {
     return intersection / Math.max(ta.size, tb.size);
 }
 
-async function rememberAction(args) {
+async function rememberAction(args, options = {}) {
     const settings = getSettings();
     const title = String(args.title || '').trim();
     const content = String(args.content || '').trim();
@@ -69,7 +69,7 @@ async function rememberAction(args) {
     }
 
     try {
-        const result = await createEntry(targetBook, title, content);
+        const result = await createEntry(targetBook, title, content, [], getToolWriteOptions(targetBook, options));
         logToolCallCompleted(TOOL_NAMES.REMEMBER, `Created: ${title}`);
         return `✅ Remembered "${title}" in lorebook "${result.bookName}" (UID: ${result.uid}). The entry is filed under the appropriate waypoint.`;
     } catch (err) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js
@@ -1,4 +1,4 @@
-import { getSettings } from '../tree-store.js';
+import { canReadBook, getSettings, isEntryEligible } from '../tree-store.js';
 import { createEntry } from '../entry-manager.js';
 import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
@@ -48,13 +48,13 @@ async function rememberAction(args) {
         return 'No Pathfinder-enabled lorebooks available for writing. Enable at least one lorebook.';
     }
 
-    if (settings.dedupDetection) {
+    if (settings.dedupDetection && canReadBook(targetBook)) {
         try {
             const ctx = window?.SillyTavern?.getContext?.();
             const bookData = await ctx?.loadWorldInfo?.(targetBook);
             if (bookData?.entries) {
                 for (const [, entry] of Object.entries(bookData.entries)) {
-                    if (entry && !entry.disable) {
+                    if (isEntryEligible(entry)) {
                         const sim = trigramSimilarity(entry.content || '', content);
                         if (sim >= (settings.dedupThreshold || 0.85)) {
                             logToolCallError(TOOL_NAMES.REMEMBER, `Duplicate of UID ${entry.uid}`);
@@ -71,7 +71,7 @@ async function rememberAction(args) {
     try {
         const result = await createEntry(targetBook, title, content);
         logToolCallCompleted(TOOL_NAMES.REMEMBER, `Created: ${title}`);
-        return `✅ Remembered "${title}" in lorebook "${targetBook}" (UID: ${result.uid}). The entry is filed under the appropriate waypoint.`;
+        return `✅ Remembered "${title}" in lorebook "${result.bookName}" (UID: ${result.uid}). The entry is filed under the appropriate waypoint.`;
     } catch (err) {
         logToolCallError(TOOL_NAMES.REMEMBER, err.message);
         return `❌ Failed to remember: ${err.message}`;

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/reorganize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/reorganize.js
@@ -1,12 +1,12 @@
 import { moveEntry, createCategory } from '../entry-manager.js';
 import { parseEntryUid } from '../tree-store.js';
-import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getToolWriteOptions, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
 const COMPACT_DESCRIPTION = 'Move entries between waypoints or create new waypoints to reorganize the lorebook.';
 
-async function reorganizeAction(args) {
+async function reorganizeAction(args, options = {}) {
     const action = String(args.action || '').trim().toLowerCase();
     const bookName = String(args.book || '').trim();
 
@@ -36,7 +36,7 @@ async function reorganizeAction(args) {
             const targetNodeId = typeof args.target_node_id === 'string' ? args.target_node_id.trim() : '';
             if (uid === null) return 'Error: "uid" required for move.';
             if (!targetNodeId) return 'Error: "target_node_id" required for move.';
-            const result = await moveEntry(targetBook, uid, targetNodeId);
+            const result = await moveEntry(targetBook, uid, targetNodeId, getToolWriteOptions(targetBook, options));
             logToolCallCompleted(TOOL_NAMES.REORGANIZE, `Moved UID:${uid} to ${targetNodeId}`);
             return `🔀 Moved entry UID:${uid} to waypoint ${targetNodeId} in "${result.bookName}".`;
         }
@@ -46,7 +46,7 @@ async function reorganizeAction(args) {
             const parentNodeId = String(args.parent_node_id || '').trim() || null;
             const description = String(args.description || '').trim();
             if (!name) return 'Error: "name" required for create_waypoint.';
-            const result = await createCategory(targetBook, parentNodeId, name, description);
+            const result = await createCategory(targetBook, parentNodeId, name, description, getToolWriteOptions(targetBook, options));
             logToolCallCompleted(TOOL_NAMES.REORGANIZE, `Created waypoint: ${name}`);
             return `🔀 Created waypoint "${name}" (ID: ${result.nodeId}) in "${result.bookName}".${parentNodeId ? ` Under node ${parentNodeId}.` : ' At top level.'}`;
         }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/reorganize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/reorganize.js
@@ -1,4 +1,5 @@
 import { moveEntry, createCategory } from '../entry-manager.js';
+import { parseEntryUid } from '../tree-store.js';
 import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
@@ -31,13 +32,13 @@ async function reorganizeAction(args) {
 
     try {
         if (action === 'move') {
-            const uid = Number(args.uid);
-            const targetNodeId = String(args.target_node_id || '').trim();
-            if (!uid && uid !== 0) return 'Error: "uid" required for move.';
+            const uid = parseEntryUid(args.uid);
+            const targetNodeId = typeof args.target_node_id === 'string' ? args.target_node_id.trim() : '';
+            if (uid === null) return 'Error: "uid" required for move.';
             if (!targetNodeId) return 'Error: "target_node_id" required for move.';
-            await moveEntry(targetBook, uid, targetNodeId);
+            const result = await moveEntry(targetBook, uid, targetNodeId);
             logToolCallCompleted(TOOL_NAMES.REORGANIZE, `Moved UID:${uid} to ${targetNodeId}`);
-            return `🔀 Moved entry UID:${uid} to waypoint ${targetNodeId} in "${targetBook}".`;
+            return `🔀 Moved entry UID:${uid} to waypoint ${targetNodeId} in "${result.bookName}".`;
         }
 
         if (action === 'create_waypoint') {
@@ -47,7 +48,7 @@ async function reorganizeAction(args) {
             if (!name) return 'Error: "name" required for create_waypoint.';
             const result = await createCategory(targetBook, parentNodeId, name, description);
             logToolCallCompleted(TOOL_NAMES.REORGANIZE, `Created waypoint: ${name}`);
-            return `🔀 Created waypoint "${name}" (ID: ${result.nodeId}) in "${targetBook}".${parentNodeId ? ` Under node ${parentNodeId}.` : ' At top level.'}`;
+            return `🔀 Created waypoint "${name}" (ID: ${result.nodeId}) in "${result.bookName}".${parentNodeId ? ` Under node ${parentNodeId}.` : ' At top level.'}`;
         }
 
         logToolCallError(TOOL_NAMES.REORGANIZE, `Unknown action: ${action}`);

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/search.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/search.js
@@ -1,6 +1,6 @@
-import { getTree, findNodeById, getSettings } from '../tree-store.js';
+import { findNodeById, getSettings, isEntryEligible } from '../tree-store.js';
 import { getReadableBooks, TOOL_NAMES, getBookListWithDescriptions } from '../pathfinder-tool-bridge.js';
-import { buildTreeFromMetadata } from '../tree-builder.js';
+import { getTreeWithAutoBuild } from '../tree-builder.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -17,7 +17,8 @@ function getTreeOverview(tree, bookName, searchMode = 'traversal') {
 function formatTopLevel(tree) {
     if (!tree) return '';
     const lines = [];
-    for (const child of tree.children || []) {
+    const nodes = tree.entries?.length ? [tree, ...(tree.children || [])] : (tree.children || []);
+    for (const child of nodes) {
         const entries = (child.entries || []).length;
         const subWaypoints = (child.children || []).length;
         let line = `🧭 ${child.name}`;
@@ -37,7 +38,7 @@ function formatCollapsed(tree, depth = 0) {
     let line = `${indent}${tree.name}`;
     if (entries) line += ` (${entries} entries)`;
     if (subWaypoints) line += ` [${subWaypoints} sub-waypoints]`;
-    if (tree.id && depth > 0) line += ` [id: ${tree.id}]`;
+    if (tree.id) line += ` [id: ${tree.id}]`;
     let result = line + '\n';
     for (const child of tree.children || []) {
         result += formatCollapsed(child, depth + 1);
@@ -93,8 +94,11 @@ async function searchAction(args) {
     for (const bookName of books) {
         const tree = await getTreeWithAutoBuild(bookName);
         if (!tree) continue;
-        const node = findNodeById(tree, nodeId);
-        if (!node) continue;
+        const cachedNode = findNodeById(tree, nodeId);
+        if (!cachedNode) continue;
+        const bookData = await loadWorldInfoSafe(bookName);
+        if (!bookData) continue;
+        const node = { ...cachedNode, entries: (cachedNode.entries || []).filter(uid => findEntrySafe(bookData.entries, uid)) };
 
         // A node can hold both sub-waypoints and entries: list the children
         // for navigation AND return the entry contents below.
@@ -105,9 +109,6 @@ async function searchAction(args) {
                 return childListing;
             }
         }
-
-        const bookData = await loadWorldInfoSafe(bookName);
-        if (!bookData) continue;
 
         for (const uid of node.entries || []) {
             const entry = findEntrySafe(bookData.entries, uid);
@@ -143,24 +144,10 @@ async function loadWorldInfoSafe(name) {
     }
 }
 
-async function getTreeWithAutoBuild(bookName) {
-    const cachedTree = getTree(bookName);
-    if (cachedTree) {
-        return cachedTree;
-    }
-
-    const bookData = await loadWorldInfoSafe(bookName);
-    if (!bookData?.entries) {
-        return null;
-    }
-
-    return await buildTreeFromMetadata(bookName, bookData);
-}
-
 function findEntrySafe(entries, uid) {
     if (!entries) return null;
     for (const [, entry] of Object.entries(entries)) {
-        if (entry && entry.uid === uid) return entry;
+        if (isEntryEligible(entry) && entry.uid === uid) return entry;
     }
     return null;
 }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
@@ -1,5 +1,5 @@
 import { createEntry } from '../entry-manager.js';
-import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getToolWriteOptions, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 import { setSummaryMemoryCreated } from '../summary-memory-store.js';
@@ -93,7 +93,7 @@ export async function createSummaryMemoryEntry(args = {}, options = {}) {
 
     try {
         const result = await createEntry(targetBook, summaryTitle, formattedContent, ['summary', significance.toLowerCase()], {
-            arc, signal: options.signal, isCurrent: options.isCurrent,
+            arc, ...getToolWriteOptions(targetBook, options),
         });
         if (trackLatest) {
             setSummaryMemoryCreated({
@@ -138,9 +138,9 @@ export async function createSeparateSummaryMemoryEntry(args = {}) {
     }, { trackLatest: false });
 }
 
-async function summarizeAction(args) {
+async function summarizeAction(args, options = {}) {
     try {
-        const result = await createSummaryMemoryEntry(args);
+        const result = await createSummaryMemoryEntry(args, options);
         // SillyBunny: reset the auto-summary counter only after a summary is
         // successfully written, not when the prompt is injected. This ensures
         // the interval is not consumed when the model skips or fails the tool

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
@@ -1,6 +1,5 @@
-import { getTree, createTreeNode, saveTree } from '../tree-store.js';
 import { createEntry } from '../entry-manager.js';
-import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 import { setSummaryMemoryCreated } from '../summary-memory-store.js';
@@ -22,7 +21,7 @@ function trimDerivedTitle(value) {
         return normalized;
     }
 
-    const clipped = normalized.slice(0, MAX_DERIVED_TITLE_LENGTH);
+    const clipped = Array.from(normalized).slice(0, MAX_DERIVED_TITLE_LENGTH).join('');
     return clipped.replace(/\s+\S*$/, '').trim() || clipped.trim();
 }
 
@@ -42,10 +41,10 @@ function stripSummaryMetadata(content) {
 
 function deriveTitleFromContent(content) {
     const body = stripSummaryMetadata(content);
-    const firstSentence = body.split(/[.!?]\s+|\n+/).find(part => part.trim()) || body;
-    const withoutSpeaker = firstSentence.replace(/^[\w .'-]{1,32}:\s+/, '').trim();
+    const firstSentence = body.split(/[.!?]\s+|[\u3002\uff01\uff1f\n]+/u).find(part => part.trim()) || body;
+    const withoutSpeaker = firstSentence.replace(/^[\p{L}\p{M}\p{N} .'-]{1,32}:\s+/u, '').trim();
     const words = withoutSpeaker
-        .replace(/[^\w\s'-]/g, ' ')
+        .replace(/[^\p{L}\p{M}\p{N}\s'-]/gu, ' ')
         .split(/\s+/)
         .filter(Boolean)
         .slice(0, MAX_DERIVED_TITLE_WORDS);
@@ -78,6 +77,11 @@ export async function createSummaryMemoryEntry(args = {}, options = {}) {
     }
 
     const writableBooks = getWritableBooks();
+    const bookError = getUnknownBookError(bookName, writableBooks);
+    if (bookError) {
+        logToolCallError(TOOL_NAMES.SUMMARIZE, `Unknown book: ${bookName}`);
+        throw new Error(bookError);
+    }
     const targetBook = resolveTargetBook(bookName, writableBooks);
     if (!targetBook) {
         logToolCallError(TOOL_NAMES.SUMMARIZE, 'No writable lorebooks');
@@ -88,53 +92,25 @@ export async function createSummaryMemoryEntry(args = {}, options = {}) {
     const formattedContent = `Significance: ${significance}\n\n${content}`;
 
     try {
-        const result = await createEntry(targetBook, summaryTitle, formattedContent, ['summary', significance.toLowerCase()]);
+        const result = await createEntry(targetBook, summaryTitle, formattedContent, ['summary', significance.toLowerCase()], {
+            arc, signal: options.signal, isCurrent: options.isCurrent,
+        });
         if (trackLatest) {
             setSummaryMemoryCreated({
                 title: summaryTitle,
                 content,
                 significance,
                 arc,
-                bookName: targetBook,
+                bookName: result.bookName,
                 uid: result.uid,
             });
-        }
-
-        // Arc filing is best-effort: the entry is already saved, so a tree
-        // problem must not fail the tool (that skipped the auto-summary
-        // counter reset and produced duplicate summaries).
-        try {
-            const tree = getTree(targetBook);
-            if (tree && arc) {
-                let summaryWaypoint = (tree.children || []).find(c => /summar/i.test(c.name));
-                if (!summaryWaypoint) {
-                    summaryWaypoint = createTreeNode('Summaries', 'Event summaries and recaps');
-                    if (!Array.isArray(tree.children)) tree.children = [];
-                    tree.children.push(summaryWaypoint);
-                }
-
-                let arcNode = (summaryWaypoint.children || []).find(c => c.name.toLowerCase() === arc.toLowerCase());
-                if (!arcNode) {
-                    arcNode = createTreeNode(`Arc: ${arc}`, `Narrative arc: ${arc}`);
-                    if (!Array.isArray(summaryWaypoint.children)) summaryWaypoint.children = [];
-                    summaryWaypoint.children.push(arcNode);
-                }
-                if (!Array.isArray(arcNode.entries)) arcNode.entries = [];
-                if (!arcNode.entries.includes(result.uid)) {
-                    arcNode.entries.push(result.uid);
-                }
-
-                saveTree(targetBook, tree);
-            }
-        } catch (treeErr) {
-            console.warn('[Pathfinder] Failed to file summary under its arc waypoint:', treeErr);
         }
 
         logToolCallCompleted(TOOL_NAMES.SUMMARIZE, `Summarized: ${title}`);
         return {
             title,
             summaryTitle,
-            targetBook,
+            targetBook: result.bookName,
             uid: result.uid,
             significance,
             arc,

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js
@@ -1,4 +1,5 @@
 import { updateEntry } from '../entry-manager.js';
+import { parseEntryUid } from '../tree-store.js';
 import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
@@ -6,14 +7,14 @@ import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../a
 const COMPACT_DESCRIPTION = 'Edit an existing lorebook entry when information changes.';
 
 async function updateAction(args) {
-    const uid = Number(args.uid);
+    const uid = parseEntryUid(args.uid);
     const newContent = String(args.content || '').trim();
     const newTitle = String(args.title || '').trim();
     const bookName = String(args.book || '').trim();
 
     logToolCallStarted(TOOL_NAMES.UPDATE, { uid, bookName });
 
-    if (!uid && uid !== 0) {
+    if (uid === null) {
         logToolCallError(TOOL_NAMES.UPDATE, 'Missing UID');
         return 'Error: "uid" is required. Use Search first to find the entry UID.';
     }
@@ -37,9 +38,9 @@ async function updateAction(args) {
     }
 
     try {
-        await updateEntry(targetBook, uid, newContent || undefined, newTitle || undefined);
+        const result = await updateEntry(targetBook, uid, newContent || undefined, newTitle || undefined);
         logToolCallCompleted(TOOL_NAMES.UPDATE, `Updated UID:${uid}`);
-        return `✏️ Updated entry UID:${uid} in "${targetBook}".`;
+        return `✏️ Updated entry UID:${uid} in "${result.bookName}".`;
     } catch (err) {
         logToolCallError(TOOL_NAMES.UPDATE, err.message);
         return `❌ Failed to update: ${err.message}`;

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js
@@ -1,12 +1,12 @@
 import { updateEntry } from '../entry-manager.js';
 import { parseEntryUid } from '../tree-store.js';
-import { getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getToolWriteOptions, getUnknownBookError, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
 const COMPACT_DESCRIPTION = 'Edit an existing lorebook entry when information changes.';
 
-async function updateAction(args) {
+async function updateAction(args, options = {}) {
     const uid = parseEntryUid(args.uid);
     const newContent = String(args.content || '').trim();
     const newTitle = String(args.title || '').trim();
@@ -38,7 +38,7 @@ async function updateAction(args) {
     }
 
     try {
-        const result = await updateEntry(targetBook, uid, newContent || undefined, newTitle || undefined);
+        const result = await updateEntry(targetBook, uid, newContent || undefined, newTitle || undefined, null, getToolWriteOptions(targetBook, options));
         logToolCallCompleted(TOOL_NAMES.UPDATE, `Updated UID:${uid}`);
         return `✏️ Updated entry UID:${uid} in "${result.bookName}".`;
     } catch (err) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js
@@ -1,50 +1,84 @@
-import { createTreeNode, createEmptyTree, addEntryToNode, saveTree, getSettings } from './tree-store.js';
+import { addEntryToNode, saveTree, getSettings, getTree, isEntryEligible, syncTrackerUidsForLorebook } from './tree-store.js';
+import { createLayoutNode, getEntryPlacement, readTreeLayout } from './tree-layout.js';
 
-function categorizeEntries(entries) {
-    const categories = {};
-    for (const [, entry] of Object.entries(entries)) {
-        if (!entry || entry.disable) continue;
-        const title = (entry.comment || entry.key?.[0] || `Entry ${entry.uid}`).trim();
-        let category = 'Uncategorized';
-        if (/^\[Tracker\]/i.test(title)) category = 'Trackers';
-        else if (/^\[Summary\]/i.test(title)) category = 'Summaries';
-        else if (/^(character|npc|creature|faction)/i.test(title)) category = 'Characters';
-        else if (/^(location|place|area|room|building|city|town|dungeon)/i.test(title)) category = 'Locations';
-        else if (/^(rule|mechanic|system|magic|combat|skill)/i.test(title)) category = 'World Rules';
-        if (!categories[category]) categories[category] = [];
-        categories[category].push({ uid: entry.uid, title, content: entry.content || '' });
-    }
-    return categories;
+function getCategory(entry) {
+    const title = String(entry.comment || entry.key?.[0] || `Entry ${entry.uid}`).trim();
+    if (/^\[Tracker\]/i.test(title)) return 'Trackers';
+    if (/^\[Summary\]/i.test(title)) return 'Summaries';
+    if (/^(character|npc|creature|faction)/i.test(title)) return 'Characters';
+    if (/^(location|place|area|room|building|city|town|dungeon)/i.test(title)) return 'Locations';
+    if (/^(rule|mechanic|system|magic|combat|skill)/i.test(title)) return 'World Rules';
+    return 'Uncategorized';
 }
 
-export async function buildTreeFromMetadata(bookName, bookData) {
-    if (!bookData || !bookData.entries) {
-        return createEmptyTree();
-    }
-
-    const tree = createEmptyTree();
-    const categories = categorizeEntries(bookData.entries);
-
-    for (const [catName, catEntries] of Object.entries(categories)) {
-        const catNode = createTreeNode(catName, `${catName} waypoint`);
-        for (const entry of catEntries) {
-            addEntryToNode(catNode, entry.uid);
+export function deriveTreeFromMetadata(bookName, bookData, cachedTree = null) {
+    const layout = readTreeLayout(bookData);
+    const nodes = new Map();
+    const categories = new Map();
+    const restore = (stored, runtime = false) => {
+        const node = createLayoutNode(bookName, stored.name, stored.description, runtime ? stored.localId : stored.id);
+        if (stored.generatedCategory !== undefined) {
+            node.generatedCategory = stored.generatedCategory;
+            categories.set(node.generatedCategory, node);
         }
-        tree.children.push(catNode);
-    }
+        nodes.set(node.localId, node);
+        node.children = (stored.children || []).map(child => restore(child, runtime));
+        return node;
+    };
+    const tree = layout ? restore(layout)
+        : layout === undefined && cachedTree ? restore(cachedTree, true)
+            : createLayoutNode(bookName, 'Root', 'Top-level waypoint map', 'root');
+    nodes.set(tree.localId, tree);
 
-    saveTree(bookName, tree);
+    const seen = new Set();
+    for (const entry of Object.values(bookData?.entries || {})) {
+        if (!isEntryEligible(entry) || seen.has(entry.uid)) continue;
+        seen.add(entry.uid);
+        let target = nodes.get(getEntryPlacement(entry));
+        if (!target) {
+            const category = getCategory(entry);
+            target = categories.get(category);
+            if (!target) {
+                let localId = `category_${category.replaceAll(' ', '_')}`;
+                while (nodes.has(localId)) localId += '_';
+                target = createLayoutNode(bookName, category, `${category} waypoint`, localId);
+                target.generatedCategory = category;
+                nodes.set(localId, target);
+                categories.set(category, target);
+                tree.children.push(target);
+            }
+        }
+        addEntryToNode(target, entry.uid);
+    }
     return tree;
 }
 
+export async function buildTreeFromMetadata(bookName, bookData) {
+    const tree = deriveTreeFromMetadata(bookName, bookData);
+    saveTree(bookName, tree);
+    syncTrackerUidsForLorebook(bookName, bookData);
+    return tree;
+}
+
+export async function getTreeWithAutoBuild(bookName) {
+    const cachedTree = getTree(bookName);
+    if (cachedTree) return cachedTree;
+    try {
+        const bookData = await window?.SillyTavern?.getContext?.()?.loadWorldInfo?.(bookName);
+        return bookData?.entries ? await buildTreeFromMetadata(bookName, bookData) : null;
+    } catch {
+        return null;
+    }
+}
+
 export async function buildTreeWithLLM(bookName, bookData, llmGenerate) {
-    if (!bookData || !bookData.entries) {
-        return createEmptyTree();
+    if (!bookData?.entries || readTreeLayout(bookData) !== undefined) {
+        return await buildTreeFromMetadata(bookName, bookData);
     }
 
-    const entries = Object.values(bookData.entries).filter(e => e && !e.disable);
+    const entries = Object.values(bookData.entries).filter(isEntryEligible);
     if (entries.length === 0) {
-        return createEmptyTree();
+        return await buildTreeFromMetadata(bookName, bookData);
     }
 
     const chunkSize = getSettings().llmChunkSize ?? 30000;
@@ -61,7 +95,7 @@ export async function buildTreeWithLLM(bookName, bookData, llmGenerate) {
     }
     if (current) chunks.push(current);
 
-    const tree = createEmptyTree();
+    const tree = createLayoutNode(bookName, 'Root', 'Top-level waypoint map', 'root');
     for (let i = 0; i < chunks.length; i++) {
         const prompt = `You are a knowledge base organizer. Given these lorebook entries, create a hierarchical waypoint map (tree structure) for organizing them into logical categories and sub-categories.
 
@@ -77,7 +111,7 @@ Respond ONLY with the waypoint structure. Do not add commentary.`;
 
         try {
             const response = await llmGenerate(prompt);
-            const parsed = parseLLMTreeResponse(response, entries);
+            const parsed = parseLLMTreeResponse(response, entries, bookName);
             for (const rootNode of parsed) {
                 tree.children.push(rootNode);
             }
@@ -91,10 +125,11 @@ Respond ONLY with the waypoint structure. Do not add commentary.`;
     }
 
     saveTree(bookName, tree);
+    syncTrackerUidsForLorebook(bookName, bookData);
     return tree;
 }
 
-function parseLLMTreeResponse(response, entries) {
+function parseLLMTreeResponse(response, entries, bookName) {
     const lines = (response || '').split('\n');
     const roots = [];
     let currentWaypoint = null;
@@ -109,13 +144,13 @@ function parseLLMTreeResponse(response, entries) {
         if (!trimmed) continue;
         if (trimmed.startsWith('WAYPOINT:')) {
             const name = trimmed.slice(9).trim();
-            currentWaypoint = createTreeNode(name, `${name} waypoint`);
+            currentWaypoint = createLayoutNode(bookName, name, `${name} waypoint`);
             currentSub = null;
             roots.push(currentWaypoint);
         } else if (trimmed.startsWith('SUB:')) {
             const name = trimmed.slice(4).trim();
             if (currentWaypoint) {
-                currentSub = createTreeNode(name, `${name} sub-waypoint`);
+                currentSub = createLayoutNode(bookName, name, `${name} sub-waypoint`);
                 currentWaypoint.children.push(currentSub);
             }
         } else if (trimmed.startsWith('ENTRIES:')) {
@@ -131,4 +166,3 @@ function parseLLMTreeResponse(response, entries) {
     }
     return roots;
 }
-

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tree-layout.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tree-layout.js
@@ -1,0 +1,106 @@
+import { createTreeNode, getRuntimeNodeId } from './tree-store.js';
+
+export const LAYOUT_KEY = 'sillybunny_pathfinder';
+const MAX_NODES = 2048;
+const MAX_DEPTH = 32;
+const MAX_SIZE = 262144;
+const ID_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+
+function isRecord(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getLayoutData(bookData) {
+    const native = bookData?.extensions;
+    return native && Object.hasOwn(native, LAYOUT_KEY)
+        ? native[LAYOUT_KEY]
+        : bookData?.originalData?.extensions?.[LAYOUT_KEY];
+}
+
+// Unknown versions/fields remain opaque: reading can fall back, but writing must
+// not replace an imported layout we cannot faithfully round-trip.
+function isValidLayout(layout) {
+    if (!isRecord(layout) || layout.version !== 1 || Object.keys(layout).some(key => !['version', 'tree'].includes(key))) return false;
+    const ids = new Set();
+    const pending = [[layout.tree, 0]];
+    let size = 0;
+    while (pending.length) {
+        const [node, depth] = pending.pop();
+        if (!isRecord(node) || depth > MAX_DEPTH || ids.size >= MAX_NODES
+            || typeof node.id !== 'string' || !ID_PATTERN.test(node.id) || ids.has(node.id)
+            || typeof node.name !== 'string' || node.name.length > 1024
+            || typeof node.description !== 'string' || node.description.length > 4096
+            || !Array.isArray(node.children) || node.children.length > MAX_NODES
+            || (node.generatedCategory !== undefined && (typeof node.generatedCategory !== 'string' || node.generatedCategory.length > 128))
+            || Object.keys(node).some(key => !['id', 'name', 'description', 'children', 'generatedCategory'].includes(key))) return false;
+        ids.add(node.id);
+        size += node.id.length + node.name.length + node.description.length + 64;
+        if (size > MAX_SIZE) return false;
+        for (const child of node.children) pending.push([child, depth + 1]);
+    }
+    return JSON.stringify(layout).length <= MAX_SIZE;
+}
+
+// undefined means absent; null means present but unsafe to rewrite.
+export function readTreeLayout(bookData) {
+    const layout = getLayoutData(bookData);
+    if (layout === undefined) return undefined;
+    return isValidLayout(layout) ? layout.tree : null;
+}
+
+export function createLayoutNode(bookName, name, description = '', localId = null) {
+    const node = createTreeNode(name, description);
+    node.localId = localId ?? node.id;
+    node.id = getRuntimeNodeId(bookName, node.localId);
+    return node;
+}
+
+export function getEntryPlacement(entry) {
+    const placement = entry?.extensions?.[LAYOUT_KEY];
+    return isRecord(placement) && placement.version === 1 && typeof placement.nodeId === 'string' && ID_PATTERN.test(placement.nodeId)
+        ? placement.nodeId : null;
+}
+
+export function setEntryPlacement(entry, node) {
+    if ((entry.extensions !== undefined && !isRecord(entry.extensions))
+        || (entry.extensions && Object.hasOwn(entry.extensions, LAYOUT_KEY) && !getEntryPlacement(entry))) {
+        throw new Error('Cannot move unsupported or invalid waypoint placement.');
+    }
+    entry.extensions ??= {};
+    entry.extensions[LAYOUT_KEY] = { ...entry.extensions[LAYOUT_KEY], version: 1, nodeId: node.localId };
+}
+
+export function syncBookLayoutMetadata(bookData) {
+    const layout = getLayoutData(bookData);
+    if (layout === undefined) return;
+    if ((bookData.extensions !== undefined && !isRecord(bookData.extensions))
+        || (bookData.originalData?.extensions !== undefined && !isRecord(bookData.originalData.extensions))) {
+        throw new Error('Invalid format found inside the lorebook\u2019s additional data; unable to save while preserving.');
+    }
+    bookData.extensions ??= {};
+    bookData.extensions[LAYOUT_KEY] = structuredClone(layout);
+    if (bookData.originalData) {
+        bookData.originalData.extensions ??= {};
+        bookData.originalData.extensions[LAYOUT_KEY] = structuredClone(layout);
+    }
+}
+
+export function writeTreeLayout(bookData, tree) {
+    if (readTreeLayout(bookData) === null) throw new Error('The saved waypoint layout is damaged or uses an unsupported format and will not be overwritten.');
+    let count = 0;
+    const serialize = (node, depth = 0) => {
+        if (depth > MAX_DEPTH || ++count > MAX_NODES) throw new Error('The waypoint layout has too many categories or nested levels.');
+        return {
+            id: node.localId,
+            name: node.name,
+            description: node.description || '',
+            ...(node.generatedCategory === undefined ? {} : { generatedCategory: node.generatedCategory }),
+            children: (node.children || []).map(child => serialize(child, depth + 1)),
+        };
+    };
+    const layout = { version: 1, tree: serialize(tree) };
+    if (!isValidLayout(layout) || (bookData.extensions !== undefined && !isRecord(bookData.extensions))) throw new Error('The proposed waypoint layout fails and cannot be saved.');
+    bookData.extensions ??= {};
+    bookData.extensions[LAYOUT_KEY] = layout;
+    syncBookLayoutMetadata(bookData);
+}

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js
@@ -78,22 +78,37 @@ export function replaceSettings(newSettings) {
 }
 
 const trees = new Map();
+const nodeIds = new Map();
+const runtimeNodePrefix = generateNodeId();
+let nextNodeId = 0;
+
+// Keep book-local stored IDs distinct at runtime, including for duplicated books.
+// Cache invalidation deliberately does not discard these mappings.
+export function getRuntimeNodeId(bookName, localId) {
+    if (!nodeIds.has(bookName)) nodeIds.set(bookName, new Map());
+    const ids = nodeIds.get(bookName);
+    if (!ids.has(localId)) ids.set(localId, `${runtimeNodePrefix}${(++nextNodeId).toString(36)}`);
+    return ids.get(localId);
+}
 
 // Lets the WORLDINFO_UPDATED handler distinguish Pathfinder's own saves
-// (tree already maintained in place) from external edits (tree must be
-// invalidated). Relies on the host emitting the event within the awaited save.
+// (cache refreshed after commit) from external edits (tree must be invalidated).
+// Relies on the host emitting the event within the awaited save.
 let selfWriteDepth = 0;
+const selfWriteBooks = new Set();
 
-export function beginPathfinderSelfWrite() {
+export function beginPathfinderSelfWrite(bookName) {
     selfWriteDepth++;
+    if (bookName) selfWriteBooks.add(bookName);
 }
 
 export function endPathfinderSelfWrite() {
     selfWriteDepth = Math.max(0, selfWriteDepth - 1);
+    if (!selfWriteDepth) selfWriteBooks.clear();
 }
 
-export function isPathfinderSelfWrite() {
-    return selfWriteDepth > 0;
+export function isPathfinderSelfWrite(bookName) {
+    return bookName ? selfWriteBooks.has(bookName) : selfWriteDepth > 0;
 }
 
 export function getTree(bookName) {
@@ -104,8 +119,20 @@ export function saveTree(bookName, tree) {
     trees.set(bookName, tree);
 }
 
-export function deleteTree(bookName) {
+export function deleteTree(bookName, resetIds = false) {
     trees.delete(bookName);
+    trackerUids.delete(bookName);
+    if (resetIds) nodeIds.delete(bookName);
+}
+
+export function renameTree(oldName, newName) {
+    if (selfWriteBooks.has(oldName)) selfWriteBooks.add(newName);
+    if (oldName === newName || (!trees.has(oldName) && !trackerUids.has(oldName) && !nodeIds.has(oldName))) return;
+    deleteTree(newName, true);
+    if (trees.has(oldName)) trees.set(newName, trees.get(oldName));
+    if (trackerUids.has(oldName)) trackerUids.set(newName, trackerUids.get(oldName));
+    if (nodeIds.has(oldName)) nodeIds.set(newName, nodeIds.get(oldName));
+    deleteTree(oldName, true);
 }
 
 export function clearAllTrees() {
@@ -171,7 +198,17 @@ export function getAllEntryUids(tree) {
     for (const child of tree.children || []) {
         uids.push(...getAllEntryUids(child));
     }
-    return uids;
+    return [...new Set(uids)];
+}
+
+export function isEntryEligible(entry) {
+    return Boolean(entry && !entry.disable && !entry.agentBlacklisted);
+}
+
+export function parseEntryUid(value) {
+    if (typeof value !== 'number' && (typeof value !== 'string' || !value.trim())) return null;
+    const uid = Number(value);
+    return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
 }
 
 export function buildTreeDescription(tree, depth = 0) {
@@ -225,7 +262,7 @@ export function syncTrackerUidsForLorebook(bookName, bookData) {
     if (!bookData || !bookData.entries) return;
     const trackerSet = new Set();
     for (const [, entry] of Object.entries(bookData.entries)) {
-        if (entry && isTrackerTitle(entry.comment || entry.key?.[0])) {
+        if (isEntryEligible(entry) && isTrackerTitle(entry.comment || entry.key?.[0])) {
             trackerSet.add(entry.uid);
         }
     }
@@ -242,9 +279,9 @@ export function setSelectedLorebook(name) {
     s.selectedLorebook = name;
 }
 
-export function isLorebookEnabled(bookName) {
-    const s = getSettings();
-    return Array.isArray(s.enabledLorebooks) && s.enabledLorebooks.includes(bookName);
+export function isLorebookEnabled(bookName, s = getSettings()) {
+    return s.bookPermissions?.[bookName]?.enabled !== false
+        && Array.isArray(s.enabledLorebooks) && s.enabledLorebooks.includes(bookName);
 }
 
 export function setLorebookEnabled(bookName, enabled) {
@@ -306,8 +343,7 @@ export function listConnectionProfiles() {
     return listSupportedConnectionProfiles();
 }
 
-export function getBookPermission(bookName, permission) {
-    const s = getSettings();
+export function getBookPermission(bookName, permission, s = getSettings()) {
     const perms = s.bookPermissions?.[bookName];
     return perms?.[permission] ?? 'readwrite';
 }
@@ -336,17 +372,17 @@ function isPermissionAllowed(value) {
     return !['none', 'false', 'off', 'deny', 'denied', 'no', '0', 'disabled'].includes(normalized);
 }
 
-export function canReadBook(bookName) {
-    const perm = getBookPermission(bookName, 'read');
-    return isPermissionAllowed(perm);
+export function canReadBook(bookName, s = getSettings()) {
+    const perm = getBookPermission(bookName, 'read', s);
+    return s.bookPermissions?.[bookName]?.enabled !== false && isPermissionAllowed(perm);
 }
 
-export function canWriteBook(bookName) {
-    const perm = getBookPermission(bookName, 'write');
-    return isPermissionAllowed(perm);
+export function canWriteBook(bookName, s = getSettings()) {
+    const perm = getBookPermission(bookName, 'write', s);
+    return s.bookPermissions?.[bookName]?.enabled !== false && isPermissionAllowed(perm);
 }
 
-export function canDeleteBook(bookName) {
-    const perm = getBookPermission(bookName, 'delete');
-    return isPermissionAllowed(perm);
+export function canDeleteBook(bookName, s = getSettings()) {
+    const perm = getBookPermission(bookName, 'delete', s);
+    return s.bookPermissions?.[bookName]?.enabled !== false && isPermissionAllowed(perm);
 }

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -777,7 +777,7 @@ export class ToolManager {
      * @param {any} data Reply data
      * @returns {Promise<ToolInvocationResult>} Successful tool invocations
      */
-    static async invokeFunctionTools(data, { reasoningText = null } = {}) {
+    static async invokeFunctionTools(data, { reasoningText = null, isCurrent = () => true, signal = null } = {}) {
         /** @type {ToolInvocationResult} */
         const result = {
             invocations: [],
@@ -791,6 +791,8 @@ export class ToolManager {
         }
 
         for (const toolCall of toolCalls) {
+            // SillyBunny: every call belongs to the response that requested the batch.
+            if (signal?.aborted || !isCurrent()) break;
             if (!toolCall || !toolCall.function || typeof toolCall.function !== 'object') {
                 continue;
             }
@@ -802,9 +804,15 @@ export class ToolManager {
             const displayName = ToolManager.getDisplayName(name);
             const isStealth = ToolManager.isStealthTool(name);
             const message = await ToolManager.formatToolCallMessage(name, parameters);
+            if (signal?.aborted || !isCurrent()) break;
             const toast = message && toastr.info(message, 'Tool Calling', { timeOut: 0 });
-            const toolResult = await ToolManager.invokeFunctionTool(name, parameters);
-            toastr.clear(toast);
+            let toolResult;
+            try {
+                toolResult = await ToolManager.invokeFunctionTool(name, parameters);
+            } finally {
+                toastr.clear(toast);
+            }
+            if (signal?.aborted || !isCurrent()) break;
             console.log('[ToolManager] Function tool result:', result);
 
             // Handle tool errors — still create an invocation so the LLM sees the failure

--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -171,7 +171,8 @@ export function serializeWorldInfoEntry(entry, positions, originalEntry = {}) {
     const normalizedPosition = normalizeWorldInfoPosition(entry.position, positions);
     const serializedEntry = {
         ...originalEntry,
-        id: entry.uid,
+        // SillyBunny: imported card IDs are independent of the native UID map.
+        id: originalEntry.id ?? entry.uid,
         keys,
         secondary_keys: secondaryKeys,
         comment: entry.comment ?? '',
@@ -228,4 +229,11 @@ export function serializeWorldInfoEntry(entry, positions, originalEntry = {}) {
     }
 
     return serializedEntry;
+}
+
+export function getFreeCharacterBookEntryId(entries) {
+    const ids = new Set(entries.map(entry => String(entry.id ?? entry.uid)));
+    let id = 0;
+    while (ids.has(String(id))) id++;
+    return id;
 }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,4 +1,4 @@
-import { Fuse } from '../lib.js';
+import { Fuse, lodash } from '../lib.js';
 
 import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1, getOneCharacter, select_selected_character, getEntitiesList } from '../script.js';
 import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent, escapeHtml } from './utils.js';
@@ -23,7 +23,7 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
-import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from './world-info-character-book.js';
+import { escapeCharacterBookRegex, getFreeCharacterBookEntryId, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from './world-info-character-book.js';
 import { detectEmbeddedLorebookCandidates, findMatchingLorebookName, getLinkedAuxBooks, isEmbeddedBookLinked } from './world-info-batch-helpers.js';
 import { getTimedEffectWindow, getWorldInfoGroupNames, normalizeWorldInfoKey, normalizeWorldInfoProbability, passesWorldInfoProbability } from './world-info-scan-core.js';
 
@@ -84,12 +84,18 @@ export let world_info_use_group_scoring = false;
 export let world_info_character_strategy = world_info_insertion_strategy.character_first;
 export let world_info_budget_cap = 0;
 export let world_info_max_recursion_steps = 0;
-/** @type {Map<string, {timer: ReturnType<typeof setTimeout>, data: object}>} */
+/** @type {Map<string, {timer: ReturnType<typeof setTimeout>, data: object, snapshot: object}>} */
 const pendingWorldInfoSaves = new Map();
-/** @type {Map<string, Promise<void>>} */
+/** @type {Map<string, Promise<string>>} */
 const worldInfoSaveQueues = new Map();
 /** @type {Map<string, Promise<string|null>>} */
 const worldInfoSaveBlocks = new Map();
+// SillyBunny: retain load baselines so independent same-tab editors save changes, not stale books.
+const worldInfoDataSnapshots = new WeakMap();
+const worldInfoEntryInstances = new WeakMap();
+const worldInfoCommittedEntryInstances = new Map();
+const worldInfoCacheVersions = new Map();
+let worldInfoEditor = null;
 const saveSettingsDebounced = debounce(() => {
     Object.assign(world_info, { globalSelect: selected_world_info });
     saveSettings();
@@ -912,9 +918,10 @@ export const worldInfoCache = new StructuredCloneMap({ cloneOnGet: true, cloneOn
  * @param {number} maxContext - The maximum context size of the generation.
  * @param {boolean} isDryRun - If true, the function will not emit any events.
  * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
+ * @param {object|null} [generationContext=null] Origin captured by the host before this scan
  * @returns {Promise<WIPromptResult>} The world info string and depth.
  */
-export async function getWorldInfoPrompt(chat, maxContext, isDryRun, globalScanData) {
+export async function getWorldInfoPrompt(chat, maxContext, isDryRun, globalScanData, generationContext = null) {
     let worldInfoString = '', worldInfoBefore = '', worldInfoAfter = '';
 
     const activatedWorldInfo = await checkWorldInfo(chat, maxContext, isDryRun, globalScanData);
@@ -924,7 +931,8 @@ export async function getWorldInfoPrompt(chat, maxContext, isDryRun, globalScanD
 
     if (!isDryRun && activatedWorldInfo.allActivatedEntries && activatedWorldInfo.allActivatedEntries.size > 0) {
         const arg = Array.from(activatedWorldInfo.allActivatedEntries.values());
-        await eventSource.emit(event_types.WORLD_INFO_ACTIVATED, arg);
+        // SillyBunny: forward the scan's origin, never the context at completion.
+        await eventSource.emit(event_types.WORLD_INFO_ACTIVATED, arg, ...(generationContext ? [generationContext] : []));
     }
 
     return {
@@ -1063,9 +1071,17 @@ export function setWorldInfoSettings(settings, data) {
  * @param {boolean} [loadIfNotSelected=false] - Indicates whether to load the file even if it's not currently selected
  */
 export function reloadEditor(file, loadIfNotSelected = false) {
-    const currentIndex = Number($('#world_editor_select').val());
+    const currentIndex = Number.parseInt(String($('#world_editor_select').val()), 10);
     const selectedIndex = world_names.indexOf(file);
     if (selectedIndex !== -1 && (loadIfNotSelected || currentIndex === selectedIndex)) {
+        const input = document.activeElement;
+        if (worldInfoEditor?.name === file && input?.matches('input, textarea, select') && input.closest('#WorldInfo, #world_popup_editor_pane')) {
+            // Keys can still be a DOM-only draft until blur; never replace a focused form.
+            $(input).off('blur.worldInfoReload').one('blur.worldInfoReload', () => {
+                setTimeout(() => reloadEditor(file, loadIfNotSelected), 0);
+            });
+            return;
+        }
         $('#world_editor_select').val(selectedIndex).trigger('change');
     }
 }
@@ -2058,10 +2074,20 @@ export async function showWorldEditor(name) {
         return;
     }
 
-    const wiData = await loadWorldInfo(name);
+    let wiData = await loadWorldInfo(name);
     if (loadId !== worldInfoEditorLoadId) {
         return;
     }
+    if (wiData && worldInfoEditor?.name === name) {
+        const draft = worldInfoEditor.data;
+        const baseline = worldInfoDataSnapshots.get(draft);
+        const loadedSnapshot = worldInfoDataSnapshots.get(wiData);
+        if (baseline) {
+            wiData = mergeWorldInfoData(baseline.data, draft, wiData) ?? wiData;
+            worldInfoDataSnapshots.set(wiData, loadedSnapshot);
+        }
+    }
+    worldInfoEditor = wiData ? { name, data: wiData } : null;
     await displayWorldEntries(name, wiData);
 }
 
@@ -2079,9 +2105,12 @@ export async function loadWorldInfo(name) {
     }
 
     if (worldInfoCache.has(name)) {
-        return worldInfoCache.get(name);
+        const data = getWorldInfoCachedData(name);
+        if (data && typeof data === 'object') worldInfoDataSnapshots.set(data, { name, data: cloneWorldInfoData(data), committed: true });
+        return data;
     }
 
+    const version = worldInfoCacheVersions.get(name);
     const response = await fetch('/api/worldinfo/get', {
         method: 'POST',
         headers: getRequestHeaders(),
@@ -2090,8 +2119,15 @@ export async function loadWorldInfo(name) {
     });
 
     if (response.ok) {
-        const data = await response.json();
+        let data = await response.json();
+        if (worldInfoCacheVersions.get(name) !== version) {
+            return worldInfoCache.has(name) ? loadWorldInfo(name) : null;
+        }
+        data = cloneWorldInfoData(data, worldInfoCommittedEntryInstances.get(name));
+        worldInfoCommittedEntryInstances.set(name, worldInfoEntryInstances.get(data));
         worldInfoCache.set(name, data);
+        data = cloneWorldInfoData(data);
+        if (data && typeof data === 'object') worldInfoDataSnapshots.set(data, { name, data: cloneWorldInfoData(data), committed: true });
         return data;
     }
 
@@ -2125,6 +2161,7 @@ export async function updateWorldInfoList() {
 
 async function hideWorldEditor() {
     worldInfoEditorLoadId++;
+    worldInfoEditor = null;
     desktopSelectedWorldInfoUid = null;
     clearWorldInfoDesktopEditor();
     await displayWorldEntries(null, null);
@@ -2564,6 +2601,13 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
         desktopSelectedWorldInfoUid = null;
     }
 
+    const baseline = worldInfoDataSnapshots.get(data);
+    if (baseline) {
+        const entries = Object.values(baseline.data.entries).filter(lodash.isPlainObject);
+        entries.forEach(entry => entry.displayIndex ??= entry.uid);
+        addMissingWorldInfoFields(entries);
+    }
+
     // Regardless of whether success is displayed or not. Make sure the delete button is available.
     // Do not put this code behind.
     $('#world_popup_delete').off('click').on('click', async () => {
@@ -2819,10 +2863,16 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
         const finalName = await Popup.show.input('Create a new World Info?', 'Enter a name for the new file:', tempName);
 
         if (finalName) {
-            await saveWorldInfo(finalName, data, true);
+            const targetName = await getCanonicalWorldInfoName(finalName);
+            if (!targetName) return;
+            const baseline = worldInfoDataSnapshots.get(data);
+            const latest = getWorldInfoCachedData(name);
+            const copy = baseline && latest ? mergeWorldInfoData(baseline.data, data, latest) : data;
+            if (!copy) return;
+            const savedName = await replaceWorldInfoData(targetName, copy);
             await updateWorldInfoList();
 
-            const selectedIndex = world_names.indexOf(finalName);
+            const selectedIndex = world_names.indexOf(savedName);
             if (selectedIndex !== -1) {
                 $('#world_editor_select').val(selectedIndex).trigger('change');
             } else {
@@ -3643,6 +3693,7 @@ function setCommentPlaceholder(keys, commentInput) {
  */
 export async function getWorldEntry(name, data, entry, options = {}) {
     if (!data.entries[entry.uid]) return;
+    const finishRender = trackWorldInfoEntryRender(data, entry.uid);
 
     const {
         desktopEditorHost = $('#world_popup_editor_host'),
@@ -3829,6 +3880,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
     const editOutlet = headerTemplate.find('.inline-drawer-outlet');
 
     function addEditorDrawerContent(targetOutlet = editOutlet, { desktop = false } = {}) {
+        const finishRender = trackWorldInfoEntryRender(data, entry.uid);
         const editTemplate = WI_ENTRY_EDIT_TEMPLATE.clone();
         const editorSurface = desktop
             ? $('<div class="world_entry world_entry_editor_surface"></div>').attr('uid', entry.uid)
@@ -4167,6 +4219,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
         } else {
             targetOutlet.append(editTemplate);
         }
+        finishRender();
     }
 
     if (isDesktopSplit) {
@@ -4217,6 +4270,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
 
     headerTemplate.find('.inline-drawer-content').css('display', 'none');
 
+    finishRender();
     return headerTemplate;
 }
 
@@ -4382,7 +4436,8 @@ export function duplicateWorldInfoEntry(data, uid) {
     Object.assign(entry, originalData);
     const targetOriginalIndex = data.originalDataUidMap?.[entry.uid];
     if (Number.isInteger(targetOriginalIndex)) {
-        data.originalData.entries[targetOriginalIndex] = structuredClone(serializeWorldInfoEntry(entry, world_info_position, sourceOriginalEntry ?? undefined));
+        const id = data.originalData.entries[targetOriginalIndex].id;
+        data.originalData.entries[targetOriginalIndex] = structuredClone(serializeWorldInfoEntry(entry, world_info_position, { ...sourceOriginalEntry, id }));
     }
 
     return entry;
@@ -4513,32 +4568,174 @@ function appendWIOriginalDataEntry(data, entry, originalEntry = undefined) {
 
     data.originalDataUidMap ??= {};
     data.originalDataUidMap[entry.uid] = data.originalData.entries.length;
+    // SillyBunny: card IDs are separate from native UIDs, including records written since this editor opened.
+    const snapshot = worldInfoDataSnapshots.get(data);
+    const cachedEntries = snapshot ? worldInfoCache.get(snapshot.name)?.originalData?.entries : [];
+    const id = getFreeCharacterBookEntryId([...data.originalData.entries, ...(cachedEntries ?? [])]);
     // Clone: the serialized record aliases live entry objects (extensions, triggers)
     // and must not track later editor mutations.
-    data.originalData.entries.push(structuredClone(serializeWorldInfoEntry(entry, world_info_position, originalEntry)));
+    data.originalData.entries.push(structuredClone(serializeWorldInfoEntry(entry, world_info_position, { ...originalEntry, id })));
 }
 
-async function _save(name, data) {
+function cloneWorldInfoData(data, instances = worldInfoEntryInstances.get(data)) {
+    const copy = structuredClone(data);
+    if (lodash.isPlainObject(copy?.entries)) {
+        const copiedInstances = new Map(Object.keys(copy.entries).map(uid => [uid, instances?.get(uid) ?? Symbol()]));
+        worldInfoEntryInstances.set(copy, copiedInstances);
+        if (!worldInfoEntryInstances.has(data)) worldInfoEntryInstances.set(data, new Map(copiedInstances));
+    }
+    return copy;
+}
+
+function getWorldInfoCachedData(name) {
+    const data = Map.prototype.get.call(worldInfoCache, name);
+    return cloneWorldInfoData(data, worldInfoEntryInstances.get(data) ?? worldInfoCommittedEntryInstances.get(name));
+}
+
+function mergeWorldInfoChanges(before, after, current) {
+    if (lodash.isEqual(before, after)) {
+        return current;
+    }
+    if (![after, current].every(lodash.isPlainObject)) {
+        return after;
+    }
+    before = lodash.isPlainObject(before) ? before : {};
+    const result = { ...current };
+    for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+        if (!Object.hasOwn(after, key)) {
+            delete result[key];
+        } else if (Object.hasOwn(before, key) && lodash.isEqual(before[key], after[key])) {
+            continue;
+        } else {
+            // Define own properties instead of invoking inherited setters in foreign metadata.
+            Object.defineProperty(result, key, {
+                value: mergeWorldInfoChanges(Object.hasOwn(before, key) ? before[key] : undefined, after[key], Object.hasOwn(current, key) ? current[key] : undefined),
+                enumerable: true, configurable: true, writable: true,
+            });
+        }
+    }
+    return result;
+}
+
+function trackWorldInfoEntryRender(data, uid) {
+    const before = structuredClone(data.entries[uid]);
+    const originalBefore = structuredClone(data.originalData?.entries?.[getWIOriginalDataIndex(data, uid)]);
+    return () => {
+        const baseline = worldInfoDataSnapshots.get(data)?.data;
+        if (!baseline?.entries[uid]) return;
+        // Rendering normalises fields and mirrors them to cards; those changes are not human edits.
+        baseline.entries[uid] = structuredClone(mergeWorldInfoChanges(before, data.entries[uid], baseline.entries[uid]));
+        const originalIndex = getWIOriginalDataIndex(baseline, uid);
+        if (originalBefore && originalIndex >= 0) {
+            baseline.originalData.entries[originalIndex] = structuredClone(mergeWorldInfoChanges(originalBefore,
+                data.originalData.entries[getWIOriginalDataIndex(data, uid)], baseline.originalData.entries[originalIndex]));
+        }
+    };
+}
+
+function mergeWorldInfoData(base, draft, latest) {
+    if (![base, draft, latest].every(book => lodash.isPlainObject(book?.entries))) return null;
+    const beforeInstances = worldInfoEntryInstances.get(base);
+    const afterInstances = worldInfoEntryInstances.get(draft);
+    const currentInstances = worldInfoEntryInstances.get(latest);
+    // SillyBunny: numeric UIDs can be reused. Only changes to the same session-local entry instance may merge.
+    for (const uid of new Set([...Object.keys(base.entries), ...Object.keys(draft.entries)])) {
+        const existed = Object.hasOwn(base.entries, uid);
+        const exists = Object.hasOwn(draft.entries, uid);
+        const before = existed ? base.entries[uid] : undefined;
+        const after = exists ? draft.entries[uid] : undefined;
+        const beforeInstance = beforeInstances?.get(uid);
+        const afterInstance = afterInstances?.get(uid);
+        const currentInstance = currentInstances?.get(uid);
+        if (lodash.isEqual(before, after) && (!exists || beforeInstance === afterInstance)) continue;
+        if (existed && (!Object.hasOwn(latest.entries, uid) || (beforeInstance && currentInstance && beforeInstance !== currentInstance))) return null;
+        if (!existed && Object.hasOwn(latest.entries, uid) && (!afterInstance || afterInstance !== currentInstance)) return null;
+    }
+    const instances = new Map(currentInstances);
+    for (const [uid, instance] of afterInstances ?? []) {
+        if (instance !== beforeInstances?.get(uid)) instances.set(uid, instance);
+    }
+    const result = cloneWorldInfoData(mergeWorldInfoChanges(base, draft, latest), instances);
+    if ([base, draft, latest].every(book => Array.isArray(book.originalData?.entries))
+        && !lodash.isEqual(base.originalData.entries, draft.originalData.entries)
+        && !lodash.isEqual(base.originalData.entries, latest.originalData.entries)) {
+        // Imported records are indexed by the native UID map, not by their array position or card ID.
+        const uids = Object.keys(result.entries).sort((a, b) => {
+            const aIndex = getWIOriginalDataIndex(latest, a);
+            const bIndex = getWIOriginalDataIndex(latest, b);
+            return (aIndex < 0 ? Infinity : aIndex) - (bIndex < 0 ? Infinity : bIndex);
+        });
+        result.originalData.entries = uids.map(uid => {
+            // An absent native UID may match another entry's card ID through the legacy lookup fallback.
+            const records = [base, draft, latest].map(book => Object.hasOwn(book.entries, uid)
+                ? book.originalData.entries[getWIOriginalDataIndex(book, uid)] : undefined);
+            return structuredClone(mergeWorldInfoChanges(...records));
+        });
+        result.originalDataUidMap = Object.fromEntries(uids.map((uid, index) => [uid, index]));
+    }
+    return result;
+}
+
+function invalidateWorldInfoCache(name) {
+    worldInfoCache.delete(name);
+    worldInfoCacheVersions.set(name, {});
+}
+
+async function _save(name, data, { snapshot, notify = true } = {}) {
     const previousSave = worldInfoSaveQueues.get(name) ?? Promise.resolve();
     const save = previousSave.catch(() => undefined).then(async () => {
-        const response = await fetch('/api/worldinfo/edit', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify({ name: name, data: data }),
-        });
-        if (!response.ok) {
-            throw new Error(`World Info save failed with status ${response.status}`);
+        let savedName;
+        try {
+            const response = await fetch('/api/worldinfo/edit', {
+                method: 'POST',
+                headers: getRequestHeaders(),
+                body: JSON.stringify({ name: name, data: data }),
+            });
+            if (!response.ok) {
+                throw new Error(`World Info save failed with status ${response.status}`);
+            }
+            savedName = (await response.json()).name;
+        } catch (error) {
+            // Compare identity without StructuredCloneMap's cloning getter; a later save owns its cache.
+            if (Map.prototype.get.call(worldInfoCache, name) === data) {
+                invalidateWorldInfoCache(name);
+            }
+            if (snapshot && worldInfoDataSnapshots.get(snapshot.source) === snapshot) {
+                let previous = snapshot.previous;
+                while (previous && !previous.committed) previous = previous.previous;
+                if (previous) worldInfoDataSnapshots.set(snapshot.source, previous);
+                else worldInfoDataSnapshots.delete(snapshot.source);
+            }
+            throw error;
         }
-        await eventSource.emit(event_types.WORLDINFO_UPDATED, name, data);
+        if (snapshot) {
+            snapshot.committed = true;
+            snapshot.previous = null;
+        }
+        worldInfoCommittedEntryInstances.set(savedName, worldInfoEntryInstances.get(data));
+        if (savedName !== name && Map.prototype.get.call(worldInfoCache, name) === data) {
+            invalidateWorldInfoCache(name);
+            worldInfoCache.set(savedName, data);
+            worldInfoCacheVersions.set(savedName, data);
+        }
+        return savedName;
     });
     worldInfoSaveQueues.set(name, save);
+    let savedName;
     try {
-        await save;
+        savedName = await save;
     } finally {
         if (worldInfoSaveQueues.get(name) === save) {
             worldInfoSaveQueues.delete(name);
         }
     }
+    if (notify) {
+        // Listeners can save again; notify outside the write queue and retain unchanged extension-owned identities.
+        const eventData = snapshot?.source !== worldInfoEditor?.data && lodash.isEqual(snapshot?.source, data) ? snapshot.source : data;
+        await eventSource.emit(event_types.WORLDINFO_UPDATED, savedName, eventData);
+        if (snapshot?.source !== worldInfoEditor?.data) reloadEditor(savedName);
+    }
+    return savedName;
 }
 
 function cancelPendingWorldInfoSave(name) {
@@ -4547,14 +4744,14 @@ function cancelPendingWorldInfoSave(name) {
         clearTimeout(pendingSave.timer);
         pendingWorldInfoSaves.delete(name);
     }
-    return pendingSave?.data;
+    return pendingSave;
 }
 
 async function settleWorldInfoSave(name) {
     while (true) {
-        const pendingData = cancelPendingWorldInfoSave(name);
-        if (pendingData) {
-            await _save(name, pendingData);
+        const pending = cancelPendingWorldInfoSave(name);
+        if (pending) {
+            await _save(name, pending.data, { snapshot: pending.snapshot });
         }
         const pendingSave = worldInfoSaveQueues.get(name);
         if (!pendingSave) {
@@ -4602,59 +4799,96 @@ async function getCanonicalWorldInfoName(name) {
  * Saves the world info
  *
  * This will also refresh the `worldInfoCache`.
- * Note, for performance reasons the saved cache will not make a deep clone of the data.
- * It is your responsibility to not modify the saved data object after calling this function, or there will be data inconsistencies.
- * Call `loadWorldInfoData` or query directly from cache if you need the object again.
+ * Pass the object returned by loadWorldInfo to merge changes against its load baseline; untracked objects are full-book writes.
+ * Later changes to the caller's object do not change a queued write.
  *
  * @param {string} name - The name of the world info
  * @param {any} data - The data to be saved
  * @param {boolean} [immediately=false] - Whether to save immediately or use debouncing
- * @return {Promise<void>} A promise that resolves when the world info is saved
+ * @return {Promise<string|null|undefined>} Immediate saves resolve to the committed name, or null if invalid/discarded.
+ * Debounced saves resolve to undefined when scheduled (not committed), or null if invalid/discarded; failures are reported by toast.
  */
 export async function saveWorldInfo(name, data, immediately = false) {
-    if (!name || !data) {
-        return;
+    if (typeof name !== 'string' || !name.trim() || !lodash.isPlainObject(data) || !lodash.isPlainObject(data.entries)
+        || !Object.values(data.entries).every(lodash.isPlainObject)) {
+        return null;
     }
 
-    const saveBlock = worldInfoSaveBlocks.get(name);
-    if (saveBlock) {
-        const targetName = await saveBlock;
-        if (!targetName) {
-            return;
+    const source = data;
+    const baseline = worldInfoDataSnapshots.get(source);
+    const requestedName = name;
+    const draft = cloneWorldInfoData(data, worldInfoEntryInstances.get(data) ?? worldInfoEntryInstances.get(Map.prototype.get.call(worldInfoCache, name)));
+    while (true) {
+        if (worldInfoSaveBlocks.has(name)) {
+            const targetName = await worldInfoSaveBlocks.get(name);
+            if (!targetName) {
+                return null;
+            }
+            name = targetName;
+            continue;
         }
-        name = targetName;
+        if (baseline?.name === requestedName && !worldInfoCache.has(name)) {
+            if (!await loadWorldInfo(name)) return null;
+            if (worldInfoSaveBlocks.has(name)) continue;
+        }
+        break;
     }
 
+    const latest = getWorldInfoCachedData(name);
+    data = baseline?.name === requestedName && latest ? mergeWorldInfoData(baseline.data, draft, latest) : draft;
+    if (!data) return null;
+    const pending = cancelPendingWorldInfoSave(name);
+    if (pending && pending.snapshot.source !== source) {
+        // Another writer's draft must reach disk even if this replacement snapshot fails.
+        _save(name, pending.data, { snapshot: pending.snapshot }).catch(error => {
+            console.error(`Failed to save World Info ${name}:`, error);
+            toastr.error(String(error), t`World Info Save Failed`);
+        });
+    } else if (pending) {
+        pending.snapshot.cancelled = true;
+    }
+    let previous = baseline;
+    while (previous?.cancelled) previous = previous.previous;
+    const snapshot = { name, source, data: draft, previous, committed: false };
+    worldInfoDataSnapshots.set(source, snapshot);
+    worldInfoEntryInstances.set(source, new Map(worldInfoEntryInstances.get(draft)));
     // Update cache immediately, so any future call can pull from this
     worldInfoCache.set(name, data);
+    worldInfoCacheVersions.set(name, data);
 
     if (immediately) {
-        cancelPendingWorldInfoSave(name);
-        return await _save(name, data);
+        return await _save(name, data, { snapshot });
     }
 
-    cancelPendingWorldInfoSave(name);
     const timer = setTimeout(() => {
         pendingWorldInfoSaves.delete(name);
-        _save(name, data).catch(error => {
+        _save(name, data, { snapshot }).catch(error => {
             console.error(`Failed to save World Info ${name}:`, error);
             toastr.error(String(error), t`World Info Save Failed`);
         });
     }, debounce_timeout.relaxed);
-    pendingWorldInfoSaves.set(name, { timer, data });
+    pendingWorldInfoSaves.set(name, { timer, data, snapshot });
 }
 
 async function replaceWorldInfoData(name, data) {
     const releaseSaveBlock = blockWorldInfoSaves(name);
     let saveTarget = name;
+    let savedName;
+    data = cloneWorldInfoData(data, new Map());
     try {
         await settleWorldInfoSave(name);
-        await _save(name, data);
+        savedName = await _save(name, data, { notify: false });
         saveTarget = null;
-        worldInfoCache.set(name, data);
+        invalidateWorldInfoCache(name);
+        worldInfoCache.set(savedName, data);
+        worldInfoCacheVersions.set(savedName, data);
+        if (worldInfoEditor?.name === name) worldInfoEditor = null;
     } finally {
         releaseSaveBlock(saveTarget);
     }
+    await eventSource.emit(event_types.WORLDINFO_UPDATED, savedName, data, { replaced: true });
+    reloadEditor(savedName);
+    return savedName;
 }
 
 async function renameWorldInfo(name, data) {
@@ -4684,6 +4918,10 @@ async function renameWorldInfo(name, data) {
     let saveTarget = oldName;
     try {
         await settleWorldInfoSave(oldName);
+        const baseline = worldInfoDataSnapshots.get(data);
+        const latest = getWorldInfoCachedData(oldName);
+        data = baseline && latest ? mergeWorldInfoData(baseline.data, data, latest) : cloneWorldInfoData(data);
+        if (!data) return;
         const response = await fetch('/api/worldinfo/rename', {
             method: 'POST',
             headers: getRequestHeaders(),
@@ -4695,8 +4933,11 @@ async function renameWorldInfo(name, data) {
         }
         saveTarget = newName;
 
-        worldInfoCache.delete(oldName);
+        invalidateWorldInfoCache(oldName);
+        worldInfoCommittedEntryInstances.delete(oldName);
+        worldInfoCommittedEntryInstances.set(newName, worldInfoEntryInstances.get(data));
         worldInfoCache.set(newName, data);
+        worldInfoCacheVersions.set(newName, data);
         if (entryPreviouslySelected !== -1) {
             selected_world_info[entryPreviouslySelected] = newName;
             saveSettingsDebounced();
@@ -4717,6 +4958,7 @@ async function renameWorldInfo(name, data) {
         }
     } finally {
         releaseSaveBlock(saveTarget);
+        if (saveTarget === newName) await eventSource.emit(event_types.WORLDINFO_RENAMED, oldName, newName);
     }
 }
 
@@ -4850,9 +5092,9 @@ export async function deleteWorldInfo(worldInfoName) {
         }
         saveTarget = null;
 
-        if (worldInfoCache.has(worldInfoName)) {
-            worldInfoCache.delete(worldInfoName);
-        }
+        invalidateWorldInfoCache(worldInfoName);
+        worldInfoCommittedEntryInstances.delete(worldInfoName);
+        if (worldInfoEditor?.name === worldInfoName) worldInfoEditor = null;
 
         const existingWorldIndex = selected_world_info.findIndex((e) => e === worldInfoName);
         if (existingWorldIndex !== -1) {
@@ -4880,11 +5122,11 @@ export async function deleteWorldInfo(worldInfoName) {
             $('#persona_lore_button').toggleClass('world_set', false);
             saveSettingsDebounced();
         }
-
-        return true;
     } finally {
         releaseSaveBlock(saveTarget);
+        if (saveTarget === null) await eventSource.emit(event_types.WORLDINFO_DELETED, worldInfoName);
     }
+    return true;
 }
 
 export function getFreeWorldEntryUid(data) {
@@ -4892,9 +5134,12 @@ export function getFreeWorldEntryUid(data) {
         return null;
     }
 
+    const snapshot = worldInfoDataSnapshots.get(data);
+    const cachedEntries = snapshot ? worldInfoCache.get(snapshot.name)?.entries : null;
     const MAX_UID = 1_000_000; // <- should be safe enough :)
     for (let uid = 0; uid < MAX_UID; uid++) {
-        if (uid in data.entries) {
+        // An open editor may not yet display entries created by another same-tab writer.
+        if (uid in data.entries || (cachedEntries && uid in cachedEntries)) {
             continue;
         }
         return uid;
@@ -6143,6 +6388,7 @@ function convertNovelLorebook(inputObj) {
 export function convertCharacterBook(characterBook) {
     const originalData = structuredClone(characterBook);
     const result = { entries: {}, originalData, originalDataUidMap: {} };
+    if (characterBook.extensions) result.extensions = structuredClone(characterBook.extensions);
 
     characterBook.entries.forEach((entry, index) => {
         const uid = getFreeWorldEntryUid(result);
@@ -6601,10 +6847,9 @@ export async function importWorldInfo(file) {
 
     const formData = new FormData();
     formData.append('avatar', file);
+    let jsonData;
 
     try {
-        let jsonData;
-
         if (file.name.endsWith('.png')) {
             const buffer = new Uint8Array(await getFileBuffer(file));
             jsonData = extractDataFromPng(buffer, 'naidata');
@@ -6660,6 +6905,8 @@ export async function importWorldInfo(file) {
     formData.set('name', persistedWorldName);
     const releaseSaveBlock = blockWorldInfoSaves(persistedWorldName);
     let saveTarget = persistedWorldName;
+    let importedName;
+    let importedData;
 
     try {
         await settleWorldInfoSave(persistedWorldName);
@@ -6678,7 +6925,13 @@ export async function importWorldInfo(file) {
         const data = await result.json();
 
         if (data.name) {
-            worldInfoCache.delete(data.name);
+            importedName = data.name;
+            importedData = cloneWorldInfoData(formData.has('convertedData') ? JSON.parse(String(formData.get('convertedData'))) : jsonData, new Map());
+            worldInfoCommittedEntryInstances.set(data.name, worldInfoEntryInstances.get(importedData));
+            invalidateWorldInfoCache(data.name);
+            worldInfoCache.set(data.name, importedData);
+            worldInfoCacheVersions.set(data.name, importedData);
+            if (worldInfoEditor?.name === data.name) worldInfoEditor = null;
             await updateWorldInfoList();
 
             const newIndex = world_names.indexOf(data.name);
@@ -6693,6 +6946,9 @@ export async function importWorldInfo(file) {
         toastr.error(t`Failed to import World Info`);
     } finally {
         releaseSaveBlock(saveTarget);
+    }
+    if (importedName) {
+        await eventSource.emit(event_types.WORLDINFO_UPDATED, importedName, importedData, { replaced: true });
     }
 }
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -820,7 +820,7 @@ function charaFormatData(data, directories) {
                 _.set(char, 'data.character_book', originalData);
             } else if (file && file.entries) {
                 // File was not imported - convert the world info to the character book
-                _.set(char, 'data.character_book', convertWorldInfoToCharacterBook(data.world, file.entries));
+                _.set(char, 'data.character_book', convertWorldInfoToCharacterBook(data.world, file.entries, file.extensions));
             }
         } catch {
             console.warn(`Failed to read world info file: ${data.world}. Character book will not be available.`);
@@ -843,10 +843,12 @@ function charaFormatData(data, directories) {
 /**
  * @param {string} name Name of World Info file
  * @param {object} entries Entries object
+ * @param {object} [extensions] Book extensions
  */
-function convertWorldInfoToCharacterBook(name, entries) {
+function convertWorldInfoToCharacterBook(name, entries, extensions = {}) {
     /** @type {{ entries: object[]; name: string; extensions: object }} */
-    const result = { entries: [], name, extensions: {} };
+    // SillyBunny: native book metadata, including waypoint layouts, travels with embedded cards.
+    const result = { entries: [], name, extensions: structuredClone(extensions ?? {}) };
     const sortedEntries = Object.values(entries).sort((a, b) => (a.displayIndex ?? a.uid ?? 0) - (b.displayIndex ?? b.uid ?? 0));
 
     for (const entry of sortedEntries) {

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -216,6 +216,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "sendTextareaMessage",
   "setActiveCharacter",
   "setActiveGroup",
+  "setAgentGenerationContextProvider",
   "setAnimationDuration",
   "setCharacterId",
   "setCharacterMenuEntityView",

--- a/tests/character-card-metadata-preservation.test.js
+++ b/tests/character-card-metadata-preservation.test.js
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
 
 import extract from 'png-chunks-extract';
 import PNGtext from 'png-chunk-text';
@@ -14,6 +15,7 @@ import { AVATAR_HEIGHT, AVATAR_WIDTH } from '../src/constants.js';
 import { Jimp } from '../src/jimp.js';
 import { setConfigFilePath } from '../src/util.js';
 import encode from '../src/png/encode.js';
+import { escapeCharacterBookRegex, normalizeCharacterBookPosition } from '../public/scripts/world-info-character-book.js';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const originalWorkingDirectory = process.cwd();
@@ -27,6 +29,18 @@ process.chdir(repoRoot);
 setConfigFilePath(path.join(repoRoot, 'default', 'config.yaml'));
 
 const { router: charactersRouter, sanitiseFilenameForWindows } = await import('../src/endpoints/characters.js');
+const worldInfoSource = fs.readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+const conversionFunctions = ['convertCharacterBook', 'getFreeWorldEntryUid', 'parseRegexFromString'].map(name => {
+    const match = worldInfoSource.match(new RegExp(`^(?:export )?(function ${name}\\([\\s\\S]*?^})`, 'm'));
+    if (!match) throw new Error(`Missing function ${name}`);
+    return match[1];
+});
+const restoreCharacterBook = vm.runInNewContext(`${conversionFunctions.join('\n')}\nconvertCharacterBook`, {
+    structuredClone, escapeCharacterBookRegex, normalizeCharacterBookPosition,
+    worldInfoDataSnapshots: new WeakMap(), newWorldInfoEntryTemplate: {},
+    world_info_position: { before: 0, after: 1 }, world_info_logic: { AND_ANY: 0 },
+    extension_prompt_roles: { SYSTEM: 0 }, DEFAULT_DEPTH: 4, DEFAULT_WEIGHT: 100,
+});
 
 describe('character card metadata preservation', () => {
     let baseUrl;
@@ -190,6 +204,43 @@ describe('character card metadata preservation', () => {
         expect(fs.readFileSync(cardPath).equals(cardBefore)).toBe(true);
         expect(fs.statSync(cardPath).mtimeMs).toBe(statBefore.mtimeMs);
     });
+
+    for (const format of ['native', 'imported']) {
+        const extensions = { foreign: { kept: true }, sillybunny_pathfinder: { version: 1, tree: { id: 'root', children: [{ id: 'place' }] } } };
+        const entryExtensions = { foreign: 'entry metadata', sillybunny_pathfinder: { version: 1, nodeId: 'place' } };
+        const originalData = { name: 'Lore', extensions, foreign: 'original book metadata', entries: [{ id: 74, keys: ['place'], content: 'A place', extensions: entryExtensions, foreign: 'original entry metadata' }] };
+        const book = {
+            extensions, entries: { 42: { uid: 42, key: ['place'], content: 'A place', extensions: entryExtensions } },
+            ...(format === 'imported' ? { originalData, originalDataUidMap: { 42: 0 } } : {}),
+        };
+
+        test(`embeds ${format} lorebook layouts and foreign extensions in both PNG card formats`, async () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            jest.spyOn(console, 'info').mockImplementation(() => {});
+            const worldPath = path.join(directories.worlds, 'Lore.json');
+            const worldBefore = JSON.stringify(book);
+            fs.writeFileSync(worldPath, worldBefore);
+            await createAlice();
+            const character = await getCharacter('Alice.png');
+            character.data.extensions.world = 'Lore';
+            expect((await saveCharacter(character)).status).toBe(200);
+
+            const cards = decodeCardChunks(fs.readFileSync(path.join(directories.characters, 'Alice.png')));
+            expect(cards.map(chunk => chunk.keyword)).toEqual(['chara', 'ccv3']);
+            for (const { card } of cards) {
+                expect(card.data.character_book.extensions).toEqual(extensions);
+                expect(card.data.character_book.entries[0].extensions).toMatchObject(entryExtensions);
+                expect(card.data.character_book.entries[0].id).toBe(format === 'imported' ? 74 : 42);
+                expect(card.data.character_book.foreign).toBe(format === 'imported' ? 'original book metadata' : undefined);
+                expect(card.data.character_book.entries[0].foreign).toBe(format === 'imported' ? 'original entry metadata' : undefined);
+                const restored = restoreCharacterBook(card.data.character_book);
+                expect(restored.extensions).toEqual(extensions);
+                expect(restored.entries[0]).toMatchObject({ uid: 0, content: 'A place', extensions: entryExtensions });
+                expect(restored.originalData).toEqual(card.data.character_book);
+            }
+            expect(fs.readFileSync(worldPath, 'utf8')).toBe(worldBefore);
+        });
+    }
 
     test('updates the original card when its filename stem contains .png', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/generation-lifecycle-wiring.test.js
+++ b/tests/generation-lifecycle-wiring.test.js
@@ -132,6 +132,7 @@ describe('generation lifecycle wiring', () => {
             eventSource: { emit: (...args) => emitted.push(args) },
             event_types: { GENERATION_ENDED: 'generation_ended' },
             chat: { length: 3 },
+            activeGenerationRun: null,
         });
 
         expect(emitted).toEqual([['generation_ended', 3]]);
@@ -140,7 +141,7 @@ describe('generation lifecycle wiring', () => {
 
     test('routes provider-error cleanup through stopped lifecycle semantics', () => {
         expect(scriptSource).toContain('this.markUIGenStopped({ emitGenerationEnded: false, emitGenerationStopped: true });');
-        expect(scriptSource).toContain('eventSource.emit(event_types.GENERATION_STOPPED);');
+        expect(scriptSource).toContain('eventSource.emit(event_types.GENERATION_STOPPED, ...(agentGenerationContext ? [agentGenerationContext] : []));');
         expect(scriptSource).toContain('unblockGeneration(type, { emitGenerationEnded: false });');
     });
 
@@ -167,7 +168,7 @@ describe('generation lifecycle wiring', () => {
 
         expect(generateSource).toContain('const shouldBufferOutput = await shouldBufferMainGenerationOutput({ type, isStreaming: true });');
         expect(generateSource).toContain('await activeStreamingProcessor.generateBuffered()');
-        expect(normalizedGenerateSource).toContain('const interceptResult = await applyMainGenerationOutputInterceptors({\n                            type,\n                            text: getMessage,\n                            isStreaming: true,');
+        expect(normalizedGenerateSource).toMatch(/const interceptResult = await applyMainGenerationOutputInterceptors\(\{\s+type,\s+text: getMessage,\s+isStreaming: true,/);
         expect(generateSource).toContain('const saveReplyType = originalType !== \'continue\' ? type : \'appendFinal\';');
         expect(generateSource).toContain('type: saveReplyType,');
         expect(generateSource).toContain('!shouldBufferOutput && hasToolCalls && !shouldDeleteMessage');
@@ -176,7 +177,7 @@ describe('generation lifecycle wiring', () => {
     test('runs main output intercept event before saveReply stores non-streaming replies', () => {
         const generateSource = getFunctionSource('Generate', { exported: true });
         const interceptIndex = generateSource.indexOf('await applyMainGenerationOutputInterceptors({');
-        const saveIndex = generateSource.indexOf('await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens })');
+        const saveIndex = generateSource.indexOf('await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens, isCurrent })');
 
         expect(interceptIndex).toBeGreaterThanOrEqual(0);
         expect(saveIndex).toBeGreaterThanOrEqual(0);

--- a/tests/guided-generations-correction-wiring.test.js
+++ b/tests/guided-generations-correction-wiring.test.js
@@ -28,8 +28,8 @@ describe('Guided Correction generation wiring', () => {
     });
 
     test('carries the companion rewrite target through group generation only', () => {
-        expect(scriptSource).toContain('generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget })');
-        expect(groupChatsSource).toContain("Generate(generateType, { automatic_trigger: byAutoMode, ...mergedParams })");
-        expect(groupChatsSource).toContain("Generate('continue', { automatic_trigger: byAutoMode, ...mergedParams, companionHistoryTarget: undefined })");
+        expect(scriptSource).toContain('generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope, preserveLastMessage, companionHistoryTarget: companionFeedbackTarget })');
+        expect(groupChatsSource).toContain('Generate(generateType, { automatic_trigger: byAutoMode, ...mergedParams })');
+        expect(groupChatsSource).toContain('Generate(\'continue\', { automatic_trigger: byAutoMode, ...mergedParams, companionHistoryTarget: undefined })');
     });
 });

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -188,6 +188,10 @@ beforeAll(async () => {
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js', () => ({
         openPathfinderSettings: jest.fn(),
+        closePathfinderSettings: jest.fn(),
+        canClosePathfinderSettings: jest.fn(async () => true),
+        cancelPathfinderSummary: jest.fn(),
+        refreshPathfinderSettings: jest.fn(),
         isPathfinderAgent: jest.fn(() => false),
     }));
 

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-duplicate-hooks */
+/* eslint-disable playwright/no-duplicate-hooks, playwright/no-standalone-expect */
 /* global document, globalThis */
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 
@@ -39,6 +39,10 @@ describe('in-chat agent post-processing runner', () => {
     let generateQuietPrompt;
     let generateRaw;
     let runSidecarRetrieval;
+    let injectPathfinderRetrieval;
+    let isGroupGenerating;
+    let pathfinderEnabled;
+    let registeredTools;
     let streamingProcessor;
     let updateMessageTokenAccounting;
     let updateMessageMetaBadges;
@@ -89,8 +93,11 @@ describe('in-chat agent post-processing runner', () => {
             CHAT_COMPLETION_PROMPT_READY: 'chat_completion_prompt_ready',
             CHAT_COMPLETION_SETTINGS_READY: 'chat_completion_settings_ready',
             WORLDINFO_ENTRIES_LOADED: 'worldinfo_entries_loaded',
+            WORLD_INFO_ACTIVATED: 'world_info_activated',
             CHAT_CHANGED: 'chat_changed',
             WORLDINFO_UPDATED: 'worldinfo_updated',
+            WORLDINFO_RENAMED: 'worldinfo_renamed',
+            WORLDINFO_DELETED: 'worldinfo_deleted',
             MESSAGE_UPDATED: 'message_updated',
         };
         saveChatDebounced = jest.fn();
@@ -99,7 +106,11 @@ describe('in-chat agent post-processing runner', () => {
         updateMessageBlock = jest.fn();
         generateQuietPrompt = jest.fn(async () => 'quiet result');
         generateRaw = jest.fn(async () => 'raw result');
-        runSidecarRetrieval = jest.fn();
+        runSidecarRetrieval = jest.fn(async () => ({ success: true, selectedEntries: [] }));
+        injectPathfinderRetrieval = jest.fn();
+        isGroupGenerating = false;
+        pathfinderEnabled = true;
+        registeredTools = new Map();
         streamingProcessor = {
             messageId: -1,
             type: 'normal',
@@ -221,7 +232,7 @@ describe('in-chat agent post-processing runner', () => {
                 const promptName = typeof name === 'string' ? name.trim() : '';
                 extensionPrompts[key] = { value, ...(promptName && { name: promptName }) };
                 Object.defineProperties(extensionPrompts[key], {
-                    position: { value, enumerable: false },
+                    position: { value: position, enumerable: false },
                     depth: { value: depth, enumerable: false },
                     scan: { value: scan, enumerable: false },
                     role: { value: role, enumerable: false },
@@ -233,7 +244,9 @@ describe('in-chat agent post-processing runner', () => {
                 .replaceAll('{{original}}', options.original ?? '')),
             substituteParamsExtended: jest.fn(value => String(value ?? '')),
             generateQuietPrompt,
+            generateRaw,
             getCurrentChatId: jest.fn(() => currentChatId),
+            setAgentGenerationContextProvider: jest.fn(),
             itemizedPrompts,
             normalizeContentText: jest.fn(value => String(value ?? '')),
             main_api: mainApi,
@@ -300,6 +313,10 @@ describe('in-chat agent post-processing runner', () => {
             event_types: eventTypes,
         }));
 
+        await jest.unstable_mockModule('../public/scripts/group-chats.js', () => ({
+            is_group_generating: isGroupGenerating,
+        }));
+
         await jest.unstable_mockModule('../public/scripts/reasoning.js', () => ({
             removeReasoningFromString: jest.fn(value => String(value ?? '')),
         }));
@@ -343,8 +360,17 @@ describe('in-chat agent post-processing runner', () => {
                 canPerformToolCalls: jest.fn(() => false),
                 hasToolCalls: jest.fn(() => false),
                 isToolCallingSupported: jest.fn(() => false),
-                registerFunctionTool: jest.fn(),
-                unregisterFunctionTool: jest.fn(),
+                get tools() { return [...registeredTools.values()]; },
+                registerFunctionTool: jest.fn(({ name, displayName, description, parameters, action, formatMessage, shouldRegister }) => {
+                    registeredTools.set(name, {
+                        displayName,
+                        invoke: action,
+                        formatMessage,
+                        shouldRegister,
+                        toFunctionOpenAI: () => ({ type: 'function', function: { name, description, parameters } }),
+                    });
+                }),
+                unregisterFunctionTool: jest.fn(name => registeredTools.delete(name)),
             },
         }));
 
@@ -360,8 +386,8 @@ describe('in-chat agent post-processing runner', () => {
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
             DEFAULT_AGENT_MAX_TOKENS: 8192,
             MAX_AGENT_MAX_TOKENS: 64000,
-            areAgentsGloballyEnabled: jest.fn(() => true),
-            getAgentById: jest.fn(id => enabledAgents.find(agent => agent.id === id)),
+            areAgentsGloballyEnabled: jest.fn(() => globalSettings.enabled),
+            getAgentById: jest.fn(id => [...enabledAgents, ...enabledToolAgents].find(agent => agent.id === id)),
             getAgents: jest.fn(() => [...enabledAgents]),
             getCompanionConfig: jest.fn(agent => ({
                 trigger: agent?.companion?.trigger === 'manual' ? 'manual' : 'auto',
@@ -408,10 +434,16 @@ describe('in-chat agent post-processing runner', () => {
                     (Array.isArray(agent.regexScripts) && agent.regexScripts.length > 0)
                 );
             }),
-            isPathfinderSubmoduleEnabled: jest.fn(() => true),
-            saveAgent: jest.fn(async () => {}),
+            isPathfinderSubmoduleEnabled: jest.fn(() => pathfinderEnabled),
+            saveAgent: jest.fn(async (agent, { update } = {}) => {
+                const saved = update ? update(structuredClone([...enabledAgents, ...enabledToolAgents].find(item => item.id === agent))) : agent;
+                if (!saved) return null;
+                enabledAgents = enabledAgents.map(agent => agent.id === saved.id ? structuredClone(saved) : agent);
+                enabledToolAgents = enabledToolAgents.map(agent => agent.id === saved.id ? structuredClone(saved) : agent);
+                return saved;
+            }),
             isCompanionAgent: jest.fn(agent => agent?.execution === 'companion' || agent?.category === 'companion'),
-            isToolAgent: jest.fn(() => false),
+            isToolAgent: jest.fn(agent => agent?.category === 'tool'),
             normalizeCompanionConfig: jest.fn(value => value ?? {}),
             normalizePreProcessMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),
             normalizePromptTransformMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),
@@ -433,6 +465,12 @@ describe('in-chat agent post-processing runner', () => {
             isPathfinderSelfWrite: jest.fn(() => false),
         }));
 
+        await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js', () => ({
+            onPathfinderWorldInfoUpdated: jest.fn(),
+            onPathfinderWorldInfoRenamed: jest.fn(),
+            onPathfinderWorldInfoDeleted: jest.fn(),
+        }));
+
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js', () => ({
             getPathfinderToolDefinitions: jest.fn(() => [
                 { name: 'Pathfinder_Search', displayName: 'Search', description: 'Search', parameters: {}, actionKey: 'pathfinder.search' },
@@ -441,13 +479,14 @@ describe('in-chat agent post-processing runner', () => {
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
-            CONFIRMABLE_TOOLS: new Set(),
+            CONFIRMABLE_TOOLS: new Set(['Pathfinder_Summarize']),
             getContextualLorebooks: jest.fn(() => []),
             getForcedToolChoice,
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js', () => ({
             PATHFINDER_RETRIEVAL_PROMPT_KEYS: ['pathfinder_sidecar_retrieval', 'pathfinder_pipeline_retrieval'],
+            injectPathfinderRetrieval,
             runSidecarRetrieval,
         }));
 
@@ -468,6 +507,7 @@ describe('in-chat agent post-processing runner', () => {
         delete globalThis.requestAnimationFrame;
         delete globalThis.toastr;
         delete globalThis.$;
+        delete globalThis.window;
     });
 
     function useAppendPostAgent() {
@@ -513,6 +553,32 @@ describe('in-chat agent post-processing runner', () => {
                 generationTypes: ['normal'],
             },
         }];
+    }
+
+    function usePathfinderAgent(settings = {}) {
+        const agent = {
+            id: 'agent-pathfinder',
+            name: 'Pathfinder',
+            category: 'tool',
+            sourceTemplateId: 'tpl-pathfinder',
+            phase: 'both',
+            prompt: '',
+            injection: { order: 0 },
+            settings: { pipelineEnabled: true, sidecarEnabled: false, enabledLorebooks: ['Book A'], ...settings },
+            tools: [],
+            conditions: { triggerKeywords: [], triggerProbability: 100, generationTypes: ['normal'] },
+        };
+        enabledAgents.unshift(agent);
+        enabledToolAgents = [agent];
+        return agent;
+    }
+
+    function addPathfinderCacheTarget() {
+        chat.push(
+            { name: 'User', mes: 'Question', is_user: true, extra: {} },
+            { name: 'Assistant', mes: 'Answer', is_user: false, is_system: false, extra: {} },
+        );
+        return chat[1];
     }
 
     function createCompanionAgent(overrides = {}) {
@@ -854,7 +920,8 @@ describe('in-chat agent post-processing runner', () => {
     }
 
     test('does not register duplicate event listeners when initialized twice', async () => {
-        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const { initAgentRunner, getAgentGenerationContext } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const { setAgentGenerationContextProvider } = await import('../public/script.js');
 
         initAgentRunner();
         initAgentRunner();
@@ -865,6 +932,8 @@ describe('in-chat agent post-processing runner', () => {
         expect(listenerCount(eventTypes.MESSAGE_RECEIVED)).toBe(1);
         expect(listenerCount(eventTypes.GENERATION_ENDED)).toBe(1);
         expect(listenerCount(eventTypes.WORLDINFO_UPDATED)).toBe(1);
+        expect(setAgentGenerationContextProvider).toHaveBeenCalledTimes(1);
+        expect(setAgentGenerationContextProvider).toHaveBeenCalledWith(getAgentGenerationContext);
         expect(document.addEventListener).toHaveBeenCalledTimes(2);
         expect(globalThis.addEventListener).toHaveBeenCalledTimes(2);
     });
@@ -3778,9 +3847,10 @@ describe('in-chat agent post-processing runner', () => {
         const retrievalDone = new Promise(resolve => {
             resolveRetrieval = resolve;
         });
-        runSidecarRetrieval.mockImplementation(async () => {
+        runSidecarRetrieval.mockImplementation(async (setPrompt) => {
             await retrievalDone;
-            extensionPrompts.pathfinder_pipeline_retrieval = { value: 'retrieved lore' };
+            setPrompt('pathfinder_pipeline_retrieval', 'retrieved lore');
+            return { success: true, selectedEntries: [] };
         });
 
         const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
@@ -3838,6 +3908,50 @@ describe('in-chat agent post-processing runner', () => {
             pipelinePrompts: { promptB: { id: 'promptB' } },
             pipelines: { pipelineB: { id: 'pipelineB' } },
         }));
+    });
+
+    test('only the selected Pathfinder owns duplicate tool names and confirmation settings', async () => {
+        const owner = usePathfinderAgent({ sidecarEnabled: true, confirmTools: { Pathfinder_Summarize: true } });
+        const copy = { ...structuredClone(owner), id: 'locked-copy', phaseLocked: true, settings: { sidecarEnabled: true, confirmTools: {} } };
+        enabledAgents.push(copy);
+        enabledToolAgents.push(copy);
+        const action = jest.fn(async () => 'written');
+        getToolAction.mockReturnValue(action);
+        const { syncToolAgentRegistrations } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        syncToolAgentRegistrations();
+        await registeredTools.get('Pathfinder_Summarize').invoke({ title: 'memory' });
+        expect(action).not.toHaveBeenCalled();
+        const { ToolManager } = await import('../public/scripts/tool-calling.js');
+        expect(ToolManager.registerFunctionTool.mock.calls.filter(([tool]) => tool.name === 'Pathfinder_Summarize')).toHaveLength(1);
+        expect(enabledToolAgents).toHaveLength(2);
+    });
+
+    test.each(['chat change', 'new run', 'Stop'])('does not restore suspended text-helper prompts after %s', async reason => {
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        extensionPrompts.inchat_agent_saved = { value: 'original chat prompt' };
+        let finish;
+        generateQuietPrompt.mockImplementationOnce(() => new Promise(resolve => { finish = resolve; }));
+        const request = runner.requestPromptTransform({ id: 'helper' }, [{ role: 'user', content: 'transform' }], 100);
+        await Promise.resolve();
+        const cancel = {
+            'chat change': async () => { currentChatId = 'chat-b'; await eventSource.emit(eventTypes.CHAT_CHANGED); },
+            'new run': () => eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false),
+            Stop: () => eventSource.emit(eventTypes.GENERATION_STOPPED),
+        };
+        await cancel[reason]();
+        extensionPrompts.inchat_agent_saved = { value: 'current prompt' };
+        finish('late result');
+        await request;
+        expect(extensionPrompts.inchat_agent_saved.value).toBe('current prompt');
+    });
+
+    test('restores suspended prompts when the quiet helper still belongs to the same run and chat', async () => {
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        extensionPrompts.inchat_agent_saved = { value: 'original prompt' };
+        await runner.requestPromptTransform({ id: 'helper' }, [{ role: 'user', content: 'transform' }], 100);
+        expect(extensionPrompts.inchat_agent_saved.value).toBe('original prompt');
     });
 
     test('forces tool use only when the recursion budget leaves a tool pass', async () => {
@@ -3918,6 +4032,7 @@ describe('in-chat agent post-processing runner', () => {
         );
         runSidecarRetrieval.mockImplementation(async (setPrompt, promptTypes, promptRoles) => {
             setPrompt('pathfinder_pipeline_retrieval', 'retrieved lore', promptTypes.IN_PROMPT, 4, false, promptRoles.SYSTEM);
+            return { success: true, selectedEntries: [] };
         });
 
         const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
@@ -3982,6 +4097,381 @@ describe('in-chat agent post-processing runner', () => {
         await generationPromise;
 
         expect(globalThis.toastr.clear).toHaveBeenCalledWith({ toast: true });
+    });
+
+    test.each([
+        ['chat change', async () => { currentChatId = 'chat-b'; await eventSource.emit(eventTypes.CHAT_CHANGED); }],
+        ['Stop', () => eventSource.emit(eventTypes.GENERATION_STOPPED)],
+        ['disable', async runner => { pathfinderEnabled = false; runner.deactivatePathfinderRuntime(); }],
+        ['settings change', async runner => { enabledAgents[0].settings.bookPermissions = { 'Book A': { read: 'none' } }; runner.syncToolAgentRegistrations(); }],
+        ['lorebook edit', () => eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} })],
+        ['new generation', () => eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false)],
+        ['ended', () => eventSource.emit(eventTypes.GENERATION_ENDED)],
+    ])('rejects late retrieval writes, caches and follow-up injections after %s', async (_name, cancel) => {
+        usePrePromptAgent();
+        usePathfinderAgent();
+        const target = addPathfinderCacheTarget();
+        let resolveRetrieval;
+        let retrievalSignal;
+        runSidecarRetrieval.mockImplementation(async (writePrompt, _types, _roles, signal) => {
+            retrievalSignal = signal;
+            await new Promise(resolve => { resolveRetrieval = resolve; });
+            writePrompt('pathfinder_pipeline_retrieval', 'stale lore');
+            return { success: true, selectedEntries: [] };
+        });
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const pending = eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        await Promise.resolve();
+        expect(runner.isAgentGenerationActive()).toBe(true);
+        await cancel(runner);
+        extensionPrompts.pathfinder_pipeline_retrieval = { value: 'current lore' };
+        resolveRetrieval();
+        await pending;
+
+        expect(retrievalSignal.aborted).toBe(true);
+        expect(extensionPrompts.pathfinder_pipeline_retrieval.value).toBe('current lore');
+        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toBeUndefined();
+        expect(target.extra.pathfinderRetrievalCache).toBeUndefined();
+        expect(runner.isAgentGenerationActive()).toBe(false);
+    });
+
+    test.each([
+        ['failure', { success: false }],
+        ['optional-stage failure', { success: true, cacheable: false, selectedEntries: [] }],
+    ])('retries %s and only caches a successful empty selection', async (_name, failed) => {
+        usePathfinderAgent();
+        const target = addPathfinderCacheTarget();
+        runSidecarRetrieval.mockResolvedValueOnce(failed).mockResolvedValue({ success: true, selectedEntries: [] });
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        expect(target.extra.pathfinderRetrievalCache).toBeUndefined();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        expect(target.extra.pathfinderRetrievalCache).toHaveLength(1);
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        expect(runSidecarRetrieval).toHaveBeenCalledTimes(2);
+    });
+
+    test.each([
+        ['edit', () => eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} })],
+        ['replacement', () => eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} }, { replaced: true })],
+        ['deletion', () => eventSource.emit(eventTypes.WORLDINFO_DELETED, 'Book A')],
+    ])('invalidates stored swipe retrieval after lorebook %s, including edits in another chat', async (_name, update) => {
+        usePathfinderAgent();
+        addPathfinderCacheTarget();
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        currentChatId = 'chat-b';
+        await update();
+        currentChatId = 'chat-a';
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        expect(runSidecarRetrieval).toHaveBeenCalledTimes(2);
+        const storage = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
+        expect(storage.onPathfinderWorldInfoUpdated.mock.calls.concat(storage.onPathfinderWorldInfoDeleted.mock.calls)).toEqual([
+            expect.arrayContaining(['Book A']),
+        ]);
+    });
+
+    test('retargets saved book names on rename without widening destination permissions, and removes deleted names', async () => {
+        usePathfinderAgent({
+            enabledLorebooks: ['Book A', 'Book B'],
+            selectedLorebook: 'Book A',
+            bookPermissions: { 'Book A': { read: 'readwrite' }, 'Book B': { read: 'none' } },
+        });
+        const { initAgentRunner, syncToolAgentRegistrations } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+        syncToolAgentRegistrations();
+        const { getAgentById } = await import('../public/scripts/extensions/in-chat-agents/agent-store.js');
+        await eventSource.emit(eventTypes.WORLDINFO_RENAMED, 'Book A', 'Book B');
+        const agent = getAgentById('agent-pathfinder');
+        expect(agent.settings.enabledLorebooks).toEqual(['Book B']);
+        expect(agent.settings.selectedLorebook).toBe('Book B');
+        expect(agent.settings.bookPermissions).toEqual({ 'Book B': { read: 'none' } });
+        await eventSource.emit(eventTypes.WORLDINFO_DELETED, 'Book B');
+        expect(getAgentById(agent.id).settings.enabledLorebooks).toEqual([]);
+        expect(getAgentById(agent.id).settings.selectedLorebook).toBe('');
+        expect(getAgentById(agent.id).settings.bookPermissions).toEqual({});
+    });
+
+    test.each(['auto-sync', 'retarget'])('publishes %s settings and notifies subscribers only after saving', async operation => {
+        const agent = usePathfinderAgent({
+            enabledLorebooks: ['Book A'], selectedLorebook: 'Book A',
+            bookPermissions: { 'Excluded': { enabled: false, read: true, write: false, delete: 'none' } },
+        });
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const store = await import('../public/scripts/extensions/in-chat-agents/agent-store.js');
+        const bridge = await import('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js');
+        bridge.getContextualLorebooks.mockReturnValue(['Excluded', 'Book B']);
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        const before = structuredClone(agent.settings);
+        let release;
+        const commit = store.saveAgent.getMockImplementation();
+        store.saveAgent.mockImplementationOnce(async (...args) => {
+            await new Promise(resolve => { release = resolve; });
+            return await commit(...args);
+        });
+        const notifications = [];
+        const unsubscribe = runner.onAgentGenerationStateChanged(() => notifications.push(structuredClone(pathfinderRuntimeSettings)));
+        const pending = operation === 'auto-sync'
+            ? runner.syncPathfinderAgentLorebooksForCurrentChat(agent, { persist: true })
+            : eventSource.emit(eventTypes.WORLDINFO_RENAMED, 'Book A', 'Book B');
+        expect(store.getAgentById(agent.id).settings).toEqual(before);
+        expect(pathfinderRuntimeSettings.enabledLorebooks).toEqual(['Book A']);
+        notifications.length = 0;
+        release();
+        await pending;
+        expect(store.getAgentById(agent.id).settings).toMatchObject({ enabledLorebooks: ['Book B'], selectedLorebook: 'Book B', bookPermissions: before.bookPermissions });
+        expect(notifications).toEqual([expect.objectContaining({ enabledLorebooks: ['Book B'] })]);
+        unsubscribe();
+    });
+
+    test.each(['auto-sync', 'retarget'])('does not publish failed %s settings', async operation => {
+        const agent = usePathfinderAgent({ selectedLorebook: 'Book A' });
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const store = await import('../public/scripts/extensions/in-chat-agents/agent-store.js');
+        const bridge = await import('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js');
+        bridge.getContextualLorebooks.mockReturnValue(['Book B']);
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        const before = structuredClone(agent.settings);
+        store.saveAgent.mockRejectedValueOnce(new Error('offline'));
+        const pending = operation === 'auto-sync'
+            ? runner.syncPathfinderAgentLorebooksForCurrentChat(agent, { persist: true })
+            : eventSource.emit(eventTypes.WORLDINFO_RENAMED, 'Book A', 'Book B');
+        await expect(pending).rejects.toThrow('offline');
+        expect(store.getAgentById(agent.id).settings).toEqual(before);
+        expect(pathfinderRuntimeSettings.enabledLorebooks).toEqual(['Book A']);
+    });
+
+    test('uses only native activation received for the current completed retrieval', async () => {
+        usePathfinderAgent();
+        const result = { success: true, selectedEntries: [{ name: 'Town', bookName: 'Book A', uid: 1, content: 'Town lore' }] };
+        runSidecarRetrieval.mockResolvedValue(result);
+        const { initAgentRunner, getAgentGenerationContext } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+        const oldEntries = [{ world: 'Book A', uid: 2 }];
+        await eventSource.emit(eventTypes.WORLD_INFO_ACTIVATED, oldEntries);
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        expect(injectPathfinderRetrieval).not.toHaveBeenCalled();
+        const nativeEntries = [{ world: 'Book A', uid: 1 }];
+        await eventSource.emit(eventTypes.WORLD_INFO_ACTIVATED, nativeEntries);
+        expect(injectPathfinderRetrieval).not.toHaveBeenCalled();
+        const generationContext = getAgentGenerationContext();
+        await eventSource.emit(eventTypes.WORLD_INFO_ACTIVATED, nativeEntries, generationContext);
+        expect(injectPathfinderRetrieval).toHaveBeenCalledWith(result, expect.any(Function), expect.any(Object), expect.any(Object), nativeEntries);
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        await eventSource.emit(eventTypes.WORLD_INFO_ACTIVATED, oldEntries, generationContext);
+        expect(injectPathfinderRetrieval).toHaveBeenCalledTimes(1);
+        await eventSource.emit(eventTypes.GENERATION_STOPPED);
+        await eventSource.emit(eventTypes.WORLD_INFO_ACTIVATED, oldEntries);
+        expect(injectPathfinderRetrieval).toHaveBeenCalledTimes(1);
+    });
+
+    test.each([false, true])('skips the group dispatch wrapper but preserves member retrieval (member active: %s)', async memberActive => {
+        contextGroupId = 'group-1';
+        isGroupGenerating = memberActive;
+        usePathfinderAgent();
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        expect(runSidecarRetrieval).toHaveBeenCalledTimes(memberActive ? 1 : 0);
+    });
+
+    test.each([
+        ['Stop', () => eventSource.emit(eventTypes.GENERATION_STOPPED)],
+        ['chat change', async () => { currentChatId = 'chat-b'; await eventSource.emit(eventTypes.CHAT_CHANGED); }],
+        ['disable', async runner => { pathfinderEnabled = false; runner.deactivatePathfinderRuntime(); }],
+        ['ended', () => eventSource.emit(eventTypes.GENERATION_ENDED)],
+        ['tool disabled', async runner => { enabledToolAgents[0].settings.toolStates = { Pathfinder_Summarize: false }; runner.syncToolAgentRegistrations(); }],
+        ['agent disabled', async runner => { enabledToolAgents = []; runner.syncToolAgentRegistrations(); }],
+        ['lorebook replacement', () => eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} }, { replaced: true })],
+    ])('invalidates pending approval on %s, even if its old dialog later approves', async (_name, cancel) => {
+        usePathfinderAgent({ sidecarEnabled: true, confirmTools: { Pathfinder_Summarize: true } });
+        const action = jest.fn(async () => 'written');
+        getToolAction.mockReturnValue(action);
+        let approve;
+        const completeCancelled = jest.fn();
+        globalThis.window = { SillyTavern: { getContext: () => ({
+            Popup: class {
+                show() { return new Promise(resolve => { approve = resolve; }); }
+                completeCancelled = completeCancelled;
+            },
+            POPUP_TYPE: { CONFIRM: 2 },
+            POPUP_RESULT: { AFFIRMATIVE: 1 },
+        }) } };
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const tool = registeredTools.get('Pathfinder_Summarize');
+        expect(tool.toFunctionOpenAI().function.name).toBe('Pathfinder_Summarize');
+        const pending = tool.invoke({ title: 'Memory', content: 'Original chat' });
+        await cancel(runner);
+        await expect(pending).resolves.toContain('The user declined this tool call.');
+        approve(1);
+        expect(completeCancelled).toHaveBeenCalledTimes(1);
+        expect(action).not.toHaveBeenCalled();
+    });
+
+    test('rechecks tool enablement after approval even without a registration sync', async () => {
+        const agent = usePathfinderAgent({ sidecarEnabled: true, confirmTools: { Pathfinder_Summarize: true } });
+        const action = jest.fn(async () => 'written');
+        getToolAction.mockReturnValue(action);
+        let approve;
+        globalThis.window = { SillyTavern: { getContext: () => ({
+            Popup: class { show() { return new Promise(resolve => { approve = resolve; }); } },
+            POPUP_TYPE: { CONFIRM: 2 },
+            POPUP_RESULT: { AFFIRMATIVE: 1 },
+        }) } };
+        const { syncToolAgentRegistrations } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        syncToolAgentRegistrations();
+        const pending = registeredTools.get('Pathfinder_Summarize').invoke({ title: 'Memory' });
+        approve(1);
+        agent.settings.toolStates = { Pathfinder_Summarize: false };
+        await expect(pending).resolves.toContain('The user declined this tool call.');
+        expect(action).not.toHaveBeenCalled();
+    });
+
+    test.each(['GENERATION_ENDED', 'GENERATION_STOPPED', 'CHAT_CHANGED'])('applies deferred registration changes on %s', async eventName => {
+        const agent = usePathfinderAgent();
+        getToolAction.mockReturnValue(jest.fn(async () => 'ok'));
+        const { initAgentRunner, syncToolAgentRegistrations } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+        syncToolAgentRegistrations();
+        expect([...registeredTools.keys()]).toEqual(['Pathfinder_Summarize']);
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        agent.settings.sidecarEnabled = true;
+        syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} });
+        expect([...registeredTools.keys()]).toEqual(['Pathfinder_Summarize']);
+        await eventSource.emit(eventTypes[eventName]);
+        expect([...registeredTools.keys()].sort()).toEqual(['Pathfinder_Search', 'Pathfinder_Summarize']);
+    });
+
+    test('can disable and unregister Pathfinder immediately after Stop', async () => {
+        usePathfinderAgent({ sidecarEnabled: true });
+        getToolAction.mockReturnValue(jest.fn(async () => 'ok'));
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_STOPPED);
+        pathfinderEnabled = false;
+        runner.deactivatePathfinderRuntime();
+        expect(registeredTools.size).toBe(0);
+        expect(runner.isAgentGenerationStopped()).toBe(true);
+    });
+
+    test('ignores delayed terminal events from an older host generation', async () => {
+        const agent = usePathfinderAgent();
+        getToolAction.mockReturnValue(jest.fn(async () => 'ok'));
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const oldContext = runner.getAgentGenerationContext();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        agent.settings.sidecarEnabled = true;
+        runner.syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STOPPED, oldContext);
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length, oldContext);
+        expect(runner.isAgentGenerationStopped()).toBe(false);
+        expect([...registeredTools.keys()]).toEqual(['Pathfinder_Summarize']);
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length, runner.getAgentGenerationContext());
+        expect([...registeredTools.keys()].sort()).toEqual(['Pathfinder_Search', 'Pathfinder_Summarize']);
+    });
+
+    test('disabling Pathfinder does not cancel unrelated agent requests', async () => {
+        const { deactivatePathfinderRuntime, getAgentGenerationCancelRevision } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const revision = getAgentGenerationCancelRevision();
+        pathfinderEnabled = false;
+        deactivatePathfinderRuntime();
+        expect(getAgentGenerationCancelRevision()).toBe(revision);
+    });
+
+    test('isolates raw Pathfinder requests from main premodifiers and forced tool settings', async () => {
+        enabledAgents = [createPreInterceptAgent()];
+        usePathfinderAgent({ sidecarEnabled: true, mandatoryTools: true });
+        getToolAction.mockReturnValue(jest.fn(async () => 'ok'));
+        getForcedToolChoice.mockReturnValue('required');
+        globalThis.window = { SillyTavern: { getContext: () => ({}) } };
+        const { initAgentRunner, syncToolAgentRegistrations } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const { sidecarGenerateWithProfile } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js');
+        initAgentRunner();
+        syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const textData = { prompt: 'auxiliary text', dryRun: false };
+        const chatData = { chat: [{ role: 'user', content: 'auxiliary chat' }], dryRun: false };
+        const settingsData = { tools: [{}], chat_completion_source: 'openai' };
+        generateRaw.mockImplementation(async () => {
+            await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, textData);
+            await eventSource.emit(eventTypes.CHAT_COMPLETION_PROMPT_READY, chatData);
+            await eventSource.emit(eventTypes.CHAT_COMPLETION_SETTINGS_READY, settingsData);
+            return 'auxiliary result';
+        });
+        await expect(sidecarGenerateWithProfile('request')).resolves.toBe('auxiliary result');
+        expect(textData.prompt).toBe('auxiliary text');
+        expect(chatData.chat[0].content).toBe('auxiliary chat');
+        expect(settingsData.tool_choice).toBeUndefined();
+        expect(generateQuietPrompt).not.toHaveBeenCalled();
+
+        const mainData = { prompt: 'main prompt', dryRun: false };
+        await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, mainData);
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(1);
+        expect(mainData.prompt).toBe('quiet result');
+    });
+
+    test('releases the internal request guard immediately on cancellation while its transport is still pending', async () => {
+        const { runAsInternalPromptTransform, isAgentGenerationActive } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const controller = new AbortController();
+        let finish;
+        const pending = runAsInternalPromptTransform(() => new Promise(resolve => { finish = resolve; }), controller.signal);
+        expect(isAgentGenerationActive()).toBe(true);
+        controller.abort();
+        expect(isAgentGenerationActive()).toBe(false);
+        finish('finished');
+        await pending;
+        expect(isAgentGenerationActive()).toBe(false);
+    });
+
+    test('starts a real successor generation even while an older raw retrieval is internally guarded', async () => {
+        usePathfinderAgent();
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        let finish;
+        let retrievalSignal;
+        runSidecarRetrieval.mockImplementation((writePrompt, _types, _roles, signal) => {
+            retrievalSignal = signal;
+            return runner.runAsInternalPromptTransform(async () => {
+                await new Promise(resolve => { finish = resolve; });
+                writePrompt('pathfinder_pipeline_retrieval', 'old retrieval');
+                return { success: true, selectedEntries: [] };
+            }, signal);
+        });
+        runner.initAgentRunner();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const oldContext = runner.getAgentGenerationContext();
+        const old = eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        await Promise.resolve();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        expect(retrievalSignal.aborted).toBe(true);
+        expect(runner.getAgentGenerationContext().runId).toBeGreaterThan(oldContext.runId);
+        extensionPrompts.pathfinder_pipeline_retrieval = { value: 'new retrieval' };
+        finish();
+        await old;
+        expect(extensionPrompts.pathfinder_pipeline_retrieval.value).toBe('new retrieval');
     });
 
     test('runs pre-generation intercept agents on text prompts without injecting their prompt', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -4326,6 +4326,56 @@ describe('in-chat agent post-processing runner', () => {
         expect(action).not.toHaveBeenCalled();
     });
 
+    test.each([
+        ['Stop', () => eventSource.emit(eventTypes.GENERATION_STOPPED)],
+        ['chat change', async () => { currentChatId = 'chat-b'; await eventSource.emit(eventTypes.CHAT_CHANGED); }],
+        ['replacement', () => eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} }, { replaced: true })],
+    ])('keeps an executing tool cancellable on %s until its promise settles', async (_name, cancel) => {
+        usePathfinderAgent({ confirmTools: { Pathfinder_Summarize: false } });
+        let release;
+        let context;
+        getToolAction.mockReturnValue(jest.fn((_args, options) => {
+            context = options;
+            return new Promise(resolve => { release = resolve; });
+        }));
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const pending = registeredTools.get('Pathfinder_Summarize').invoke({ title: 'Memory', content: 'Original chat' });
+        await cancel();
+        release('cancelled');
+        await pending;
+        expect(context?.signal.aborted).toBe(true);
+        expect(context?.isCurrent()).toBe(false);
+    });
+
+    test('a sibling tool save does not cancel another executing tool, but a later external edit does', async () => {
+        usePathfinderAgent({ confirmTools: { Pathfinder_Summarize: false } });
+        const { isPathfinderSelfWrite } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+        let release;
+        let context;
+        getToolAction.mockReturnValue(jest.fn((_args, options) => {
+            context = options;
+            return new Promise(resolve => { release = resolve; });
+        }));
+        const runner = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        runner.initAgentRunner();
+        runner.syncToolAgentRegistrations();
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const pending = registeredTools.get('Pathfinder_Summarize').invoke({ title: 'Memory', content: 'Original chat' });
+        isPathfinderSelfWrite.mockReturnValue(true);
+        await eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} });
+        expect(context.signal.aborted).toBe(false);
+        expect(context.isCurrent()).toBe(true);
+        isPathfinderSelfWrite.mockReturnValue(false);
+        await eventSource.emit(eventTypes.WORLDINFO_UPDATED, 'Book A', { entries: {} });
+        release('cancelled');
+        await pending;
+        expect(context.signal.aborted).toBe(true);
+        expect(context.isCurrent()).toBe(false);
+    });
+
     test('rechecks tool enablement after approval even without a registration sync', async () => {
         const agent = usePathfinderAgent({ sidecarEnabled: true, confirmTools: { Pathfinder_Summarize: true } });
         const action = jest.fn(async () => 'written');

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -57,6 +57,32 @@ describe('in-chat agent scoped enabled state', () => {
         ]);
     }
 
+    test('deleting an agent waits for its pending save so it cannot reappear locally or on the server', async () => {
+        const store = await importStore();
+        useAgents(store);
+        const persisted = new Map(store.getAgents().map(agent => [agent.id, structuredClone(agent)]));
+        let finishSave;
+        let started;
+        const saving = new Promise(resolve => { started = resolve; });
+        globalThis.fetch = jest.fn(async (url, request) => {
+            const data = JSON.parse(request.body);
+            if (url.endsWith('/save')) {
+                await new Promise(resolve => { finishSave = resolve; started(); });
+                persisted.set(data.id, data);
+            } else {
+                persisted.delete(data.id);
+            }
+            return { ok: true };
+        });
+        const pending = store.saveAgent({ ...store.getAgentById('agent-individual'), name: 'Edited' });
+        await saving;
+        const deletion = store.deleteAgent('agent-individual');
+        finishSave();
+        await Promise.all([pending, deletion]);
+        expect(store.getAgents().some(agent => agent.id === 'agent-individual')).toBe(false);
+        expect(persisted.has('agent-individual')).toBe(false);
+    });
+
     test('keeps individual and group enabled agents separate when scoped toggles are enabled', async () => {
         const store = await importStore();
         useAgents(store);

--- a/tests/pathfinder-diagnostics.test.js
+++ b/tests/pathfinder-diagnostics.test.js
@@ -1,157 +1,109 @@
 /* eslint-disable playwright/no-duplicate-hooks */
 /* global globalThis */
-import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-const TOOL_NAMES = [
-    'Pathfinder_Search',
-    'Pathfinder_Summarize',
-    'Pathfinder_Remember',
-];
+const toolSource = readFileSync(new URL('../public/scripts/tool-calling.js', import.meta.url), 'utf8');
+const ToolDefinition = new Function(`return (${toolSource.match(/class ToolDefinition \{[\s\S]*?\n\}/)[0]});`)();
+const TOOL_NAMES = ['Pathfinder_Search', 'Pathfinder_Summarize', 'Pathfinder_Remember'];
+let runtimeAgent;
+let refreshRegistrations;
 
-let mockSettings;
-let mockTrees;
-let mockActiveBooks;
-let mockContextualBooks;
-let mockEnabledAgents;
-let mockRuntimeAgent;
-let mockSyncToolAgentRegistrations;
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
-    canDeleteBook: jest.fn(() => true),
-    canReadBook: jest.fn(() => true),
-    canWriteBook: jest.fn(() => true),
-    getSettings: jest.fn(() => mockSettings),
-    getTree: jest.fn(bookName => mockTrees[bookName] ?? null),
-    getAllEntryUids: jest.fn(tree => tree.uids ?? []),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
-    ALL_TOOL_NAMES: TOOL_NAMES,
-    getActiveTunnelVisionBooks: jest.fn(() => mockActiveBooks),
-    getContextualLorebooks: jest.fn(() => mockContextualBooks),
-}));
-
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
-    getEnabledToolAgents: jest.fn(() => mockEnabledAgents),
+    isPathfinderSubmoduleEnabled: () => true,
+    getEnabledToolAgents: () => runtimeAgent ? [runtimeAgent] : [],
 }));
-
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
-    getPathfinderRuntimeAgent: jest.fn(() => mockRuntimeAgent),
-    getToolRecursionState: jest.fn(() => ({ depth: 0, limit: 5, registeredToolNames: TOOL_NAMES })),
-    isPathfinderToolEnabledForAgent: jest.fn((agent, toolName) => {
-        const states = agent?.settings?.toolStates;
-        if (states && Object.prototype.hasOwnProperty.call(states, toolName)) {
-            return states[toolName] !== false;
-        }
-        const savedTool = agent?.tools?.find(tool => tool?.name === toolName);
-        return savedTool?.enabled !== false;
-    }),
-    syncToolAgentRegistrations: jest.fn(() => mockSyncToolAgentRegistrations()),
+    getPathfinderRuntimeAgent: () => runtimeAgent,
+    getToolRecursionState: () => ({ depth: 0, limit: 5, registeredToolNames: TOOL_NAMES }),
+    isPathfinderToolEnabledForAgent: (agent, name) => agent?.tools?.find(tool => tool.name === name)?.enabled === true,
+    syncToolAgentRegistrations: () => refreshRegistrations(),
 }));
 
+const { clearAllTrees, getSettings, getTree, replaceSettings, saveTree } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
 const { runDiagnostics } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/diagnostics.js');
 
 describe('Pathfinder diagnostics', () => {
+    let manager;
+    let load;
+    let save;
+
     beforeEach(() => {
-        mockSettings = {
-            enabledLorebooks: ['Manual Book'],
-            includeContextualLorebooks: true,
-            pipelineEnabled: false,
-            sidecarEnabled: true,
+        clearAllTrees();
+        replaceSettings({
+            enabledLorebooks: ['Manual Book'], includeContextualLorebooks: false, sidecarEnabled: true,
             toolStates: Object.fromEntries(TOOL_NAMES.map(name => [name, true])),
-            autoSyncLorebooksOnChatChange: true,
-            dedupeNaturalActivation: true,
+        });
+        saveTree('Manual Book', { id: 'root', entries: [0, 1], children: [] });
+        runtimeAgent = { tools: TOOL_NAMES.map(name => ({ name, enabled: true })) };
+        refreshRegistrations = jest.fn();
+        manager = {
+            tools: TOOL_NAMES.map(name => new ToolDefinition(name, name, '', {}, jest.fn())),
+            isToolCallingSupported: () => true,
         };
-        mockTrees = {
-            'Manual Book': { uids: ['uid-1', 'uid-2'] },
-        };
-        mockActiveBooks = ['Manual Book'];
-        mockContextualBooks = ['Chat Book'];
-        mockEnabledAgents = [];
-        mockRuntimeAgent = {
-            tools: TOOL_NAMES.map(name => ({ name, enabled: true })),
-        };
-        mockSyncToolAgentRegistrations = jest.fn();
-        globalThis.window = {
-            SillyTavern: {
-                getContext: () => ({
-                    ToolManager: {
-                        tools: TOOL_NAMES.map(name => ({ name })),
-                        isToolCallingSupported: jest.fn(() => true),
-                    },
-                }),
-            },
-        };
+        load = jest.fn();
+        save = jest.fn();
+        globalThis.window = { SillyTavern: { getContext: () => ({ ToolManager: manager, loadWorldInfo: load, saveWorldInfo: save }) } };
     });
 
-    afterEach(() => {
-        delete globalThis.window;
-    });
+    afterEach(() => { delete globalThis.window; });
 
-    test('accepts active enabled Pathfinder tools when each enabled tool is registered', async () => {
+    test('recognises registered real ToolDefinitions, which have no public name property', async () => {
+        expect(manager.tools[0].name).toBeUndefined();
+        expect(manager.tools[0].toFunctionOpenAI().function.name).toBe('Pathfinder_Search');
         const results = await runDiagnostics();
-
-        expect(mockSyncToolAgentRegistrations).toHaveBeenCalledTimes(1);
-        expect(results['Tool Registration']).toEqual({
-            ok: true,
-            message: 'All 3 enabled Pathfinder tool(s) registered and active. Registered: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Enabled: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Recursion: 0/5.',
-        });
+        expect(refreshRegistrations).toHaveBeenCalledTimes(1);
+        expect(results['Tool Registration'].ok).toBe(true);
+        expect(results['Tool Registration'].message).toContain('All 3 enabled Pathfinder tool(s) registered and active.');
+        expect(results['Tool Registration'].message).toContain('Recursion: 0/5.');
     });
 
-    test('reports a missing Pathfinder runtime agent even when tools are registered', async () => {
-        mockRuntimeAgent = null;
-
+    test('reports a missing runtime agent rather than guessing from registration', async () => {
+        runtimeAgent = null;
         const results = await runDiagnostics();
-
-        expect(results['Tool Registration']).toEqual({
-            ok: false,
-            message: 'Tool mode is enabled, but the Pathfinder tool agent is not active right now. Enable Pathfinder as a tool agent, then reopen settings or reload agents.',
-        });
+        expect(results['Tool Registration'].ok).toBe(false);
+        expect(results['Tool Registration'].message).toContain('Pathfinder tool agent is not active');
     });
 
-    test('uses enabled tools from the active Pathfinder agent instead of registered disabled-state guesses', async () => {
-        mockRuntimeAgent = {
-            tools: [
-                { name: 'Pathfinder_Search', enabled: false },
-                { name: 'Pathfinder_Summarize', enabled: true },
-                { name: 'Pathfinder_Remember', enabled: false },
-            ],
-        };
-        mockSettings.toolStates = {};
-        globalThis.window.SillyTavern.getContext = () => ({
-            ToolManager: {
-                tools: new Map([
-                    ['Pathfinder_Search', { name: 'Pathfinder_Search' }],
-                    ['Pathfinder_Summarize', { name: 'Pathfinder_Summarize' }],
-                    ['Pathfinder_Remember', { name: 'Pathfinder_Remember' }],
-                ]),
-                isToolCallingSupported: jest.fn(() => true),
-            },
-        });
-
+    test('uses enabled tools from the active agent when no canonical tool state is configured', async () => {
+        runtimeAgent.tools.forEach(tool => { tool.enabled = tool.name === 'Pathfinder_Summarize'; });
+        getSettings().toolStates = {};
+        manager.tools = new Map(manager.tools.map(tool => [tool.toFunctionOpenAI().function.name, tool]));
         const results = await runDiagnostics();
-
-        expect(results['Tool Registration']).toEqual({
-            ok: true,
-            message: 'All 1 enabled Pathfinder tool(s) registered and active. Registered: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Enabled: Pathfinder_Summarize. Recursion: 0/5.',
-        });
+        expect(results['Tool Registration'].ok).toBe(true);
+        expect(results['Tool Registration'].message).toContain('All 1 enabled Pathfinder tool(s)');
+        expect(results['Tool Registration'].message).toContain('Enabled: Pathfinder_Summarize.');
     });
 
-    test('prefers canonical toolStates over stale agent tool arrays', async () => {
-        mockRuntimeAgent = {
-            tools: TOOL_NAMES.map(name => ({ name, enabled: true })),
-        };
-        mockSettings.toolStates = {
-            Pathfinder_Search: false,
-            Pathfinder_Summarize: true,
-            Pathfinder_Remember: false,
-        };
-
+    test('prefers canonical tool states over stale agent tool arrays', async () => {
+        getSettings().toolStates = { Pathfinder_Search: false, Pathfinder_Summarize: true, Pathfinder_Remember: false };
         const results = await runDiagnostics();
+        expect(results['Tool Registration'].ok).toBe(true);
+        expect(results['Tool Registration'].message).toContain('Enabled: Pathfinder_Summarize.');
+    });
 
-        expect(results['Tool Registration']).toEqual({
-            ok: true,
-            message: 'All 1 enabled Pathfinder tool(s) registered and active. Registered: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Enabled: Pathfinder_Summarize. Recursion: 0/5.',
-        });
+    test('acquires settings after registration refresh replaces the settings object', async () => {
+        const oldSettings = getSettings();
+        refreshRegistrations.mockImplementation(() => replaceSettings({
+            enabledLorebooks: ['New Book'], includeContextualLorebooks: false, sidecarEnabled: false, pipelineEnabled: true,
+        }));
+        const results = await runDiagnostics();
+        expect(getSettings()).not.toBe(oldSettings);
+        expect(results['Lorebooks'].message).toContain('New Book');
+        expect(results['Tool Mode'].message).toBe('Disabled - AI cannot call Pathfinder tools');
+        expect(results['Pipeline Mode'].message).toContain('Enabled (default pipeline)');
+        expect(results['Tool Registration'].message).toContain('Tool mode disabled');
+    });
+
+    test('reports actually missing registrations without loading, building or saving lorebooks', async () => {
+        manager.tools.pop();
+        const before = structuredClone(getTree('Manual Book'));
+        const results = await runDiagnostics();
+        expect(results['Tool Registration'].ok).toBe(false);
+        expect(results['Tool Registration'].message).toContain('Missing: Pathfinder_Remember.');
+        expect(getTree('Manual Book')).toEqual(before);
+        expect(load).not.toHaveBeenCalled();
+        expect(save).not.toHaveBeenCalled();
     });
 });

--- a/tests/pathfinder-entry-manager.test.js
+++ b/tests/pathfinder-entry-manager.test.js
@@ -1,114 +1,260 @@
+/* eslint-disable playwright/no-standalone-expect */
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { getFreeCharacterBookEntryId, serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
 
-await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
-    getContext: jest.fn(() => null),
+const positions = { before: 0, after: 1, ANTop: 2, ANBottom: 3, atDepth: 4, EMTop: 5, EMBottom: 6, outlet: 7 };
+const hostSource = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+const host = vm.createContext({
+    structuredClone, serializeWorldInfoEntry, getFreeCharacterBookEntryId, world_info_position: positions,
+    worldInfoDataSnapshots: new WeakMap(), worldInfoCache: new Map(),
+});
+for (const name of ['getWIOriginalDataIndex', 'syncWIOriginalDataEntry', 'deleteWIOriginalDataValue', 'appendWIOriginalDataEntry']) {
+    const match = hostSource.match(new RegExp(`^(?:export )?(function ${name}\\([\\s\\S]*?^})`, 'm'));
+    if (!match) throw new Error(`Missing function ${name}`);
+    vm.runInContext(match[1], host);
+}
+const syncOriginal = jest.fn((data, uid) => host.syncWIOriginalDataEntry(data, uid));
+const deleteOriginal = jest.fn((data, uid) => host.deleteWIOriginalDataValue(data, uid));
+const reloadEditor = jest.fn();
+
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: jest.fn(() => null) }));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({
+    accountStorage: { getItem: jest.fn(() => null), setItem: jest.fn() },
 }));
-
 await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
     createWorldInfoEntry: jest.fn(),
+    syncWIOriginalDataEntry: syncOriginal,
+    deleteWIOriginalDataValue: deleteOriginal,
+    reloadEditor,
 }));
 
+const { clearAllTrees, getAllEntryUids, getTree, findNodeById, isPathfinderSelfWrite } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const { LAYOUT_KEY } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-layout.js');
 const {
-    clearAllTrees,
-    createTreeNode,
-    getTree,
-    saveTree,
-} = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
-
-const {
-    createEntry,
-    forgetEntry,
-    initEntryManagerAPIs,
-    mergeEntries,
-    moveEntry,
+    createEntry, createCategory, updateEntry, forgetEntry, initEntryManagerAPIs, mergeEntries, moveEntry, splitEntry,
 } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
 
 describe('Pathfinder entry manager', () => {
     let store;
     let nextUid;
+    let save;
 
-    beforeEach(() => {
+    beforeEach(async () => {
+        jest.clearAllMocks();
         clearAllTrees();
+        const first = {
+            uid: 1, comment: 'Character First', content: 'first content', key: ['/first/i'], keysecondary: ['other'],
+            selective: true, selectiveLogic: 2, constant: true, position: 4, depth: 8, order: 75,
+            probability: 35, useProbability: true, sticky: 3, cooldown: 4, triggers: ['normal'],
+            characterFilter: { names: ['Hero'], isExclude: false }, extensions: { custom: { kept: true } },
+        };
+        const second = { uid: 2, comment: 'Location Second', content: 'second content', key: ['second'] };
         store = {
             'Memory Book': {
-                entries: {
-                    '1': { uid: 1, comment: 'First', content: 'first content', key: ['first'] },
-                    '2': { uid: 2, comment: 'Second', content: 'second content', key: ['second'] },
+                entries: { 1: first, 2: second },
+                originalData: {
+                    entries: [
+                        { ...serializeWorldInfoEntry(first, positions), id: 901, customCardField: 'retained' },
+                        { ...serializeWorldInfoEntry(second, positions), id: 902 },
+                    ],
+                    extensions: { foreign: 'retained' },
                 },
+                originalDataUidMap: { 1: 0, 2: 1 },
             },
         };
         nextUid = 10;
-
+        save = jest.fn(async (name, data) => {
+            store[name] = structuredClone(data);
+            return name;
+        });
         initEntryManagerAPIs(
-            jest.fn(async name => (store[name] ? structuredClone(store[name]) : null)),
+            jest.fn(async name => store[name] ? structuredClone(store[name]) : null),
             jest.fn(async (name, data) => {
-                const entry = { uid: nextUid++ };
-                data.entries[String(entry.uid)] = entry;
+                const entry = { uid: nextUid++, key: [], keysecondary: [], disable: false };
+                data.entries[entry.uid] = entry;
+                host.appendWIOriginalDataEntry(data, entry);
                 return entry;
             }),
-            jest.fn(async (name, data) => {
-                store[name] = structuredClone(data);
-            }),
+            save,
         );
+        await buildTreeFromMetadata('Memory Book', store['Memory Book']);
     });
 
-    test('refuses to merge an entry with itself and leaves the entry intact', async () => {
-        await expect(mergeEntries('Memory Book', 1, 1)).rejects.toThrow('merge an entry with itself');
-
-        expect(store['Memory Book'].entries['1']).toMatchObject({ uid: 1, content: 'first content' });
+    test('refuses a self-merge, including equivalent numeric strings', async () => {
+        await expect(mergeEntries('Memory Book', 1, '1')).rejects.toThrow('merge an entry with itself');
+        expect(store['Memory Book'].entries[1].content).toBe('first content');
+        expect(save).not.toHaveBeenCalled();
     });
 
-    test('merges two entries and removes the second from book and tree', async () => {
-        const tree = createTreeNode('Root', '', [], [createTreeNode('Characters', '', [1, 2])]);
-        saveTree('Memory Book', tree);
-
-        const result = await mergeEntries('Memory Book', 1, 2);
-
+    test('merges entries, retains the first placement and resynchronises the imported record', async () => {
+        const firstNode = getTree('Memory Book').children.find(node => node.entries.includes(1));
+        const result = await mergeEntries('Memory Book', 1, 2, 'Location combined');
+        const data = store['Memory Book'];
         expect(result).toEqual({ mergedUid: 1, removedUid: 2, bookName: 'Memory Book' });
-        expect(store['Memory Book'].entries['1'].content).toContain('second content');
-        expect(store['Memory Book'].entries['2']).toBeUndefined();
-        expect(getTree('Memory Book').children[0].entries).toEqual([1]);
+        expect(data.entries[1].content).toContain('second content');
+        expect(data.entries[2]).toBeUndefined();
+        expect(findNodeById(getTree('Memory Book'), firstNode.id).entries).toEqual([1]);
+        expect(data.originalData.entries).toHaveLength(1);
+        expect(data.originalData.entries[0]).toMatchObject({ content: data.entries[1].content, customCardField: 'retained' });
+        expect(data.originalDataUidMap).toEqual({ 1: 0 });
+        expect(deleteOriginal).toHaveBeenCalledTimes(1);
     });
 
-    test('rejects moving an entry to a nonexistent waypoint without unfiling it', async () => {
-        const tree = createTreeNode('Root', '', [], [createTreeNode('Characters', '', [1])]);
-        saveTree('Memory Book', tree);
-
+    test('rejects a nonexistent waypoint without unfiling the entry', async () => {
+        const before = structuredClone(getTree('Memory Book'));
         await expect(moveEntry('Memory Book', 1, 'node_missing')).rejects.toThrow('not found');
-
-        expect(getTree('Memory Book').children[0].entries).toEqual([1]);
+        expect(getTree('Memory Book')).toEqual(before);
+        expect(save).not.toHaveBeenCalled();
     });
 
-    test('moves an entry between waypoints', async () => {
-        const source = createTreeNode('Characters', '', [1]);
-        const target = createTreeNode('Locations', '', []);
-        saveTree('Memory Book', createTreeNode('Root', '', [], [source, target]));
-
-        await moveEntry('Memory Book', 1, target.id);
-
-        expect(source.entries).toEqual([]);
-        expect(target.entries).toEqual([1]);
+    test('moves an entry using a private tree and updates both native and imported placement', async () => {
+        const target = await createCategory('Memory Book', null, 'Custom');
+        const before = getTree('Memory Book');
+        await moveEntry('Memory Book', '1', target.nodeId);
+        expect(findNodeById(before, target.nodeId).entries).toEqual([]);
+        expect(findNodeById(getTree('Memory Book'), target.nodeId).entries).toEqual([1]);
+        const data = store['Memory Book'];
+        expect(data.originalData.entries[0].extensions[LAYOUT_KEY]).toEqual(data.entries[1].extensions[LAYOUT_KEY]);
     });
 
-    test('serializes concurrent writes so neither snapshot clobbers the other', async () => {
-        await Promise.all([
+    test('serialises concurrent entry writes and populates the imported records after creation', async () => {
+        const created = await Promise.all([
             createEntry('Memory Book', 'Alpha', 'alpha content'),
             createEntry('Memory Book', 'Beta', 'beta content'),
         ]);
-
-        const comments = Object.values(store['Memory Book'].entries).map(entry => entry.comment);
-        expect(comments).toEqual(expect.arrayContaining(['Alpha', 'Beta']));
-        expect(Object.keys(store['Memory Book'].entries)).toHaveLength(4);
+        const data = store['Memory Book'];
+        expect(Object.keys(data.entries)).toHaveLength(4);
+        expect(data.originalData.entries).toHaveLength(4);
+        expect(data.originalData.entries.slice(2).map(entry => entry.content)).toEqual(['alpha content', 'beta content']);
+        expect(data.originalDataUidMap[created[1].uid]).toBe(3);
+        expect(reloadEditor).toHaveBeenLastCalledWith('Memory Book');
     });
 
-    test('soft forget disables the entry and drops it from the tree', async () => {
-        const tree = createTreeNode('Root', '', [], [createTreeNode('Characters', '', [2])]);
-        saveTree('Memory Book', tree);
+    test('updates content and title without changing activation or custom metadata', async () => {
+        const before = structuredClone(store['Memory Book'].entries[1]);
+        await updateEntry('Memory Book', '1', 'edited', 'New title');
+        const data = store['Memory Book'];
+        expect(data.entries[1]).toEqual({ ...before, content: 'edited', comment: 'New title' });
+        expect(data.originalData.entries[0]).toMatchObject({
+            id: 901, content: 'edited', comment: 'New title', customCardField: 'retained',
+            constant: true, selective: true, extensions: { custom: { kept: true }, depth: 8, probability: 35 },
+        });
+    });
 
+    test('splits all applicable native and card-only metadata while preserving the new UID and source placement', async () => {
+        store['Memory Book'].originalData.entries[1].id = 10;
+        const before = structuredClone(store['Memory Book'].entries[1]);
+        const firstNode = getTree('Memory Book').children.find(node => node.entries.includes(1));
+        const result = await splitEntry('Memory Book', 1, 'First half', 'one', 'Location second half', 'two');
+        const data = store['Memory Book'];
+        expect(result.newUid).not.toBe(1);
+        expect(data.entries[result.newUid]).toEqual({
+            ...before, uid: result.newUid, comment: 'Location second half', content: 'two', disable: false,
+            extensions: { ...before.extensions, [LAYOUT_KEY]: data.entries[1].extensions[LAYOUT_KEY] },
+        });
+        expect(data.entries[result.newUid].extensions.custom).not.toBe(data.entries[1].extensions.custom);
+        expect(findNodeById(getTree('Memory Book'), firstNode.id).entries).toEqual([1, result.newUid]);
+        expect(data.originalData.entries[data.originalDataUidMap[result.newUid]]).toMatchObject({
+            id: 0, content: 'two', comment: 'Location second half', customCardField: 'retained',
+            constant: true, selective: true, extensions: { custom: { kept: true }, sticky: 3, cooldown: 4 },
+        });
+        expect(data.originalData.entries[0].content).toBe('one');
+        expect(data.originalData.entries.map(entry => entry.id)).toEqual([901, 10, 0]);
+    });
+
+    test('updates mapped original IDs [74, 0] without replacing them with native UIDs [0, 1]', async () => {
+        const data = store['Memory Book'];
+        data.entries = { 0: { ...data.entries[1], uid: 0 }, 1: { ...data.entries[2], uid: 1 } };
+        data.originalData.entries[0].id = 74;
+        data.originalData.entries[1].id = 0;
+        data.originalDataUidMap = { 0: 0, 1: 1 };
+        await updateEntry('Memory Book', 0, 'updated');
+        await forgetEntry('Memory Book', 1);
+        const records = store['Memory Book'].originalData.entries;
+        expect(records.map(entry => entry.id)).toEqual([74, 0]);
+        expect(records[0]).toMatchObject({ content: 'updated', customCardField: 'retained' });
+        expect(records[1].enabled).toBe(false);
+    });
+
+    test('new entries receive a free original ID even when their native UID is already a card ID', async () => {
+        store['Memory Book'].originalData.entries[1].id = 10;
+        const created = await createEntry('Memory Book', 'New', 'new');
+        expect(created.uid).toBe(10);
+        expect(store['Memory Book'].originalData.entries.map(entry => entry.id)).toEqual([901, 10, 0]);
+    });
+
+    test('soft forget hides content without losing saved placement and updates the imported enabled flag', async () => {
+        const target = await createCategory('Memory Book', null, 'Custom');
+        await moveEntry('Memory Book', 2, target.nodeId);
+        const placement = structuredClone(store['Memory Book'].entries[2].extensions[LAYOUT_KEY]);
         const result = await forgetEntry('Memory Book', 2, false);
-
         expect(result).toMatchObject({ disabled: true, deleted: false });
-        expect(store['Memory Book'].entries['2'].disable).toBe(true);
-        expect(getTree('Memory Book').children[0].entries).toEqual([]);
+        expect(store['Memory Book'].entries[2].extensions[LAYOUT_KEY]).toEqual(placement);
+        expect(store['Memory Book'].originalData.entries[1].enabled).toBe(false);
+        expect(getAllEntryUids(getTree('Memory Book'))).not.toContain(2);
+    });
+
+    test('hard forget updates the UID map before a later update and reused UID creation', async () => {
+        await forgetEntry('Memory Book', 1, true);
+        await updateEntry('Memory Book', 2, 'survives');
+        nextUid = 1;
+        await createEntry('Memory Book', 'Fresh', 'new entry');
+        const data = store['Memory Book'];
+        expect(data.originalDataUidMap).toEqual({ 2: 0, 1: 1 });
+        expect(data.originalData.entries.map(entry => entry.content)).toEqual(['survives', 'new entry']);
+        expect(data.entries[1].extensions?.[LAYOUT_KEY]).toBeUndefined();
+    });
+
+    test('a previously disabled entry can still be edited without enabling it and permanently deleted', async () => {
+        await forgetEntry('Memory Book', 1);
+        await updateEntry('Memory Book', 1, 'edited while disabled');
+        expect(store['Memory Book'].entries[1]).toMatchObject({ disable: true, content: 'edited while disabled' });
+        expect(store['Memory Book'].originalData.entries[0]).toMatchObject({ enabled: false, content: 'edited while disabled' });
+        await forgetEntry('Memory Book', 1, true);
+        expect(store['Memory Book'].entries[1]).toBeUndefined();
+        expect(store['Memory Book'].originalDataUidMap).toEqual({ 2: 0 });
+    });
+
+    test.each([false, true])('blacklisted entries reject update and both forget modes, including disabled=%p', async disable => {
+        Object.assign(store['Memory Book'].entries[1], { agentBlacklisted: true, disable });
+        const before = structuredClone(store);
+        await expect(updateEntry('Memory Book', 1, 'blocked')).rejects.toThrow('not found');
+        await expect(forgetEntry('Memory Book', 1)).rejects.toThrow('not found');
+        await expect(forgetEntry('Memory Book', 1, true)).rejects.toThrow('not found');
+        expect(store).toEqual(before);
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('queued creation still checks isCurrent before mutation or saving', async () => {
+        const before = structuredClone(store);
+        await expect(createEntry('Memory Book', 'Cancelled', 'cancelled', [], { isCurrent: () => false })).rejects.toMatchObject({ name: 'AbortError' });
+        expect(store).toEqual(before);
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        ['create', () => createEntry('Memory Book', 'New', 'new')],
+        ['update', () => updateEntry('Memory Book', 1, 'changed')],
+        ['forget', () => forgetEntry('Memory Book', 1, true)],
+        ['merge', () => mergeEntries('Memory Book', 1, 2)],
+        ['split', () => splitEntry('Memory Book', 1, 'One', 'one', 'Two', 'two')],
+    ])('keeps committed data and tree unchanged on a failed %s', async (name, operation) => {
+        const before = structuredClone(store);
+        const tree = structuredClone(getTree('Memory Book'));
+        save.mockRejectedValueOnce(new Error('offline'));
+        await expect(operation()).rejects.toThrow('offline');
+        expect(store).toEqual(before);
+        expect(getTree('Memory Book')).toEqual(tree);
+        expect(isPathfinderSelfWrite()).toBe(false);
+    });
+
+    test.each([null, undefined])('does not report an uncommitted save result %p as success', async result => {
+        save.mockResolvedValueOnce(result);
+        await expect(createEntry('Memory Book', 'Discarded', 'not saved')).rejects.toThrow('The lorebook save did not complete.');
+        expect(Object.keys(store['Memory Book'].entries)).toHaveLength(2);
+        expect(reloadEditor).not.toHaveBeenCalled();
     });
 });

--- a/tests/pathfinder-generation-wiring.test.js
+++ b/tests/pathfinder-generation-wiring.test.js
@@ -1,0 +1,410 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { EventEmitter } from '../public/lib/eventemitter.js';
+import { event_types } from '../public/scripts/events.js';
+import { resolveGenerationUiLockState, resolveGenerationUnblockState, resolveStopGenerationState } from '../public/scripts/generation-lifecycle/index.js';
+
+await jest.unstable_mockModule('../public/script.js', () => ({ chat: [], getCurrentChatId: () => 'chat-a' }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => true }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({ listConnectionProfiles: () => [] }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({ getReadableBooks: () => ['Lore'] }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js', () => ({ sidecarGenerate: jest.fn(), sidecarGenerateWithProfile: jest.fn() }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js', () => ({ isSummaryMemoryEntry: () => false, markSummaryMemoryInjected: jest.fn() }));
+const { injectPathfinderRetrieval } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js');
+
+const scriptSource = readFileSync(new URL('../public/script.js', import.meta.url), 'utf8');
+const worldSource = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+const runnerSource = readFileSync(new URL('../public/scripts/extensions/in-chat-agents/agent-runner.js', import.meta.url), 'utf8');
+
+function functionSource(source, name) {
+    const match = source.match(new RegExp(`^(?:export )?((?:async )?function ${name}\\([\\s\\S]*?^})`, 'm'));
+    if (!match) throw new Error(`Missing function ${name}`);
+    return match[1];
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+    return { promise, resolve, reject };
+}
+
+function createHost() {
+    const events = new EventEmitter();
+    const context = vm.createContext({
+        AbortController, AbortSignal, structuredClone, console,
+        eventSource: events, event_types,
+        resolveGenerationUiLockState, resolveGenerationUnblockState, resolveStopGenerationState,
+        activeGenerationRun: null, agentGenerationContextProvider: null, abortController: null,
+        generationChatFilter: null,
+        chatId: 'chat-a', chatGeneration: 0, agentRunId: 0, cancelRevision: 0,
+        chat: [], chat_metadata: {}, characters: [{ name: 'Assistant', data: { extensions: {} } }],
+        this_chid: 0, selected_group: null, is_group_generating: false, is_send_press: false, streamingProcessor: null,
+        name1: 'User', name2: 'Assistant', main_api: 'openai', online_status: 'connected', generation_started: null,
+        power_user: { instruct: { enabled: false }, sysprompt: {}, context: {} },
+        oai_settings: { send_if_empty: '' }, kai_settings: {}, kai_flags: {}, nai_settings: {},
+        amount_gen: 100, max_context: 4096, world_info_include_names: false,
+        depth_prompt_depth_default: 4, depth_prompt_role_default: 0,
+        extension_settings: { note: { allowWIScan: false } },
+        extension_prompts: {}, extension_prompt_types: { IN_PROMPT: 0, IN_CHAT: 1, BEFORE_PROMPT: 2 }, extension_prompt_roles: { SYSTEM: 0 },
+        inject_ids: { DEPTH_PROMPT: 'depth', QUIET_PROMPT: 'quiet', STORY_STRING: 'story' },
+        GENERATION_TYPE_TRIGGERS: ['normal', 'swipe', 'continue'], IGNORE_SYMBOL: Symbol('ignore'),
+        wi_anchor_position: { before: 0, after: 1 }, persona_description_positions: { IN_PROMPT: 0 },
+        itemizedPrompts: [], openai_messages_count: 0, kobold_horde_model: '',
+        internalPromptTransformDepth: 0, isGenerationInProgress: false, pathfinderRetrievalRun: null,
+        injectPathfinderRetrieval,
+        document: { body: { dataset: {} } },
+        Event: class {},
+        unshallowCharacter: jest.fn(async () => {}), processCommands: jest.fn(async () => false),
+        getBiasStrings: () => ({ messageBias: '', promptBias: '', isUserPromptBias: false }),
+        hasPendingFileAttachment: () => false, shouldBatchMobileChatRendering: () => false,
+        isHordeGenerationNotAllowed: jest.fn(() => false), pingServer: jest.fn(async () => true),
+        getCharacterCardFields: () => ({ description: '', personality: '', persona: '', scenario: '', mesExamples: '', system: '', jailbreak: '' }),
+        getGroupDepthPrompts: () => [],
+        getExtensionPromptRoleByName: role => role,
+        ToolManager: { isToolCallingSupported: () => false, canPerformToolCalls: () => false, RECURSE_LIMIT: 5 },
+        selectCompanionChatHistory: () => [], consolidateCompanionChatHistory: () => ({ host: null, entries: [] }),
+        PromptReasoning: class { removePrefix(text) { return text; } },
+        getMaxPromptTokens: () => 4096, runGenerationInterceptors: jest.fn(async () => false),
+        getGuidanceScale: () => null, parseMesExamples: () => [], buildWorldInfoScanChat: () => [],
+        checkWorldInfo: jest.fn(async () => ({ worldInfoBefore: 'Native town lore.', worldInfoAfter: '', allActivatedEntries: new Set([{ world: 'Lore', uid: 1 }]) })),
+        setOpenAIMessages: messages => messages, setOpenAIMessageExamples: messages => messages,
+        addChatsPreamble: text => text, addChatsSeparator: text => text, getTokenCountAsync: async () => 0,
+        renderStoryString: () => '', substituteParams: text => text, baseChatReplace: text => text,
+        getAllExtensionPrompts: async () => '', getFriendlyTokenizerName: () => ({}), getPresetManager: () => null,
+        getChatCompletionModel: () => 'model', isStreamingEnabled: () => false,
+        sendGenerationRequest: jest.fn(async () => ({ message: 'reply' })),
+        extractMessageFromData: data => data.message, extractTitleFromData: () => '', extractReasoningFromData: () => '',
+        extractImagesFromData: () => [], extractReasoningSignatureFromData: () => '', extractMultiSwipes: () => [],
+        cleanUpMessage: ({ getMessage }) => getMessage, getRegexedString: text => text, regex_placement: { REASONING: 0 },
+        applyMainGenerationOutputInterceptors: jest.fn(async ({ text }) => ({ text, cancelled: false })),
+        saveReply: jest.fn(async data => data), saveChatConditional: jest.fn(async () => {}),
+        TempResponseLength: { isCustomized: () => false }, removeReasoningFromString: text => text,
+        t: (strings, ...values) => String.raw({ raw: strings }, ...values),
+        toastr: { error: jest.fn(), warning: jest.fn() },
+    });
+    const buttons = { visible: false, generatingClass: false };
+    const input = { val(value) { return arguments.length ? input : ''; }, 0: { dispatchEvent() {} } };
+    context.$ = selector => ({
+        '#send_textarea': input,
+        '#send_form': { addClass() { buttons.generatingClass = true; }, removeClass() { buttons.generatingClass = false; } },
+        '#mes_stop': { css(value) {
+            if (typeof value === 'string') return buttons.generatingClass && buttons.visible ? 'flex' : 'none';
+            buttons.visible = value.display !== 'none';
+        } },
+    }[selector]);
+    for (const name of ['setGenerationProgress', 'showSwipeButtons', 'hideSwipeButtons', 'removeDepthPrompts', 'setFloatingPrompt', 'flushWIInjections', 'flushEphemeralStoppingStrings', 'addPersonaDescriptionExtensionPrompt', 'setInContextMessages', 'parseAndSaveLogprobs', 'playMessageSound', 'triggerAutoContinue']) {
+        context[name] = jest.fn();
+    }
+    context.getCurrentChatId = () => context.chatId;
+    context.clearStreamingProcessorIfCurrent = processor => { if (context.streamingProcessor === processor) context.streamingProcessor = null; };
+    context.setExtensionPrompt = jest.fn((key, value) => { context.extension_prompts[key] = { value }; });
+    context.getExtensionPrompt = async () => context.extension_prompts.pathfinder_pipeline_retrieval?.value ?? '';
+    context.prepareOpenAIMessages = jest.fn(async data => [[{ role: 'system', content: data.extensionPrompts.pathfinder_pipeline_retrieval?.value ?? '' }], false]);
+    const scriptFunctions = ['setAgentGenerationContextProvider', 'Generate', 'generateQuietPrompt', 'showStopButton', 'hideStopButton', 'activateSendButtons', 'deactivateSendButtons', 'stopGeneration', 'unblockGeneration', 'getNextMessageId'];
+    vm.runInContext(scriptFunctions.map(name => functionSource(scriptSource, name)).join('\n'), context);
+    vm.runInContext(functionSource(worldSource, 'getWorldInfoPrompt'), context);
+    vm.runInContext(functionSource(runnerSource, 'onWorldInfoActivated'), context);
+    context.setAgentGenerationContextProvider(() => ({ chatId: context.chatId, runId: context.agentRunId, cancelRevision: context.cancelRevision }));
+    events.on(event_types.GENERATION_STARTED, (_type, options, dryRun) => {
+        if (!dryRun && !options.isAuxiliaryGeneration && !(context.selected_group && !context.is_group_generating)) {
+            context.agentRunId++;
+            context.isGenerationInProgress = true;
+        }
+    });
+    events.on(event_types.GENERATION_AFTER_COMMANDS, (type, options, dryRun) => {
+        if (dryRun || type === 'quiet' || options.isAuxiliaryGeneration || (context.selected_group && !context.is_group_generating)) return;
+        const result = {
+            success: true, promptKey: 'pathfinder_pipeline_retrieval', mode: 'pipeline', books: ['Lore'],
+            selectedEntries: [{ bookName: 'Lore', uid: 1, name: 'Town', content: 'Town lore.' }, { bookName: 'Lore', uid: 2, name: 'Forest', content: 'Forest lore.' }],
+        };
+        context.pathfinderRetrievalRun = {
+            ...context.agentGenerationContextProvider(), result, isCurrent: () => true,
+            writePrompt: context.setExtensionPrompt, nativeApplied: false,
+        };
+        injectPathfinderRetrieval(result, context.setExtensionPrompt, context.extension_prompt_types, context.extension_prompt_roles);
+    });
+    events.on(event_types.WORLD_INFO_ACTIVATED, context.onWorldInfoActivated);
+    events.on(event_types.GENERATION_STOPPED, () => { context.cancelRevision++; context.isGenerationInProgress = false; });
+    events.on(event_types.GENERATION_ENDED, () => { context.isGenerationInProgress = false; });
+    const emitted = jest.spyOn(events, 'emit');
+    return { context, events, emitted, buttons, generate: (type = 'normal', options = {}, dryRun = false) => context.Generate(type, { suppressUserMessage: true, ...options }, dryRun) };
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('Pathfinder integration with the real extracted host generation flow', () => {
+    test('tags the actual native scan and removes only its activated entries before prompt assembly', async () => {
+        const host = createHost();
+        await host.generate();
+        expect(host.context.checkWorldInfo).toHaveBeenCalledTimes(1);
+        const native = host.emitted.mock.calls.find(([event]) => event === event_types.WORLD_INFO_ACTIVATED);
+        expect(native[2]).toEqual({ chatId: 'chat-a', runId: 1, cancelRevision: 0 });
+        expect(host.context.prepareOpenAIMessages.mock.calls[0][0].worldInfoBefore).toBe('Native town lore.');
+        const prompt = host.context.sendGenerationRequest.mock.calls[0][1].prompt[0].content;
+        expect(prompt).not.toContain('Town lore.');
+        expect(prompt).toContain('Forest lore.');
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+        expect(host.context.activeGenerationRun).toBeNull();
+    });
+
+    test.each([
+        ['commands', host => host.context.processCommands.mockResolvedValue(true)],
+        ['blocked provider', host => host.context.isHordeGenerationNotAllowed.mockReturnValue(true)],
+        ['no connection', host => { host.context.online_status = 'no_connection'; }],
+    ])('emits one terminal event for %s, including before the Stop button becomes visible', async (_name, setup) => {
+        const host = createHost();
+        setup(host);
+        await host.generate();
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+        expect(host.context.is_send_press).toBe(false);
+        expect(host.context.sendGenerationRequest).not.toHaveBeenCalled();
+        expect(host.context.activeGenerationRun).toBeNull();
+    });
+
+    test('cleans up a prompt preparation exception that occurs before the API error handler', async () => {
+        const host = createHost();
+        host.context.checkWorldInfo.mockRejectedValueOnce(new Error('scan failed'));
+        await expect(host.generate()).rejects.toThrow('scan failed');
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+        expect(host.buttons.visible).toBe(false);
+        expect(host.context.activeGenerationRun).toBeNull();
+    });
+
+    test('creates the abort controller before start listeners and honours Stop while the busy UI is still unset', async () => {
+        const host = createHost();
+        const started = deferred();
+        const release = deferred();
+        host.events.on(event_types.GENERATION_STARTED, async () => { started.resolve(); await release.promise; });
+        const pending = host.generate();
+        await started.promise;
+        expect(host.context.is_send_press).toBe(false);
+        expect(host.context.stopGeneration()).toBe(true);
+        expect(host.context.abortController.signal.aborted).toBe(true);
+        release.resolve();
+        await pending;
+        expect(host.context.processCommands).not.toHaveBeenCalled();
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(0);
+        expect(host.context.activeGenerationRun).toBeNull();
+    });
+
+    test('uses the current cancellation revision when explicit Stop follows agent cancellation', async () => {
+        const host = createHost();
+        const started = deferred();
+        const release = deferred();
+        const stopped = jest.fn();
+        host.events.on(event_types.GENERATION_STOPPED, stopped);
+        host.events.on(event_types.GENERATION_AFTER_COMMANDS, async () => { started.resolve(); await release.promise; });
+        const pending = host.generate();
+        await started.promise;
+        host.context.cancelRevision++;
+        host.context.stopGeneration();
+        expect(stopped).toHaveBeenCalledWith({ chatId: 'chat-a', runId: 1, cancelRevision: 1 });
+        release.resolve();
+        await pending;
+    });
+
+    test.each(['Stop', 'chat change', 'new generation'])('does not continue past pending retrieval after %s', async reason => {
+        const host = createHost();
+        const started = deferred();
+        const release = deferred();
+        host.events.on(event_types.GENERATION_AFTER_COMMANDS, async () => { started.resolve(); await release.promise; });
+        const pending = host.generate();
+        await started.promise;
+        const cancel = {
+            Stop: () => host.context.stopGeneration(),
+            'chat change': async () => { host.context.chatId = 'chat-b'; host.context.chatGeneration++; await host.events.emit(event_types.CHAT_CHANGED); },
+            'new generation': () => { host.context.activeGenerationRun = { controller: new AbortController(), type: 'normal' }; },
+        };
+        await cancel[reason]();
+        host.context.chat_metadata = {};
+        host.context.extension_prompts = { sentinel: { value: 'new chat' } };
+        release.resolve();
+        await pending;
+        expect(host.context.chat_metadata).toEqual({});
+        expect(host.context.extension_prompts).toEqual({ sentinel: { value: 'new chat' } });
+        expect(host.context.checkWorldInfo).not.toHaveBeenCalled();
+        expect(host.context.sendGenerationRequest).not.toHaveBeenCalled();
+    });
+
+    test('rejects a late native activation from a replaced run and leaves the new prompt untouched', async () => {
+        const host = createHost();
+        const started = deferred();
+        const release = deferred();
+        host.context.checkWorldInfo.mockImplementationOnce(async () => { started.resolve(); return release.promise; });
+        const pending = host.generate();
+        await started.promise;
+        host.context.agentRunId++;
+        host.context.pathfinderRetrievalRun.runId = host.context.agentRunId;
+        host.context.pathfinderRetrievalRun.nativeApplied = false;
+        host.context.extension_prompts = { sentinel: { value: 'new run' } };
+        release.resolve({ worldInfoBefore: '', worldInfoAfter: '', allActivatedEntries: new Set([{ world: 'Lore', uid: 1 }]) });
+        await pending;
+        expect(host.context.pathfinderRetrievalRun.nativeApplied).toBe(false);
+        expect(host.context.extension_prompts).toEqual({ sentinel: { value: 'new run' } });
+        expect(host.context.sendGenerationRequest).not.toHaveBeenCalled();
+    });
+
+    test('awaits a group child without its outer wrapper ending or cancelling that child', async () => {
+        const host = createHost();
+        host.context.selected_group = 'group';
+        const childStarted = deferred();
+        const releaseChild = deferred();
+        host.context.sendGenerationRequest.mockImplementationOnce(async () => { childStarted.resolve(); await releaseChild.promise; return { message: 'group reply' }; });
+        host.context.generateGroupWrapper = jest.fn(async (_auto, type, options) => {
+            host.context.is_group_generating = true;
+            try { return await host.generate(type, options); }
+            finally { host.context.is_group_generating = false; }
+        });
+        const pending = host.generate();
+        await childStarted.promise;
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(0);
+        expect(host.context.abortController.signal.aborted).toBe(false);
+        releaseChild.resolve();
+        const result = await pending;
+        expect(String(result)).toBe('group reply');
+        expect(host.context.checkWorldInfo).toHaveBeenCalledTimes(1);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+    });
+
+    test('does not tag a dry preview or let it end the active generation', async () => {
+        const host = createHost();
+        const parent = { controller: new AbortController(), type: 'normal' };
+        host.context.activeGenerationRun = parent;
+        host.context.is_send_press = true;
+        await host.generate('normal', {}, true);
+        expect(host.context.activeGenerationRun).toBe(parent);
+        expect(host.context.is_send_press).toBe(true);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.WORLD_INFO_ACTIVATED || event === event_types.GENERATION_ENDED)).toHaveLength(0);
+        expect(host.context.sendGenerationRequest).not.toHaveBeenCalled();
+    });
+
+    test('keeps nested quiet scans untagged and preserves the main controller and terminal lifecycle', async () => {
+        const host = createHost();
+        const started = deferred();
+        const release = deferred();
+        host.events.on(event_types.GENERATION_AFTER_COMMANDS, async type => {
+            if (type !== 'quiet') { started.resolve(); await release.promise; }
+        });
+        const pending = host.generate();
+        await started.promise;
+        const mainController = host.context.abortController;
+        await host.context.generateQuietPrompt({ quietPrompt: 'helper', skipWIAN: true });
+        const native = host.emitted.mock.calls.find(([event]) => event === event_types.WORLD_INFO_ACTIVATED);
+        expect(native).toHaveLength(2);
+        expect(host.context.pathfinderRetrievalRun.nativeApplied).toBe(false);
+        expect(host.context.abortController).toBe(mainController);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(0);
+        release.resolve();
+        await pending;
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+    });
+
+    test.each([
+        ['failure', request => request.mockRejectedValueOnce(new Error('quiet failed'))],
+        ['empty response', request => request.mockResolvedValueOnce(null)],
+    ])('does not stop the main generation on a nested quiet %s', async (_name, setup) => {
+        const host = createHost();
+        const started = deferred();
+        const release = deferred();
+        host.events.on(event_types.GENERATION_AFTER_COMMANDS, async type => {
+            if (type !== 'quiet') { started.resolve(); await release.promise; }
+        });
+        const main = host.generate();
+        await started.promise;
+        const mainController = host.context.abortController;
+        setup(host.context.sendGenerationRequest);
+        await host.context.generateQuietPrompt({ quietPrompt: 'helper' }).catch(() => undefined);
+        expect(mainController.signal.aborted).toBe(false);
+        expect(host.context.abortController).toBe(mainController);
+        expect(host.context.is_send_press).toBe(false);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED || event === event_types.GENERATION_STOPPED)).toHaveLength(0);
+        release.resolve();
+        await main;
+    });
+
+    test('does not let a late quiet failure stop a newer main request', async () => {
+        const host = createHost();
+        const oldStarted = deferred();
+        const oldRelease = deferred();
+        host.events.on(event_types.GENERATION_AFTER_COMMANDS, async type => {
+            if (type !== 'quiet' && host.context.agentRunId === 1) { oldStarted.resolve(); await oldRelease.promise; }
+        });
+        const old = host.generate();
+        await oldStarted.promise;
+        const quietStarted = deferred();
+        const quietResponse = deferred();
+        const nextStarted = deferred();
+        const nextResponse = deferred();
+        host.context.sendGenerationRequest.mockImplementationOnce(() => { quietStarted.resolve(); return quietResponse.promise; })
+            .mockImplementationOnce(() => { nextStarted.resolve(); return nextResponse.promise; });
+        const quiet = host.context.generateQuietPrompt({ quietPrompt: 'helper' }).catch(error => error);
+        await quietStarted.promise;
+        const next = host.generate();
+        await nextStarted.promise;
+        const nextController = host.context.abortController;
+        quietResponse.reject(new Error('quiet failed'));
+        await expect(quiet).resolves.toMatchObject({ message: 'quiet failed' });
+        oldRelease.resolve();
+        await old;
+        expect(nextController.signal.aborted).toBe(false);
+        expect(host.context.abortController).toBe(nextController);
+        expect(host.context.is_send_press).toBe(true);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED || event === event_types.GENERATION_STOPPED)).toHaveLength(0);
+        nextResponse.resolve({ message: 'new reply' });
+        await next;
+    });
+
+    test('preserves a recursive tool pass result without duplicate terminal events', async () => {
+        const host = createHost();
+        Object.assign(host.context.ToolManager, {
+            canPerformToolCalls: () => true,
+            hasToolCalls: data => Boolean(data.tool),
+            invokeFunctionTools: jest.fn(async data => ({ invocations: data.tool ? [{}] : [], stealthCalls: [] })),
+            saveFunctionToolInvocations: jest.fn(async () => {}),
+        });
+        host.context.sendGenerationRequest.mockResolvedValueOnce({ message: 'tool plan', tool: true }).mockResolvedValueOnce({ message: 'final reply' });
+        const result = await host.generate();
+        expect(String(result)).toBe('final reply');
+        expect(host.context.sendGenerationRequest).toHaveBeenCalledTimes(2);
+        expect(host.context.ToolManager.invokeFunctionTools.mock.calls[0][1]).toEqual(expect.objectContaining({ isCurrent: expect.any(Function), signal: expect.any(AbortSignal) }));
+        expect(host.context.ToolManager.invokeFunctionTools.mock.calls[0][1].isCurrent()).toBe(false);
+        expect(host.context.sendGenerationRequest.mock.calls[1][2].signal).toBe(host.context.sendGenerationRequest.mock.calls[0][2].signal);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+    });
+
+    test('preserves a recursive streaming tool result while the successor owns completion', async () => {
+        const host = createHost();
+        let streamIndex = 0;
+        host.context.StreamingProcessor = class {
+            constructor() {
+                this.abortController = new AbortController();
+                [this.result, this.toolCalls] = [['tool plan', [{}]], ['final stream', []]][streamIndex++];
+                this.reasoningHandler = { reasoning: '' };
+                this.isFinished = true;
+            }
+            async generate() { return this.result; }
+            async finalizeIntermediaryMessage() {}
+            async onFinishStreaming() { host.context.unblockGeneration('normal'); }
+            onStopStreaming() { this.abortController.abort(); this.isStopped = true; }
+        };
+        host.context.isStreamingEnabled = () => true;
+        host.context.shouldBufferMainGenerationOutput = async () => false;
+        host.context.sendStreamingRequest = jest.fn(async () => () => {});
+        Object.assign(host.context.ToolManager, {
+            canPerformToolCalls: () => true,
+            hasToolCalls: data => data.length > 0,
+            invokeFunctionTools: jest.fn(async () => ({ invocations: [{}], stealthCalls: [] })),
+            saveFunctionToolInvocations: jest.fn(async () => {}),
+        });
+        const result = await host.generate();
+        expect(String(result)).toBe('final stream');
+        expect(result.fromStream).toBe(true);
+        expect(host.context.sendStreamingRequest).toHaveBeenCalledTimes(2);
+        expect(host.context.ToolManager.invokeFunctionTools.mock.calls[0][1]).toEqual(expect.objectContaining({ isCurrent: expect.any(Function), signal: expect.any(AbortSignal) }));
+        expect(host.context.ToolManager.invokeFunctionTools.mock.calls[0][1].isCurrent()).toBe(false);
+        expect(host.emitted.mock.calls.filter(([event]) => event === event_types.GENERATION_ENDED)).toHaveLength(1);
+    });
+});

--- a/tests/pathfinder-lifecycle.test.js
+++ b/tests/pathfinder-lifecycle.test.js
@@ -1,0 +1,59 @@
+import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({ listConnectionProfiles: () => [] }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({ getWritableBooks: () => ['Book A'] }));
+
+const { replaceSettings } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { initAutoSummary, deinitAutoSummary, getAutoSummaryCount, resetAutoSummaryCount, shouldAutoSummarize } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/auto-summary.js');
+
+describe('Pathfinder lifecycle integration', () => {
+    beforeEach(() => {
+        deinitAutoSummary();
+        replaceSettings({ autoSummary: true, autoSummaryInterval: 2 });
+    });
+
+    test('keeps native activation before both prompt builders consume retrieval injections', () => {
+        const source = readFileSync(new URL('../public/script.js', import.meta.url), 'utf8');
+        const native = source.indexOf('= await getWorldInfoPrompt(chatForWI,');
+        const story = source.indexOf('const afterScenarioAnchor = await getExtensionPrompt(');
+        const chatCompletion = source.indexOf('await prepareOpenAIMessages(', native);
+        expect(native).toBeGreaterThan(0);
+        expect(story).toBeGreaterThan(native);
+        expect(chatCompletion).toBeGreaterThan(native);
+        const worldInfo = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+        expect(worldInfo.indexOf('await eventSource.emit(event_types.WORLD_INFO_ACTIVATED')).toBeGreaterThan(worldInfo.indexOf('const activatedWorldInfo = await checkWorldInfo('));
+    });
+
+    test('keeps the dispatch wrapper after the pre-generation hook, before member generation', () => {
+        const source = readFileSync(new URL('../public/script.js', import.meta.url), 'utf8');
+        const afterCommands = source.indexOf('await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS');
+        const wrapper = source.indexOf('if (selected_group && !is_group_generating)', afterCommands);
+        expect(afterCommands).toBeGreaterThan(0);
+        expect(wrapper).toBeGreaterThan(afterCommands);
+        expect(source.indexOf('return await generateGroupWrapper(', wrapper)).toBeGreaterThan(wrapper);
+    });
+
+    test('does not duplicate auto-summary listeners across init, teardown and re-enable', () => {
+        const events = new EventEmitter();
+        const types = { MESSAGE_RECEIVED: 'received', MESSAGE_SENT: 'sent' };
+        initAutoSummary(events, types);
+        initAutoSummary(events, types);
+        events.emit(types.MESSAGE_SENT);
+        expect(getAutoSummaryCount()).toBe(1);
+        events.emit(types.MESSAGE_RECEIVED);
+        expect(shouldAutoSummarize()).toBe(true);
+        resetAutoSummaryCount();
+        expect(shouldAutoSummarize()).toBe(false);
+        deinitAutoSummary();
+        events.emit(types.MESSAGE_RECEIVED);
+        expect(getAutoSummaryCount()).toBe(0);
+        initAutoSummary(events, types);
+        events.emit(types.MESSAGE_RECEIVED);
+        expect(getAutoSummaryCount()).toBe(1);
+        deinitAutoSummary();
+        expect(events.listenerCount(types.MESSAGE_RECEIVED)).toBe(0);
+        expect(events.listenerCount(types.MESSAGE_SENT)).toBe(0);
+    });
+});

--- a/tests/pathfinder-notebook.test.js
+++ b/tests/pathfinder-notebook.test.js
@@ -1,0 +1,60 @@
+/* eslint-disable playwright/no-standalone-expect, playwright/no-duplicate-hooks */
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => true }));
+const { replaceSettings } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildNotebookPrompt, registerActions, resetNotebookWriteGuard } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/notebook.js');
+const { getToolAction } = await import('../public/scripts/extensions/in-chat-agents/tool-action-registry.js');
+registerActions();
+
+describe('Pathfinder notebook baseline', () => {
+    let context;
+
+    beforeEach(() => {
+        replaceSettings({ enabledLorebooks: ['Book'], includeContextualLorebooks: false });
+        context = { chatMetadata: { unrelated: 'retained' }, saveMetadataDebounced: jest.fn() };
+        globalThis.window = { SillyTavern: { getContext: () => context } };
+    });
+
+    afterEach(() => { delete globalThis.window; });
+
+    test.each(['chatMetadata', 'chat_metadata'])('reads, updates and deletes notes using %s without changing other metadata', async key => {
+        context = { [key]: { unrelated: 'retained' }, saveMetadataDebounced: jest.fn() };
+        const action = getToolAction('pathfinder_notebook');
+        await action({ action: 'write', key: 'Plan', content: 'first' });
+        await action({ action: 'write', key: 'Plan', content: 'revised' });
+        expect(context[key].pathfinder_notebook.entries).toHaveLength(1);
+        expect(await action({ action: 'read' })).toContain('revised');
+        expect(buildNotebookPrompt()).toContain('revised');
+        await action({ action: 'delete', key: 'Plan' });
+        expect(context[key].pathfinder_notebook.entries).toEqual([]);
+        expect(context[key].unrelated).toBe('retained');
+        expect(context.saveMetadataDebounced).toHaveBeenCalledTimes(3);
+    });
+
+    test('chat switches isolate notebook contents and allow a fresh write in each chat', async () => {
+        const action = getToolAction('pathfinder_notebook');
+        const first = context;
+        await action({ action: 'write', key: 'First', content: 'first chat only' });
+        context = { chatMetadata: {}, saveMetadataDebounced: jest.fn() };
+        resetNotebookWriteGuard();
+        expect(await action({ action: 'read' })).not.toContain('first chat only');
+        await action({ action: 'write', key: 'Second', content: 'second chat only' });
+        expect(buildNotebookPrompt()).toContain('second chat only');
+        expect(first.chatMetadata.pathfinder_notebook.entries).toHaveLength(1);
+        context = first;
+        expect(buildNotebookPrompt()).toContain('first chat only');
+        expect(buildNotebookPrompt()).not.toContain('second chat only');
+    });
+
+    test('continues allowing reads but blocks writes without an active book', async () => {
+        const action = getToolAction('pathfinder_notebook');
+        await action({ action: 'write', key: 'Saved', content: 'retained note' });
+        replaceSettings({ enabledLorebooks: [], includeContextualLorebooks: false });
+        expect(await action({ action: 'read' })).toContain('retained note');
+        expect(await action({ action: 'write', key: 'Blocked', content: 'not saved' })).toContain('Notebook is still available for reading');
+        expect(context.chatMetadata.pathfinder_notebook.entries).toHaveLength(1);
+    });
+});

--- a/tests/pathfinder-retrieval.test.js
+++ b/tests/pathfinder-retrieval.test.js
@@ -1,0 +1,302 @@
+/* eslint-disable playwright/no-duplicate-hooks */
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const chat = [];
+let chatId;
+let enabled;
+let books;
+let context;
+const generateRaw = jest.fn();
+const sendRequest = jest.fn();
+const loadWorldInfo = jest.fn();
+const markSummaryMemoryInjected = jest.fn();
+const runAsInternalPromptTransform = jest.fn(request => request());
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    chat,
+    getCurrentChatId: () => chatId,
+    generateRaw,
+    normalizeContentText: value => String(value ?? ''),
+}));
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => context }));
+await jest.unstable_mockModule('../public/scripts/reasoning.js', () => ({ removeReasoningFromString: value => value }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => enabled }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({ runAsInternalPromptTransform }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js', () => ({
+    isSummaryMemoryEntry: entry => entry.name?.startsWith('[Summary]'),
+    markSummaryMemoryInjected,
+}));
+
+const { runSidecarRetrieval, injectPathfinderRetrieval } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js');
+const { sidecarGenerateWithProfile } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js');
+const { runPipeline } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/pipeline-runner.js');
+const { initializePromptStore, savePrompt } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/prompt-store.js');
+const { getDefaultPrompts, getDefaultPipelines } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/default-prompts.js');
+const { replaceSettings, setSettings, getTree, clearAllTrees } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const { clearFeed } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/activity-feed.js');
+const promptTypes = { IN_PROMPT: 0 };
+const promptRoles = { SYSTEM: 0 };
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+describe('Pathfinder retrieval with real pipeline and model transport stubs', () => {
+    let prompts;
+    let writePrompt;
+
+    beforeEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+        clearAllTrees();
+        clearFeed();
+        chatId = 'chat-a';
+        enabled = true;
+        chat.splice(0, chat.length, { name: 'User', is_user: true, mes: 'We enter the town.' });
+        books = {
+            'Book A': { entries: { 1: { uid: 1, comment: 'Town', content: 'The first town.', key: ['town'] } } },
+        };
+        loadWorldInfo.mockReset().mockImplementation(async name => structuredClone(books[name]));
+        sendRequest.mockReset().mockResolvedValue('{"candidates":["Town"]}');
+        generateRaw.mockReset().mockResolvedValue('{"candidates":["Town"]}');
+        context = { chat, loadWorldInfo, ConnectionManagerRequestService: { sendRequest } };
+        globalThis.window = { SillyTavern: { getContext: () => context } };
+        globalThis.toastr = { warning: jest.fn(), error: jest.fn() };
+        replaceSettings({
+            pipelineEnabled: true,
+            pipelineId: 'single-pass',
+            enabledLorebooks: ['Book A'],
+            includeContextualLorebooks: false,
+            connectionProfile: 'profile-a',
+            retrievalTimeoutSeconds: 1,
+        });
+        initializePromptStore(getDefaultPrompts(), getDefaultPipelines());
+        prompts = {};
+        writePrompt = jest.fn((key, value) => { prompts[key] = value; });
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+        delete globalThis.window;
+        delete globalThis.toastr;
+    });
+
+    test('preserves configured templates and accepts unique titles from existing prompts', async () => {
+        const custom = { ...getDefaultPrompts()['candidate-selector'], userPromptTemplate: '{{chat_history}}\n{{entry_list}}', connectionProfile: 'custom-profile' };
+        savePrompt(custom);
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+
+        expect(result.success).toBe(true);
+        expect(result.selectedEntries).toEqual([expect.objectContaining({ bookName: 'Book A', uid: 1, name: 'Town' })]);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+        expect(sendRequest).toHaveBeenCalledWith('custom-profile', [
+            { role: 'system', content: custom.systemPrompt },
+            { role: 'user', content: 'User: We enter the town.\n- ["Book A",1] Town' },
+        ], 64000, expect.objectContaining({ stream: false }));
+    });
+
+    test('keeps duplicate titles tied to their book and UID through both stages and injection', async () => {
+        books['Book B'] = { entries: { 1: { uid: 1, comment: 'Town', content: 'The second town.' } } };
+        setSettings({ enabledLorebooks: ['Book A', 'Book B'], pipelineId: 'default' });
+        sendRequest.mockResolvedValueOnce(JSON.stringify({ candidates: ['["Book A",1] Town', '["Book B",1] Town'] }))
+            .mockResolvedValueOnce(JSON.stringify({ selected: ['["Book B",1] Town'] }));
+
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+
+        expect(sendRequest.mock.calls[1][1][1].content).toContain('### ["Book A",1] Town\nThe first town.');
+        expect(sendRequest.mock.calls[1][1][1].content).toContain('### ["Book B",1] Town\nThe second town.');
+        expect(result.selectedEntries).toEqual([expect.objectContaining({ bookName: 'Book B', uid: 1 })]);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The second town.');
+        expect(prompts.pathfinder_pipeline_retrieval).not.toContain('The first town.');
+        injectPathfinderRetrieval(result, writePrompt, promptTypes, promptRoles, [{ world: 'Book A', uid: 1 }]);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The second town.');
+    });
+
+    test('does not resolve a bare duplicate title to the first or last book', async () => {
+        books['Book B'] = structuredClone(books['Book A']);
+        setSettings({ enabledLorebooks: ['Book A', 'Book B'] });
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(result.selectedEntries).toEqual([]);
+        expect(prompts.pathfinder_pipeline_retrieval).toBe('');
+    });
+
+    test('only actual native activation removes lore, not old keywords or a constant rejected by the native budget', async () => {
+        books['Book A'].entries[2] = { uid: 2, comment: 'Forest', content: 'Forest lore.', key: ['forest'] };
+        books['Book A'].entries[3] = { uid: 3, comment: 'Always', content: 'Budget-rejected lore.', constant: true };
+        chat.unshift({ name: 'User', is_user: true, mes: 'forest' }, ...Array.from({ length: 6 }, () => ({ mes: 'Elsewhere.' })));
+        sendRequest.mockResolvedValue('{"candidates":["Town","Forest","Always"]}');
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('Forest lore.');
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('Budget-rejected lore.');
+        injectPathfinderRetrieval(result, writePrompt, promptTypes, promptRoles, [{ world: 'Book A', uid: 1 }]);
+        expect(prompts.pathfinder_pipeline_retrieval).not.toContain('The first town.');
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('Forest lore.');
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('Budget-rejected lore.');
+    });
+
+    test('includes a bounded snapshot of chat in the tool-only prepass', async () => {
+        setSettings({ pipelineEnabled: false, sidecarEnabled: true });
+        chat.splice(0, chat.length, ...Array.from({ length: 15 }, (_, index) => ({ is_user: true, mes: `turn-${index}!` })));
+        sendRequest.mockImplementation(async () => getTree('Book A').children[0].id);
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+
+        expect(result.success).toBe(true);
+        expect(sendRequest.mock.calls[0][1][1].content).not.toContain('turn-4!');
+        expect(sendRequest.mock.calls[0][1][1].content).toContain('User: turn-5!');
+        expect(sendRequest.mock.calls[0][1][1].content).toContain('User: turn-14!');
+        expect(prompts.pathfinder_sidecar_retrieval).toContain('The first town.');
+    });
+
+    test('does not write after switching chats while the transport ignores cancellation', async () => {
+        const started = deferred();
+        const response = deferred();
+        sendRequest.mockImplementation(() => { started.resolve(); return response.promise; });
+        const pending = runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        await started.promise;
+        chatId = 'chat-b';
+        chat.splice(0, chat.length, { is_user: true, mes: 'Different chat.' });
+        writePrompt.mockClear();
+        response.resolve('{"candidates":["Town"]}');
+
+        await expect(pending).resolves.toEqual({ success: false });
+        expect(writePrompt).not.toHaveBeenCalled();
+        expect(markSummaryMemoryInjected).not.toHaveBeenCalled();
+        expect(sendRequest.mock.calls[0][1][1].content).toContain('We enter the town.');
+        expect(sendRequest.mock.calls[0][1][1].content).not.toContain('Different chat.');
+    });
+
+    test('warns at the slow threshold and still injects the eventual successful response', async () => {
+        jest.useFakeTimers();
+        const started = deferred();
+        const response = deferred();
+        const controller = new AbortController();
+        sendRequest.mockImplementation(() => { started.resolve(); return response.promise; });
+        const pending = runSidecarRetrieval(writePrompt, promptTypes, promptRoles, controller.signal);
+        await started.promise;
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(globalThis.toastr.warning).toHaveBeenCalledWith('Pathfinder is processing lore for this reply...', 'Please wait');
+        expect(controller.signal.aborted).toBe(false);
+        response.resolve('{"candidates":["Town"]}');
+        const result = await pending;
+        expect(result.success).toBe(true);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    test('explicit cancellation still aborts and never falls back to another request', async () => {
+        const started = deferred();
+        const controller = new AbortController();
+        sendRequest.mockImplementation((_profile, _messages, _tokens, { signal }) => new Promise((resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+            started.resolve();
+        }));
+        const pending = runSidecarRetrieval(writePrompt, promptTypes, promptRoles, controller.signal);
+        await started.promise;
+        controller.abort();
+        await expect(pending).resolves.toEqual({ success: false });
+        expect(generateRaw).not.toHaveBeenCalled();
+        expect(prompts.pathfinder_pipeline_retrieval).toBe('');
+    });
+
+    test('reports terminal failure distinctly from a successful empty selection on retry', async () => {
+        sendRequest.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce('[]');
+        generateRaw.mockRejectedValueOnce(new Error('offline'));
+        const failed = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(failed.success).toBe(false);
+        const retried = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(retried.success).toBe(true);
+        expect(retried.selectedEntries).toEqual([]);
+        expect(sendRequest).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not report a failed lorebook read as a successful empty selection', async () => {
+        await buildTreeFromMetadata('Book A', books['Book A']);
+        loadWorldInfo.mockRejectedValueOnce(new Error('offline'));
+        await expect(runSidecarRetrieval(writePrompt, promptTypes, promptRoles)).resolves.toEqual({ success: false });
+        const retried = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(retried.success).toBe(true);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+    });
+
+    test('retains first-stage entries when the optional filter exhausts both transports', async () => {
+        setSettings({ pipelineId: 'default' });
+        sendRequest.mockResolvedValueOnce('{"candidates":["Town"]}').mockRejectedValueOnce(new Error('profile offline'));
+        generateRaw.mockRejectedValueOnce(new Error('main offline'));
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+
+        expect(result.success).toBe(true);
+        expect(result.cacheable).toBe(false);
+        expect(result.stageResults.map(stage => stage.success)).toEqual([true, false]);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+    });
+
+    test('treats blank transport output as failure instead of deleting valid first-stage entries', async () => {
+        setSettings({ pipelineId: 'default' });
+        sendRequest.mockResolvedValueOnce('{"candidates":["Town"]}').mockResolvedValueOnce('');
+        generateRaw.mockResolvedValueOnce('');
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(result.cacheable).toBe(false);
+        expect(result.stageResults.map(stage => stage.success)).toEqual([true, false]);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+    });
+
+    test('does not send blacklisted entries from an outdated tree to the model', async () => {
+        books['Book A'].entries[2] = { uid: 2, comment: 'Private', content: 'Private lore.' };
+        await buildTreeFromMetadata('Book A', books['Book A']);
+        books['Book A'].entries[2].agentBlacklisted = true;
+        await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(sendRequest.mock.calls[0][1][1].content).not.toContain('Private');
+    });
+
+    test('does not send revoked book content to the optional filter or inject it afterwards', async () => {
+        setSettings({ pipelineId: 'default' });
+        sendRequest.mockImplementationOnce(async () => {
+            setSettings({ bookPermissions: { 'Book A': { read: 'none' } } });
+            return '{"candidates":["Town"]}';
+        }).mockResolvedValueOnce('{"selected":["Town"]}');
+        await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        expect(sendRequest.mock.calls[1][1][1].content).not.toContain('The first town.');
+        expect(prompts.pathfinder_pipeline_retrieval).toBe('');
+    });
+
+    test('keeps native duplicates when the existing de-duplication setting is off', async () => {
+        setSettings({ dedupeNaturalActivation: false });
+        const result = await runSidecarRetrieval(writePrompt, promptTypes, promptRoles);
+        injectPathfinderRetrieval(result, writePrompt, promptTypes, promptRoles, [{ world: 'Book A', uid: 1 }]);
+        expect(prompts.pathfinder_pipeline_retrieval).toContain('The first town.');
+    });
+
+    test('keeps the public pipeline title list and also returns unambiguous entry data', async () => {
+        await buildTreeFromMetadata('Book A', books['Book A']);
+        const result = await runPipeline('single-pass', chat);
+        expect(result.selectedEntries).toEqual(['Town']);
+        expect(result.selectedEntryData).toEqual([expect.objectContaining({ bookName: 'Book A', uid: 1 })]);
+    });
+
+    test('propagates terminal LLM failure and guards the raw fallback as auxiliary work', async () => {
+        sendRequest.mockRejectedValue(new Error('profile offline'));
+        const failure = new Error('main offline');
+        generateRaw.mockRejectedValue(failure);
+        await expect(sidecarGenerateWithProfile('prompt', 'system', 'profile-a', 123)).rejects.toBe(failure);
+        expect(runAsInternalPromptTransform).toHaveBeenCalledTimes(2);
+        expect(generateRaw).toHaveBeenCalledWith(expect.objectContaining({ responseLength: 123, cacheScope: 'auxiliary', trimNames: false }));
+    });
+
+    test('does not start either transport with an already-cancelled signal', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await expect(sidecarGenerateWithProfile('prompt', '', 'profile-a', 123, controller.signal)).rejects.toBe(controller.signal.reason);
+        expect(sendRequest).not.toHaveBeenCalled();
+        expect(generateRaw).not.toHaveBeenCalled();
+    });
+});

--- a/tests/pathfinder-runtime-lifecycle.test.js
+++ b/tests/pathfinder-runtime-lifecycle.test.js
@@ -1,0 +1,193 @@
+/* eslint-disable playwright/no-duplicate-hooks */
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { EventEmitter } from '../public/lib/eventemitter.js';
+import { event_types } from '../public/scripts/events.js';
+
+let enabled = true;
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => enabled }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({ listConnectionProfiles: () => [] }));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({ accountStorage: { getItem: () => null, setItem: jest.fn() } }));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
+    createWorldInfoEntry: jest.fn(), syncWIOriginalDataEntry: jest.fn(), deleteWIOriginalDataValue: jest.fn(), reloadEditor: jest.fn(),
+}));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/tool-action-registry.js', () => ({ unregisterToolAction: jest.fn(), unregisterToolFormatter: jest.fn() }));
+for (const tool of ['search', 'remember', 'update', 'forget', 'summarize', 'reorganize', 'merge-split', 'notebook']) {
+    await jest.unstable_mockModule(`../public/scripts/extensions/in-chat-agents/pathfinder/tools/${tool}.js`, () => ({
+        registerActions: jest.fn(), getDefinition: () => ({ actionKey: tool, formatMessageKey: tool }),
+    }));
+}
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/commands.js', () => ({ initCommands: jest.fn(), removeCommands: jest.fn() }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/diagnostics.js', () => ({ runDiagnostics: jest.fn() }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js', () => ({ sidecarGenerateWithProfile: jest.fn() }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/prompt-editor-ui.js', () => ({ initPromptEditorUI: jest.fn(), refreshPromptEditorUI: jest.fn() }));
+
+const { initPathfinder, teardownPathfinder } = await import('../public/scripts/extensions/in-chat-agents/pathfinder-init.js');
+const storage = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
+const { setSummaryMemoryCreated, getSummaryMemoryState, saveSummaryMemoryContent } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js');
+const { replaceSettings, getSettings, clearAllTrees, getTree, findNodeById } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const runnerSource = readFileSync(new URL('../public/scripts/extensions/in-chat-agents/agent-runner.js', import.meta.url), 'utf8');
+
+function functionSource(name) {
+    const match = runnerSource.match(new RegExp(`^(?:export )?((?:async )?function ${name}\\([\\s\\S]*?^})`, 'm'));
+    if (!match) throw new Error(`Missing function ${name}`);
+    return match[1];
+}
+
+function installRunner(events) {
+    const context = vm.createContext({
+        console,
+        eventSource: events, event_types,
+        agentRunnerInitialized: false, pathfinderRetrievalCacheRevision: 0,
+        initPostGenerationRecoveryHooks() {}, setAgentGenerationContextProvider() {}, getAgentGenerationContext() {},
+        setPromptStorePersistHook() {}, abortActivePathfinderRetrieval() {}, clearPathfinderRetrievalToast() {}, clearPathfinderExtensionPrompts() {},
+        syncToolAgentRegistrations: jest.fn(), getAgents: () => [], isPathfinderToolAgent: () => false,
+        getPathfinderRuntimeSettings: getSettings, replacePathfinderRuntimeSettings: replaceSettings,
+        onPathfinderWorldInfoUpdated: jest.fn(storage.onPathfinderWorldInfoUpdated),
+        onPathfinderWorldInfoRenamed: jest.fn(storage.onPathfinderWorldInfoRenamed),
+        onPathfinderWorldInfoDeleted: jest.fn(storage.onPathfinderWorldInfoDeleted),
+    });
+    const init = functionSource('initAgentRunner');
+    for (const [, handler] of init.matchAll(/eventSource\.on\([^,\n]+,\s*(\w+)\)/g)) {
+        context[handler] ??= () => {};
+    }
+    vm.runInContext(['invalidatePathfinderRetrieval', 'onWorldInfoUpdatedToolSync', 'onWorldInfoRenamedOrDeleted', 'initAgentRunner'].map(functionSource).join('\n'), context);
+    context.initAgentRunner();
+    return context;
+}
+
+describe('Pathfinder storage and runtime lifecycle wiring', () => {
+    let books;
+    let events;
+    let context;
+    let runner;
+
+    beforeEach(() => {
+        teardownPathfinder();
+        clearAllTrees();
+        enabled = true;
+        replaceSettings({ enabledLorebooks: ['Book'], includeContextualLorebooks: false });
+        setSummaryMemoryCreated({ title: '[Summary] Scene', content: 'original', bookName: 'Book', uid: 0 });
+        books = { Book: { entries: { 0: { uid: 0, comment: '[Summary] Scene', content: 'original' } } } };
+        events = new EventEmitter();
+        context = {
+            eventSource: events, eventTypes: event_types,
+            loadWorldInfo: jest.fn(async name => books[name] ? structuredClone(books[name]) : null),
+            createWorldInfoEntry: (_name, data) => {
+                let uid = 0;
+                while (data.entries[uid]) uid++;
+                return (data.entries[uid] = { uid });
+            },
+            saveWorldInfo: jest.fn(async (name, data) => {
+                books[name] = structuredClone(data);
+                await events.emit(event_types.WORLDINFO_UPDATED, name, structuredClone(data));
+                return name;
+            }),
+        };
+        globalThis.window = { SillyTavern: { getContext: () => context } };
+        runner = installRunner(events);
+    });
+
+    afterEach(() => {
+        teardownPathfinder();
+        delete globalThis.window;
+        jest.restoreAllMocks();
+    });
+
+    test('wires each storage event once and keeps own-write summary updates linked', async () => {
+        initPathfinder(context);
+        initPathfinder(context);
+        runner.initAgentRunner();
+        await new Promise(resolve => setImmediate(resolve));
+        expect(events.events[event_types.WORLDINFO_UPDATED]).toHaveLength(1);
+        expect(events.events[event_types.WORLDINFO_RENAMED]).toHaveLength(1);
+        expect(events.events[event_types.WORLDINFO_DELETED]).toHaveLength(1);
+        await storage.updateEntry('Book', 0, 'updated by Pathfinder', '[Summary] Updated');
+        expect(runner.onPathfinderWorldInfoUpdated).toHaveBeenCalledTimes(1);
+        expect(runner.onPathfinderWorldInfoUpdated).toHaveBeenCalledWith('Book', expect.any(Object), undefined);
+        expect(getSummaryMemoryState()).toMatchObject({ uid: 0, bookName: 'Book', title: '[Summary] Updated', content: 'updated by Pathfinder' });
+        expect(runner.pathfinderRetrievalCacheRevision).toBe(1);
+    });
+
+    test('forwards replacement metadata and retires the linked summary and cached node IDs', async () => {
+        initPathfinder(context);
+        await new Promise(resolve => setImmediate(resolve));
+        const tree = await buildTreeFromMetadata('Book', books.Book);
+        await events.emit(event_types.WORLDINFO_UPDATED, 'Book', structuredClone(books.Book), { replaced: true });
+        expect(runner.onPathfinderWorldInfoUpdated).toHaveBeenCalledWith('Book', books.Book, { replaced: true });
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: '', uid: null, content: 'original' });
+        const rebuilt = await buildTreeFromMetadata('Book', books.Book);
+        expect(rebuilt.id).not.toBe(tree.id);
+    });
+
+    test('preserves runtime IDs and the tracked summary on rename, then detaches on deletion', async () => {
+        initPathfinder(context);
+        await new Promise(resolve => setImmediate(resolve));
+        const tree = await buildTreeFromMetadata('Book', books.Book);
+        books.Renamed = books.Book;
+        delete books.Book;
+        await events.emit(event_types.WORLDINFO_RENAMED, 'Book', 'Renamed');
+        expect(runner.onPathfinderWorldInfoRenamed).toHaveBeenCalledTimes(1);
+        expect(getTree('Book')).toBeNull();
+        expect(findNodeById(getTree('Renamed'), tree.id)).not.toBeNull();
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: 'Renamed', uid: 0 });
+        delete books.Renamed;
+        await events.emit(event_types.WORLDINFO_DELETED, 'Renamed');
+        expect(runner.onPathfinderWorldInfoDeleted).toHaveBeenCalledTimes(1);
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: '', uid: null });
+    });
+
+    test('continues tracking file lifecycle while disabled without registering duplicate listeners on re-enable', async () => {
+        initPathfinder(context);
+        await new Promise(resolve => setImmediate(resolve));
+        teardownPathfinder();
+        enabled = false;
+        await events.emit(event_types.WORLDINFO_RENAMED, 'Book', 'Renamed');
+        expect(getSummaryMemoryState().bookName).toBe('Renamed');
+        await events.emit(event_types.WORLDINFO_DELETED, 'Renamed');
+        expect(getSummaryMemoryState().uid).toBeNull();
+        enabled = true;
+        initPathfinder(context);
+        expect(events.events[event_types.WORLDINFO_UPDATED]).toHaveLength(1);
+    });
+
+    test('revalidates stale links when no change event arrived while disabled', async () => {
+        initPathfinder(context);
+        await new Promise(resolve => setImmediate(resolve));
+        teardownPathfinder();
+        books.Book.entries[0] = { uid: 0, comment: 'Replacement', content: 'unrelated' };
+        initPathfinder(context);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: '', uid: null, content: 'original' });
+        expect(books.Book.entries[0].content).toBe('unrelated');
+        expect(context.saveWorldInfo).not.toHaveBeenCalled();
+    });
+
+    test('guards an editor save before re-enable validation has finished', async () => {
+        initPathfinder(context);
+        await new Promise(resolve => setImmediate(resolve));
+        teardownPathfinder();
+        books.Book.entries[0] = { uid: 0, comment: 'Replacement', content: 'unrelated' };
+        await expect(saveSummaryMemoryContent('must not overwrite replacement')).rejects.toThrow('The summary or its linked entry changed while the user was editing. Saves are blocked to prevent overwriting.');
+        expect(books.Book.entries[0].content).toBe('unrelated');
+        expect(context.saveWorldInfo).not.toHaveBeenCalled();
+        expect(getSummaryMemoryState().uid).toBeNull();
+    });
+
+    test('does not let a stale enable-time read detach a newer summary', async () => {
+        let release;
+        context.loadWorldInfo.mockImplementationOnce(() => new Promise(resolve => { release = resolve; }));
+        initPathfinder(context);
+        await Promise.resolve();
+        teardownPathfinder();
+        books.Book.entries[1] = { uid: 1, comment: '[Summary] New', content: 'new' };
+        setSummaryMemoryCreated({ title: '[Summary] New', content: 'new', bookName: 'Book', uid: 1 });
+        initPathfinder(context);
+        release({ entries: {} });
+        await new Promise(resolve => setImmediate(resolve));
+        expect(getSummaryMemoryState()).toMatchObject({ uid: 1, bookName: 'Book', content: 'new' });
+    });
+});

--- a/tests/pathfinder-runtime-lifecycle.test.js
+++ b/tests/pathfinder-runtime-lifecycle.test.js
@@ -27,7 +27,7 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/path
 const { initPathfinder, teardownPathfinder } = await import('../public/scripts/extensions/in-chat-agents/pathfinder-init.js');
 const storage = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
 const { setSummaryMemoryCreated, getSummaryMemoryState, saveSummaryMemoryContent } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js');
-const { replaceSettings, getSettings, clearAllTrees, getTree, findNodeById } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { replaceSettings, getSettings, clearAllTrees, getTree, findNodeById, isPathfinderSelfWrite } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
 const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
 const runnerSource = readFileSync(new URL('../public/scripts/extensions/in-chat-agents/agent-runner.js', import.meta.url), 'utf8');
 
@@ -41,7 +41,7 @@ function installRunner(events) {
     const context = vm.createContext({
         console,
         eventSource: events, event_types,
-        agentRunnerInitialized: false, pathfinderRetrievalCacheRevision: 0,
+        agentRunnerInitialized: false, pathfinderRetrievalCacheRevision: 0, pathfinderToolRevision: 0, isPathfinderSelfWrite,
         initPostGenerationRecoveryHooks() {}, setAgentGenerationContextProvider() {}, getAgentGenerationContext() {},
         setPromptStorePersistHook() {}, abortActivePathfinderRetrieval() {}, clearPathfinderRetrievalToast() {}, clearPathfinderExtensionPrompts() {},
         syncToolAgentRegistrations: jest.fn(), getAgents: () => [], isPathfinderToolAgent: () => false,

--- a/tests/pathfinder-search.test.js
+++ b/tests/pathfinder-search.test.js
@@ -1,0 +1,120 @@
+/* eslint-disable playwright/no-standalone-expect, playwright/no-duplicate-hooks */
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => true }));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({ accountStorage: { getItem: () => null, setItem: jest.fn() } }));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
+    createWorldInfoEntry: jest.fn(), syncWIOriginalDataEntry: jest.fn(), deleteWIOriginalDataValue: jest.fn(), reloadEditor: jest.fn(),
+}));
+const parser = { commands: {}, addCommandObject(command) { this.commands[command.name] = command; } };
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommand.js', () => ({ SlashCommand: { fromProps: props => props } }));
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommandArgument.js', () => ({
+    ARGUMENT_TYPE: { STRING: 'string' }, SlashCommandArgument: { fromProps: props => props },
+}));
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommandParser.js', () => ({ SlashCommandParser: parser }));
+
+const { clearAllTrees, getTree, getSettings, getAllEntryUids, replaceSettings, setBookPermission } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata, buildTreeWithLLM } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const { LAYOUT_KEY } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-layout.js');
+const { initEntryManagerAPIs, listNodeEntries } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
+const { initCommands, removeCommands } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/commands.js');
+const { registerActions } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/search.js');
+const { getToolAction } = await import('../public/scripts/extensions/in-chat-agents/tool-action-registry.js');
+registerActions();
+
+describe('Pathfinder search and category reads', () => {
+    let book;
+    let load;
+    let save;
+
+    beforeEach(() => {
+        clearAllTrees();
+        replaceSettings({ enabledLorebooks: ['Book', 'Denied'], includeContextualLorebooks: false });
+        setBookPermission('Denied', 'read', false);
+        book = {
+            extensions: { [LAYOUT_KEY]: { version: 1, tree: {
+                id: 'root', name: 'Root', description: '', children: [{ id: 'child', name: 'Child', description: '', children: [] }],
+            } } },
+            entries: {
+                0: { uid: 0, comment: 'Root memory', content: 'root text', extensions: { [LAYOUT_KEY]: { version: 1, nodeId: 'root' } } },
+                1: { uid: 1, comment: 'Child memory', content: 'child text', extensions: { [LAYOUT_KEY]: { version: 1, nodeId: 'child' } } },
+                2: { uid: 2, comment: 'Disabled secret', content: 'disabled content', disable: true, extensions: { [LAYOUT_KEY]: { version: 1, nodeId: 'root' } } },
+                3: { uid: 3, comment: 'Blacklisted secret', content: 'blacklisted content', agentBlacklisted: true, extensions: { [LAYOUT_KEY]: { version: 1, nodeId: 'root' } } },
+            },
+        };
+        load = jest.fn(async () => structuredClone(book));
+        save = jest.fn(async name => name);
+        initEntryManagerAPIs(load, jest.fn(), save);
+        globalThis.window = { SillyTavern: { getContext: () => ({ loadWorldInfo: load }) } };
+        initCommands();
+    });
+
+    afterEach(() => {
+        removeCommands();
+        delete globalThis.window;
+    });
+
+    test.each(['traversal', 'collapsed'])('root-held entries remain navigable in %s mode', async mode => {
+        getSettings().searchMode = mode;
+        const overview = await getToolAction('pathfinder_search')({});
+        const tree = getTree('Book');
+        expect(overview).toContain(`[id: ${tree.id}]`);
+        expect(overview).not.toContain('Denied');
+        const root = await getToolAction('pathfinder_search')({ node_id: tree.id });
+        expect(root).toContain('root text');
+        expect(root).toContain(`[id: ${tree.children[0].id}]`);
+        expect(root).not.toContain('child text');
+        const child = await getToolAction('pathfinder_search')({ node_id: tree.children[0].id });
+        expect(child).toContain('child text');
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('actual reads and UID listings recheck exclusions even when the cached tree is stale', async () => {
+        book.entries[2].disable = false;
+        book.entries[3].agentBlacklisted = false;
+        const tree = await buildTreeFromMetadata('Book', book);
+        book.entries[2].disable = true;
+        book.entries[3].agentBlacklisted = true;
+        const result = await getToolAction('pathfinder_search')({ node_id: tree.id });
+        expect(result).toContain('root text');
+        expect(result).not.toContain('secret');
+        expect(result).not.toContain('disabled content');
+        expect(result).not.toContain('blacklisted content');
+        expect(result).not.toContain('UID:2');
+        expect(result).not.toContain('UID:3');
+        expect((await listNodeEntries('Book', tree.id)).map(entry => entry.uid)).toEqual([0]);
+    });
+
+    test('slash search lazily builds readable books and keeps IDs usable by the tool', async () => {
+        expect(getTree('Book')).toBeNull();
+        const result = await parser.commands['pf-search'].callback({}, 'Child');
+        expect(result).toContain('Book: Child (1 entries)');
+        expect(load).toHaveBeenCalledWith('Book');
+        expect(load).not.toHaveBeenCalledWith('Denied');
+        expect(await getToolAction('pathfinder_search')({ node_id: getTree('Book').children[0].id })).toContain('child text');
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('slash search handles a failed lazy load without a write or an unhandled rejection', async () => {
+        load.mockRejectedValueOnce(new Error('offline'));
+        expect(await parser.commands['pf-search'].callback({}, 'Child')).toBe('No waypoints found matching query.');
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('metadata and model category building both exclude hidden entries without changing the source book', async () => {
+        delete book.extensions;
+        const before = structuredClone(book);
+        const metadata = await buildTreeFromMetadata('Book', book);
+        expect(getAllEntryUids(metadata)).toEqual([0, 1]);
+        const generate = jest.fn(async () => 'WAYPOINT: Known\nENTRIES: 0, 1, 2, 3');
+        const modelTree = await buildTreeWithLLM('Book', book, generate);
+        expect(getAllEntryUids(modelTree)).toEqual([0, 1]);
+        expect(generate.mock.calls[0][0]).not.toContain('secret');
+        expect(generate.mock.calls[0][0]).not.toContain('disabled content');
+        expect(generate.mock.calls[0][0]).not.toContain('blacklisted content');
+        expect(book).toEqual(before);
+        expect(save).not.toHaveBeenCalled();
+    });
+});

--- a/tests/pathfinder-settings-ui.test.js
+++ b/tests/pathfinder-settings-ui.test.js
@@ -1,0 +1,574 @@
+/* global globalThis */
+/* eslint-disable playwright/no-duplicate-hooks, playwright/no-standalone-expect -- Jest hooks and parameterised tests. */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+// Only the DOM is doubled. Saves run through the real agent store and fetch boundary.
+class Control {
+    constructor() {
+        this[0] = this;
+        this.length = 1;
+        this.value = '';
+        this.dataset = {};
+        this.attributes = {};
+        this.queries = new Map();
+        this.handlers = new Map();
+        this.classes = new Set();
+    }
+
+    find(selector) {
+        if (!this.queries.has(selector)) this.queries.set(selector, new Control());
+        return this.queries.get(selector);
+    }
+    on(event, selector, handler) {
+        this.handlers.set(`${event}:${typeof selector === 'string' ? selector : ''}`, handler ?? selector);
+        return this;
+    }
+    fire(event, selector = '', target = this) { return this.handlers.get(`${event}:${selector}`)?.call(target); }
+    off() { this.handlers.clear(); return this; }
+    each() { return this; }
+    first() { return this; }
+    children(selector) { return this.find(selector); }
+    closest() { return this.parent ?? this; }
+    empty() { return this; }
+    append() { return this; }
+    html(value) { this.markup = value; return this; }
+    show() { this.visible = true; return this; }
+    hide() { this.visible = false; return this; }
+    toggle(value) { this.visible = value; return this; }
+    stop() { return this; }
+    slideUp() { return this.hide(); }
+    val(value) { if (value === undefined) return this.value; this.value = value; return this; }
+    prop(key, value) { if (value === undefined) return this[key]; this[key] = value; return this; }
+    attr(key, value) { if (value === undefined) return this.attributes[key]; this.attributes[key] = value; return this; }
+    data(key) { return this.dataset[key]; }
+    text(value) { if (value === undefined) return this.textValue ?? ''; this.textValue = String(value); return this; }
+    addClass(value) { value.split(' ').forEach(name => this.classes.add(name)); return this; }
+    removeClass(value) { value.split(' ').forEach(name => this.classes.delete(name)); return this; }
+    toggleClass(value, enabled) { return enabled ? this.addClass(value) : this.removeClass(value); }
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+    return { promise, resolve, reject };
+}
+
+const events = new EventEmitter();
+const eventTypes = { CHAT_CHANGED: 'chat', SETTINGS_UPDATED: 'settings' };
+const summaryListeners = new Set();
+const generationListeners = new Set();
+const template = jest.fn(async () => new Control());
+const loadWorldInfo = jest.fn();
+const sidecarGenerate = jest.fn();
+const createSummaryMemoryEntry = jest.fn();
+const createSeparateSummaryMemoryEntry = jest.fn();
+const saveSummaryMemoryContent = jest.fn();
+const syncTools = jest.fn();
+let context;
+let generation;
+let stopped;
+let summary;
+let profiles;
+let store;
+let tree;
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    eventSource: events,
+    event_types: eventTypes,
+    online_status: 'connected',
+    getRequestHeaders: () => ({}),
+    saveSettingsDebounced: jest.fn(),
+}));
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+    getContext: () => context,
+    extension_settings: {},
+    renderExtensionTemplateAsync: template,
+}));
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    uuidv4: () => 'test-id',
+    escapeHtml: value => String(value),
+    regexFromString: value => new RegExp(value),
+}));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({
+    accountStorage: { getItem: () => null, setItem: jest.fn() },
+}));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({ world_names: ['Book A', 'Book B'], loadWorldInfo }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/textarea-fullscreen.js', () => ({ attachTextareaFullscreen: jest.fn() }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-init.js', () => ({ runDiagnostics: jest.fn(async () => ({})) }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({
+    listConnectionProfiles: () => profiles,
+    populateConnectionProfileSelect: jest.fn(),
+}));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
+    getAgentGenerationContext: () => ({ ...generation }),
+    getAgentGenerationCancelRevision: () => generation.cancelRevision,
+    isAgentGenerationStopped: () => stopped,
+    getPathfinderRuntimeAgent: () => store.getEnabledToolAgents()[0] ?? null,
+    isPathfinderToolEnabledForAgent: (agent, name) => agent.settings?.toolStates?.[name] !== false,
+    syncToolAgentRegistrations: syncTools,
+    onAgentGenerationStateChanged: listener => { generationListeners.add(listener); return () => generationListeners.delete(listener); },
+}));
+
+const { ALL_TOOL_NAMES: toolNames, getActiveTunnelVisionBooks: activeBooks } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js');
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/activity-feed.js', () => ({ clearFeed: jest.fn(), getFeedItems: () => [] }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js', () => ({
+    getSummaryMemoryState: () => ({ ...summary }),
+    onSummaryMemoryChanged: listener => { summaryListeners.add(listener); return () => summaryListeners.delete(listener); },
+    saveSummaryMemoryContent,
+}));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/llm-sidecar.js', () => ({ sidecarGenerate }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js', () => ({
+    createSummaryMemoryEntry,
+    createSeparateSummaryMemoryEntry,
+    deriveSummaryLorebookTitle: ({ title }) => title,
+}));
+
+store = await import('../public/scripts/extensions/in-chat-agents/agent-store.js');
+tree = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const ui = await import('../public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js');
+const prompts = await import('../public/scripts/extensions/in-chat-agents/pathfinder/prompts/prompt-store.js');
+
+function setting(panel, key, value) {
+    const input = new Control();
+    input.dataset.pfSetting = key;
+    input.type = typeof value === 'boolean' ? 'checkbox' : 'text';
+    input.checked = value;
+    input.value = value;
+    return panel.fire('change', '[data-pf-setting]', input);
+}
+function editSummary(panel, text) {
+    const input = panel.find('#pf--summary-content');
+    input.val(text);
+    input.fire('input');
+}
+function click(panel, selector) { return panel.find(selector).fire('click'); }
+function notifySummary() { for (const listener of summaryListeners) listener(); }
+
+function backgroundSaves() {
+    const source = readFileSync(new URL('../public/scripts/extensions/in-chat-agents/agent-runner.js', import.meta.url), 'utf8');
+    const runtime = vm.createContext({
+        console, structuredClone, pathfinderChatSyncRevision: 0,
+        isPathfinderSubmoduleEnabled: store.isPathfinderSubmoduleEnabled,
+        getPathfinderRuntimeAgent: () => store.getEnabledToolAgents()[0], isPathfinderToolAgent: () => true,
+        getAgentById: store.getAgentById, getAgents: store.getAgents,
+        getCurrentSnapshotChatId: () => generation.chatId,
+        getPathfinderRuntimeSettings: tree.getSettings,
+        getContextualLorebooks: () => [context.chatMetadata.world_info],
+        saveAgent: store.saveAgent, syncToolAgentRegistrations: syncTools,
+        notifyAgentGenerationStateChanged: () => { for (const listener of generationListeners) listener(); },
+        onPathfinderWorldInfoRenamed() {}, onPathfinderWorldInfoDeleted() {}, invalidatePathfinderRetrieval() {},
+    });
+    for (const name of ['syncPathfinderAgentLorebooksForCurrentChat', 'onWorldInfoRenamedOrDeleted']) {
+        const match = source.match(new RegExp(`^(?:export )?((?:async )?function ${name}\\([\\s\\S]*?^})`, 'm'));
+        vm.runInContext(match[1], runtime);
+    }
+    return runtime;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    globalThis.$ = value => value instanceof Control ? value : new Control();
+    globalThis.toastr = { info: jest.fn(), error: jest.fn(), warning: jest.fn(), success: jest.fn() };
+    globalThis.window = { SillyTavern: { getContext: () => context }, matchMedia: () => ({ matches: true }) };
+    globalThis.fetch = jest.fn(async () => ({ ok: true }));
+    profiles = [];
+    generation = { chatId: 'chat-a', runId: 1, cancelRevision: 0 };
+    stopped = false;
+    context = {
+        groupId: null,
+        chatMetadata: { world_info: 'Book B' },
+        chat: [{ name: 'Character', mes: 'A remembered scene.', is_user: false }],
+        ToolManager: { isToolCallingSupported: () => true, tools: toolNames.map(name => ({ toFunctionOpenAI: () => ({ function: { name } }) })) },
+    };
+    store.setGlobalSettings({ enabled: true, pathfinderEnabled: true, separateRecentChats: false });
+    store.loadAgents(['agent-a', 'agent-b'].map(id => ({
+        id, name: 'Pathfinder', sourceTemplateId: 'tpl-pathfinder', category: 'tool', enabled: true,
+        settings: { sidecarEnabled: false, autoSummary: false, enabledLorebooks: ['Book A'], selectedLorebook: 'Book A', toolStates: { Pathfinder_Summarize: false } },
+        tools: toolNames.map(name => ({ name, enabled: name !== 'Pathfinder_Summarize' })),
+    })));
+    tree.replaceSettings(store.getAgentById('agent-a').settings);
+    syncTools.mockImplementation(() => tree.replaceSettings(store.getEnabledToolAgents()[0]?.settings ?? {}));
+    summary = { title: 'Saved summary', content: 'Saved memory.', bookName: 'Book A', uid: 0, updatedAt: 1, injectedAt: 0 };
+    saveSummaryMemoryContent.mockImplementation(async content => { summary = { ...summary, content }; notifySummary(); });
+    createSummaryMemoryEntry.mockResolvedValue({ uid: 1 });
+    createSeparateSummaryMemoryEntry.mockResolvedValue({ uid: 2, summaryTitle: 'Separate summary' });
+    sidecarGenerate.mockResolvedValue('{"title":"Scene","content":"New memory."}');
+});
+
+afterEach(() => {
+    ui.closePathfinderSettings();
+    delete globalThis.$;
+    delete globalThis.toastr;
+    delete globalThis.window;
+    delete globalThis.fetch;
+});
+
+describe('Pathfinder settings persistence', () => {
+    test('serialises chat auto-sync with panel edits without losing the newer setting', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const runtime = backgroundSaves();
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const syncing = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        const editing = setting(panel, 'connectionProfile', 'new-profile');
+        await Promise.resolve();
+        const inFlight = globalThis.fetch.mock.calls.length;
+        request.resolve({ ok: true });
+        await Promise.all([syncing, editing]);
+        expect(inFlight).toBe(1);
+        expect(store.getAgentById('agent-a').settings).toMatchObject({ connectionProfile: 'new-profile', enabledLorebooks: ['Book B'] });
+    });
+
+    test('merges queued auto-sync and retargeting into the latest panel save', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const runtime = backgroundSaves();
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const editing = setting(panel, 'connectionProfile', 'new-profile');
+        await Promise.resolve();
+        const syncing = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        const retargeting = runtime.onWorldInfoRenamedOrDeleted('Book B', 'Renamed');
+        request.resolve({ ok: true });
+        await Promise.all([editing, syncing, retargeting]);
+        expect(store.getAgentById('agent-a').settings).toMatchObject({ connectionProfile: 'new-profile', enabledLorebooks: ['Renamed'], selectedLorebook: 'Renamed' });
+    });
+
+    test('drops obsolete queued chat synchronisation on a rapid switch', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const runtime = backgroundSaves();
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const editing = setting(panel, 'connectionProfile', 'new-profile');
+        await Promise.resolve();
+        const obsolete = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        generation.chatId = 'chat-b';
+        runtime.pathfinderChatSyncRevision++;
+        context.chatMetadata.world_info = 'Book C';
+        const current = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        request.resolve({ ok: true });
+        await Promise.all([editing, obsolete, current]);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(store.getAgentById('agent-a').settings).toMatchObject({ connectionProfile: 'new-profile', enabledLorebooks: ['Book C'] });
+    });
+
+    test('does not skip the current chat sync using state from before an in-flight save', async () => {
+        const runtime = backgroundSaves();
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const old = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        await Promise.resolve();
+        generation.chatId = 'chat-b';
+        runtime.pathfinderChatSyncRevision++;
+        context.chatMetadata.world_info = 'Book A';
+        const current = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        request.resolve({ ok: true });
+        await Promise.all([old, current]);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+        expect(store.getAgentById('agent-a').settings.enabledLorebooks).toEqual(['Book A']);
+    });
+
+    test('drops queued sync even when navigation returns to the original chat ID', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const runtime = backgroundSaves();
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const editing = setting(panel, 'connectionProfile', 'new-profile');
+        await Promise.resolve();
+        const obsolete = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        runtime.pathfinderChatSyncRevision += 2;
+        context.chatMetadata.world_info = 'Book A';
+        const current = runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        request.resolve({ ok: true });
+        await editing;
+        await expect(obsolete).resolves.toBe(false);
+        await current;
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        expect(store.getAgentById('agent-a').settings.enabledLorebooks).toEqual(['Book A']);
+    });
+
+    test('does not publish an agent before a successful server save', async () => {
+        const original = structuredClone(store.getAgentById('agent-a'));
+        const changed = structuredClone(original);
+        changed.settings.sidecarEnabled = true;
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const save = store.saveAgent(changed);
+        expect(store.getAgentById('agent-a')).toEqual(original);
+        request.resolve({ ok: false });
+        await expect(save).rejects.toThrow('Failed to save agent');
+        expect(store.getAgentById('agent-a')).toEqual(original);
+        await store.saveAgent(changed);
+        expect(store.getAgentById('agent-a').settings.sidecarEnabled).toBe(true);
+    });
+
+    test('opens without lorebook reads, tree builds, saves or changing live settings', async () => {
+        const before = structuredClone(tree.getSettings());
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        expect(panel).toBeInstanceOf(Control);
+        expect(loadWorldInfo).not.toHaveBeenCalled();
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(tree.getSettings()).toEqual(before);
+        expect(panel.find('#pf--permission-matrix').markup).toContain('Book A');
+    });
+
+    test('captures each rapid toggle and registers tools only after its save', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const firstRequest = deferred();
+        globalThis.fetch.mockReturnValueOnce(firstRequest.promise);
+        const first = setting(panel, 'sidecarEnabled', true);
+        const second = setting(panel, 'autoSummary', true);
+        await Promise.resolve();
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        expect(syncTools).not.toHaveBeenCalled();
+        expect(store.getAgentById('agent-a').settings.sidecarEnabled).toBe(false);
+        expect(tree.getSettings().autoSummary).toBe(false);
+        firstRequest.resolve({ ok: true });
+        await Promise.all([first, second]);
+        const payloads = globalThis.fetch.mock.calls.map(([, options]) => JSON.parse(options.body));
+        expect(payloads[0].settings).toMatchObject({ sidecarEnabled: true, autoSummary: false, toolStates: { Pathfinder_Summarize: false } });
+        expect(payloads[1].settings).toMatchObject({ sidecarEnabled: true, autoSummary: true, toolStates: { Pathfinder_Summarize: true } });
+        expect(syncTools).toHaveBeenCalledTimes(2);
+        expect(tree.getSettings()).toMatchObject({ sidecarEnabled: true, autoSummary: true });
+        expect(store.getAgentById('agent-a').phaseLocked).toBe(false);
+    });
+
+    test('keeps failed prompt edits out of runtime and makes them retryable without false success', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        panel.find('#pf--prompt-selector').val('candidate-selector');
+        panel.find('#pf--prompt-selector').fire('change');
+        panel.find('#pf--prompt-system').val('Private edited prompt');
+        const cached = prompts.getPrompt('candidate-selector');
+        globalThis.fetch.mockResolvedValueOnce({ ok: false });
+        await click(panel, '#pf--prompt-save');
+        expect(panel.find('#pf--prompt-status').text()).toContain('Save failed:');
+        expect(panel.find('#pf--prompt-system').val()).toBe('Private edited prompt');
+        expect(store.getAgentById('agent-a').settings.pipelinePrompts).toBeUndefined();
+        expect(prompts.getPrompt('candidate-selector')).toBe(cached);
+        expect(syncTools).not.toHaveBeenCalled();
+        expect(panel.find('#pf--settings-retry').visible).toBe(true);
+        await click(panel, '#pf--settings-retry');
+        expect(store.getAgentById('agent-a').settings.pipelinePrompts['candidate-selector'].systemPrompt).toBe('Private edited prompt');
+        expect(panel.find('#pf--settings-save-status').text()).toBe('Saved!');
+    });
+
+    test('preserves a failed prompt draft and retry across a background lorebook save', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const runtime = backgroundSaves();
+        panel.find('#pf--prompt-selector').val('candidate-selector');
+        panel.find('#pf--prompt-selector').fire('change');
+        panel.find('#pf--prompt-system').val('Private edited prompt');
+        globalThis.fetch.mockResolvedValueOnce({ ok: false });
+        await click(panel, '#pf--prompt-save');
+        await runtime.syncPathfinderAgentLorebooksForCurrentChat(undefined, { persist: true });
+        expect(panel.find('#pf--prompt-system').val()).toBe('Private edited prompt');
+        expect(panel.find('#pf--settings-retry').visible).toBe(true);
+        await click(panel, '#pf--settings-retry');
+        expect(store.getAgentById('agent-a').settings.enabledLorebooks).toEqual(['Book B']);
+        expect(store.getAgentById('agent-a').settings.pipelinePrompts['candidate-selector'].systemPrompt).toBe('Private edited prompt');
+    });
+
+    test('Close waits for queued autosaves and leaves failed settings available for retry', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const save = setting(panel, 'sidecarEnabled', true);
+        const closing = ui.canClosePathfinderSettings(panel);
+        request.resolve({ ok: false });
+        await save;
+        await expect(closing).resolves.toBe(false);
+        await expect(ui.canClosePathfinderSettings(panel)).resolves.toBe(true);
+        await click(panel, '#pf--settings-retry');
+        await expect(ui.canClosePathfinderSettings(panel)).resolves.toBe(true);
+    });
+
+    test('commits the master switch only after saving and preserves the other chat scope', async () => {
+        store.setGlobalSettings({
+            separateRecentChats: true,
+            scopedEnabledAgentIdsInitialized: true,
+            enabledAgentIdsByChatType: { individual: ['agent-a'], group: ['agent-a'] },
+        });
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        globalThis.fetch.mockResolvedValueOnce({ ok: false });
+        const master = panel.find('#pf--master-enable');
+        master.checked = false;
+        await master.fire('change');
+        expect(store.getGlobalSettings().enabledAgentIdsByChatType.individual).toEqual(['agent-a']);
+        await click(panel, '#pf--settings-retry');
+        expect(store.getGlobalSettings().enabledAgentIdsByChatType).toEqual({ individual: [], group: ['agent-a'] });
+        expect(store.getAgentById('agent-a').enabled).toBe(true);
+        expect(master.checked).toBe(false);
+    });
+
+    test('drops queued saves on remount and never applies the old panel to a different agent', async () => {
+        const firstPanel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const first = setting(firstPanel, 'sidecarEnabled', true);
+        await Promise.resolve();
+        const queued = setting(firstPanel, 'autoSummary', true);
+        const secondPanel = await ui.openPathfinderSettings(store.getAgentById('agent-b'));
+        request.resolve({ ok: true });
+        await Promise.all([first, queued]);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        expect(store.getAgentById('agent-a').settings).toMatchObject({ sidecarEnabled: true, autoSummary: false });
+        expect(store.getAgentById('agent-b').settings.sidecarEnabled).toBe(false);
+        expect(secondPanel.find('#pf--settings-save-status').text()).toBe('');
+        expect(summaryListeners.size).toBe(1);
+        expect(events.listenerCount('chat')).toBe(1);
+    });
+
+    test('does not overwrite a pending saved field when the same agent is remounted', async () => {
+        const firstPanel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const request = deferred();
+        globalThis.fetch.mockReturnValueOnce(request.promise);
+        const first = setting(firstPanel, 'sidecarEnabled', true);
+        await Promise.resolve();
+        const secondPanel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const second = setting(secondPanel, 'pipelineEnabled', true);
+        request.resolve({ ok: true });
+        await Promise.all([first, second]);
+        expect(store.getAgentById('agent-a').settings).toMatchObject({ sidecarEnabled: true, pipelineEnabled: true });
+    });
+
+    test('unticking a contextual book records an exclusion without erasing its permissions', async () => {
+        store.getAgentById('agent-a').settings.bookPermissions = { 'Book B': { read: 'readwrite', write: 'none', delete: false } };
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const input = new Control();
+        input.parent = new Control().attr('data-book', 'Book B');
+        input.checked = false;
+        await panel.fire('change', '#pf--lorebook-list input', input);
+        expect(store.getAgentById('agent-a').settings.bookPermissions['Book B']).toEqual({ enabled: false, read: 'readwrite', write: 'none', delete: false });
+        expect(activeBooks()).not.toContain('Book B');
+    });
+
+    test('refreshes committed auto-sync selections without overwriting a summary draft', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        editSummary(panel, 'Keep this draft');
+        store.getAgentById('agent-a').settings.enabledLorebooks = ['Book B'];
+        for (const listener of generationListeners) listener();
+        expect(panel.find('#pf--permission-matrix').markup).not.toContain('Book A');
+        expect(panel.find('#pf--permission-matrix').markup).toContain('Book B');
+        expect(panel.find('#pf--summary-content').val()).toBe('Keep this draft');
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    test('does not claim readiness for unreadable books, missing profiles or unsupported tools', async () => {
+        const agent = store.getAgentById('agent-a');
+        Object.assign(agent.settings, { pipelineEnabled: true, connectionProfile: 'missing' });
+        const panel = await ui.openPathfinderSettings(agent);
+        const banner = panel.find('#pf--status-banner');
+        expect(banner.find('.pf--status-text span').text()).toBe('Missing profile (missing)');
+        agent.settings.connectionProfile = '';
+        agent.settings.bookPermissions = { 'Book A': { read: false }, 'Book B': { read: 'none' } };
+        events.emit('settings');
+        expect(banner.find('.pf--status-text span').text()).toBe('No readable lorebooks');
+        agent.settings.bookPermissions = {};
+        agent.settings.sidecarEnabled = true;
+        context.ToolManager.isToolCallingSupported = () => false;
+        events.emit('settings');
+        expect(banner.find('.pf--status-text span').text()).toContain('Tool calling is not supported');
+        expect(banner.classes.has('pf--status-ready')).toBe(false);
+    });
+});
+
+describe('Pathfinder summary drafts and generation', () => {
+    test('retains an unfocused dirty draft and failed edit when summary events arrive', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        editSummary(panel, 'Unsaved draft');
+        summary.injectedAt = 2;
+        notifySummary();
+        expect(panel.find('#pf--summary-content').val()).toBe('Unsaved draft');
+        saveSummaryMemoryContent.mockRejectedValueOnce(new Error('offline'));
+        await click(panel, '#pf--summary-save');
+        notifySummary();
+        expect(panel.find('#pf--summary-content').val()).toBe('Unsaved draft');
+        expect(panel.find('#pf--summary-save-status').text()).toBe('Save failed: offline');
+        await click(panel, '#pf--summary-save');
+        expect(summary.content).toBe('Unsaved draft');
+        expect(panel.find('#pf--summary-save-status').text()).toBe('Saved!');
+    });
+
+    test('preserves an explicitly empty draft and supports summary UID zero', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        editSummary(panel, '');
+        notifySummary();
+        expect(panel.find('#pf--summary-content').val()).toBe('');
+        expect(panel.find('#pf--summary-save-entry').disabled).toBe(true);
+        expect(panel.find('#pf--summary-save').disabled).toBe(false);
+        await click(panel, '#pf--summary-save');
+        expect(saveSummaryMemoryContent).toHaveBeenCalledWith('');
+        expect(summary.content).toBe('');
+    });
+
+    test('does not apply a dirty draft to a different tracked summary', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        editSummary(panel, 'Original summary draft');
+        summary = { ...summary, uid: 5, content: 'Another summary' };
+        notifySummary();
+        await click(panel, '#pf--summary-save');
+        expect(saveSummaryMemoryContent).not.toHaveBeenCalled();
+        expect(panel.find('#pf--summary-content').val()).toBe('Original summary draft');
+        expect(panel.find('#pf--summary-save-status').text()).toContain('Save failed:');
+    });
+
+    test('does not relink edits typed during a save to a newly tracked summary', async () => {
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const request = deferred();
+        editSummary(panel, 'First edit');
+        saveSummaryMemoryContent.mockReturnValueOnce(request.promise);
+        const save = click(panel, '#pf--summary-save');
+        editSummary(panel, 'Still typing');
+        summary = { ...summary, uid: 5, content: 'Another summary' };
+        notifySummary();
+        request.resolve();
+        await save;
+        expect(panel.find('#pf--summary-content').val()).toBe('Still typing');
+        expect(panel.find('#pf--summary-save-status').text()).toContain('Save failed:');
+        await click(panel, '#pf--summary-save');
+        expect(saveSummaryMemoryContent).toHaveBeenCalledTimes(1);
+    });
+
+    test('binds the destination before the model responds', async () => {
+        summary = { ...summary, uid: null, content: '' };
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const request = deferred();
+        sidecarGenerate.mockReturnValueOnce(request.promise);
+        const create = click(panel, '#pf--summary-create');
+        tree.setSettings({ selectedLorebook: 'Book B' });
+        request.resolve('{"title":"Scene","content":"New memory."}');
+        await create;
+        expect(createSummaryMemoryEntry).toHaveBeenCalledWith(expect.objectContaining({ book: 'Book A', content: 'New memory.' }), expect.objectContaining({ signal: expect.anything(), isCurrent: expect.any(Function) }));
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    test.each(['stop', 'chat change', 'disable', 'remount'])('cancels summary generation on %s, including a late model response', async reason => {
+        summary = { ...summary, uid: null, content: '' };
+        const panel = await ui.openPathfinderSettings(store.getAgentById('agent-a'));
+        const request = deferred();
+        sidecarGenerate.mockReturnValueOnce(request.promise);
+        const create = click(panel, '#pf--summary-create');
+        const signal = sidecarGenerate.mock.calls[0][2];
+        if (reason === 'stop') {
+            generation.cancelRevision++;
+            stopped = true;
+            for (const listener of generationListeners) listener();
+        } else if (reason === 'chat change') {
+            generation.chatId = 'chat-b';
+            events.emit('chat');
+        } else if (reason === 'disable') {
+            store.setGlobalSettings({ pathfinderEnabled: false });
+            ui.closePathfinderSettings();
+        } else {
+            await ui.openPathfinderSettings(store.getAgentById('agent-b'));
+        }
+        expect(signal.aborted).toBe(true);
+        request.resolve('{"title":"Late scene","content":"Must not be saved."}');
+        await create;
+        expect(createSummaryMemoryEntry).not.toHaveBeenCalled();
+        expect(generationListeners.size).toBe(reason === 'disable' ? 0 : 1);
+    });
+});

--- a/tests/pathfinder-settings-ui.test.js
+++ b/tests/pathfinder-settings-ui.test.js
@@ -151,7 +151,7 @@ function notifySummary() { for (const listener of summaryListeners) listener(); 
 function backgroundSaves() {
     const source = readFileSync(new URL('../public/scripts/extensions/in-chat-agents/agent-runner.js', import.meta.url), 'utf8');
     const runtime = vm.createContext({
-        console, structuredClone, pathfinderChatSyncRevision: 0,
+        console, structuredClone, pathfinderChatSyncRevision: 0, pathfinderToolRevision: 0,
         isPathfinderSubmoduleEnabled: store.isPathfinderSubmoduleEnabled,
         getPathfinderRuntimeAgent: () => store.getEnabledToolAgents()[0], isPathfinderToolAgent: () => true,
         getAgentById: store.getAgentById, getAgents: store.getAgents,

--- a/tests/pathfinder-settings.e2e.js
+++ b/tests/pathfinder-settings.e2e.js
@@ -1,0 +1,241 @@
+/* global document, window */
+import { expect, test } from '@playwright/test';
+import { dismissOnboardingIfPresent, dismissOpenDialogIfPresent } from './chat-scroll-regression-helpers.js';
+
+test.use({ serviceWorkers: 'block', reducedMotion: 'reduce' });
+
+const MANUAL_BOOK = 'Pathfinder test memory';
+const ATTACHED_BOOK = 'Attached Pathfinder lorebook with a long name '.repeat(4).trim();
+
+async function openSettings(page, baseURL) {
+    const origin = new URL(baseURL).origin;
+    expect(['127.0.0.1', 'localhost', '[::1]']).toContain(new URL(baseURL).hostname);
+    const state = { saveMode: 'success', saves: [], heldSaves: [], generation: [], reads: [], writes: [], failBookWrite: false };
+    const books = new Map([MANUAL_BOOK, ATTACHED_BOOK].map(name => [name, {
+        entries: { 0: { uid: 0, comment: 'Saved summary', content: 'Saved memory.', key: ['summary'], disable: false, constant: false } },
+    }]));
+    await page.route('**/*', async route => {
+        const request = route.request();
+        const url = new URL(request.url());
+        if (url.origin !== origin) return route.abort();
+        if (url.pathname === '/__pathfinder-test-generation') {
+            state.generation.push(route);
+            return;
+        }
+        if (url.pathname === '/api/in-chat-agents/save') {
+            const agent = request.postDataJSON();
+            if (agent.id === 'pf-e2e-agent') {
+                state.saves.push(agent);
+                if (state.saveMode === 'hold') {
+                    state.heldSaves.push(route);
+                    return;
+                }
+                if (state.saveMode === 'fail') return route.fulfill({ status: 503, json: {} });
+            }
+            return route.fulfill({ json: {} });
+        }
+        if (url.pathname === '/api/worldinfo/get') {
+            const name = request.postDataJSON().name;
+            if (books.has(name)) {
+                state.reads.push(name);
+                return route.fulfill({ json: books.get(name) });
+            }
+        }
+        if (url.pathname === '/api/worldinfo/edit') {
+            const { name, data } = request.postDataJSON();
+            state.writes.push({ name, data });
+            if (state.failBookWrite) return route.fulfill({ status: 503, json: {} });
+            books.set(name, data);
+            return route.fulfill({ json: { ok: true, name } });
+        }
+        // Browser tests never send inference, secrets, or mutations to a real service.
+        if (url.pathname.startsWith('/api/backends/')) return route.fulfill({ json: { data: [] } });
+        if (/^\/api\/.*\/(save|delete|create|edit|rename|update|import|upload|restore|duplicate|write|set)$/.test(url.pathname)) {
+            return route.fulfill({ json: {} });
+        }
+        return route.continue();
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => !document.getElementById('preloader'), null, { timeout: 60000 });
+    await dismissOnboardingIfPresent(page);
+    const onboardingSave = page.locator('dialog[open]:has(.onboarding) .popup-button-ok');
+    if (await onboardingSave.isVisible()) await onboardingSave.click();
+    await dismissOpenDialogIfPresent(page);
+    await page.addLocatorHandler(page.locator('#qig-setup-wizard'), async wizard => {
+        await wizard.getByRole('button', { name: 'Skip', exact: true }).click();
+    });
+    await page.waitForFunction(async () => (await import('/script.js')).settingsReady, null, { timeout: 60000 });
+    await page.waitForFunction(() => typeof window.SillyTavern?.getContext === 'function');
+    await page.locator('#extension_settings_in_chat_agents_pathfinder #pf--settings').waitFor({ state: 'attached', timeout: 60000 });
+
+    await page.evaluate(async ({ manualBook, attachedBook }) => {
+        const ui = await import('/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js');
+        const store = await import('/scripts/extensions/in-chat-agents/agent-store.js');
+        const tree = await import('/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+        const runner = await import('/scripts/extensions/in-chat-agents/agent-runner.js');
+        const pathfinder = await import('/scripts/extensions/in-chat-agents/pathfinder-init.js');
+        const world = await import('/scripts/world-info.js');
+        const memory = await import('/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js');
+        const ctx = window.SillyTavern.getContext();
+        ctx.chatMetadata.world_info = attachedBook;
+        ctx.powerUserSettings.persona_description_lorebook = '';
+        for (const character of ctx.characters) {
+            character.data = { ...character.data, character_book: undefined, extensions: { ...character.data?.extensions, world: '' } };
+        }
+        if (ctx.worldInfoSettings) ctx.worldInfoSettings.charLore = [];
+        ctx.chat.splice(0, ctx.chat.length, { mes: 'The test characters reach the harbour.', name: 'Test character', is_user: false });
+        world.world_names.splice(0, world.world_names.length, manualBook, attachedBook);
+        const CMRS = ctx.ConnectionManagerRequestService;
+        CMRS.getSupportedProfiles = () => [{ id: 'pf-test-profile', name: 'Pathfinder test profile' }];
+        CMRS.sendRequest = async (_profile, messages, _tokens, { signal }) => {
+            const response = await fetch('/__pathfinder-test-generation', { method: 'POST', body: JSON.stringify(messages), signal });
+            return response.text();
+        };
+        const tools = pathfinder.getPathfinderToolDefinitions();
+        store.setGlobalSettings({ enabled: true, pathfinderEnabled: true, separateRecentChats: false });
+        store.loadAgents([{
+            id: 'pf-e2e-agent', name: 'Pathfinder', category: 'tool', sourceTemplateId: 'tpl-pathfinder', enabled: true, tools,
+            settings: {
+                pipelineEnabled: true, sidecarEnabled: false, connectionProfile: 'pf-test-profile',
+                enabledLorebooks: [manualBook], selectedLorebook: manualBook,
+                toolStates: Object.fromEntries(tools.map(tool => [tool.name, tool.name === 'Pathfinder_Search'])),
+                bookPermissions: { [attachedBook]: { read: 'readwrite', write: 'readwrite', delete: 'none' } },
+            },
+        }]);
+        tree.replaceSettings(store.getAgentById('pf-e2e-agent').settings);
+        pathfinder.initPathfinder(ctx);
+        runner.syncToolAgentRegistrations();
+        memory.setSummaryMemoryCreated({ title: 'Saved summary', content: 'Saved memory.', bookName: manualBook, uid: 0 });
+        ui.closePathfinderSettings();
+        document.querySelectorAll('#pf--settings').forEach(element => element.remove());
+
+        const host = document.createElement('div');
+        host.id = 'pf-e2e-host';
+        host.style.cssText = 'position:fixed;inset:0 0 0 auto;width:min(434px,100%);padding:12px;box-sizing:border-box;overflow:auto;z-index:10000;background:var(--SmartThemeBlurTintColor)';
+        document.body.append(host);
+        const panel = await ui.openPathfinderSettings(store.getAgentById('pf-e2e-agent'));
+        panel.filter('#pf--settings').addClass('pf--settings-embedded');
+        host.append(...panel.toArray());
+    }, { manualBook: MANUAL_BOOK, attachedBook: ATTACHED_BOOK });
+    await expect(page.locator('#pf-e2e-host #pf--master-enable')).toBeVisible();
+    return state;
+}
+
+test('Pathfinder uses native keyboard disclosures, labelled controls and narrow layouts', async ({ page, baseURL }, testInfo) => {
+    const state = await openSettings(page, baseURL);
+    expect(state.reads).toEqual([]);
+    expect(state.writes).toEqual([]);
+    const header = page.locator('#pf--lorebook-section > button');
+    await header.focus();
+    await page.keyboard.press('Space');
+    await expect(header).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('#pf--lorebook-body')).toBeHidden();
+    await page.keyboard.press('Enter');
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByRole('checkbox', { name: ATTACHED_BOOK, exact: true })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: `${ATTACHED_BOOK} Read`, exact: true })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: `${ATTACHED_BOOK} Write`, exact: true })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'Automatically include attached lorebooks, aside from excluded lorebooks', exact: true })).toBeChecked();
+    await expect(page.getByLabel('Pipeline Type', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Allow summary memory tool', { exact: true })).not.toBeChecked();
+    await expect(page.locator('#pf--permission-matrix')).toBeVisible();
+    await expect(page.locator('#pf--confirm-tool-list')).toBeVisible();
+
+    for (const width of [1440, 390]) {
+        await page.setViewportSize({ width, height: 900 });
+        for (const fontSize of [15, 30]) {
+            await page.locator('#pf-e2e-host').evaluate((host, size) => host.style.setProperty('--mainFontSize', `${size}px`), fontSize);
+            const layout = await page.locator('#pf-e2e-host').evaluate(host => {
+                const controls = [...host.querySelectorAll('button, select, input, textarea')]
+                    .filter(element => element.getClientRects().length)
+                    .map(element => element.matches('input[type="checkbox"]') ? element.closest('label') : element);
+                return {
+                    overflow: host.scrollWidth > host.clientWidth,
+                    smallestControl: Math.min(...controls.map(element => element.getBoundingClientRect().height)),
+                    bookFontSize: parseFloat(window.getComputedStyle(host.querySelector('.pf--lorebook-name')).fontSize),
+                };
+            });
+            expect(layout.overflow).toBe(false);
+            expect(layout.smallestControl).toBeGreaterThanOrEqual(width < 768 ? 44 : 38);
+            expect(layout.bookFontSize).toBeCloseTo(fontSize * 0.92, 1);
+        }
+        await page.locator('#pf-e2e-host').evaluate(host => {
+            host.style.setProperty('--mainFontSize', '15px');
+            host.scrollTop = 0;
+        });
+        await page.screenshot({ path: testInfo.outputPath(`pathfinder-${width}.png`) });
+    }
+});
+
+test('Pathfinder saves rapid toggles in order and an unticked attached book stays excluded', async ({ page, baseURL }) => {
+    const state = await openSettings(page, baseURL);
+    state.saveMode = 'hold';
+    await page.locator('#pf--enable-tools').check();
+    await expect.poll(() => state.heldSaves.length).toBe(1);
+    await page.locator('#pf--auto-summary').check();
+    expect(state.saves).toHaveLength(1);
+    expect(await page.evaluate(async () => (await import('/scripts/extensions/in-chat-agents/pathfinder/tree-store.js')).getSettings().sidecarEnabled)).toBe(false);
+    state.saveMode = 'success';
+    await state.heldSaves[0].fulfill({ json: {} });
+    await expect(page.locator('#pf--settings-save-status')).toHaveText('Saved!');
+    await expect.poll(() => state.saves.length).toBe(2);
+    expect(state.saves[0].settings.autoSummary).not.toBe(true);
+    expect(state.saves[1].settings).toMatchObject({ sidecarEnabled: true, autoSummary: true, toolStates: { Pathfinder_Summarize: true } });
+
+    await page.getByRole('checkbox', { name: ATTACHED_BOOK, exact: true }).uncheck();
+    await expect(page.locator('#pf--settings-save-status')).toHaveText('Saved!');
+    const access = await page.evaluate(async () => {
+        const bridge = await import('/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js');
+        const store = await import('/scripts/extensions/in-chat-agents/agent-store.js');
+        return { readable: bridge.getReadableBooks(), writable: bridge.getWritableBooks(), permissions: store.getAgentById('pf-e2e-agent').settings.bookPermissions };
+    });
+    expect(access.readable).not.toContain(ATTACHED_BOOK);
+    expect(access.writable).not.toContain(ATTACHED_BOOK);
+    expect(access.permissions[ATTACHED_BOOK]).toEqual({ enabled: false, read: 'readwrite', write: 'readwrite', delete: 'none' });
+    await page.locator('#pf--refresh-lorebooks').click();
+    await expect(page.getByRole('checkbox', { name: ATTACHED_BOOK, exact: true })).not.toBeChecked();
+});
+
+test('Pathfinder preserves failed prompt and summary drafts, including an empty summary', async ({ page, baseURL }) => {
+    const state = await openSettings(page, baseURL);
+    await page.locator('#pf--prompt-editor-section > button').click();
+    await page.getByLabel('Select Prompt to Edit', { exact: true }).selectOption('candidate-selector');
+    await page.getByLabel('System Prompt', { exact: true }).fill('A test prompt draft');
+    state.saveMode = 'fail';
+    await page.locator('#pf--prompt-save').click();
+    await expect(page.locator('#pf--prompt-status')).toContainText('Save failed:');
+    await expect(page.getByLabel('System Prompt', { exact: true })).toHaveValue('A test prompt draft');
+    state.saveMode = 'success';
+    await page.locator('#pf--settings-retry').click();
+    await expect(page.locator('#pf--settings-save-status')).toHaveText('Saved!');
+
+    const editor = page.getByLabel('Latest memory summary', { exact: true });
+    await editor.fill('An unsaved summary draft');
+    await page.locator('#pf--summary-save').focus();
+    await page.evaluate(async () => (await import('/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js')).markSummaryMemoryInjected({ mode: 'pipeline' }));
+    await expect(editor).toHaveValue('An unsaved summary draft');
+    state.failBookWrite = true;
+    await page.locator('#pf--summary-save').click();
+    await expect(page.locator('#pf--summary-save-status')).toContainText('Save failed:');
+    await expect(editor).toHaveValue('An unsaved summary draft');
+    state.failBookWrite = false;
+    await editor.fill('');
+    await expect(page.locator('#pf--summary-save-entry')).toBeDisabled();
+    await page.locator('#pf--summary-save').click();
+    await expect(page.locator('#pf--summary-save-status')).toHaveText('Saved!');
+    await expect(editor).toHaveValue('');
+    expect(state.writes.at(-1).data.entries[0].content).toBe('');
+});
+
+test('Stop cancels a real auxiliary request without saving a late summary', async ({ page, baseURL }) => {
+    const state = await openSettings(page, baseURL);
+    await page.evaluate(async () => (await import('/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js')).setSummaryMemoryCreated({ title: '', content: '', bookName: '', uid: null }));
+    await page.locator('#pf--summary-create').click();
+    await expect.poll(() => state.generation.length).toBe(1);
+    await page.evaluate(async () => (await import('/scripts/extensions/in-chat-agents/agent-runner.js')).cancelAgentGeneration());
+    await expect(page.locator('#pf--summary-save-status')).toHaveText('Cancelled');
+    await state.generation[0].fulfill({ body: '{"title":"Late","content":"This must not be stored."}' }).catch(() => {});
+    expect(state.writes).toEqual([]);
+    await expect(page.locator('#pf--summary-create')).toBeEnabled();
+});

--- a/tests/pathfinder-storage.test.js
+++ b/tests/pathfinder-storage.test.js
@@ -1,0 +1,287 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
+
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({ accountStorage: { getItem: () => null, setItem: jest.fn() } }));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
+    createWorldInfoEntry: jest.fn(),
+    syncWIOriginalDataEntry: (data, uid) => {
+        const index = data.originalDataUidMap?.[uid];
+        if (Number.isInteger(index)) data.originalData.entries[index] = serializeWorldInfoEntry(data.entries[uid], { before: 0, after: 1 }, data.originalData.entries[index]);
+    },
+    deleteWIOriginalDataValue: jest.fn(), reloadEditor: jest.fn(),
+}));
+
+const { clearAllTrees, deleteTree, getTree, saveTree, findNodeById, getAllEntryUids, replaceSettings } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const { LAYOUT_KEY, readTreeLayout } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-layout.js');
+const {
+    initEntryManagerAPIs, createEntry, createCategory, moveEntry, updateEntry, forgetEntry,
+    onPathfinderWorldInfoUpdated, onPathfinderWorldInfoRenamed, onPathfinderWorldInfoDeleted,
+} = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
+
+const importedLayout = () => ({ version: 1, tree: {
+    id: 'root', name: 'Root', description: 'Book description', children: [
+        { id: 'custom', name: 'Custom', description: 'Custom description', children: [] },
+    ],
+} });
+
+describe('Pathfinder portable layouts', () => {
+    let store;
+    let save;
+
+    beforeEach(async () => {
+        clearAllTrees();
+        store = { Book: { entries: {
+            0: { uid: 0, comment: 'Character First', content: 'first' },
+            1: { uid: 1, comment: 'Location Second', content: 'second' },
+        } } };
+        save = jest.fn(async (name, data) => {
+            store[name] = structuredClone(data);
+            onPathfinderWorldInfoUpdated(name, structuredClone(data));
+            return name;
+        });
+        initEntryManagerAPIs(async name => store[name] ? structuredClone(store[name]) : null, (name, data) => {
+            let uid = 0;
+            while (data.entries[uid]) uid++;
+            return (data.entries[uid] = { uid });
+        }, save);
+        await buildTreeFromMetadata('Book', store.Book);
+    });
+
+    test('persists hierarchy, order, descriptions, empty categories and entry placement, not UID arrays', async () => {
+        const parent = await createCategory('Book', null, 'Custom', 'Parent description');
+        const nested = await createCategory('Book', parent.nodeId, 'Nested', 'Nested description');
+        await createCategory('Book', null, 'Empty', 'Keep this category');
+        await moveEntry('Book', 0, nested.nodeId);
+        const layout = store.Book.extensions[LAYOUT_KEY];
+        expect(JSON.stringify(layout)).not.toContain('"entries"');
+        expect(JSON.stringify(layout)).not.toContain('"localId"');
+        expect(layout.tree.children.map(node => node.name)).toEqual(['Characters', 'Locations', 'Custom', 'Empty']);
+        expect(layout.tree.children[0].generatedCategory).toBe('Characters');
+        expect(layout.tree.children[2].children[0]).toMatchObject({ name: 'Nested', description: 'Nested description' });
+        clearAllTrees();
+        const rebuilt = await buildTreeFromMetadata('Book', structuredClone(store.Book));
+        expect(findNodeById(rebuilt, nested.nodeId).entries).toEqual([0]);
+        expect(rebuilt.children.at(-1)).toMatchObject({ name: 'Empty', entries: [] });
+        expect(getAllEntryUids(rebuilt)).toHaveLength(2);
+        await moveEntry('Book', 1, nested.nodeId);
+        expect(findNodeById(getTree('Book'), nested.nodeId).entries).toEqual([0, 1]);
+    });
+
+    test('book export/duplicate copies local IDs but exposes distinct runtime IDs', async () => {
+        const category = await createCategory('Book', null, 'Custom');
+        await moveEntry('Book', 0, category.nodeId);
+        store.Copy = JSON.parse(JSON.stringify(store.Book));
+        const copy = await buildTreeFromMetadata('Copy', store.Copy);
+        const copyCategory = copy.children.find(node => node.name === 'Custom');
+        expect(copyCategory.id).not.toBe(category.nodeId);
+        expect(copyCategory.localId).toBe(findNodeById(getTree('Book'), category.nodeId).localId);
+        expect(copyCategory.entries).toEqual([0]);
+        await expect(moveEntry('Copy', 0, category.nodeId)).rejects.toThrow('not found');
+        deleteTree('Book');
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(findNodeById(getTree('Book'), category.nodeId).entries).toEqual([0]);
+    });
+
+    test('uses originalData book metadata only when the native namespace is absent and mirrors it on write', async () => {
+        store.Book.originalData = {
+            entries: [{ id: 0, keys: [], content: 'first', extensions: {} }, { id: 1, keys: [], content: 'second', extensions: {} }],
+            extensions: { foreign: 'keep', [LAYOUT_KEY]: importedLayout() },
+        };
+        store.Book.originalDataUidMap = { 0: 0, 1: 1 };
+        store.Book.entries[0].extensions = { [LAYOUT_KEY]: { version: 1, nodeId: 'custom' } };
+        const before = structuredClone(store.Book);
+        clearAllTrees();
+        const tree = await buildTreeFromMetadata('Book', store.Book);
+        expect(tree.children[0]).toMatchObject({ name: 'Custom', entries: [0] });
+        expect(store.Book).toEqual(before);
+        expect(save).not.toHaveBeenCalled();
+        const added = await createCategory('Book', null, 'Added');
+        await moveEntry('Book', 0, added.nodeId);
+        expect(store.Book.extensions[LAYOUT_KEY]).toEqual(store.Book.originalData.extensions[LAYOUT_KEY]);
+        expect(store.Book.originalData.extensions.foreign).toBe('keep');
+        expect(store.Book.originalData.entries[0].extensions[LAYOUT_KEY]).toEqual(store.Book.entries[0].extensions[LAYOUT_KEY]);
+
+        store.Book.extensions[LAYOUT_KEY] = { version: 2, opaque: ['keep'] };
+        const native = structuredClone(store.Book.extensions[LAYOUT_KEY]);
+        expect(readTreeLayout(store.Book)).toBeNull();
+        await expect(createCategory('Book', null, 'Do not overwrite')).rejects.toThrow('The saved waypoint layout is damaged or uses an unsupported format and will not be overwritten.');
+        await updateEntry('Book', 0, 'ordinary entry edit');
+        expect(store.Book.extensions[LAYOUT_KEY]).toEqual(native);
+        expect(store.Book.originalData.extensions[LAYOUT_KEY]).toEqual(native);
+    });
+
+    test.each(['disable', 'agentBlacklisted'])('hides %s entries while retaining placement for re-enabling', async flag => {
+        const custom = await createCategory('Book', null, 'Custom');
+        await moveEntry('Book', 0, custom.nodeId);
+        const placement = structuredClone(store.Book.entries[0].extensions[LAYOUT_KEY]);
+        store.Book.entries[0][flag] = true;
+        clearAllTrees();
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(findNodeById(getTree('Book'), custom.nodeId).entries).toEqual([]);
+        expect(store.Book.entries[0].extensions[LAYOUT_KEY]).toEqual(placement);
+        store.Book.entries[0][flag] = false;
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(findNodeById(getTree('Book'), custom.nodeId).entries).toEqual([0]);
+        expect(save).toHaveBeenCalledTimes(2);
+    });
+
+    test('deleting and reusing a UID cannot inherit cached placement', async () => {
+        const custom = await createCategory('Book', null, 'Custom');
+        await moveEntry('Book', 0, custom.nodeId);
+        await forgetEntry('Book', 0, true);
+        const created = await createEntry('Book', 'Location Fresh', 'fresh');
+        expect(created.uid).toBe(0);
+        expect(store.Book.entries[0].extensions?.[LAYOUT_KEY]).toBeUndefined();
+        expect(findNodeById(getTree('Book'), custom.nodeId).entries).toEqual([]);
+        expect(getTree('Book').children.find(node => node.name === 'Locations').entries).toContain(0);
+    });
+
+    test('same-book entry duplicates copy placement; foreign copies and dangling references auto-categorise', async () => {
+        const custom = await createCategory('Book', null, 'Custom');
+        await moveEntry('Book', 0, custom.nodeId);
+        store.Book.entries[2] = { ...structuredClone(store.Book.entries[0]), uid: 2 };
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(findNodeById(getTree('Book'), custom.nodeId).entries).toEqual([0, 2]);
+        store.Foreign = { entries: { 2: structuredClone(store.Book.entries[2]) } };
+        const foreign = await buildTreeFromMetadata('Foreign', store.Foreign);
+        expect(foreign.children[0]).toMatchObject({ name: 'Characters', entries: [2] });
+        expect(store.Foreign.entries[2].extensions[LAYOUT_KEY]).toEqual(store.Book.entries[2].extensions[LAYOUT_KEY]);
+        store.Book.entries[0].extensions[LAYOUT_KEY].nodeId = 'missing';
+        const before = structuredClone(store.Book);
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(getTree('Book').children.find(node => node.name === 'Characters').entries).toContain(0);
+        expect(store.Book).toEqual(before);
+    });
+
+    test('keeps unsupported entry metadata opaque instead of overwriting it during a move', async () => {
+        const placement = { version: 2, nodeId: 'future', opaque: { retained: true } };
+        store.Book.entries[0].extensions = { [LAYOUT_KEY]: placement };
+        await expect(moveEntry('Book', 0, getTree('Book').id)).rejects.toThrow('Cannot move unsupported or invalid waypoint placement.');
+        expect(save).not.toHaveBeenCalled();
+        await updateEntry('Book', 0, 'updated content');
+        expect(store.Book.entries[0].extensions[LAYOUT_KEY]).toEqual(placement);
+    });
+
+    test('category and entry creation share the same queue', async () => {
+        await Promise.all([createCategory('Book', null, 'Concurrent category'), createEntry('Book', 'Concurrent entry', 'saved')]);
+        expect(getTree('Book').children.some(node => node.name === 'Concurrent category')).toBe(true);
+        expect(Object.values(store.Book.entries).some(entry => entry.comment === 'Concurrent entry')).toBe(true);
+        expect(save).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not publish a category or change the loaded cache until its save commits', async () => {
+        const before = structuredClone(store);
+        const tree = structuredClone(getTree('Book'));
+        let release;
+        let started;
+        const saving = new Promise(resolve => { started = resolve; });
+        save.mockImplementationOnce(async (name, data) => {
+            started();
+            await new Promise(resolve => { release = resolve; });
+            store[name] = structuredClone(data);
+            return name;
+        });
+        const operation = createCategory('Book', null, 'Pending');
+        await saving;
+        expect(store).toEqual(before);
+        expect(getTree('Book')).toEqual(tree);
+        release();
+        const result = await operation;
+        expect(findNodeById(getTree('Book'), result.nodeId).name).toBe('Pending');
+    });
+
+    test('failed category and move saves leave the persisted and cached layout intact', async () => {
+        const custom = await createCategory('Book', null, 'Custom');
+        const before = structuredClone(store);
+        const tree = structuredClone(getTree('Book'));
+        save.mockRejectedValueOnce(new Error('offline'));
+        await expect(createCategory('Book', null, 'Unsaved')).rejects.toThrow('offline');
+        save.mockResolvedValueOnce(null);
+        await expect(moveEntry('Book', 0, custom.nodeId)).rejects.toThrow('The lorebook save did not complete.');
+        expect(store).toEqual(before);
+        expect(getTree('Book')).toEqual(tree);
+    });
+
+    test('re-reads the host commit so concurrent native metadata is not hidden by the private draft', async () => {
+        save.mockImplementationOnce(async (name, data) => {
+            store[name] = structuredClone(data);
+            store[name].entries[2] = { uid: 2, comment: 'Native note', content: 'saved by editor' };
+            return name;
+        });
+        await createCategory('Book', null, 'Custom');
+        expect(getAllEntryUids(getTree('Book'))).toContain(2);
+    });
+
+    test('rename keeps returned IDs valid even when both the event and save result report it', async () => {
+        save.mockImplementationOnce(async (name, data) => {
+            store.Renamed = structuredClone(data);
+            delete store[name];
+            onPathfinderWorldInfoRenamed(name, 'Renamed');
+            return 'Renamed';
+        });
+        const custom = await createCategory('Book', null, 'Custom');
+        expect(custom.bookName).toBe('Renamed');
+        expect(getTree('Book')).toBeNull();
+        expect(findNodeById(getTree('Renamed'), custom.nodeId).name).toBe('Custom');
+        clearAllTrees();
+        await buildTreeFromMetadata('Renamed', store.Renamed);
+        expect(findNodeById(getTree('Renamed'), custom.nodeId).name).toBe('Custom');
+    });
+
+    test('replacement and deletion retire runtime IDs instead of applying stale moves to new books', async () => {
+        const custom = await createCategory('Book', null, 'Custom');
+        onPathfinderWorldInfoUpdated('Book', store.Book, { replaced: true });
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(findNodeById(getTree('Book'), custom.nodeId)).toBeNull();
+        const current = getTree('Book').id;
+        onPathfinderWorldInfoDeleted('Book');
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(getTree('Book').id).not.toBe(current);
+        await expect(moveEntry('Book', 0, custom.nodeId)).rejects.toThrow('not found');
+    });
+
+    test('tree and settings cache APIs never write lorebooks', async () => {
+        const before = structuredClone(store);
+        replaceSettings({ enabledLorebooks: ['Book'] });
+        saveTree('Book', structuredClone(getTree('Book')));
+        deleteTree('Book');
+        await buildTreeFromMetadata('Book', store.Book);
+        expect(save).not.toHaveBeenCalled();
+        expect(store).toEqual(before);
+    });
+
+    const invalidLayouts = [
+        ['unknown version', { version: 2, opaque: 'keep' }],
+        ['null namespace', null],
+        ['invalid root', { version: 1, tree: [] }],
+        ['invalid ID', { version: 1, tree: { ...importedLayout().tree, id: 'bad:id' } }],
+        ['duplicate ID', { version: 1, tree: { ...importedLayout().tree, id: 'custom' } }],
+        ['unknown fields', { ...importedLayout(), future: true }],
+        ['entry arrays', { version: 1, tree: { ...importedLayout().tree, entries: [0] } }],
+        ['oversized description', { version: 1, tree: { ...importedLayout().tree, description: 'x'.repeat(4097) } }],
+        ['too many nodes', { version: 1, tree: { ...importedLayout().tree, children: Array.from({ length: 2048 }, (_, index) => ({ id: `n${index}`, name: '', description: '', children: [] })) } }],
+        ['oversized layout', { version: 1, tree: { ...importedLayout().tree, children: Array.from({ length: 100 }, (_, index) => ({ id: `n${index}`, name: '', description: 'x'.repeat(4096), children: [] })) } }],
+    ];
+    const deep = importedLayout();
+    let last = deep.tree;
+    for (let depth = 0; depth < 34; depth++) {
+        const child = { id: `deep${depth}`, name: '', description: '', children: [] };
+        last.children = [child];
+        last = child;
+    }
+    invalidLayouts.push(['too deep', deep]);
+
+    test.each(invalidLayouts)('preserves %s imports and refuses destructive layout rewrites', async (name, layout) => {
+        store.Book.extensions = { foreign: 'retained', [LAYOUT_KEY]: layout };
+        const before = structuredClone(store);
+        const tree = await buildTreeFromMetadata('Book', store.Book);
+        expect(getAllEntryUids(tree)).toEqual([0, 1]);
+        expect(readTreeLayout(store.Book)).toBeNull();
+        await expect(createCategory('Book', null, 'Unsafe rewrite')).rejects.toThrow('The saved waypoint layout is damaged or uses an unsupported format and will not be overwritten.');
+        expect(store).toEqual(before);
+        expect(save).not.toHaveBeenCalled();
+    });
+});

--- a/tests/pathfinder-streaming-origin.test.js
+++ b/tests/pathfinder-streaming-origin.test.js
@@ -1,0 +1,187 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../public/script.js', import.meta.url), 'utf8');
+const classSource = source.slice(source.indexOf('class StreamingProcessor {'), source.indexOf('\n/**', source.indexOf('\n}\n', source.indexOf('class StreamingProcessor {'))));
+
+function replacement() {
+    return { mes: 'different chat', name: 'Other', extra: {}, swipe_id: 0, swipes: ['untouched'], swipe_info: [{ extra: { keep: true } }] };
+}
+
+async function stream(type = 'normal') {
+    const writes = [];
+    const reasoningDomWrite = jest.fn();
+    class Element {
+        isConnected = true;
+        classList = { toggle() {} };
+        querySelector() { return this; }
+        getAttribute() { return '0'; }
+    }
+    const element = new Element();
+    const context = vm.createContext({
+        console, AbortController, structuredClone,
+        chat: [], chatId: 'original', chatGeneration: 1, activeGenerationRun: {}, streamingProcessor: null,
+        document: { querySelector: () => element }, HTMLElement: Element,
+        power_user: { streaming_fps: 30 }, main_api: 'openai', scrollLock: false, scrollLockImmunityUntil: 0,
+        IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY: 'history', IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY: 'intercept',
+        ReasoningHandler: class {
+            reasoning = '';
+            process = async () => {};
+            updateDom = reasoningDomWrite;
+            updateReasoning() {}
+            hasReasoningContent() { return false; }
+            getDuration() { return 0; }
+        },
+        event_types: { STREAM_TOKEN_RECEIVED: 'token' }, eventSource: { emit: jest.fn(async () => {}) },
+        delay: async () => {}, Stopwatch: class { async tick(callback) { await callback(); } },
+        getStoppingStrings: () => [], getStreamingUpdateInterval: () => 1,
+        cleanUpMessage: ({ getMessage }) => getMessage,
+        shouldReduceStreamingDomWork: () => false, shouldGuardMobileChatScroll: () => false,
+        shouldPinMobileChatToBottom: () => false, isMobileChatManualScrollSuppressionActive: () => false,
+        isAndroidStreamingPlatform: () => false, shouldUsePlainTextStreamingPreview: () => false,
+        getPositiveTokenCount: value => Number(value) || 0,
+        updateMessageTokenAccounting: jest.fn(async () => ({ outputTokens: 1, reasoningTokens: 0 })),
+        balanceStreamingMarkdown: value => value, messageFormatting: value => value,
+        formatGenerationTimer: () => ({}), deactivateSendButtons() {}, hideSwipeButtons() {}, unblockGeneration() {},
+        scrollStartedStreamingMessageThroughLifecycle() {}, scrollChatToBottom: jest.fn(),
+        CHAT_RENDER_LIFECYCLE_ROUTE: { STREAM_PROGRESS: 'stream' },
+        isChatRenderLifecycleRolloutEnabled: () => true,
+        getStreamingVisibleWriteBuffer: () => ({ queue: (...args) => writes.push(args) }),
+        updateMessageMetaBadges: jest.fn(),
+    });
+    context.getCurrentChatId = () => context.chatId;
+    context.saveReply = async () => { context.chat.push({ ...replacement(), mes: 'original', swipes: ['original'] }); };
+    vm.runInContext(classSource + '\nthis.StreamingProcessor = StreamingProcessor;', context);
+    const apply = source.match(/^function applyStreamingVisibleWrite\([\s\S]*?^}$/m)[0];
+    vm.runInContext(apply, context);
+    const processor = new context.StreamingProcessor(type, false, new Date(), '', { prefixReasoning: '', removePrefix: text => text });
+    context.streamingProcessor = processor;
+    processor.messageId = await processor.onStartStreaming('original');
+    processor.generator = async function* () { yield { text: 'stale output', swipes: [], toolCalls: [], state: {} }; };
+    return { context, processor, writes, reasoningDomWrite };
+}
+
+describe('streaming message origin', () => {
+    test('continues updating the original message and swipe through normal stream completion', async () => {
+        const { context, processor } = await stream();
+        await processor.generate();
+        await processor.onProgressStreaming(0, 'final output', true);
+        expect(context.chat[0].mes).toBe('final output');
+        expect(context.chat[0].swipes[0]).toBe('final output');
+    });
+
+    test.each(['chat switch', 'Stop'])('rechecks after token listeners before progress writes on %s', async reason => {
+        const { context, processor } = await stream();
+        context.eventSource.emit.mockImplementationOnce(async () => {
+            if (reason === 'Stop') processor.onStopStreaming();
+            else { context.chat = [replacement()]; context.chatGeneration++; }
+        });
+        const before = reason === 'Stop' ? structuredClone(context.chat[0]) : replacement();
+        await processor.generate();
+        expect(context.chat[0]).toEqual(before);
+    });
+
+    test('does not write through a reused index after the DOM lookup await', async () => {
+        const { context, processor } = await stream();
+        const pending = processor.onProgressStreaming(0, 'stale output', false);
+        context.chat = [replacement()];
+        context.chatGeneration++;
+        await pending;
+        expect(context.chat[0]).toEqual(replacement());
+    });
+
+    test('honours the originating host run guard before updating an otherwise unchanged message', async () => {
+        const { context, processor } = await stream();
+        const before = structuredClone(context.chat[0]);
+        processor.isCurrentGeneration = () => false;
+        await processor.onProgressStreaming(0, 'cancelled output', false);
+        expect(context.chat[0]).toEqual(before);
+    });
+
+    test('does not update replacement swipe metadata after token accounting', async () => {
+        const { context, processor } = await stream('continue');
+        let release;
+        let started;
+        const accounting = new Promise(resolve => { started = resolve; });
+        context.updateMessageTokenAccounting.mockImplementationOnce(() => { started(); return new Promise(resolve => { release = resolve; }); });
+        const pending = processor.onProgressStreaming(0, 'stale output', true);
+        await accounting;
+        context.chat[0] = replacement();
+        release({ outputTokens: 1, reasoningTokens: 0 });
+        await pending;
+        expect(context.chat[0]).toEqual(replacement());
+    });
+
+    test('does not let cancellation cleanup change a different message', async () => {
+        const { context, processor } = await stream();
+        context.chat[0] = replacement();
+        processor.onStopStreaming();
+        processor.setFirstSwipe(0);
+        expect(context.chat[0]).toEqual(replacement());
+    });
+
+    test('guards the real initial saveReply after its token-count await', async () => {
+        const { context } = await stream();
+        context.chat = [];
+        Object.assign(context, {
+            name2: 'Assistant', generation_started: new Date(), selected_group: null,
+            getMessageTimeStamp: () => 'now', getGeneratingApi: () => 'openai', getGeneratingModel: () => 'model', getCurrentReasoningEffort: () => null,
+            processImageAttachment: async () => {}, addOneMessage: jest.fn(), statMesProcess() {},
+        });
+        vm.runInContext(source.match(/^export (async function saveReply\([\s\S]*?^})/m)[1], context);
+        const processor = new context.StreamingProcessor('normal', false, new Date(), '', {});
+        context.streamingProcessor = processor;
+        let release;
+        let started;
+        const counting = new Promise(resolve => { started = resolve; });
+        context.updateMessageTokenAccounting.mockImplementationOnce(() => { started(); return new Promise(resolve => { release = resolve; }); });
+        const pending = processor.onStartStreaming('initial');
+        await counting;
+        context.chat = [replacement()];
+        context.chatGeneration++;
+        release({ outputTokens: 1, reasoningTokens: 0 });
+        await pending;
+        expect(context.chat[0]).toEqual(replacement());
+        expect(context.addOneMessage).not.toHaveBeenCalled();
+    });
+
+    test('does not let delayed reasoning completion repaint a different chat', async () => {
+        const { context, processor, reasoningDomWrite } = await stream();
+        let release;
+        let started;
+        const processing = new Promise(resolve => { started = resolve; });
+        processor.reasoningHandler.process = async () => {
+            started();
+            await new Promise(resolve => { release = resolve; });
+            processor.reasoningHandler.updateDom(0);
+        };
+        const pending = processor.onProgressStreaming(0, 'valid output', false);
+        await processing;
+        context.chat = [replacement()];
+        context.chatGeneration++;
+        release();
+        await pending;
+        expect(context.chat[0]).toEqual(replacement());
+        expect(reasoningDomWrite).not.toHaveBeenCalled();
+    });
+
+    test('rejects a queued DOM write after a chat switch', async () => {
+        const { context, processor, writes } = await stream();
+        await processor.onProgressStreaming(0, 'valid output', false);
+        expect(writes).toHaveLength(1);
+        context.chat = [replacement()];
+        context.chatGeneration++;
+        context.applyStreamingVisibleWrite(...writes[0]);
+        expect(context.updateMessageMetaBadges).not.toHaveBeenCalled();
+    });
+
+    test('rejects a queued write when the renderer reused its DOM node for a different message', async () => {
+        const { context, processor, writes } = await stream();
+        await processor.onProgressStreaming(0, 'valid output', false);
+        writes[0][1].messageDom.getAttribute = () => 'another-message';
+        context.applyStreamingVisibleWrite(...writes[0]);
+        expect(context.updateMessageMetaBadges).not.toHaveBeenCalled();
+    });
+});

--- a/tests/pathfinder-summary-memory-account-storage.test.js
+++ b/tests/pathfinder-summary-memory-account-storage.test.js
@@ -1,77 +1,162 @@
-import { describe, expect, jest, test } from '@jest/globals';
+/* eslint-disable playwright/no-standalone-expect */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-const accountStorageValues = new Map([
-    ['pathfinder-summary-memory-state', JSON.stringify({
-        title: 'Existing summary',
-        content: 'Stored content',
-        significance: 'Stored significance',
-        arc: 'Stored arc',
-        bookName: 'Stored book',
-        uid: 42,
-        updatedAt: 100,
-        injectedAt: 90,
-        injectedMode: 'auto',
-    })],
-]);
+const storedState = {
+    title: 'Existing summary', content: 'Stored content', significance: 'Stored significance', arc: 'Stored arc',
+    bookName: 'Stored book', uid: 42, updatedAt: 100, injectedAt: 90, injectedMode: 'auto',
+};
+const accountStorageValues = new Map([['pathfinder-summary-memory-state', JSON.stringify(storedState)]]);
 const accountStorage = {
     getItem: jest.fn(key => accountStorageValues.get(key) ?? null),
     setItem: jest.fn((key, value) => accountStorageValues.set(key, String(value))),
 };
-
-await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({
-    accountStorage,
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js', () => ({
-    updateEntry: jest.fn(async () => {}),
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({ accountStorage }));
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
+    createWorldInfoEntry: jest.fn(), syncWIOriginalDataEntry: jest.fn(), deleteWIOriginalDataValue: jest.fn(), reloadEditor: jest.fn(),
 }));
 
 const {
-    getSummaryMemoryState,
-    setSummaryMemoryCreated,
+    getSummaryMemoryState, setSummaryMemoryCreated, saveSummaryMemoryContent, isSummaryMemoryEntry, markSummaryMemoryInjected,
 } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js');
+const {
+    initEntryManagerAPIs, createEntry, updateEntry, forgetEntry, mergeEntries, splitEntry,
+    onPathfinderWorldInfoUpdated, onPathfinderWorldInfoRenamed, onPathfinderWorldInfoDeleted,
+} = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
+const { clearAllTrees } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const loadedState = getSummaryMemoryState();
 
 describe('Pathfinder summary memory account storage', () => {
-    test('loads and persists the existing key with the same serialized state shape', () => {
-        expect(getSummaryMemoryState()).toEqual({
-            title: 'Existing summary',
-            content: 'Stored content',
-            significance: 'Stored significance',
-            arc: 'Stored arc',
-            bookName: 'Stored book',
-            uid: 42,
-            updatedAt: 100,
-            injectedAt: 90,
-            injectedMode: 'auto',
-        });
+    let store;
+    let save;
 
-        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(500);
+    beforeEach(() => {
+        clearAllTrees();
+        setSummaryMemoryCreated({ title: '[Summary] Current', content: 'current', significance: 'high', bookName: 'Memory Book', uid: 0 });
+        store = { 'Memory Book': { entries: {
+            0: { uid: 0, comment: '[Summary] Current', content: 'Significance: high\n\ncurrent' },
+            1: { uid: 1, comment: 'Other', content: 'other' },
+        } } };
+        save = jest.fn(async (name, data) => {
+            store[name] = structuredClone(data);
+            onPathfinderWorldInfoUpdated(name, structuredClone(data));
+            return name;
+        });
+        initEntryManagerAPIs(async name => store[name] ? structuredClone(store[name]) : null, (name, data) => {
+            let uid = 0;
+            while (data.entries[uid]) uid++;
+            return (data.entries[uid] = { uid });
+        }, save);
+    });
+
+    test('loads and persists the existing account-wide key with the same state shape', () => {
+        expect(loadedState).toEqual(storedState);
+        const now = jest.spyOn(Date, 'now').mockReturnValue(500);
         try {
             setSummaryMemoryCreated({
-                title: 'New summary',
-                content: 'Significance: Important\n\nNew content',
-                significance: 'Important',
-                arc: 'New arc',
-                bookName: 'New book',
-                uid: 7,
+                title: 'New summary', content: 'Significance: Important\n\nNew content', significance: 'Important',
+                arc: 'New arc', bookName: 'New book', uid: 7,
             });
         } finally {
-            nowSpy.mockRestore();
+            now.mockRestore();
         }
+        expect(accountStorage.setItem).toHaveBeenLastCalledWith('pathfinder-summary-memory-state', JSON.stringify({
+            title: 'New summary', content: 'New content', significance: 'Important', arc: 'New arc',
+            bookName: 'New book', uid: 7, updatedAt: 500, injectedAt: 0, injectedMode: '',
+        }));
+    });
 
-        expect(accountStorage.setItem).toHaveBeenCalledWith(
-            'pathfinder-summary-memory-state',
-            JSON.stringify({
-                title: 'New summary',
-                content: 'New content',
-                significance: 'Important',
-                arc: 'New arc',
-                bookName: 'New book',
-                uid: 7,
-                updatedAt: 500,
-                injectedAt: 0,
-                injectedMode: '',
-            }),
-        );
+    test('does not coerce missing or malformed persisted UIDs into entry zero on reload', async () => {
+        for (const uid of [null, false, '', [], {}, 0.5]) {
+            accountStorageValues.set('pathfinder-summary-memory-state', JSON.stringify({ ...storedState, uid }));
+            jest.resetModules();
+            const reloaded = await import('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js');
+            expect(reloaded.getSummaryMemoryState().uid).toBeNull();
+        }
+    });
+
+    test('commits the edited summary state only after a successful lorebook write', async () => {
+        markSummaryMemoryInjected({ mode: 'pipeline' });
+        const before = getSummaryMemoryState();
+        save.mockRejectedValueOnce(new Error('offline'));
+        await expect(saveSummaryMemoryContent('unsaved')).rejects.toThrow('offline');
+        expect(getSummaryMemoryState()).toEqual(before);
+        expect(store['Memory Book'].entries[0].content).toBe('Significance: high\n\ncurrent');
+        await saveSummaryMemoryContent('saved');
+        expect(getSummaryMemoryState()).toMatchObject({ content: 'saved', uid: 0, injectedAt: 0, injectedMode: '' });
+        expect(store['Memory Book'].entries[0].content).toBe('Significance: high\n\nsaved');
+    });
+
+    test('synchronises title, content and significance after a direct entry update', async () => {
+        await updateEntry('Memory Book', 0, 'Significance: low\n\nupdated', '[Summary] Updated');
+        expect(getSummaryMemoryState()).toMatchObject({ title: '[Summary] Updated', content: 'updated', significance: 'low', uid: 0 });
+    });
+
+    test('keeps the tracked original when splitting and follows its new content', async () => {
+        const result = await splitEntry('Memory Book', 0, '[Summary] First', 'first', '[Summary] Second', 'second');
+        expect(getSummaryMemoryState()).toMatchObject({ title: '[Summary] First', content: 'first', significance: '', uid: result.originalUid });
+        expect(getSummaryMemoryState().uid).not.toBe(result.newUid);
+    });
+
+    test.each([
+        ['disable', () => forgetEntry('Memory Book', 0)],
+        ['delete', () => forgetEntry('Memory Book', 0, true)],
+        ['merge into another entry', () => mergeEntries('Memory Book', 1, 0)],
+    ])('detaches rather than pointing at removed or hidden content after %s', async (name, mutate) => {
+        await mutate();
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: '', uid: null, content: 'current', injectedAt: 0 });
+    });
+
+    test('UID reuse after deletion does not inherit the old summary link', async () => {
+        await forgetEntry('Memory Book', 0, true);
+        const created = await createEntry('Memory Book', 'Replacement', 'unrelated');
+        expect(created.uid).toBe(0);
+        expect(getSummaryMemoryState().uid).toBeNull();
+        expect(isSummaryMemoryEntry({ ...store['Memory Book'].entries[0], bookName: 'Memory Book' })).toBe(false);
+    });
+
+    test('verifies the expected entry before an editor save even if no external event arrived', async () => {
+        store['Memory Book'].entries[0] = { uid: 0, comment: 'Replacement', content: 'unrelated' };
+        await expect(saveSummaryMemoryContent('do not overwrite')).rejects.toThrow('The summary or its linked entry changed while the user was editing. Saves are blocked to prevent overwriting.');
+        expect(store['Memory Book'].entries[0].content).toBe('unrelated');
+        expect(save).not.toHaveBeenCalled();
+        expect(getSummaryMemoryState()).toMatchObject({ uid: null, content: 'current' });
+    });
+
+    test('native edits detach stale snapshots, and replacements detach even identical entries', () => {
+        store['Memory Book'].entries[0].content = 'native edit';
+        onPathfinderWorldInfoUpdated('Memory Book', store['Memory Book']);
+        expect(getSummaryMemoryState().uid).toBeNull();
+        setSummaryMemoryCreated({ title: '[Summary] Current', content: 'native edit', bookName: 'Memory Book', uid: 0 });
+        onPathfinderWorldInfoUpdated('Memory Book', store['Memory Book'], { replaced: true });
+        expect(getSummaryMemoryState().uid).toBeNull();
+    });
+
+    test('book rename preserves the link and book deletion detaches it', () => {
+        onPathfinderWorldInfoRenamed('Memory Book', 'Renamed');
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: 'Renamed', uid: 0 });
+        onPathfinderWorldInfoDeleted('Renamed');
+        expect(getSummaryMemoryState()).toMatchObject({ bookName: '', uid: null });
+    });
+
+    test('injection matching requires the current title, content, book and eligible entry', () => {
+        const entry = { ...store['Memory Book'].entries[0], bookName: 'Memory Book' };
+        expect(isSummaryMemoryEntry(entry)).toBe(true);
+        expect(isSummaryMemoryEntry({ ...entry, bookName: 'Other Book' })).toBe(false);
+        expect(isSummaryMemoryEntry({ ...entry, content: 'changed' })).toBe(false);
+        expect(isSummaryMemoryEntry({ ...entry, comment: 'changed' })).toBe(false);
+        expect(isSummaryMemoryEntry({ ...entry, disable: true })).toBe(false);
+        expect(isSummaryMemoryEntry({ ...entry, agentBlacklisted: true })).toBe(false);
+    });
+
+    test('an older pending edit cannot replace or detach a newly tracked summary', async () => {
+        save.mockImplementationOnce(async (name, data) => {
+            setSummaryMemoryCreated({ title: 'Other', content: 'other', bookName: name, uid: 1 });
+            store[name] = structuredClone(data);
+            return name;
+        });
+        await saveSummaryMemoryContent('saved to the old entry');
+        expect(store['Memory Book'].entries[0].content).toContain('saved to the old entry');
+        expect(getSummaryMemoryState()).toMatchObject({ uid: 1, title: 'Other', content: 'other' });
     });
 });

--- a/tests/pathfinder-summary-tool.test.js
+++ b/tests/pathfinder-summary-tool.test.js
@@ -1,105 +1,181 @@
+/* eslint-disable playwright/no-standalone-expect */
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-let mockWritableBooks;
-let mockCreatedEntries;
-let mockSummaryState;
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
-    createTreeNode: jest.fn((name, description, entries = [], children = []) => ({ name, description, entries, children })),
-    getTree: jest.fn(() => null),
-    saveTree: jest.fn(),
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => true }));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({
+    accountStorage: { getItem: () => null, setItem: jest.fn() },
+}));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
+    createWorldInfoEntry: jest.fn(), syncWIOriginalDataEntry: jest.fn(), deleteWIOriginalDataValue: jest.fn(), reloadEditor: jest.fn(),
 }));
 
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js', () => ({
-    createEntry: jest.fn(async (bookName, title, content, keys = []) => {
-        const entry = {
-            uid: mockCreatedEntries.length + 1,
-            bookName,
-            title,
-            content,
-            keys,
-        };
-        mockCreatedEntries.push(entry);
-        return { uid: entry.uid, title, bookName };
-    }),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
-    TOOL_NAMES: { SUMMARIZE: 'Pathfinder_Summarize' },
-    getWritableBooks: jest.fn(() => mockWritableBooks),
-    getActiveTunnelVisionBooks: jest.fn(() => mockWritableBooks),
-    resolveTargetBook: jest.fn((requestedBook, writableBooks) => {
-        if (requestedBook && writableBooks.includes(requestedBook)) {
-            return requestedBook;
-        }
-
-        return writableBooks[0] ?? null;
-    }),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/tool-action-registry.js', () => ({
-    registerToolAction: jest.fn(),
-    registerToolFormatter: jest.fn(),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/activity-feed.js', () => ({
-    logToolCallStarted: jest.fn(),
-    logToolCallCompleted: jest.fn(),
-    logToolCallError: jest.fn(),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js', () => ({
-    setSummaryMemoryCreated: jest.fn(payload => {
-        mockSummaryState = payload;
-    }),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/auto-summary.js', () => ({
-    markAutoSummaryComplete: jest.fn(),
-}));
-await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
-    escapeRegex: value => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
-}));
-
-const {
-    createSeparateSummaryMemoryEntry,
-    createSummaryMemoryEntry,
-    deriveSummaryLorebookTitle,
-} = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js');
+const { clearAllTrees, getTree, getAllEntryUids, replaceSettings } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const { createEntry, initEntryManagerAPIs, onPathfinderWorldInfoUpdated } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
+const { getSummaryMemoryState, setSummaryMemoryCreated } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js');
+const { LAYOUT_KEY } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-layout.js');
+const { createSeparateSummaryMemoryEntry, createSummaryMemoryEntry, deriveSummaryLorebookTitle } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js');
 
 describe('Pathfinder summary lorebook entries', () => {
+    let store;
+    let save;
+    let load;
+    let create;
+
     beforeEach(() => {
-        mockWritableBooks = ['Memory Book'];
-        mockCreatedEntries = [];
-        mockSummaryState = null;
+        clearAllTrees();
+        replaceSettings({ enabledLorebooks: ['Memory Book'], includeContextualLorebooks: false });
+        setSummaryMemoryCreated({});
+        store = { 'Memory Book': { entries: {} } };
+        save = jest.fn(async (name, data) => {
+            store[name] = structuredClone(data);
+            onPathfinderWorldInfoUpdated(name, structuredClone(data));
+            return name;
+        });
+        load = jest.fn(async name => store[name] ? structuredClone(store[name]) : null);
+        create = jest.fn((name, data) => {
+            const uid = Math.max(-1, ...Object.keys(data.entries).map(Number)) + 1;
+            return (data.entries[uid] = { uid });
+        });
+        initEntryManagerAPIs(load, create, save);
     });
 
-    test('derives a specific title when the tracked summary title is generic', () => {
+    test('derives a specific title when the tracked title is generic', () => {
         expect(deriveSummaryLorebookTitle({
             title: '[Summary] Recent scene summary',
             content: 'Significance: high\n\nMira discovered the hidden observatory beneath the old chapel. The party still needs the moon key.',
         })).toBe('Mira discovered the hidden observatory beneath the old chapel');
     });
 
-    test('creates a separate summary entry without replacing the tracked latest summary', async () => {
-        const tracked = await createSummaryMemoryEntry({
-            title: 'First tracked summary',
-            content: 'The original tracked summary remains selected.',
-            significance: 'medium',
-        });
+    test.each([
+        ['\u00c9lodie retrouve la cl\u00e9 perdue.', '\u00c9lodie retrouve la cl\u00e9 perdue'],
+        ['\u5c0f\u660e\u627e\u5230\u4e86\u5730\u56fe\u3002\u4ed6\u56de\u5bb6\u4e86\u3002', '\u5c0f\u660e\u627e\u5230\u4e86\u5730\u56fe'],
+        ['\u041c\u0438\u0440\u0430 \u043d\u0430\u0448\u043b\u0430 \u043a\u0430\u0440\u0442\u0443.', '\u041c\u0438\u0440\u0430 \u043d\u0430\u0448\u043b\u0430 \u043a\u0430\u0440\u0442\u0443'],
+    ])('derives a Unicode title from %s', (content, title) => {
+        expect(deriveSummaryLorebookTitle({ title: 'Summary', content })).toBe(title);
+    });
 
-        expect(mockSummaryState.title).toBe('[Summary] First tracked summary');
-
+    test('creates a separate entry without replacing the tracked latest summary', async () => {
+        const tracked = await createSummaryMemoryEntry({ title: 'First tracked summary', content: 'The original tracked summary remains selected.' });
+        const before = getSummaryMemoryState();
         const archived = await createSeparateSummaryMemoryEntry({
             title: '[Summary] Recent scene summary',
             content: 'Rin promised to return the stolen map before dawn. The guard captain suspects her.',
             significance: 'high',
         });
-
         expect(archived.uid).not.toBe(tracked.uid);
-        expect(mockCreatedEntries).toHaveLength(2);
-        expect(mockCreatedEntries[1].title).toBe('[Summary] Rin promised to return the stolen map before dawn');
-        expect(mockCreatedEntries[1].content).toContain('Significance: high');
-        expect(mockSummaryState.title).toBe('[Summary] First tracked summary');
+        expect(Object.keys(store['Memory Book'].entries)).toHaveLength(2);
+        expect(store['Memory Book'].entries[archived.uid].comment).toBe('[Summary] Rin promised to return the stolen map before dawn');
+        expect(getSummaryMemoryState()).toEqual(before);
+    });
+
+    test('reuses an arc for concurrent summaries and counts each entry once after invalidation', async () => {
+        const summaries = await Promise.all([
+            createSummaryMemoryEntry({ title: 'One', content: 'one', arc: 'Return' }),
+            createSummaryMemoryEntry({ title: 'Two', content: 'two', arc: 'return' }),
+        ]);
+        const data = store['Memory Book'];
+        const persisted = data.extensions[LAYOUT_KEY];
+        expect(save).toHaveBeenCalledTimes(2);
+        expect(persisted.tree.children[0].children).toHaveLength(1);
+        expect(JSON.stringify(persisted)).not.toContain('"entries"');
+        clearAllTrees();
+        const tree = await buildTreeFromMetadata('Memory Book', structuredClone(data));
+        const summaryNode = tree.children.find(node => node.name === 'Summaries');
+        expect(summaryNode.entries).toEqual([]);
+        expect(summaryNode.children[0].entries).toEqual(summaries.map(summary => summary.uid));
+        expect(getAllEntryUids(tree)).toHaveLength(2);
+        expect(getSummaryMemoryState().uid).toBe(summaries[1].uid);
+    });
+
+    test('rejects an explicit bad target rather than silently choosing the first book', async () => {
+        await expect(createSummaryMemoryEntry({ title: 'Summary', content: 'content', book: 'Wrong Book' })).rejects.toThrow('"Wrong Book" is not available');
+        expect(save).not.toHaveBeenCalled();
+        expect(getSummaryMemoryState().uid).toBeNull();
+    });
+
+    test.each(['queued', 'loading', 'creating'].flatMap(phase => ['signal', 'context'].map(reason => [phase, reason])))('cancels a summary while %s via %s without saving or publishing it', async (phase, reason) => {
+        const controller = new AbortController();
+        let current = true;
+        let release;
+        let started;
+        const waiting = new Promise(resolve => { started = resolve; });
+        const gate = new Promise(resolve => { release = resolve; });
+        const api = phase === 'queued' ? save : phase === 'loading' ? load : create;
+        const implementation = api.getMockImplementation();
+        api.mockImplementationOnce(async (...args) => {
+            started();
+            await gate;
+            return implementation(...args);
+        });
+        const blocker = phase === 'queued' ? createEntry('Memory Book', 'Earlier write', 'keep') : null;
+        if (blocker) await waiting;
+        const pending = createSummaryMemoryEntry({ title: 'Cancelled', content: 'discard', arc: 'Unsaved' }, {
+            signal: controller.signal, isCurrent: () => current,
+        });
+        const rejected = pending.catch(error => error);
+        await waiting;
+        // Both contracts are independent: Stop uses the signal, chat switching can invalidate the predicate.
+        if (reason === 'context') current = false;
+        else controller.abort();
+        release();
+        await blocker;
+        await expect(rejected).resolves.toMatchObject({ name: 'AbortError' });
+        expect(save).toHaveBeenCalledTimes(blocker ? 1 : 0);
+        expect(Object.values(store['Memory Book'].entries).map(entry => entry.comment)).toEqual(blocker ? ['Earlier write'] : []);
+        expect(getSummaryMemoryState().uid).toBeNull();
+        expect(JSON.stringify(store)).not.toContain('Unsaved');
+        await expect(createSummaryMemoryEntry({ title: 'Next', content: 'works' })).resolves.toMatchObject({ title: 'Next' });
+    });
+
+    test('keeps a successful summary and its tracked state when cancellation arrives after save was sent', async () => {
+        const controller = new AbortController();
+        let release;
+        let started;
+        const waiting = new Promise(resolve => { started = resolve; });
+        const gate = new Promise(resolve => { release = resolve; });
+        const commit = save.getMockImplementation();
+        save.mockImplementationOnce(async (...args) => {
+            started();
+            await gate;
+            return commit(...args);
+        });
+        const pending = createSummaryMemoryEntry({ title: 'Committed', content: 'keep' }, {
+            signal: controller.signal, isCurrent: () => !controller.signal.aborted,
+        });
+        await waiting;
+        controller.abort();
+        release();
+        const result = await pending;
+        expect(store['Memory Book'].entries[result.uid].comment).toBe('[Summary] Committed');
+        expect(getSummaryMemoryState()).toMatchObject({ uid: result.uid, content: 'keep', bookName: 'Memory Book' });
+        expect(getAllEntryUids(getTree('Memory Book'))).toEqual([result.uid]);
+        expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    test.each(['offline', 'discarded'])('does not publish an entry, arc or latest state after a %s save', async failure => {
+        await createSummaryMemoryEntry({ title: 'Old', content: 'old' });
+        const previousState = getSummaryMemoryState();
+        const previousStore = structuredClone(store);
+        const previousTree = structuredClone(getTree('Memory Book'));
+        if (failure === 'offline') save.mockRejectedValueOnce(new Error('offline'));
+        else save.mockResolvedValueOnce(null);
+        await expect(createSummaryMemoryEntry({ title: 'New', content: 'new', arc: 'Unsaved' })).rejects.toThrow();
+        expect(store).toEqual(previousStore);
+        expect(getTree('Memory Book')).toEqual(previousTree);
+        expect(getSummaryMemoryState()).toEqual(previousState);
+    });
+
+    test('tracks the committed book name returned by the host', async () => {
+        save.mockImplementationOnce(async (name, data) => {
+            store['Renamed Book'] = structuredClone(data);
+            delete store[name];
+            return 'Renamed Book';
+        });
+        const summary = await createSummaryMemoryEntry({ title: 'Renamed', content: 'saved', arc: 'Return' });
+        expect(summary.targetBook).toBe('Renamed Book');
+        expect(getSummaryMemoryState().bookName).toBe('Renamed Book');
+        expect(getAllEntryUids(getTree('Renamed Book'))).toEqual([summary.uid]);
     });
 });

--- a/tests/pathfinder-tool-batch.test.js
+++ b/tests/pathfinder-tool-batch.test.js
@@ -1,0 +1,54 @@
+/* eslint-disable playwright/no-standalone-expect */
+import { describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../public/scripts/tool-calling.js', import.meta.url), 'utf8');
+
+function tools() {
+    const context = vm.createContext({ console, Error, toastr: { info: jest.fn(), clear: jest.fn() }, stringify: value => JSON.stringify(value) });
+    vm.runInContext(source.slice(source.indexOf('class ToolDefinition {')).replace('export class ToolManager', 'class ToolManager') + '\nthis.ToolManager = ToolManager;', context);
+    return context;
+}
+
+const response = ['Pathfinder_Search', 'Pathfinder_Remember'].map((name, index) => ({ id: String(index), function: { name, arguments: '{}' } }));
+
+describe('tool response origin', () => {
+    test.each(['chat response', 'stream response'])('preserves active multi-tool batches for a %s', async format => {
+        const context = tools();
+        const action = jest.fn(async () => 'ok');
+        for (const name of ['Pathfinder_Search', 'Pathfinder_Remember']) context.ToolManager.registerFunctionTool({ name, action });
+        const data = { 'chat response': { choices: [{ index: 0, message: { tool_calls: response } }] }, 'stream response': [response] }[format];
+        const result = await context.ToolManager.invokeFunctionTools(data);
+        expect(action).toHaveBeenCalledTimes(2);
+        expect(result.invocations).toHaveLength(2);
+    });
+
+    test.each(['chat', 'signal'])('does not start a second tool after the first tool changes %s', async mode => {
+        const context = tools();
+        const controller = new AbortController();
+        let chatId = 'original';
+        const original = chatId;
+        const search = jest.fn(async () => {
+            await Promise.resolve();
+            ({ chat: () => { chatId = 'different'; }, signal: () => controller.abort() })[mode]();
+            return 'found';
+        });
+        context.ToolManager.registerFunctionTool({ name: 'Pathfinder_Search', action: search });
+        const remember = jest.fn();
+        context.ToolManager.registerFunctionTool({ name: 'Pathfinder_Remember', action: remember });
+        await context.ToolManager.invokeFunctionTools({ choices: [{ index: 0, message: { tool_calls: response } }] }, { isCurrent: () => chatId === original, signal: controller.signal });
+        expect(search).toHaveBeenCalledTimes(1);
+        expect(remember).not.toHaveBeenCalled();
+    });
+
+    test('rechecks origin after an asynchronous formatter, before executing or showing a toast', async () => {
+        const context = tools();
+        let current = true;
+        const action = jest.fn();
+        context.ToolManager.registerFunctionTool({ name: 'Pathfinder_Search', action, formatMessage: async () => { current = false; return 'Search'; } });
+        await context.ToolManager.invokeFunctionTools({ choices: [{ index: 0, message: { tool_calls: response.slice(0, 1) } }] }, { isCurrent: () => current });
+        expect(action).not.toHaveBeenCalled();
+        expect(context.toastr.info).not.toHaveBeenCalled();
+    });
+});

--- a/tests/pathfinder-tool-bridge.test.js
+++ b/tests/pathfinder-tool-bridge.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/no-duplicate-hooks */
+/* eslint-disable playwright/no-duplicate-hooks, playwright/no-standalone-expect */
 /* global globalThis */
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 
@@ -8,26 +8,27 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agen
     isPathfinderSubmoduleEnabled: jest.fn(() => true),
 }));
 
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
-    getSettings: jest.fn(() => mockSettings),
-    getTree: jest.fn(() => null),
-    isLorebookEnabled: jest.fn(bookName => mockSettings.enabledLorebooks.includes(bookName)),
-    canReadBook: jest.fn(() => true),
-    canWriteBook: jest.fn(() => true),
-    canDeleteBook: jest.fn(() => true),
-}));
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: () => null }));
+
+const { getSettings, replaceSettings, setBookPermission, getBookPermission, isLorebookEnabled, canReadBook, canWriteBook, canDeleteBook } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
 
 const {
     getActiveTunnelVisionBooks,
     getContextualLorebookDetails,
+    getAllEntriesWithContent,
+    getEntryContent,
+    getReadableBooks,
+    getWritableBooks,
+    getDeletableBooks,
 } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js');
 
 describe('Pathfinder lorebook source selection', () => {
     beforeEach(() => {
-        mockSettings = {
+        replaceSettings({
             enabledLorebooks: ['Manual Book'],
             includeContextualLorebooks: true,
-        };
+        });
+        mockSettings = getSettings();
         globalThis.window = {
             SillyTavern: {
                 getContext: () => ({
@@ -65,6 +66,56 @@ describe('Pathfinder lorebook source selection', () => {
         expect(getActiveTunnelVisionBooks()).toEqual(['Manual Book']);
     });
 
+    test('reads a settings copy without changing live selections or independent permissions', () => {
+        const live = structuredClone(mockSettings);
+        const copy = {
+            enabledLorebooks: ['Draft Book', 'Manual Book'],
+            includeContextualLorebooks: false,
+            autoUseAttachedLorebook: true,
+            bookPermissions: {
+                'Manual Book': { enabled: false, read: true, write: true, delete: true },
+                'Chat Book': { enabled: false },
+                'Draft Book': { read: 'none', write: true, delete: 0 },
+                'Persona Book': { read: true, write: 'off', delete: 'readwrite' },
+            },
+        };
+        const before = structuredClone(copy);
+        expect(getActiveTunnelVisionBooks(copy)).toEqual(['Draft Book', 'Persona Book', 'Primary Book', 'Extra Book']);
+        expect(getReadableBooks(copy)).toEqual(['Persona Book', 'Primary Book', 'Extra Book']);
+        expect(getWritableBooks(copy)).toEqual(['Draft Book', 'Primary Book', 'Extra Book']);
+        expect(getDeletableBooks(copy)).toEqual(['Persona Book', 'Primary Book', 'Extra Book']);
+        expect(isLorebookEnabled('Manual Book', copy)).toBe(false);
+        expect(getBookPermission('Manual Book', 'write', copy)).toBe(true);
+        for (const check of [canReadBook, canWriteBook, canDeleteBook]) {
+            expect(check('Manual Book', copy)).toBe(false);
+            expect(check('Manual Book')).toBe(true);
+        }
+        expect(getSettings()).toEqual(live);
+        expect(copy).toEqual(before);
+    });
+
+    test('explicit exclusions block contextual inclusion and direct content reads', async () => {
+        setBookPermission('Chat Book', 'enabled', false);
+        const load = jest.fn();
+        const context = globalThis.window.SillyTavern.getContext();
+        globalThis.window.SillyTavern.getContext = () => ({ ...context, loadWorldInfo: load });
+        expect(getActiveTunnelVisionBooks()).not.toContain('Chat Book');
+        expect(await getEntryContent('Chat Book', 0)).toBeNull();
+        expect(await getAllEntriesWithContent('Chat Book')).toEqual([]);
+        expect(load).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        [undefined, true], [null, true], ['readwrite', true], [true, true], [1, true],
+        [false, false], [0, false], ['none', false], [' FALSE ', false], ['off', false],
+        ['deny', false], ['denied', false], ['no', false], ['0', false], ['disabled', false],
+    ])('preserves legacy permission value %p as %p', (value, allowed) => {
+        const copy = { bookPermissions: { Book: { read: value, write: value, delete: value } } };
+        expect(canReadBook('Book', copy)).toBe(allowed);
+        expect(canWriteBook('Book', copy)).toBe(allowed);
+        expect(canDeleteBook('Book', copy)).toBe(allowed);
+    });
+
     test('includes group member lorebooks, chat metadata aliases, and embedded card book names', () => {
         globalThis.window.SillyTavern.getContext = () => ({
             chat_metadata: { world_info: 'Group Chat Book' },
@@ -97,5 +148,28 @@ describe('Pathfinder lorebook source selection', () => {
             expect.objectContaining({ name: 'Hero Primary', types: ['group'] }),
             expect.objectContaining({ name: 'Mage Card Book', types: ['group'] }),
         ]));
+    });
+
+    test('single and bulk reads both recheck disabled and agent-blacklisted entries', async () => {
+        const load = jest.fn(async () => ({ entries: {
+            0: { uid: 0, comment: 'Visible', content: 'allowed' },
+            1: { uid: 1, comment: 'Disabled secret', content: 'hidden', disable: true },
+            2: { uid: 2, comment: 'Blacklisted secret', content: 'private', agentBlacklisted: true },
+        } }));
+        globalThis.window.SillyTavern.getContext = () => ({ loadWorldInfo: load });
+        const warning = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            expect((await getAllEntriesWithContent('Manual Book')).map(entry => entry.uid)).toEqual([0]);
+            expect(await getEntryContent('Manual Book', 0)).toMatchObject({ content: 'allowed' });
+            expect(await getEntryContent('Manual Book', 1)).toBeNull();
+            expect(await getEntryContent('Manual Book', 2)).toBeNull();
+            setBookPermission('Manual Book', 'read', false);
+            load.mockClear();
+            expect(await getAllEntriesWithContent('Manual Book')).toEqual([]);
+            expect(await getEntryContent('Manual Book', 0)).toBeNull();
+            expect(load).not.toHaveBeenCalled();
+        } finally {
+            warning.mockRestore();
+        }
     });
 });

--- a/tests/pathfinder-tool-confirmation.test.js
+++ b/tests/pathfinder-tool-confirmation.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks, playwright/no-standalone-expect */
 /* global globalThis */
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 
@@ -14,6 +15,8 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agen
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
     getSettings: jest.fn(() => mockSettings),
     getTree: jest.fn(() => null),
+    getAllEntryUids: jest.fn(() => []),
+    isEntryEligible: jest.fn(entry => entry && !entry.disable && !entry.agentBlacklisted),
     isLorebookEnabled: jest.fn(() => true),
     canReadBook: jest.fn(() => true),
     canWriteBook: jest.fn(() => true),
@@ -28,19 +31,23 @@ const {
 } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tool-confirmation.js');
 
 function installPopup(result) {
+    const show = jest.fn(async () => result);
+    const completeCancelled = jest.fn();
     globalThis.window = {
         SillyTavern: {
             getContext: () => ({
                 Popup: class {
                     async show() {
-                        return result;
+                        return show();
                     }
+                    completeCancelled = completeCancelled;
                 },
                 POPUP_TYPE: { CONFIRM: 2 },
                 POPUP_RESULT: { AFFIRMATIVE: 1, NEGATIVE: 0 },
             }),
         },
     };
+    return { show, completeCancelled };
 }
 
 describe('Pathfinder tool confirmation', () => {
@@ -84,6 +91,33 @@ describe('Pathfinder tool confirmation', () => {
 
         expect(preview).toBe('uid: 3\nbook: Memory Book');
         expect(formatToolArgsPreview({ content: 'x'.repeat(500) })).toHaveLength('content: '.length + 300 + 1);
+    });
+
+    test('uses live agent confirmation settings even while runtime registration is deferred', () => {
+        expect(shouldConfirmToolCall('Pathfinder_Forget', { confirmTools: { Pathfinder_Forget: true } })).toBe(true);
+        expect(shouldConfirmToolCall('Pathfinder_Forget')).toBe(false);
+    });
+
+    test('does not open an already-cancelled approval', async () => {
+        const popup = installPopup(1);
+        const controller = new AbortController();
+        controller.abort();
+        await expect(confirmToolCall('Pathfinder Forget', { uid: 3 }, controller.signal)).resolves.toBe(false);
+        expect(popup.show).not.toHaveBeenCalled();
+    });
+
+    test('cancels without waiting for the dialog and ignores a later affirmative result', async () => {
+        let approve;
+        const popup = installPopup(new Promise(resolve => { approve = resolve; }));
+        const controller = new AbortController();
+        const removeListener = jest.spyOn(controller.signal, 'removeEventListener');
+        const pending = confirmToolCall('Pathfinder Forget', { uid: 3 }, controller.signal);
+        controller.abort();
+        await expect(pending).resolves.toBe(false);
+        expect(popup.completeCancelled).toHaveBeenCalledTimes(1);
+        expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+        approve(1);
+        await expect(pending).resolves.toBe(false);
     });
 });
 

--- a/tests/pathfinder-write-tools.test.js
+++ b/tests/pathfinder-write-tools.test.js
@@ -15,13 +15,14 @@ const { clearAllTrees, getTree, getSettings, replaceSettings, setBookPermission 
 const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
 const { initEntryManagerAPIs } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
 const { getToolAction } = await import('../public/scripts/extensions/in-chat-agents/tool-action-registry.js');
-for (const tool of ['remember', 'update', 'forget', 'merge-split', 'reorganize']) {
+for (const tool of ['remember', 'update', 'forget', 'merge-split', 'reorganize', 'summarize']) {
     (await import(`../public/scripts/extensions/in-chat-agents/pathfinder/tools/${tool}.js`)).registerActions();
 }
 
 describe('Pathfinder write tool actions', () => {
     let store;
     let save;
+    let load;
 
     beforeEach(async () => {
         clearAllTrees();
@@ -33,7 +34,7 @@ describe('Pathfinder write tool actions', () => {
             } },
             'Second Book': { entries: { 3: { uid: 3, comment: 'Unrelated', content: 'untouched' } } },
         };
-        const load = jest.fn(async name => store[name] ? structuredClone(store[name]) : null);
+        load = jest.fn(async name => store[name] ? structuredClone(store[name]) : null);
         save = jest.fn(async (name, data) => {
             store[name] = structuredClone(data);
             return name;
@@ -47,6 +48,42 @@ describe('Pathfinder write tool actions', () => {
     });
 
     afterEach(() => { delete globalThis.window; });
+
+    test.each([
+        ['remember', { title: 'New', content: 'new' }],
+        ['update', { uid: 3, content: 'changed' }],
+        ['forget', { uid: 3 }],
+        ['forget', { uid: 3, hard_delete: true }],
+        ['merge_split', { action: 'merge', uid1: 0, uid2: 3 }],
+        ['merge_split', { action: 'split', uid: 3, content1: 'one', content2: 'two' }],
+        ['reorganize', { action: 'create_waypoint', name: 'New' }],
+        ['reorganize', { action: 'move', uid: 3 }],
+        ['summarize', { title: 'Summary', content: 'new summary' }],
+    ])('cancels a pending %s before saving after Stop or a permission change (%j)', async (tool, args) => {
+        getSettings().dedupDetection = false;
+        const before = structuredClone(store);
+        for (const reason of ['stop', 'context', 'permission']) {
+            let release;
+            let started;
+            const loading = new Promise(resolve => { started = resolve; });
+            load.mockImplementationOnce(() => new Promise(resolve => { release = resolve; started(); }));
+            const controller = new AbortController();
+            let current = true;
+            const pending = getToolAction(`pathfinder_${tool}`)({
+                ...args, book: 'Memory Book', target_node_id: getTree('Memory Book').id,
+            }, { signal: controller.signal, isCurrent: () => current });
+            await loading;
+            const permission = args.hard_delete || args.action === 'merge' ? 'delete' : 'write';
+            if (reason === 'stop') controller.abort();
+            if (reason === 'context') current = false;
+            if (reason === 'permission') setBookPermission('Memory Book', permission, false);
+            release(structuredClone(store['Memory Book']));
+            await pending;
+            expect(store).toEqual(before);
+            expect(save).not.toHaveBeenCalled();
+            setBookPermission('Memory Book', permission, true);
+        }
+    });
 
     test.each([undefined, null, false, true, '', '  ', [], [0], {}, { uid: 0 }, 0.5, '3.5', -1, NaN, Infinity])('rejects raw UID %p before it can address a real entry', async uid => {
         const before = structuredClone(store);

--- a/tests/pathfinder-write-tools.test.js
+++ b/tests/pathfinder-write-tools.test.js
@@ -1,134 +1,154 @@
+/* eslint-disable playwright/no-standalone-expect, playwright/no-duplicate-hooks */
 /* global globalThis */
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-let mockSettings;
-let mockBookData;
-const createEntryMock = jest.fn(async (bookName, title) => ({ uid: 7, title, bookName }));
-const updateEntryMock = jest.fn(async (bookName, uid) => ({ uid, bookName }));
-const forgetEntryMock = jest.fn(async (bookName, uid, hardDelete) => ({ uid, bookName, deleted: hardDelete, disabled: !hardDelete }));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
-    isPathfinderSubmoduleEnabled: jest.fn(() => true),
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({ getContext: jest.fn(() => null) }));
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({ isPathfinderSubmoduleEnabled: () => true }));
+await jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({
+    accountStorage: { getItem: () => null, setItem: jest.fn() },
+}));
+await jest.unstable_mockModule('../public/scripts/world-info.js', () => ({
+    createWorldInfoEntry: jest.fn(), syncWIOriginalDataEntry: jest.fn(), deleteWIOriginalDataValue: jest.fn(), reloadEditor: jest.fn(),
 }));
 
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
-    getSettings: jest.fn(() => mockSettings),
-    getTree: jest.fn(() => null),
-    isLorebookEnabled: jest.fn(bookName => mockSettings.enabledLorebooks.includes(bookName)),
-    canReadBook: jest.fn(() => true),
-    canWriteBook: jest.fn(() => true),
-    canDeleteBook: jest.fn(() => true),
-}));
-
-await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js', () => ({
-    createEntry: createEntryMock,
-    updateEntry: updateEntryMock,
-    forgetEntry: forgetEntryMock,
-}));
-
-const { registerActions: registerRememberActions } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js');
-const { registerActions: registerUpdateActions } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js');
-const { registerActions: registerForgetActions } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js');
+const { clearAllTrees, getTree, getSettings, replaceSettings, setBookPermission } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const { buildTreeFromMetadata } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-builder.js');
+const { initEntryManagerAPIs } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js');
 const { getToolAction } = await import('../public/scripts/extensions/in-chat-agents/tool-action-registry.js');
-
-registerRememberActions();
-registerUpdateActions();
-registerForgetActions();
+for (const tool of ['remember', 'update', 'forget', 'merge-split', 'reorganize']) {
+    (await import(`../public/scripts/extensions/in-chat-agents/pathfinder/tools/${tool}.js`)).registerActions();
+}
 
 describe('Pathfinder write tool actions', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        mockSettings = {
-            enabledLorebooks: ['Memory Book', 'Second Book'],
-            includeContextualLorebooks: false,
-            dedupDetection: false,
-            dedupThreshold: 0.85,
+    let store;
+    let save;
+
+    beforeEach(async () => {
+        clearAllTrees();
+        replaceSettings({ enabledLorebooks: ['Memory Book', 'Second Book'], includeContextualLorebooks: false });
+        store = {
+            'Memory Book': { entries: {
+                0: { uid: 0, comment: 'Zero', content: 'zero' },
+                3: { uid: 3, comment: 'Existing', content: 'existing' },
+            } },
+            'Second Book': { entries: { 3: { uid: 3, comment: 'Unrelated', content: 'untouched' } } },
         };
-        mockBookData = { entries: {} };
-        globalThis.window = {
-            SillyTavern: {
-                getContext: () => ({
-                    loadWorldInfo: async () => mockBookData,
-                }),
-            },
-        };
+        const load = jest.fn(async name => store[name] ? structuredClone(store[name]) : null);
+        save = jest.fn(async (name, data) => {
+            store[name] = structuredClone(data);
+            return name;
+        });
+        initEntryManagerAPIs(load, (name, data) => {
+            const uid = Math.max(-1, ...Object.keys(data.entries).map(Number)) + 1;
+            return (data.entries[uid] = { uid });
+        }, save);
+        globalThis.window = { SillyTavern: { getContext: () => ({ loadWorldInfo: load }) } };
+        await buildTreeFromMetadata('Memory Book', store['Memory Book']);
     });
 
-    afterEach(() => {
-        delete globalThis.window;
+    afterEach(() => { delete globalThis.window; });
+
+    test.each([undefined, null, false, true, '', '  ', [], [0], {}, { uid: 0 }, 0.5, '3.5', -1, NaN, Infinity])('rejects raw UID %p before it can address a real entry', async uid => {
+        const before = structuredClone(store);
+        const calls = [
+            ['pathfinder_update', { uid, content: 'new' }],
+            ['pathfinder_forget', { uid, hard_delete: true }],
+            ['pathfinder_merge_split', { action: 'merge', uid1: uid, uid2: 3 }],
+            ['pathfinder_merge_split', { action: 'merge', uid1: 0, uid2: uid }],
+            ['pathfinder_merge_split', { action: 'split', uid, content1: 'one', content2: 'two' }],
+            ['pathfinder_reorganize', { action: 'move', uid, target_node_id: getTree('Memory Book').id }],
+        ];
+        for (const [action, args] of calls) {
+            expect(await getToolAction(action)(args)).toContain('uid');
+        }
+        expect(save).not.toHaveBeenCalled();
+        expect(store).toEqual(before);
     });
 
-    test('forget treats a stringified "false" hard_delete as a soft disable', async () => {
-        const result = await getToolAction('pathfinder_forget')({ uid: 3, hard_delete: 'false' });
+    test.each([0, '0', ' 3 '])('continues accepting numeric zero and numeric strings: %p', async uid => {
+        const result = await getToolAction('pathfinder_update')({ uid, content: 'changed' });
+        expect(result).toContain('Updated');
+        expect(store['Memory Book'].entries[Number(uid)].content).toBe('changed');
+        expect(store['Second Book'].entries[3].content).toBe('untouched');
+    });
 
-        expect(forgetEntryMock).toHaveBeenCalledWith('Memory Book', 3, false);
+    test.each([false, 'false', '0', 'no'])('uses explicit false deletion flag %p for a soft disable', async hardDelete => {
+        const result = await getToolAction('pathfinder_forget')({ uid: 3, hard_delete: hardDelete });
         expect(result).toContain('Disabled');
+        expect(store['Memory Book'].entries[3].disable).toBe(true);
     });
 
-    test('forget honors a real hard delete request', async () => {
-        await getToolAction('pathfinder_forget')({ uid: 3, hard_delete: true });
-
-        expect(forgetEntryMock).toHaveBeenCalledWith('Memory Book', 3, true);
+    test.each([true, 'true', '1', 'yes'])('uses explicit true deletion flag %p for permanent deletion', async hardDelete => {
+        const result = await getToolAction('pathfinder_forget')({ uid: 3, hard_delete: hardDelete });
+        expect(result).toContain('Deleted');
+        expect(store['Memory Book'].entries[3]).toBeUndefined();
     });
 
-    test('update refuses an explicitly named book that is not available instead of retargeting', async () => {
-        const result = await getToolAction('pathfinder_update')({ uid: 3, content: 'new', book: 'Wrong Book' });
-
-        expect(result).toContain('"Wrong Book" is not available');
-        expect(result).toContain('Memory Book');
-        expect(updateEntryMock).not.toHaveBeenCalled();
+    test.each([null, 0, 1, [], {}, 'maybe', ''])('rejects invalid deletion flag %p without even disabling', async hardDelete => {
+        expect(await getToolAction('pathfinder_forget')({ uid: 3, hard_delete: hardDelete })).toBe('Permanent deletion request refused; the tool supplied an invalid permanent deletion choice.');
+        expect(save).not.toHaveBeenCalled();
+        expect(store['Memory Book'].entries[3].disable).toBeUndefined();
     });
 
-    test('update still defaults to the first writable book when no book is named', async () => {
-        await getToolAction('pathfinder_update')({ uid: 3, content: 'new' });
-
-        expect(updateEntryMock).toHaveBeenCalledWith('Memory Book', 3, 'new', undefined);
+    test('refuses explicit unavailable books instead of retargeting any write', async () => {
+        for (const [action, args] of [
+            ['pathfinder_update', { uid: 3, content: 'new' }],
+            ['pathfinder_forget', { uid: 3 }],
+            ['pathfinder_remember', { title: 'New', content: 'new' }],
+            ['pathfinder_merge_split', { action: 'merge', uid1: 0, uid2: 3 }],
+            ['pathfinder_reorganize', { action: 'create_waypoint', name: 'New' }],
+        ]) {
+            expect(await getToolAction(action)({ ...args, book: 'Wrong Book' })).toContain('"Wrong Book" is not available');
+        }
+        expect(save).not.toHaveBeenCalled();
     });
 
-    test('remember refuses an explicitly named book that is not available instead of retargeting', async () => {
-        const result = await getToolAction('pathfinder_remember')({
-            title: 'Dragon',
-            content: 'The dragon guards the northern pass every night.',
-            book: 'Wrong Book',
-        });
-
-        expect(result).toContain('"Wrong Book" is not available');
-        expect(result).toContain('Memory Book');
-        expect(createEntryMock).not.toHaveBeenCalled();
+    test.each(['write', 'delete'])('merge requires %s permission as well as the other permission', async permission => {
+        setBookPermission('Memory Book', permission, false);
+        const result = await getToolAction('pathfinder_merge_split')({ action: 'merge', uid1: 0, uid2: 3, book: 'Memory Book' });
+        expect(result).toContain('is not available');
+        expect(save).not.toHaveBeenCalled();
     });
 
-    test('remember reports a skipped save when dedup finds a similar entry', async () => {
-        mockSettings.dedupDetection = true;
-        mockBookData = {
-            entries: {
-                '4': { uid: 4, comment: 'Existing note', content: 'The dragon guards the northern pass every night.' },
-            },
-        };
+    test('split requires write permission, not delete permission', async () => {
+        setBookPermission('Memory Book', 'delete', false);
+        const result = await getToolAction('pathfinder_merge_split')({ action: 'split', uid: '0', content1: 'one', content2: 'two', book: 'Memory Book' });
+        expect(result).toContain('Split UID:0');
+        expect(Object.values(store['Memory Book'].entries).map(entry => entry.content)).toEqual(expect.arrayContaining(['one', 'two']));
+    });
 
-        const result = await getToolAction('pathfinder_remember')({
-            title: 'Dragon',
-            content: 'The dragon guards the northern pass every night.',
-        });
+    test.each(['disable', 'agentBlacklisted'])('rejects a move of an excluded entry: %s', async flag => {
+        store['Memory Book'].entries[3][flag] = true;
+        const result = await getToolAction('pathfinder_reorganize')({ action: 'move', uid: 3, target_node_id: getTree('Memory Book').id });
+        expect(result).toContain('not found');
+        expect(save).not.toHaveBeenCalled();
+    });
 
+    test('rejects an array masquerading as a destination ID', async () => {
+        const result = await getToolAction('pathfinder_reorganize')({ action: 'move', uid: 0, target_node_id: [getTree('Memory Book').id] });
+        expect(result).toContain('"target_node_id" required');
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    test('reports an eligible duplicate without saving', async () => {
+        getSettings().dedupDetection = true;
+        store['Memory Book'].entries[3].content = 'The dragon guards the northern pass every night.';
+        const result = await getToolAction('pathfinder_remember')({ title: 'Dragon', content: store['Memory Book'].entries[3].content });
         expect(result).toContain('Not saved');
-        expect(result).toContain('UID: 4');
-        expect(createEntryMock).not.toHaveBeenCalled();
+        expect(result).toContain('UID: 3');
+        expect(save).not.toHaveBeenCalled();
     });
 
-    test('remember saves normally when no similar entry exists', async () => {
-        mockSettings.dedupDetection = true;
-        mockBookData = {
-            entries: {
-                '4': { uid: 4, comment: 'Existing note', content: 'Completely unrelated topic.' },
-            },
-        };
-
-        const result = await getToolAction('pathfinder_remember')({
-            title: 'Dragon',
-            content: 'The dragon guards the northern pass every night.',
-        });
-
-        expect(createEntryMock).toHaveBeenCalledWith('Memory Book', 'Dragon', 'The dragon guards the northern pass every night.');
+    test.each(['disable', 'agentBlacklisted', 'readDenied'])('duplicate checking never exposes excluded contents: %s', async flag => {
+        getSettings().dedupDetection = true;
+        store['Memory Book'].entries[3].comment = 'Secret title';
+        store['Memory Book'].entries[3].content = 'The dragon guards the northern pass every night.';
+        if (flag === 'readDenied') setBookPermission('Memory Book', 'read', false);
+        else store['Memory Book'].entries[3][flag] = true;
+        const result = await getToolAction('pathfinder_remember')({ title: 'Dragon', content: store['Memory Book'].entries[3].content });
         expect(result).toContain('Remembered');
+        expect(result).not.toContain('Secret title');
+        expect(result).not.toContain('UID: 3');
+        expect(save).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, test } from '@jest/globals';
 import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
 
-import { escapeCharacterBookRegex, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
+import { escapeCharacterBookRegex, getFreeCharacterBookEntryId, normalizeCharacterBookPosition, normalizeWorldInfoPosition, serializeCharacterBookKeys, serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
 
 const positions = {
     before: 0,
@@ -300,7 +301,7 @@ describe('serializeWorldInfoEntry', () => {
         };
 
         expect(serializeWorldInfoEntry(entry, positions, originalEntry)).toMatchObject({
-            id: 9,
+            id: 2,
             comment: 'Current comment',
             character_filter: entry.characterFilter,
             foreign_top_level: 'kept',
@@ -316,6 +317,13 @@ describe('serializeWorldInfoEntry', () => {
             character_filter: { isExclude: true, names: ['stale.png'], tags: [] },
         });
         expect(record).not.toHaveProperty('character_filter');
+    });
+
+    test('preserves original ID zero and allocates a separate ID for new card records', () => {
+        expect(serializeWorldInfoEntry({ uid: 1 }, positions, { id: 0 }).id).toBe(0);
+        expect(getFreeCharacterBookEntryId([{ id: 74 }, { id: 0 }])).toBe(1);
+        expect(getFreeCharacterBookEntryId([{ id: '0' }, { id: 1 }, { id: 74 }])).toBe(2);
+        expect(getFreeCharacterBookEntryId([])).toBe(0);
     });
 
     test('applies server-parity defaults for absent fields', () => {
@@ -353,8 +361,100 @@ describe('serializeWorldInfoEntry', () => {
 });
 
 describe('convertCharacterBook', () => {
+    const worldInfoSource = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+    const charactersSource = readFileSync(new URL('../src/endpoints/characters.js', import.meta.url), 'utf8');
+    const functions = [
+        'convertCharacterBook', 'getFreeWorldEntryUid', 'parseRegexFromString', 'convertWorldInfoToCharacterBook',
+        'getWIOriginalDataIndex', 'syncWIOriginalDataEntry', 'appendWIOriginalDataEntry', 'createWorldInfoEntry', 'duplicateWorldInfoEntry',
+    ];
+    const context = vm.createContext({
+        structuredClone, escapeCharacterBookRegex, normalizeCharacterBookPosition, serializeWorldInfoEntry, getFreeCharacterBookEntryId,
+        worldInfoDataSnapshots: new WeakMap(), worldInfoCache: new Map(),
+        newWorldInfoEntryTemplate: {}, world_info_position: positions,
+        world_info_logic: { AND_ANY: 0 }, extension_prompt_roles: { SYSTEM: 0 }, DEFAULT_DEPTH: 4, DEFAULT_WEIGHT: 100,
+    });
+    for (const name of functions) {
+        const source = name === 'convertWorldInfoToCharacterBook' ? charactersSource : worldInfoSource;
+        const match = source.match(new RegExp(`^(?:export )?(function ${name}\\([\\s\\S]*?^})`, 'm'));
+        if (!match) throw new Error(`Missing function ${name}`);
+        vm.runInContext(match[1], context);
+    }
+
     test('maps CharacterBook filters to native entries', () => {
-        const source = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
-        expect(source).toMatch(/characterFilter:\s*entry\.character_filter,/);
+        const characterFilter = { isExclude: true, names: ['Alice'], tags: ['tag'] };
+        const result = context.convertCharacterBook({ entries: [{ id: 74, content: 'Entry', character_filter: characterFilter }] });
+        expect(result.entries[0].characterFilter).toEqual(characterFilter);
+    });
+
+    test('real import, resync, create, duplicate and cross-book append keep distinct original card IDs', () => {
+        const native = context.convertCharacterBook({ entries: [
+            { id: 74, content: 'First', foreign: 'kept', extensions: { foreign: { retained: true } } },
+            { id: 0, content: 'Second', extensions: {} },
+        ] });
+        native.entries[0].content = 'Edited';
+        context.syncWIOriginalDataEntry(native, 0);
+        context.syncWIOriginalDataEntry(native, 1);
+        expect(native.originalData.entries.map(entry => entry.id)).toEqual([74, 0]);
+        expect(native.originalData.entries[0]).toMatchObject({ content: 'Edited', foreign: 'kept' });
+
+        const created = context.createWorldInfoEntry('Book', native);
+        const duplicated = context.duplicateWorldInfoEntry(native, 0);
+        context.syncWIOriginalDataEntry(native, duplicated.uid);
+        expect(native.originalData.entries.map(entry => entry.id)).toEqual([74, 0, 1, 2]);
+        expect(native.originalData.entries[native.originalDataUidMap[created.uid]].id).toBe(1);
+        expect(native.originalData.entries[native.originalDataUidMap[duplicated.uid]]).toMatchObject({
+            id: 2, foreign: 'kept', extensions: { foreign: { retained: true } },
+        });
+
+        const destination = context.convertCharacterBook({ entries: [{ id: 74, content: 'Destination' }, { id: 0, content: 'Other' }] });
+        const copied = { ...structuredClone(native.entries[0]), uid: context.getFreeWorldEntryUid(destination) };
+        destination.entries[copied.uid] = copied;
+        context.appendWIOriginalDataEntry(destination, copied, native.originalData.entries[0]);
+        expect(destination.originalData.entries.map(entry => entry.id)).toEqual([74, 0, 1]);
+        expect(destination.originalData.entries[2]).toMatchObject({ foreign: 'kept', extensions: { foreign: { retained: true } } });
+        expect(native.originalData.entries[0].id).toBe(74);
+    });
+
+    test('native book to card to native roundtrip keeps layout and entry node IDs through UID renumbering', () => {
+        const extensions = { foreign: { nested: ['kept'] }, sillybunny_pathfinder: { version: 1, tree: { id: 'root', children: [{ id: 'place' }] } } };
+        const native = {
+            extensions,
+            entries: {
+                7: { uid: 7, displayIndex: 1, content: 'Second', extensions: { foreign: 'seven', sillybunny_pathfinder: { version: 1, nodeId: 'place' } } },
+                42: { uid: 42, displayIndex: 0, content: 'First', extensions: { foreign: 'forty-two', sillybunny_pathfinder: { version: 1, nodeId: 'root' } } },
+            },
+        };
+        const card = context.convertWorldInfoToCharacterBook('Lore', native.entries, native.extensions);
+        const restored = context.convertCharacterBook(card);
+
+        expect(card.entries.map(entry => entry.id)).toEqual([42, 7]);
+        expect(restored.extensions).toEqual(extensions);
+        expect(restored.originalData.extensions).toEqual(extensions);
+        expect(restored.originalDataUidMap).toEqual({ 0: 0, 1: 1 });
+        expect(restored.entries[0]).toMatchObject({ uid: 0, content: 'First', extensions: native.entries[42].extensions });
+        expect(restored.entries[1]).toMatchObject({ uid: 1, content: 'Second', extensions: native.entries[7].extensions });
+        expect(native).not.toHaveProperty('originalData');
+        card.extensions.foreign.nested.push('card-only');
+        expect(native.extensions.foreign.nested).toEqual(['kept']);
+        expect(restored.extensions.foreign.nested).toEqual(['kept']);
+    });
+
+    test('imported books preserve foreign book and entry metadata alongside Pathfinder metadata', () => {
+        const card = {
+            name: 'Imported', foreign: 'original book metadata',
+            extensions: { foreign: 'book extension', sillybunny_pathfinder: { version: 1, tree: { id: 'root' } } },
+            entries: [{ id: 91, content: 'Imported entry', foreign: 'original entry metadata', extensions: { foreign: 'entry extension', sillybunny_pathfinder: { version: 1, nodeId: 'root' } } }],
+        };
+        const native = context.convertCharacterBook(card);
+        const exported = structuredClone(native.originalData);
+        const restored = context.convertCharacterBook(exported);
+        expect(exported).toEqual(card);
+        expect(restored.extensions).toEqual(card.extensions);
+        expect(restored.entries[0]).toMatchObject({ uid: 0, extensions: card.entries[0].extensions });
+        expect(restored.originalData.entries[0]).toMatchObject({ id: 91, foreign: 'original entry metadata' });
+    });
+
+    test('the existing two-argument native conversion still supplies empty extensions', () => {
+        expect(context.convertWorldInfoToCharacterBook('Lore', {}).extensions).toEqual({});
     });
 });

--- a/tests/world-info-save.test.js
+++ b/tests/world-info-save.test.js
@@ -1,0 +1,885 @@
+/* eslint-disable playwright/no-standalone-expect -- These are parameterised Jest tests. */
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import lodash from 'lodash';
+
+import { event_types } from '../public/scripts/events.js';
+import { StructuredCloneMap } from '../public/scripts/util/StructuredCloneMap.js';
+import { escapeCharacterBookRegex, getFreeCharacterBookEntryId, normalizeCharacterBookPosition, serializeWorldInfoEntry } from '../public/scripts/world-info-character-book.js';
+
+const source = readFileSync(new URL('../public/scripts/world-info.js', import.meta.url), 'utf8');
+
+function functionSource(name) {
+    const match = source.match(new RegExp(`^(?:export )?((?:async )?function ${name}\\([\\s\\S]*?^})`, 'm'));
+    if (!match) throw new Error(`Missing function ${name}`);
+    return match[1];
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+    return { promise, resolve, reject };
+}
+
+function book() {
+    return {
+        entries: {
+            0: { uid: 0, content: 'Original', depth: 4, extensions: { foreign: 'entry metadata' } },
+            1: { uid: 1, content: 'Delete this' },
+            2: { uid: 2, content: 'Update this' },
+        },
+        extensions: { foreign: { retained: true } },
+    };
+}
+
+function createHost(initialBook = book()) {
+    const books = new Map([['Lore', structuredClone(initialBook)]]);
+    const holds = new Map();
+    const renders = [];
+    const elements = new Map();
+    let editorData;
+    const context = vm.createContext({
+        lodash, structuredClone, Map, WeakMap, Set, TextEncoder, FormData, console,
+        escapeCharacterBookRegex, getFreeCharacterBookEntryId, normalizeCharacterBookPosition, serializeWorldInfoEntry,
+        setTimeout, clearTimeout, event_types,
+        worldInfoCache: new StructuredCloneMap({ cloneOnGet: true, cloneOnSet: false }),
+        worldInfoEditorLoadId: 0,
+        world_names: ['Lore'], selected_world_info: [], world_info: {},
+        power_user: {}, chat_metadata: {}, characters: [],
+        debounce_timeout: { relaxed: 1000 }, MAX_WORLD_INFO_NAME_BYTES: 234,
+        navigation_option: { none: -2000 }, desktopSelectedWorldInfoUid: null,
+        newWorldInfoEntryTemplate: { content: '', depth: 4 },
+        world_info_position: { before: 0, after: 1 }, world_info_logic: { AND_ANY: 0 },
+        extension_prompt_roles: { SYSTEM: 0 }, DEFAULT_DEPTH: 4, DEFAULT_WEIGHT: 100,
+        getRequestHeaders: () => ({}), getSanitizedFilename: async name => name.replace(/[/?]/g, ''),
+        equalsIgnoreCaseAndAccents: (a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }) === 0,
+        findMatchingLorebookName: (names, name) => names.find(item => item === name),
+        checkOverwriteExistingData: async () => true,
+        parseJsonFile: async file => JSON.parse(await file.text()),
+        setValueByPath: lodash.set,
+        t: (strings, ...values) => String.raw({ raw: strings }, ...values),
+        toastr: { error: jest.fn(), success: jest.fn(), warning: jest.fn() },
+        Popup: { show: { input: jest.fn(async () => 'Renamed') } },
+        saveSettingsDebounced: jest.fn(), updateWorldInfoLinks: jest.fn(async () => {}),
+        clearWorldInfoDesktopEditor: jest.fn(),
+        document: { activeElement: null },
+        eventSource: { emit: jest.fn(async () => {}) },
+        displayWorldEntries: jest.fn(async (_name, data) => { editorData = data; }),
+    });
+    context.$ = value => {
+        if (typeof value !== 'string') return value;
+        if (!elements.has(value)) {
+            const element = {
+                value: value === '#world_editor_select' ? '0' : '',
+                val(next) { if (arguments.length) { this.value = String(next); return this; } return this.value; },
+                find() { return this; },
+                prop() { return this; },
+                trigger() {
+                    if (value === '#world_editor_select') renders.push(context.showWorldEditor(context.world_names[Number(this.value)]));
+                    return this;
+                },
+            };
+            elements.set(value, element);
+        }
+        return elements.get(value);
+    };
+    context.updateWorldInfoList = jest.fn(async () => { context.world_names = [...books.keys()]; });
+    context.fetch = jest.fn(async (url, options) => {
+        const body = options.body instanceof FormData ? options.body : JSON.parse(options.body);
+        const held = holds.get(url)?.shift();
+        const readData = url === '/api/worldinfo/get' ? structuredClone(books.get(body.name)) : undefined;
+        if (held) {
+            held.started.resolve();
+            const status = await held.result.promise;
+            if (status !== 200) return { ok: false, status, statusText: 'Rejected' };
+        }
+        let result;
+        switch (url) {
+            case '/api/worldinfo/get':
+                return { ok: Boolean(readData), json: async () => readData };
+            case '/api/worldinfo/edit': {
+                const name = body.name.replace(/[/?]/g, '');
+                books.set(name, structuredClone(body.data));
+                result = { ok: true, name };
+                break;
+            }
+            case '/api/worldinfo/rename':
+                books.delete(body.oldName);
+                books.set(body.newName, structuredClone(body.data));
+                result = { ok: true, name: body.newName };
+                break;
+            case '/api/worldinfo/delete':
+                books.delete(body.name);
+                break;
+            case '/api/worldinfo/import': {
+                const name = String(body.get('name'));
+                books.set(name, JSON.parse(String(body.get('convertedData') ?? await body.get('avatar').text())));
+                result = { name };
+                break;
+            }
+            default: throw new Error(`Unexpected request ${url}`);
+        }
+        return { ok: true, json: async () => result };
+    });
+    vm.runInContext(source.slice(source.indexOf('const pendingWorldInfoSaves'), source.indexOf('const saveSettingsDebounced')), context);
+    const functions = [
+        'reloadEditor', 'showWorldEditor', 'hideWorldEditor', 'loadWorldInfo',
+        'cloneWorldInfoData', 'getWorldInfoCachedData', 'mergeWorldInfoData', 'mergeWorldInfoChanges', 'trackWorldInfoEntryRender', 'invalidateWorldInfoCache', '_save', 'cancelPendingWorldInfoSave',
+        'settleWorldInfoSave', 'blockWorldInfoSaves', 'getCanonicalWorldInfoName', 'saveWorldInfo',
+        'replaceWorldInfoData', 'renameWorldInfo', 'deleteWorldInfo', 'importWorldInfo',
+        'getWIOriginalDataIndex', 'setWIOriginalDataValue', 'deleteWIOriginalDataValue', 'syncWIOriginalDataEntry', 'duplicateWorldInfoEntry',
+        'getFreeWorldEntryUid', 'createWorldInfoEntry', 'appendWIOriginalDataEntry', 'handleNumberInputHelper',
+        'convertCharacterBook', 'parseRegexFromString',
+    ];
+    vm.runInContext(functions.map(functionSource).join('\n'), context);
+    return {
+        context, books,
+        get editorData() { return editorData; },
+        async render() { await Promise.all(renders.splice(0)); },
+        hold(url = '/api/worldinfo/edit') {
+            const held = { started: deferred(), result: deferred() };
+            if (!holds.has(url)) holds.set(url, []);
+            holds.get(url).push(held);
+            return held;
+        },
+        nativeDepthInput() {
+            const handlers = new Map();
+            const metadata = new Map();
+            const input = {
+                value: '',
+                data(key, value) { if (arguments.length > 1) { metadata.set(key, value); return this; } return metadata.get(key); },
+                val(value) { if (arguments.length) { this.value = value; return this; } return this.value; },
+                on(event, handler) { handlers.set(event, handler); return this; },
+                off(event) { handlers.delete(event); return this; },
+                one(event, handler) { handlers.set(event, handler); return this; },
+                matches: () => true, closest: () => true,
+                async edit(value) { this.value = value; await handlers.get('input').call(this); },
+                blur() {
+                    context.document.activeElement = null;
+                    handlers.get('blur.worldInfoReload')?.();
+                },
+            };
+            context.handleNumberInputHelper({ inputElem: input, entry: editorData.entries[0], entryKey: 'depth', data: editorData, name: 'Lore', min: 0, max: 100 });
+            context.document.activeElement = input;
+            return input;
+        },
+    };
+}
+
+afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+});
+
+describe('shared World Info saves', () => {
+    test.each(['create', 'duplicate'])('stale native %s avoids card IDs reserved in the latest cache', async operation => {
+        const host = createHost();
+        const { context } = host;
+        const imported = context.convertCharacterBook({ entries: [
+            { id: 74, content: 'First', foreign: 'kept' },
+            { id: 0, content: 'Second' },
+        ] });
+        await context.replaceWorldInfoData('Lore', imported);
+        const native = await context.loadWorldInfo('Lore');
+        const external = await context.loadWorldInfo('Lore');
+        const externalEntry = context.createWorldInfoEntry('Lore', external);
+        externalEntry.content = 'External';
+        context.syncWIOriginalDataEntry(external, externalEntry.uid);
+        const held = host.hold();
+        const externalSave = context.saveWorldInfo('Lore', external, true);
+        await held.started.promise;
+
+        const nativeEntry = operation === 'create'
+            ? context.createWorldInfoEntry('Lore', native) : context.duplicateWorldInfoEntry(native, 0);
+        nativeEntry.content = 'Native';
+        context.syncWIOriginalDataEntry(native, nativeEntry.uid);
+        const nativeSave = context.saveWorldInfo('Lore', native, true);
+        held.result.resolve(200);
+        await externalSave;
+        await nativeSave;
+
+        const saved = host.books.get('Lore');
+        expect([externalEntry.uid, nativeEntry.uid]).toEqual([2, 3]);
+        expect(saved.originalData.entries.map(entry => entry.id)).toEqual([74, 0, 1, 2]);
+        expect(saved.originalData.entries[saved.originalDataUidMap[externalEntry.uid]]).toMatchObject({ id: 1, content: 'External' });
+        expect(saved.originalData.entries[saved.originalDataUidMap[nativeEntry.uid]]).toMatchObject({ id: 2, content: 'Native' });
+        expect(saved.originalData.entries[0]).toMatchObject({ id: 74, content: 'First', foreign: 'kept' });
+    });
+
+    test('a duplicate retains allocated card ID zero rather than its source card ID', async () => {
+        const host = createHost();
+        const native = host.context.convertCharacterBook({ entries: [{ id: 74, content: 'Original', foreign: 'kept' }] });
+        const duplicate = host.context.duplicateWorldInfoEntry(native, 0);
+        host.context.syncWIOriginalDataEntry(native, duplicate.uid);
+        expect(duplicate.uid).toBe(1);
+        expect(native.originalData.entries.map(entry => entry.id)).toEqual([74, 0]);
+        expect(native.originalData.entries[1]).toMatchObject({ id: 0, foreign: 'kept', content: 'Original' });
+    });
+
+    test('a stale native edit cannot resurrect a deleted entry', async () => {
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        host.nativeDepthInput();
+        const native = host.editorData;
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[0];
+        await host.context.saveWorldInfo('Lore', external, true);
+
+        native.entries[0].depth = 99;
+        const result = await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries).not.toHaveProperty('0');
+        expect(result).toBeNull();
+    });
+
+    test.each(['edit', 'delete'])('a stale native %s cannot target a replacement with the same UID and contents', async operation => {
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        host.nativeDepthInput();
+        const native = host.editorData;
+        const original = structuredClone(native.entries[0]);
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[0];
+        await host.context.saveWorldInfo('Lore', external, true);
+        const replacement = await host.context.loadWorldInfo('Lore');
+        const entry = host.context.createWorldInfoEntry('Lore', replacement);
+        expect(entry.uid).toBe(0);
+        Object.assign(entry, original);
+        await host.context.saveWorldInfo('Lore', replacement, true);
+
+        if (operation === 'edit') native.entries[0].depth = 99;
+        else delete native.entries[0];
+        const result = await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries[0]).toEqual(original);
+        expect(result).toBeNull();
+    });
+
+    test('a failed immediate external save cannot lose the native delayed edit it superseded', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        const native = host.editorData;
+        await host.nativeDepthInput().edit(8);
+        const external = await host.context.loadWorldInfo('Lore');
+        external.entries[2].content = 'Fail this external write';
+        const fetch = host.context.fetch;
+        host.context.fetch = jest.fn((url, options) => {
+            const data = JSON.parse(options.body).data;
+            return url === '/api/worldinfo/edit' && data.entries[2]?.content === 'Fail this external write'
+                ? Promise.resolve({ ok: false, status: 500 }) : fetch(url, options);
+        });
+        await expect(host.context.saveWorldInfo('Lore', external, true)).rejects.toThrow('World Info save failed');
+
+        native.entries[1].content = 'Later native edit';
+        await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(8);
+        expect(host.books.get('Lore').entries[1].content).toBe('Later native edit');
+        expect(host.books.get('Lore').entries[2].content).toBe('Update this');
+    });
+
+    test('unrelated native saves preserve a reused entry without adopting its instance', async () => {
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        host.nativeDepthInput();
+        const native = host.editorData;
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[0];
+        await host.context.saveWorldInfo('Lore', external, true);
+        const replacement = await host.context.loadWorldInfo('Lore');
+        Object.assign(host.context.createWorldInfoEntry('Lore', replacement), book().entries[0]);
+        await host.context.saveWorldInfo('Lore', replacement, true);
+
+        native.entries[1].content = 'Unrelated native edit';
+        await expect(host.context.saveWorldInfo('Lore', native, true)).resolves.toBe('Lore');
+        expect(host.books.get('Lore').entries[0]).toEqual(book().entries[0]);
+        const fresh = await host.context.loadWorldInfo('Lore');
+        fresh.entries[0].depth = 6;
+        await expect(host.context.saveWorldInfo('Lore', fresh, true)).resolves.toBe('Lore');
+        delete native.entries[0];
+        await expect(host.context.saveWorldInfo('Lore', native, true)).resolves.toBeNull();
+        expect(host.books.get('Lore').entries[0].depth).toBe(6);
+        expect(host.books.get('Lore').entries[1].content).toBe('Unrelated native edit');
+        expect(Object.keys(host.books.get('Lore'))).toEqual(['entries', 'extensions']);
+        expect(Object.getOwnPropertySymbols(fresh)).toEqual([]);
+    });
+
+    test('a failed deletion does not invalidate the committed entry instance', async () => {
+        const host = createHost();
+        const native = await host.context.loadWorldInfo('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[0];
+        const held = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', external, true);
+        const rejected = saving.catch(error => error);
+        await held.started.promise;
+        native.entries[0].depth = 8;
+        await expect(host.context.saveWorldInfo('Lore', native, true)).resolves.toBeNull();
+        held.result.resolve(500);
+        expect(await rejected).toHaveProperty('message', 'World Info save failed with status 500');
+        await expect(host.context.saveWorldInfo('Lore', native, true)).resolves.toBe('Lore');
+        expect(host.books.get('Lore').entries[0].depth).toBe(8);
+    });
+
+    test.each(['replace', 'import'])('a completed %s invalidates old entry instances even when the book is identical', async operation => {
+        const host = createHost();
+        const native = await host.context.loadWorldInfo('Lore');
+        if (operation === 'replace') await host.context.replaceWorldInfoData('Lore', book());
+        else await host.context.importWorldInfo(new File([JSON.stringify(book())], 'Lore.json'));
+        delete native.entries[0];
+        await expect(host.context.saveWorldInfo('Lore', native, true)).resolves.toBeNull();
+        expect(host.books.get('Lore')).toEqual(book());
+    });
+
+    test('a rejected stale imported entry edit leaves both native and original entry records intact', async () => {
+        const host = createHost();
+        const card = { entries: [{ id: 42, content: 'Original', extensions: { foreign: true } }] };
+        await host.context.replaceWorldInfoData('Lore', host.context.convertCharacterBook(card));
+        const native = await host.context.loadWorldInfo('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[0];
+        host.context.deleteWIOriginalDataValue(external, 0);
+        await host.context.saveWorldInfo('Lore', external, true);
+        native.entries[0].content = 'Stale';
+        host.context.setWIOriginalDataValue(native, 0, 'content', 'Stale');
+        await expect(host.context.saveWorldInfo('Lore', native, true)).resolves.toBeNull();
+        expect(host.books.get('Lore')).toMatchObject({ entries: {}, originalData: { entries: [] }, originalDataUidMap: {} });
+    });
+
+    test('a successful external edit is not reverted when the native writer saves again', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        const native = host.editorData;
+        await host.nativeDepthInput().edit(8);
+        const external = await host.context.loadWorldInfo('Lore');
+        external.entries[0].depth = 10;
+        await host.context.saveWorldInfo('Lore', external, true);
+        native.entries[1].content = 'Later native edit';
+        await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(10);
+        expect(host.books.get('Lore').entries[1].content).toBe('Later native edit');
+    });
+
+    test('newer native edits remain queued when the external save behind its flushed draft fails', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        const native = host.editorData;
+        const input = host.nativeDepthInput();
+        await input.edit(8);
+        const external = await host.context.loadWorldInfo('Lore');
+        external.entries[2].content = 'External';
+        const nativeWrite = host.hold();
+        const externalWrite = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', external, true);
+        const rejected = saving.catch(error => error);
+        await nativeWrite.started.promise;
+        await input.edit(9);
+        const latestSave = host.context.saveWorldInfo('Lore', native, true);
+        nativeWrite.result.resolve(200);
+        await externalWrite.started.promise;
+        externalWrite.result.resolve(500);
+        expect(await rejected).toHaveProperty('message', 'World Info save failed with status 500');
+        await latestSave;
+        expect(host.books.get('Lore').entries[0].depth).toBe(9);
+        expect(host.context.worldInfoCache.get('Lore')).toEqual(host.books.get('Lore'));
+    });
+
+    test('reloading cannot restore an invalid stale draft into the native editor', async () => {
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        const native = host.editorData;
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[0];
+        const held = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', external, true);
+        await held.started.promise;
+        native.entries[0].depth = 99;
+        held.result.resolve(200);
+        await saving;
+        await host.render();
+        expect(host.editorData.entries).not.toHaveProperty('0');
+    });
+
+    test('background saves do not select a lorebook when the native editor has no selection', async () => {
+        const host = createHost();
+        host.context.$('#world_editor_select').val('');
+        await host.context.saveWorldInfo('Lore', book(), true);
+        await host.render();
+        expect(host.context.displayWorldEntries).not.toHaveBeenCalled();
+        host.context.reloadEditor('Lore', true);
+        await host.render();
+        expect(host.context.displayWorldEntries).toHaveBeenCalled();
+    });
+
+    test('an open native editor preserves external creation, deletion, updates and book metadata', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        const { context, books } = host;
+        await context.showWorldEditor('Lore');
+        const input = host.nativeDepthInput();
+        const external = await context.loadWorldInfo('Lore');
+        const created = context.createWorldInfoEntry('Lore', external);
+        created.content = 'Created externally';
+        delete external.entries[1];
+        external.entries[2].content = 'External update';
+        external.extensions.sillybunny_pathfinder = { version: 1, tree: { id: 'root', children: [] } };
+
+        await expect(context.saveWorldInfo('Lore', external, true)).resolves.toBe('Lore');
+        await input.edit(8);
+        await context.settleWorldInfoSave('Lore');
+
+        expect(books.get('Lore')).toMatchObject({
+            entries: { 0: { depth: 8, extensions: { foreign: 'entry metadata' } }, 2: { content: 'External update' }, 3: { content: 'Created externally' } },
+            extensions: external.extensions,
+        });
+        expect(books.get('Lore').entries).not.toHaveProperty('1');
+        input.blur();
+        jest.runOnlyPendingTimers();
+        await host.render();
+        expect(host.editorData).toEqual(books.get('Lore'));
+    });
+
+    test('native edits made during a pending external save survive its completion and editor reload', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        const { context, books } = host;
+        await context.showWorldEditor('Lore');
+        const input = host.nativeDepthInput();
+        const external = await context.loadWorldInfo('Lore');
+        external.entries[0].content = 'External content';
+        const held = host.hold();
+        const saving = context.saveWorldInfo('Lore', external, true);
+        await held.started.promise;
+
+        await input.edit(9);
+        held.result.resolve(200);
+        await saving;
+        expect(context.worldInfoCache.get('Lore').entries[0].depth).toBe(9);
+        await input.edit(10);
+        await context.settleWorldInfoSave('Lore');
+        expect(books.get('Lore').entries[0]).toMatchObject({ content: 'External content', depth: 10 });
+        input.blur();
+        jest.runOnlyPendingTimers();
+        await host.render();
+        expect(host.editorData.entries[0]).toMatchObject({ content: 'External content', depth: 10 });
+        const firstWrite = JSON.parse(context.fetch.mock.calls.find(([url]) => url === '/api/worldinfo/edit')[1].body);
+        expect(firstWrite.data.entries[0].depth).toBe(4);
+    });
+
+    test('reload preserves native model changes not yet submitted to the shared saver', async () => {
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        external.entries[2].content = 'External content';
+        const held = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', external, true);
+        await held.started.promise;
+        host.editorData.entries[0].depth = 11;
+        held.result.resolve(200);
+        await saving;
+        await host.render();
+        expect(host.editorData.entries[0].depth).toBe(11);
+        await host.context.saveWorldInfo('Lore', host.editorData, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(11);
+        expect(host.books.get('Lore').entries[2].content).toBe('External content');
+    });
+
+    test('a copy loaded before a native save only changes its own fields', async () => {
+        const host = createHost();
+        const native = await host.context.loadWorldInfo('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        native.entries[0].depth = 12;
+        await host.context.saveWorldInfo('Lore', native, true);
+        external.entries[0].content = 'External content';
+        await host.context.saveWorldInfo('Lore', external, true);
+        native.entries[0].extensions.foreign = 'Updated metadata';
+        await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries[0]).toMatchObject({ content: 'External content', depth: 12, extensions: { foreign: 'Updated metadata' } });
+    });
+
+    test('native saves preserve independently cloned external data and unchanged event identity', async () => {
+        const host = createHost();
+        const native = await host.context.loadWorldInfo('Lore');
+        const external = structuredClone(await host.context.loadWorldInfo('Lore'));
+        external.entries[2].content = 'External content';
+        await host.context.saveWorldInfo('Lore', external, true);
+        expect(host.context.eventSource.emit.mock.calls[0][2]).toBe(external);
+        native.entries[0].depth = 12;
+        await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(12);
+        expect(host.books.get('Lore').entries[2].content).toBe('External content');
+    });
+
+    test('native creation does not reuse a UID allocated by a pending external save', async () => {
+        const host = createHost();
+        const native = await host.context.loadWorldInfo('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        const externalEntry = host.context.createWorldInfoEntry('Lore', external);
+        externalEntry.content = 'External';
+        const held = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', external, true);
+        await held.started.promise;
+        const nativeEntry = host.context.createWorldInfoEntry('Lore', native);
+        nativeEntry.content = 'Native';
+        expect(nativeEntry.uid).not.toBe(externalEntry.uid);
+        const nativeSave = host.context.saveWorldInfo('Lore', native, true);
+        held.result.resolve(200);
+        await saving;
+        await nativeSave;
+        expect(host.books.get('Lore').entries[externalEntry.uid].content).toBe('External');
+        expect(host.books.get('Lore').entries[nativeEntry.uid].content).toBe('Native');
+    });
+
+    test('editor initialisation is not treated as an edit to native or imported fields', async () => {
+        const initial = book();
+        initial.originalData = { entries: [{ id: 0, content: 'Original', extensions: {} }] };
+        const host = createHost(initial);
+        const native = await host.context.loadWorldInfo('Lore');
+        native.entries[0].depth = 8;
+        const finishRender = host.context.trackWorldInfoEntryRender(native, 0);
+        native.entries[0].excludeRecursion = false;
+        host.context.setWIOriginalDataValue(native, 0, 'extensions.exclude_recursion', false);
+        finishRender();
+        const external = await host.context.loadWorldInfo('Lore');
+        external.entries[0].excludeRecursion = true;
+        host.context.setWIOriginalDataValue(external, 0, 'extensions.exclude_recursion', true);
+        await host.context.saveWorldInfo('Lore', external, true);
+        await host.context.saveWorldInfo('Lore', native, true);
+        expect(host.books.get('Lore').entries[0]).toMatchObject({ depth: 8, excludeRecursion: true });
+        expect(host.books.get('Lore').originalData.entries[0].extensions.exclude_recursion).toBe(true);
+    });
+
+    test('rejected optimistic data is absent from a fresh load and can be retried without false duplicates', async () => {
+        const host = createHost();
+        const external = await host.context.loadWorldInfo('Lore');
+        contextCreate(external);
+        const held = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', external, true);
+        const rejection = saving.catch(error => error);
+        await held.started.promise;
+        held.result.resolve(500);
+        expect(await rejection).toHaveProperty('message', 'World Info save failed with status 500');
+
+        expect(host.context.worldInfoCache.has('Lore')).toBe(false);
+        const retry = await host.context.loadWorldInfo('Lore');
+        expect(retry.entries).not.toHaveProperty('3');
+        contextCreate(retry);
+        await expect(host.context.saveWorldInfo('Lore', retry, true)).resolves.toBe('Lore');
+        expect(host.books.get('Lore').entries[3].content).toBe('Created externally');
+
+        function contextCreate(data) {
+            host.context.createWorldInfoEntry('Lore', data).content = 'Created externally';
+        }
+    });
+
+    test.each([false, true])('an older failure cannot invalidate a newer snapshot (identical data: %s)', async (identical) => {
+        const host = createHost();
+        const first = await host.context.loadWorldInfo('Lore');
+        const second = await host.context.loadWorldInfo('Lore');
+        first.entries[0].content = 'First';
+        if (identical) second.entries[0].content = 'First';
+        else second.entries[2].content = 'Second';
+        const held = host.hold();
+        const firstSave = host.context.saveWorldInfo('Lore', first, true);
+        const rejection = firstSave.catch(error => error);
+        await held.started.promise;
+        const secondSave = host.context.saveWorldInfo('Lore', second, true);
+        const optimistic = host.context.worldInfoCache.get('Lore');
+        held.result.resolve(500);
+        expect(await rejection).toHaveProperty('message', 'World Info save failed with status 500');
+        expect(host.context.worldInfoCache.get('Lore')).toEqual(optimistic);
+        await secondSave;
+        expect(host.context.worldInfoCache.get('Lore')).toEqual(host.books.get('Lore'));
+    });
+
+    test('overlapping failures on a reused object retain all changes on retry', async () => {
+        const host = createHost();
+        const data = await host.context.loadWorldInfo('Lore');
+        const first = host.hold();
+        const second = host.hold();
+        data.entries[0].depth = 20;
+        const one = host.context.saveWorldInfo('Lore', data, true);
+        const rejectedOne = one.catch(error => error);
+        await first.started.promise;
+        data.entries[2].content = 'Second';
+        const two = host.context.saveWorldInfo('Lore', data, true);
+        const rejectedTwo = two.catch(error => error);
+        first.result.resolve(500);
+        expect(await rejectedOne).toHaveProperty('message', 'World Info save failed with status 500');
+        await second.started.promise;
+        second.result.resolve(500);
+        expect(await rejectedTwo).toHaveProperty('message', 'World Info save failed with status 500');
+        expect(host.context.worldInfoCache.has('Lore')).toBe(false);
+        await host.context.loadWorldInfo('Lore');
+        await host.context.saveWorldInfo('Lore', data, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(20);
+        expect(host.books.get('Lore').entries[2].content).toBe('Second');
+    });
+
+    test('debouncing snapshots input and reports a background rejection without poisoning the cache', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const host = createHost();
+        const data = await host.context.loadWorldInfo('Lore');
+        data.entries[0].depth = 6;
+        await expect(host.context.saveWorldInfo('Lore', data)).resolves.toBeUndefined();
+        data.entries[0].depth = 7;
+        expect(host.context.worldInfoCache.get('Lore').entries[0].depth).toBe(6);
+        const held = host.hold();
+        held.result.resolve(500);
+        const reported = deferred();
+        host.context.toastr.error.mockImplementation(() => reported.resolve());
+        jest.runOnlyPendingTimers();
+        await reported.promise;
+        expect(host.context.toastr.error).toHaveBeenCalled();
+        expect(host.context.worldInfoCache.has('Lore')).toBe(false);
+        await host.context.saveWorldInfo('Lore', data, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(7);
+    });
+
+    test('a later failed save restores a prior committed baseline, not a cancelled debounce', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        const data = await host.context.loadWorldInfo('Lore');
+        data.entries[0].depth = 5;
+        await host.context.saveWorldInfo('Lore', data, true);
+        data.entries[0].depth = 6;
+        await host.context.saveWorldInfo('Lore', data);
+        data.entries[2].content = 'Draft';
+        const held = host.hold();
+        const saving = host.context.saveWorldInfo('Lore', data, true);
+        const rejection = saving.catch(error => error);
+        await held.started.promise;
+        held.result.reject(new Error('Offline'));
+        expect(await rejection).toHaveProperty('message', 'Offline');
+        await host.context.loadWorldInfo('Lore');
+        await host.context.saveWorldInfo('Lore', data, true);
+        expect(host.books.get('Lore').entries[0].depth).toBe(6);
+        expect(host.books.get('Lore').entries[2].content).toBe('Draft');
+    });
+
+    test('repeated debounced edits do not retain a book-sized snapshot for every keystroke', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        const data = await host.context.loadWorldInfo('Lore');
+        for (let depth = 1; depth <= 50; depth++) {
+            data.entries[0].depth = depth;
+            await host.context.saveWorldInfo('Lore', data);
+        }
+        const baselineDepth = vm.runInContext('(data) => { let count = 0; for (let record = worldInfoDataSnapshots.get(data); record; record = record.previous) count++; return count; }', host.context);
+        expect(baselineDepth(data)).toBe(2);
+        await host.context.settleWorldInfoSave('Lore');
+        expect(host.books.get('Lore').entries[0].depth).toBe(50);
+    });
+
+    test.each([['', {}], ['Lore', null], ['Lore', []], ['Lore', {}], ['Lore', { entries: [] }], ['Lore', { entries: { 0: null } }]])('invalid arguments resolve null (%s, %j)', async (name, data) => {
+        const host = createHost();
+        await expect(host.context.saveWorldInfo(name, data, true)).resolves.toBeNull();
+        expect(host.context.fetch).not.toHaveBeenCalled();
+    });
+
+    test('immediate saves return the actual canonical server name', async () => {
+        const host = createHost();
+        await expect(host.context.saveWorldInfo('New/Book', { entries: {} }, true)).resolves.toBe('NewBook');
+        expect(host.context.worldInfoCache.has('New/Book')).toBe(false);
+        expect(host.context.worldInfoCache.get('NewBook')).toEqual({ entries: {} });
+    });
+
+    test('merges imported entry records by mapped UID while preserving card IDs and unknown metadata', async () => {
+        const imported = book();
+        imported.originalData = {
+            extensions: { foreign: 'book metadata' },
+            entries: [2, 0, 1].map(uid => ({ id: uid + 40, content: imported.entries[uid].content, extensions: { foreign: `original-${uid}` } })),
+        };
+        imported.originalDataUidMap = { 2: 0, 0: 1, 1: 2 };
+        const host = createHost(imported);
+        const native = await host.context.loadWorldInfo('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        delete external.entries[1];
+        host.context.deleteWIOriginalDataValue(external, '1');
+        external.entries[3] = { uid: 3, content: 'New', extensions: { sillybunny_pathfinder: { version: 1, nodeId: 'node' } } };
+        external.originalData.entries.push({ id: 3, content: 'New', extensions: external.entries[3].extensions });
+        external.originalDataUidMap[3] = 2;
+        external.extensions.sillybunny_pathfinder = external.originalData.extensions.sillybunny_pathfinder = { version: 1, tree: { id: 'root' } };
+        await host.context.saveWorldInfo('Lore', external, true);
+        native.entries[0].content = 'Native draft';
+        host.context.setWIOriginalDataValue(native, 0, 'content', 'Native draft');
+        await host.context.saveWorldInfo('Lore', native, true);
+        const saved = host.books.get('Lore');
+        expect(saved.originalData.entries.map(entry => entry.id)).toEqual([42, 40, 3]);
+        expect(saved.originalData.entries[1]).toMatchObject({ content: 'Native draft', extensions: { foreign: 'original-0' } });
+        expect(saved.originalData.entries[2].extensions).toEqual(external.entries[3].extensions);
+        expect(saved.originalData.extensions).toEqual(external.originalData.extensions);
+        expect(saved.originalDataUidMap).toEqual({ 2: 0, 0: 1, 3: 2 });
+        expect(saved.entries).not.toHaveProperty('1');
+    });
+
+    test('foreign metadata keys cannot modify object prototypes during a merge', () => {
+        const host = createHost();
+        const draft = JSON.parse('{"entries":{},"extensions":{"__proto__":{"polluted":true},"constructor":{"prototype":{"polluted":true}}}}');
+        const merged = host.context.mergeWorldInfoData({ entries: {}, extensions: {} }, draft, { entries: {}, extensions: { retained: true } });
+        expect(merged.extensions).toHaveProperty('retained', true);
+        expect(Object.hasOwn(merged.extensions, '__proto__')).toBe(true);
+        expect({}.polluted).toBeUndefined();
+    });
+
+    test('independent additions to a previously absent extensions object preserve both namespaces', () => {
+        const host = createHost();
+        const merged = host.context.mergeWorldInfoData({ entries: {} }, { entries: {}, extensions: { native: true } }, { entries: {}, extensions: { external: true } });
+        expect(merged.extensions).toEqual({ native: true, external: true });
+    });
+});
+
+describe('World Info lifecycle coordination', () => {
+    test('the native duplicate action copies current metadata and announces the installed replacement', async () => {
+        const host = createHost();
+        const { context } = host;
+        context.name = 'Lore';
+        context.data = await context.loadWorldInfo('Lore');
+        const external = await context.loadWorldInfo('Lore');
+        external.extensions.sillybunny_pathfinder = { version: 1, tree: { id: 'root' } };
+        await context.saveWorldInfo('Lore', external, true);
+        context.data.entries[0].depth = 6;
+        host.books.set('Copy', { entries: {}, extensions: { obsolete: true } });
+        context.world_names.push('Copy');
+        await context.loadWorldInfo('Copy');
+        context.Popup.show.input.mockResolvedValue('Co/py');
+        context.getFreeWorldName = () => 'Lore (1)';
+        const start = source.indexOf('$(\'#world_duplicate\').off(\'click\').on(\'click\', async () => {');
+        const end = source.indexOf('\n    });', start);
+        const duplicate = vm.runInContext(`(${source.slice(source.indexOf('async () => {', start), end)}\n})`, context);
+        await duplicate();
+        const copied = host.books.get('Copy');
+        expect(copied.extensions).toEqual(external.extensions);
+        expect(copied.entries[0].depth).toBe(6);
+        expect(copied).not.toHaveProperty('originalData');
+        expect(context.worldInfoCache.get('Copy')).toEqual(copied);
+        expect(context.eventSource.emit).toHaveBeenLastCalledWith(event_types.WORLDINFO_UPDATED, 'Copy', copied, { replaced: true });
+    });
+
+    test('converted card imports publish and cache the installed native data, not the old book', async () => {
+        const host = createHost();
+        await host.context.loadWorldInfo('Lore');
+        const characterBook = {
+            extensions: { foreign: true, sillybunny_pathfinder: { version: 1, tree: { id: 'root' } } },
+            entries: [{ id: 42, content: 'Imported', extensions: { sillybunny_pathfinder: { version: 1, nodeId: 'root' } } }],
+        };
+        await host.context.importWorldInfo(new File([JSON.stringify({ spec: 'lorebook_v3', data: characterBook })], 'Lore.json'));
+        const saved = host.books.get('Lore');
+        expect(saved.entries[0]).toMatchObject({ uid: 0, content: 'Imported', extensions: characterBook.entries[0].extensions });
+        expect(saved.extensions).toEqual(characterBook.extensions);
+        expect(saved.originalData).toEqual(characterBook);
+        expect(host.context.worldInfoCache.get('Lore')).toEqual(saved);
+        expect(host.context.eventSource.emit).toHaveBeenLastCalledWith(event_types.WORLDINFO_UPDATED, 'Lore', saved, { replaced: true });
+    });
+
+    test('a save redirected by rename also honours a subsequent target deletion block', async () => {
+        const host = createHost();
+        const releaseRename = host.context.blockWorldInfoSaves('Lore');
+        const releaseDelete = host.context.blockWorldInfoSaves('Renamed');
+        const saving = host.context.saveWorldInfo('Lore', book(), true);
+        releaseRename('Renamed');
+        await Promise.resolve();
+        releaseDelete(null);
+        await expect(saving).resolves.toBeNull();
+        expect(host.context.fetch).not.toHaveBeenCalled();
+    });
+
+    test('replacement flushes a queued native edit before installing new data, with no later resurrection', async () => {
+        jest.useFakeTimers();
+        const host = createHost();
+        const data = await host.context.loadWorldInfo('Lore');
+        data.entries[0].depth = 8;
+        await host.context.saveWorldInfo('Lore', data);
+        const replacement = { entries: { 7: { uid: 7, content: 'Replacement' } } };
+        await host.context.replaceWorldInfoData('Lore', replacement);
+        jest.runOnlyPendingTimers();
+        expect(host.books.get('Lore')).toEqual(replacement);
+        expect(host.context.worldInfoCache.get('Lore')).toEqual(replacement);
+        expect(host.context.fetch.mock.calls.filter(([url]) => url === '/api/worldinfo/edit')).toHaveLength(2);
+        expect(host.context.eventSource.emit).toHaveBeenLastCalledWith(event_types.WORLDINFO_UPDATED, 'Lore', replacement, { replaced: true });
+    });
+
+    test('rename keeps newer external data and retargets a blocked save to its committed name', async () => {
+        const host = createHost();
+        const staleEditor = await host.context.loadWorldInfo('Lore');
+        const external = await host.context.loadWorldInfo('Lore');
+        external.extensions.sillybunny_pathfinder = { version: 1, tree: { id: 'root' } };
+        await host.context.saveWorldInfo('Lore', external, true);
+        const held = host.hold('/api/worldinfo/rename');
+        const renaming = host.context.renameWorldInfo('Lore', staleEditor);
+        await held.started.promise;
+        staleEditor.entries[0].depth = 9;
+        const saving = host.context.saveWorldInfo('Lore', staleEditor, true);
+        held.result.resolve(200);
+        await renaming;
+        await expect(saving).resolves.toBe('Renamed');
+        expect(host.books.has('Lore')).toBe(false);
+        expect(host.context.worldInfoCache.has('Lore')).toBe(false);
+        expect(host.books.get('Renamed')).toMatchObject({ entries: { 0: { depth: 9 } }, extensions: external.extensions });
+        expect(host.context.eventSource.emit).toHaveBeenCalledWith(event_types.WORLDINFO_RENAMED, 'Lore', 'Renamed');
+    });
+
+    test.each(['delete', 'replace', 'import'])('%s discards blocked saves and publishes only installed data', async operation => {
+        const host = createHost();
+        await host.context.showWorldEditor('Lore');
+        const staleEditor = host.editorData;
+        const replacement = { entries: { 9: { uid: 9, content: 'Replacement' } }, extensions: { new: true } };
+        const held = host.hold(`/api/worldinfo/${operation === 'replace' ? 'edit' : operation}`);
+        const observed = [];
+        host.context.eventSource.emit.mockImplementation(async (event, name, data, details) => {
+            if (event === event_types.WORLDINFO_DELETED) observed.push(host.context.worldInfoCache.has(name));
+            if (details?.replaced) observed.push(await host.context.loadWorldInfo(name));
+        });
+        const changing = operation === 'delete' ? host.context.deleteWorldInfo('Lore')
+            : operation === 'replace' ? host.context.replaceWorldInfoData('Lore', replacement)
+                : host.context.importWorldInfo(new File([JSON.stringify(replacement)], 'Lore.json'));
+        await held.started.promise;
+        staleEditor.entries[0].depth = 99;
+        const saving = host.context.saveWorldInfo('Lore', staleEditor, true);
+        held.result.resolve(200);
+        await changing;
+        await expect(saving).resolves.toBeNull();
+        expect(host.books.get('Lore')).toEqual(operation === 'delete' ? undefined : replacement);
+        expect(observed).toEqual(operation === 'delete' ? [false] : [replacement]);
+        const calls = host.context.eventSource.emit.mock.calls;
+        expect(calls).toEqual(operation === 'delete'
+            ? [[event_types.WORLDINFO_DELETED, 'Lore']]
+            : [[event_types.WORLDINFO_UPDATED, 'Lore', replacement, { replaced: true }]]);
+    });
+
+    test.each(['rename', 'delete', 'replace', 'import'])('failed %s does not announce success or discard waiting edits', async operation => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const host = createHost();
+        const data = await host.context.loadWorldInfo('Lore');
+        const held = host.hold(`/api/worldinfo/${operation === 'replace' ? 'edit' : operation}`);
+        const changing = operation === 'rename' ? host.context.renameWorldInfo('Lore', data)
+            : operation === 'delete' ? host.context.deleteWorldInfo('Lore')
+                : operation === 'replace' ? host.context.replaceWorldInfoData('Lore', { entries: {} })
+                    : host.context.importWorldInfo(new File(['{"entries":{}}'], 'Lore.json'));
+        const settled = changing.catch(error => error);
+        await held.started.promise;
+        data.entries[0].depth = 17;
+        const saving = host.context.saveWorldInfo('Lore', data, true);
+        held.result.resolve(500);
+        expect((await settled)?.message).toBe(operation === 'replace' ? 'World Info save failed with status 500' : undefined);
+        await expect(saving).resolves.toBe('Lore');
+        expect(host.books.get('Lore').entries[0].depth).toBe(17);
+        expect(host.context.eventSource.emit.mock.calls.every(([event, , , details]) => event === event_types.WORLDINFO_UPDATED && !details?.replaced)).toBe(true);
+    });
+
+    test.each(['delete', 'replace'])('a delayed read cannot resurrect data after %s', async operation => {
+        const host = createHost();
+        const held = host.hold('/api/worldinfo/get');
+        const reading = host.context.loadWorldInfo('Lore');
+        await held.started.promise;
+        const replacement = { entries: {} };
+        if (operation === 'delete') await host.context.deleteWorldInfo('Lore');
+        else await host.context.replaceWorldInfoData('Lore', replacement);
+        held.result.resolve(200);
+        await expect(reading).resolves.toEqual(operation === 'delete' ? null : replacement);
+        expect(host.context.worldInfoCache.get('Lore')).toEqual(operation === 'delete' ? undefined : replacement);
+    });
+});


### PR DESCRIPTION
1. Unselected lorebooks and blacklisted entries are no longer accessible for Pathfinder to edit or delete.
2. No longer overwrites unrelated content, no longer returns previous deleted entries, and no longer undoes changes.
3. Stopping and switching chats no longer starts additional PF actions or cause late results to happen.
4. Identical lorebook entry names are now distinguished correctly. Warnings appear during slow lore searches.
5. Changes made rapidly are saved. Failed saves now are reported. Draft summary text remains even after panel updates and failed saves.
6. Waypoint organisation is permanent and survives reloads.
7. Settings panel is easier to use for keyboard controls and lazy loads lorebooks in case you have plenty.