### PR TITLE
fix(mobile): prevent the Persona picker page from being draggable to the left or right + dropdown for scenario notes

### DIFF
--- a/public/css/personas.css
+++ b/public/css/personas.css
@@ -376,8 +376,10 @@
     min-height: 0;
     max-height: clamp(20rem, calc(100dvh - 20rem), 44rem);
     overflow-y: auto;
+    overflow-x: hidden;
     overscroll-behavior: contain;
     scrollbar-gutter: stable;
+    touch-action: pan-y;
 }
 
 #user_avatar_block {
@@ -400,6 +402,7 @@
 #user_avatar_block:not(.gridView) .avatar-container {
     width: 100%;
     min-width: 0;
+    margin-inline: 0;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: start;
@@ -655,15 +658,15 @@
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 74%, transparent);
 }
 
-.persona-appendices-heading-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 8px;
-    min-width: 0;
+.persona-appendices-block > summary {
+    display: list-item;
+    cursor: pointer;
 }
 
-.persona-appendices-heading-row .persona-section-header {
+.persona-appendices-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
     min-width: 0;
 }
 
@@ -774,10 +777,10 @@
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);
 }
 
-.persona-effective-preview > summary {
+.persona-effective-preview-title {
+    display: block;
     min-height: 36px;
     padding: 8px 10px;
-    cursor: pointer;
     font-weight: 700;
 }
 
@@ -855,12 +858,14 @@
     }
 
     #user_avatar_block:not(.gridView) .avatar-container .character_select_container {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
     }
 
     #user_avatar_block:not(.gridView) .avatar-container .avatar_container_states {
         grid-column: 1;
         grid-row: auto;
+        min-width: 0;
+        flex-wrap: wrap;
         justify-content: flex-start;
     }
 
@@ -951,11 +956,6 @@
     .persona-selected-avatar {
         width: 48px;
         height: 48px;
-    }
-
-    .persona-appendices-heading-row {
-        grid-template-columns: 1fr;
-        align-items: stretch;
     }
 
     .persona-appendices-actions {
@@ -1396,12 +1396,6 @@
 }
 
 @media screen and (max-width: 760px) {
-    #PersonaManagement .persona-appendices-heading-row {
-        grid-template-columns: minmax(0, 1fr) auto;
-        align-items: center;
-        gap: 6px;
-    }
-
     #PersonaManagement .persona-appendices-actions {
         flex-wrap: nowrap;
         justify-content: flex-end;
@@ -1424,12 +1418,6 @@
 }
 
 @container persona-management (max-width: 520px) {
-    #PersonaManagement .persona-appendices-heading-row {
-        grid-template-columns: minmax(0, 1fr) auto;
-        align-items: center;
-        gap: 6px;
-    }
-
     #PersonaManagement .persona-appendices-actions {
         flex-wrap: nowrap;
         justify-content: flex-end;
@@ -1457,11 +1445,6 @@
         gap: 6px;
     }
 
-    #PersonaManagement .persona-appendices-heading-row {
-        grid-template-columns: 1fr;
-        align-items: stretch;
-    }
-
     #PersonaManagement .persona-appendices-actions {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1477,12 +1460,6 @@
 }
 
 @container persona-scenario-notes (max-width: 360px) {
-    .persona-appendices-heading-row {
-        grid-template-columns: minmax(0, 1fr) auto;
-        align-items: center;
-        gap: 6px;
-    }
-
     .persona-appendices-actions {
         flex-wrap: nowrap;
         justify-content: flex-end;
@@ -1505,11 +1482,6 @@
 }
 
 @container persona-scenario-notes (max-width: 230px) {
-    .persona-appendices-heading-row {
-        grid-template-columns: 1fr;
-        align-items: stretch;
-    }
-
     .persona-appendices-actions {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/public/css/personas.css
+++ b/public/css/personas.css
@@ -704,10 +704,9 @@
 
 .persona-appendix-card {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-        'toggle actions'
-        'description description';
+    grid-template-columns: 44px minmax(0, 1fr) auto;
+    grid-template-areas: 'toggle details actions';
+    align-items: start;
     gap: 6px 10px;
     min-width: 0;
     padding: 8px;
@@ -719,9 +718,10 @@
 .persona-appendix-toggle-row {
     grid-area: toggle;
     min-width: 0;
+    min-height: 44px;
     display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: center;
     margin: 0;
     cursor: pointer;
 }
@@ -730,16 +730,22 @@
     accent-color: var(--color-primary, var(--sb-accent));
 }
 
-.persona-appendix-name {
+.persona-appendix-details {
+    grid-area: details;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+}
+
+.persona-appendix-name {
+    display: list-item;
+    min-height: 44px;
+    padding-block: 10px;
+    list-style-position: inside;
+    overflow-wrap: anywhere;
     font-weight: 700;
+    cursor: pointer;
 }
 
 .persona-appendix-description {
-    grid-area: description;
     margin: 0;
     line-height: 1.38;
     white-space: pre-wrap;
@@ -761,14 +767,27 @@
 }
 
 .persona-appendix-actions > .menu_button {
-    width: 34px;
-    min-width: 34px;
-    height: 34px;
-    min-height: 34px;
+    width: 44px;
+    min-width: 44px;
+    height: 44px;
+    min-height: 44px;
     padding: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+}
+
+@container persona-scenario-notes (max-width: 520px) {
+    .persona-appendix-card {
+        grid-template-columns: 44px minmax(0, 1fr);
+        grid-template-areas:
+            'toggle details'
+            '. actions';
+    }
+
+    .persona-appendix-actions {
+        justify-content: flex-start;
+    }
 }
 
 .persona-effective-preview {
@@ -990,25 +1009,6 @@
         width: 44px;
         min-width: 44px;
         max-width: 44px;
-        height: 44px;
-        min-height: 44px;
-    }
-
-    .persona-appendix-card {
-        grid-template-columns: 1fr;
-        grid-template-areas:
-            'toggle'
-            'description'
-            'actions';
-    }
-
-    .persona-appendix-actions {
-        justify-content: flex-start;
-    }
-
-    .persona-appendix-actions > .menu_button {
-        width: 44px;
-        min-width: 44px;
         height: 44px;
         min-height: 44px;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -6416,9 +6416,9 @@
                                 </h4>
                                 <textarea id="persona_description" name="persona_description" data-macros data-i18n="[placeholder]Example: [{{user}} is a 28-year-old Romanian cat girl.]" placeholder="Example:&#10;[{{user}} is a 28-year-old Romanian cat girl.]" class="text_pole textarea_compact" value="" autocomplete="off" rows="8"></textarea>
 
-                                <section class="persona-appendices-block" aria-labelledby="persona_appendices_heading">
-                                    <div class="persona-appendices-heading-row">
-                                        <h4 id="persona_appendices_heading" class="persona-section-header" data-i18n="Scenario Notes">Scenario Notes</h4>
+                                <details class="persona-appendices-block" aria-labelledby="persona_appendices_heading">
+                                    <summary id="persona_appendices_heading" class="persona-section-header" data-i18n="Scenario Notes">Scenario Notes</summary>
+                                    <div class="persona-appendices-content">
                                         <div class="persona-appendices-actions">
                                             <button id="persona_appendix_add" class="menu_button menu_button_icon" type="button" title="Add scenario note" data-i18n="[title]Add scenario note">
                                                 <i class="fa-solid fa-plus fa-fw" aria-hidden="true"></i>
@@ -6429,15 +6429,15 @@
                                                 <span data-i18n="Import">Import</span>
                                             </button>
                                         </div>
+                                        <p class="persona-appendices-help text_muted" data-i18n="Scenario Notes add chat-specific details to this persona. Multiple notes can be active at once in this chat.">Scenario Notes add chat-specific details to this persona. Multiple notes can be active at once in this chat.</p>
+                                        <div id="persona_appendices_active_chips" class="persona-appendices-active-chips" aria-live="polite"></div>
+                                        <div id="persona_appendices_list" class="persona-appendices-list"></div>
+                                        <div class="persona-effective-preview">
+                                            <strong class="persona-effective-preview-title" data-i18n="Preview final prompt for this chat">Preview final prompt for this chat</strong>
+                                            <pre id="persona_effective_description_preview"></pre>
+                                        </div>
                                     </div>
-                                    <p class="persona-appendices-help text_muted" data-i18n="Scenario Notes add chat-specific details to this persona. Multiple notes can be active at once in this chat.">Scenario Notes add chat-specific details to this persona. Multiple notes can be active at once in this chat.</p>
-                                    <div id="persona_appendices_active_chips" class="persona-appendices-active-chips" aria-live="polite"></div>
-                                    <div id="persona_appendices_list" class="persona-appendices-list"></div>
-                                    <details class="persona-effective-preview">
-                                        <summary data-i18n="Preview final prompt for this chat">Preview final prompt for this chat</summary>
-                                        <pre id="persona_effective_description_preview"></pre>
-                                    </details>
-                                </section>
+                                </details>
 
                                 <div class="flex-container justifySpaceBetween persona-section-meta">
                                     <h4 class="persona-section-header persona-section-header--inline" data-i18n="Position">Position</h4>

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1157,6 +1157,11 @@ function renderPersonaAppendices() {
         renderPersonaAppendixChips(activeChips, activeAppendices);
     }
 
+    // SillyBunny: retain open notes through list refreshes, but not persona switches.
+    const expandedIds = new Set(list.dataset.avatarId === user_avatar
+        ? Array.from(list.querySelectorAll('details[open]'), details => details.closest('.persona-appendix-card').dataset.appendixId)
+        : []);
+    list.dataset.avatarId = user_avatar;
     list.replaceChildren();
 
     if (!appendices.length) {
@@ -1180,15 +1185,21 @@ function renderPersonaAppendices() {
         checkbox.className = 'persona_appendix_toggle';
         checkbox.dataset.appendixId = appendix.id;
         checkbox.checked = activeIds.has(appendix.id);
+        checkbox.setAttribute('aria-label', appendix.name);
+        label.append(checkbox);
 
-        const name = document.createElement('span');
+        const details = document.createElement('details');
+        details.className = 'persona-appendix-details';
+        details.open = expandedIds.has(appendix.id);
+
+        const name = document.createElement('summary');
         name.className = 'persona-appendix-name';
         name.textContent = appendix.name;
-        label.append(checkbox, name);
 
         const description = document.createElement('p');
         description.className = 'persona-appendix-description text_muted';
         description.textContent = appendix.description?.trim() || t`[No Scenario Note text]`;
+        details.append(name, description);
 
         const actions = document.createElement('div');
         actions.className = 'persona-appendix-actions';
@@ -1206,7 +1217,7 @@ function renderPersonaAppendices() {
         deleteButton.title = t`Delete Scenario Note`;
 
         actions.append(editButton, deleteButton);
-        card.append(label, description, actions);
+        card.append(label, details, actions);
         list.appendChild(card);
     }
 }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -17258,6 +17258,10 @@ function openPersonaAppendicesManager() {
         document.getElementById('persona_editor_tab_prompt')?.click();
         const appendicesHeading = document.getElementById('persona_appendices_heading');
         const addButton = document.getElementById('persona_appendix_add');
+        const appendicesBlock = appendicesHeading?.closest('details');
+        if (appendicesBlock instanceof HTMLDetailsElement) {
+            appendicesBlock.open = true;
+        }
         scrollElementIntoManagedView(appendicesHeading ?? addButton, { block: 'center', behavior: getReducedMotionScrollBehavior() });
         addButton?.focus({ preventScroll: true });
     }, 160);

--- a/tests/persona-management-ui.e2e.js
+++ b/tests/persona-management-ui.e2e.js
@@ -1,0 +1,108 @@
+/* global document, window */
+import { devices, expect, test } from '@playwright/test';
+import { openQuietChatForSmoke } from './chat-scroll-regression-helpers.js';
+
+test.setTimeout(60000);
+
+for (const width of [320, 390, 1280]) {
+    test.describe(`Scenario Note dropdowns at ${width}px`, () => {
+        test.use({
+            viewport: { width, height: 844 },
+            isMobile: width < 768,
+            hasTouch: width < 768,
+            userAgent: width < 768 ? devices['iPhone 13'].userAgent : undefined,
+        });
+
+        test('collapses each note independently without changing active notes', async ({ page }, testInfo) => {
+            let settingsVersion = Date.now();
+            await page.route('**/api/settings/save', route => route.fulfill({ status: 200, json: { version: ++settingsVersion } }));
+            await openQuietChatForSmoke(page, { selectCharacter: false });
+            await page.evaluate(async () => {
+                const { power_user } = await import('/scripts/power-user.js');
+                const { user_avatar, setPersonaDescription } = await import('/scripts/personas.js');
+                power_user.personas[user_avatar] = 'Dropdown Test';
+                power_user.persona_descriptions[user_avatar] = {
+                    description: 'Base persona',
+                    appendices: [
+                        { id: 'note-one', name: 'First note', description: 'Long scenario note.\n'.repeat(30) },
+                        { id: 'note-two', name: 'Second note', description: 'Second scenario note.' },
+                    ],
+                    activeAppendices: {},
+                };
+                setPersonaDescription();
+                window.SillyBunnyShell.openTab('characters', 'persona');
+            });
+            await expect(page.locator('#PersonaManagement')).toBeVisible();
+            await page.evaluate(() => document.getElementById('persona_workspace_tab_edit').click());
+            await page.locator('#persona_editor_tab_prompt').click();
+            await page.locator('#persona_appendices_heading').click();
+
+            const first = page.locator('.persona-appendix-card[data-appendix-id="note-one"]');
+            const second = page.locator('.persona-appendix-card[data-appendix-id="note-two"]');
+            const firstDetails = first.locator('details');
+            const secondDetails = second.locator('details');
+            const preview = page.locator('#persona_effective_description_preview');
+
+            await expect(firstDetails).toHaveJSProperty('open', false);
+            await expect(secondDetails).toHaveJSProperty('open', false);
+            await expect(first.locator('.persona-appendix-description')).toBeHidden();
+            await first.locator('summary').click();
+            await expect(first.locator('.persona-appendix-description')).toBeVisible();
+            await expect(secondDetails).toHaveJSProperty('open', false);
+            await expect(preview).toHaveText('Base persona');
+
+            await second.getByRole('checkbox', { name: 'Second note', exact: true }).check();
+            await expect(preview).toContainText('Second scenario note.');
+            await expect(firstDetails).toHaveJSProperty('open', true);
+            await expect(secondDetails).toHaveJSProperty('open', false);
+            await first.locator('summary').press('Space');
+            await expect(firstDetails).toHaveJSProperty('open', false);
+            await expect(preview).toContainText('Second scenario note.');
+            await first.locator('summary').press('Enter');
+            await second.locator('summary').click();
+            await expect(firstDetails).toHaveJSProperty('open', true);
+            await expect(secondDetails).toHaveJSProperty('open', true);
+
+            await second.locator('.persona_appendix_edit').click();
+            await page.locator('#persona_appendix_description_input').fill('Updated scenario note.');
+            await page.locator('dialog[open] .popup-button-ok').click();
+            await expect(preview).toContainText('Updated scenario note.');
+            await expect(firstDetails).toHaveJSProperty('open', true);
+            await expect(secondDetails).toHaveJSProperty('open', true);
+            await first.locator('summary').click();
+            await second.locator('summary').click();
+            await second.locator('.persona_appendix_delete').click();
+            await page.locator('dialog[open] .popup-button-cancel').click();
+            await expect(secondDetails).toHaveJSProperty('open', false);
+            await expect(second.getByRole('checkbox')).toBeChecked();
+            await expect(preview).toContainText('Updated scenario note.');
+            await first.scrollIntoViewIfNeeded();
+            await page.screenshot({ path: testInfo.outputPath('scenario-note-dropdowns.png') });
+
+            await page.evaluate(async () => {
+                const { power_user } = await import('/scripts/power-user.js');
+                const { user_avatar, setPersonaDescription } = await import('/scripts/personas.js');
+                power_user.persona_descriptions[user_avatar].appendices[0].name = 'LongLabel'.repeat(20);
+                setPersonaDescription();
+            });
+            await expect(first.locator('summary')).toHaveText('LongLabel'.repeat(20));
+            for (const card of [first, second]) {
+                expect(await card.evaluate(element => element.scrollWidth - element.clientWidth)).toBeLessThanOrEqual(1);
+                expect((await card.locator('summary').boundingBox()).height).toBeGreaterThanOrEqual(44);
+            }
+            await first.scrollIntoViewIfNeeded();
+            await page.screenshot({ path: testInfo.outputPath('long-note-label.png') });
+
+            await second.locator('summary').click();
+            await page.evaluate(async () => {
+                const { power_user } = await import('/scripts/power-user.js');
+                const { user_avatar, initUserAvatar, setPersonaDescription } = await import('/scripts/personas.js');
+                power_user.persona_descriptions['dropdown-other.png'] = structuredClone(power_user.persona_descriptions[user_avatar]);
+                initUserAvatar('dropdown-other.png');
+                setPersonaDescription();
+            });
+            await expect(firstDetails).toHaveJSProperty('open', false);
+            await expect(secondDetails).toHaveJSProperty('open', false);
+        });
+    });
+}

--- a/tests/persona-management-ui.test.js
+++ b/tests/persona-management-ui.test.js
@@ -35,7 +35,7 @@ describe('Persona Management mobile layout', () => {
 });
 
 describe('Scenario Notes disclosure', () => {
-    test('starts collapsed without nesting another disclosure inside it', () => {
+    test('starts collapsed with a plain final-prompt preview', () => {
         expect(indexHtml).toMatch(/<details class="persona-appendices-block"[^>]*>\s*<summary id="persona_appendices_heading"/);
         expect(indexHtml).not.toContain('<details open class="persona-appendices-block"');
         expect(indexHtml).not.toContain('<details class="persona-effective-preview">');

--- a/tests/persona-management-ui.test.js
+++ b/tests/persona-management-ui.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const personaCss = readFileSync(path.join(repoRoot, 'public', 'css', 'personas.css'), 'utf8').replace(/\r\n/g, '\n');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8').replace(/\r\n/g, '\n');
+const tabsJs = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8').replace(/\r\n/g, '\n');
+
+function getRuleBodies(cssSource, selector) {
+    const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const matches = [...cssSource.matchAll(new RegExp(`^\\s*${escapedSelector}\\s*\\{(?<body>[^}]*)\\}`, 'gms'))];
+
+    return matches.map(match => match.groups?.body ?? '');
+}
+
+describe('Persona Management mobile layout', () => {
+    test('keeps the persona list vertical-only', () => {
+        const rules = getRuleBodies(personaCss, '#persona_management_list_scroller').join('\n');
+
+        expect(rules).toContain('overflow-y: auto;');
+        expect(rules).toContain('overflow-x: hidden;');
+        expect(rules).toContain('touch-action: pan-y;');
+    });
+
+    test('shrinks persona card content and wraps mobile actions', () => {
+        const contentRules = getRuleBodies(personaCss, '#user_avatar_block:not(.gridView) .avatar-container .character_select_container').join('\n');
+        const stateRules = getRuleBodies(personaCss, '#user_avatar_block:not(.gridView) .avatar-container .avatar_container_states').join('\n');
+
+        expect(contentRules).toContain('grid-template-columns: minmax(0, 1fr);');
+        expect(stateRules).toContain('min-width: 0;');
+        expect(stateRules).toContain('flex-wrap: wrap;');
+    });
+});
+
+describe('Scenario Notes disclosure', () => {
+    test('starts collapsed without nesting another disclosure inside it', () => {
+        expect(indexHtml).toMatch(/<details class="persona-appendices-block"[^>]*>\s*<summary id="persona_appendices_heading"/);
+        expect(indexHtml).not.toContain('<details open class="persona-appendices-block"');
+        expect(indexHtml).not.toContain('<details class="persona-effective-preview">');
+        expect(indexHtml).toContain('class="persona-effective-preview-title"');
+    });
+
+    test('the Scenario Notes shortcut opens the disclosure before focusing Add', () => {
+        expect(tabsJs).toContain('const appendicesBlock = appendicesHeading?.closest(\'details\');');
+        expect(tabsJs).toContain('appendicesBlock.open = true;');
+        expect(tabsJs).toContain('addButton?.focus({ preventScroll: true });');
+    });
+});


### PR DESCRIPTION
Fixes the CSS error of the personas page being draggable on mobile. Also adds a collapsible dropdown for the Scenario Notes to make it easier to scroll down.