### PR TITLE
feat(nanogpt+openrouter): gather providers from Nano-GPT in real time instead of hardcoding, and add a Flex + Priority option for PAYG models with a Flex/Priority endpoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2412,6 +2412,12 @@
                                     </h4>
                                     <select id="openrouter_providers_text" class="openrouter_providers" multiple>
                                     </select>
+                                    <label for="openrouter_service_tier_text">Flex + Priority</label>
+                                    <select id="openrouter_service_tier_text" class="text_pole" disabled>
+                                        <option value="" data-i18n="Default">Default</option>
+                                        <option value="flex" disabled>Flex</option>
+                                        <option value="priority" disabled>Priority</option>
+                                    </select>
                                     <label class="checkbox_label" data-i18n="[title]Automatically chooses an alternative provider if chosen providers can't serve your request." for="openrouter_allow_fallbacks_textgenerationwebui" title="Automatically chooses an alternative provider if chosen providers can't serve your request.">
                                         <input id="openrouter_allow_fallbacks_textgenerationwebui" type="checkbox" />
                                         <span data-i18n="Allow fallback providers">Allow fallback providers</span>
@@ -3229,6 +3235,12 @@
                                 </h4>
                                 <select id="openrouter_providers_chat" class="openrouter_providers" multiple>
                                 </select>
+                                <label for="openrouter_service_tier_chat">Flex + Priority</label>
+                                <select id="openrouter_service_tier_chat" class="text_pole" disabled>
+                                    <option value="" data-i18n="Default">Default</option>
+                                    <option value="flex" disabled>Flex</option>
+                                    <option value="priority" disabled>Priority</option>
+                                </select>
                                 <label class="checkbox_label marginTopBot5" for="openrouter_allow_fallbacks" data-i18n="[title]Automatically chooses an alternative provider if chosen providers can't serve your request." title="Automatically chooses an alternative provider if chosen providers can't serve your request.">
                                     <input id="openrouter_allow_fallbacks" type="checkbox" />
                                     <span data-i18n="Allow fallback providers">Allow fallback providers</span>
@@ -3675,6 +3687,12 @@
                                 <input id="nanogpt_payg_override" type="checkbox">
                                 <span data-i18n="Use pay-as-you-go billing">Use pay-as-you-go billing</span>
                             </label>
+                            <label for="nanogpt_service_tier">Flex + Priority</label>
+                            <select id="nanogpt_service_tier" class="text_pole" disabled>
+                                <option value="" data-i18n="Default">Default</option>
+                                <option value="flex" disabled>Flex</option>
+                                <option value="priority" disabled>Priority</option>
+                            </select>
                         </div>
                         <div id="workers_ai_form" data-source="workers_ai">
                             <h4><a href="https://dash.cloudflare.com/?to=/:account/ai/workers-ai/api-quick-start" target="_blank" rel="noopener noreferrer" data-i18n="Cloudflare Workers AI API Key">Cloudflare Workers AI API Key</a></h4>

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -3,7 +3,7 @@ import { extractJsonFromData, extractMessageFromData, getGenerateUrl, getRequest
 import { getTextGenServer, createTextGenGenerationData, setting_names, textgenerationwebui_settings } from './textgen-settings.js';
 import { extractReasoningFromData } from './reasoning.js';
 import { formatInstructModeChat, formatInstructModePrompt, getInstructStoppingSequences } from './instruct-mode.js';
-import { chat_completion_sources, getStreamingReply, tryParseStreamingError, createGenerationParameters, settingsToUpdate, oai_settings } from './openai.js';
+import { chat_completion_sources, getStreamingReply, tryParseStreamingError, createGenerationParameters, getNanoGptServiceTier, settingsToUpdate, oai_settings } from './openai.js';
 import EventSourceStream from './sse-stream.js';
 import { fetchResumable } from './resumable-generation.js';
 import { migrateNanoGptProviderSettings } from './openai-preset-utils.js';
@@ -165,6 +165,7 @@ export class TextCompletionService {
      * @throws {Error}
      */
     static async sendRequest(data, extractData = true, signal = null) {
+        if (data.service_tier === '') delete data.service_tier;
         if (!data.stream) {
             const response = await fetchResumable(getGenerateUrl(this.TYPE), {
                 method: 'POST',
@@ -452,6 +453,7 @@ export class TextCompletionService {
 
         // Only take fields from the preset specified in setting_names to use as TextCompletionSettings
         const settings = structuredClone(textgenerationwebui_settings);
+        settings.openrouter_service_tier = preset.openrouter_service_tier ?? '';
         for (const [key, value] of Object.entries(preset)) {
             if (!setting_names.includes(key)) continue;
             settings[key] = value;
@@ -525,6 +527,10 @@ export class ChatCompletionService {
     static async sendRequest(data, extractData = true, signal = null) {
         delete data.__connectionProfileRequestFields;
         delete data.modelOverride;
+        if (data.service_tier === '') delete data.service_tier;
+        if (data.chat_completion_source === chat_completion_sources.NANOGPT && data.service_tier) {
+            data.service_tier = await getNanoGptServiceTier({ ...data, nanogpt_service_tier: data.service_tier }, data.model);
+        }
         const response = await fetchResumable('/api/backends/chat-completions/generate', {
             method: 'POST',
             headers: getRequestHeaders(),
@@ -656,6 +662,9 @@ export class ChatCompletionService {
 
         // Convert from preset to ChatCompletionSettings
         const settings = structuredClone(oai_settings);
+        // SillyBunny: a preset without a tier predates paid-tier opt-in.
+        settings.nanogpt_service_tier = preset.nanogpt_service_tier ?? '';
+        settings.openrouter_service_tier = preset.openrouter_service_tier ?? '';
         for (const [key, value] of Object.entries(preset)) {
             const settingToUpdate = settingsToUpdate[key];
             if (!settingToUpdate) continue;
@@ -695,6 +704,13 @@ export class ChatCompletionService {
         }
         if (overridePayload.model) {
             settings.openai_model = overridePayload.model;
+        }
+        if (overridePayload.service_tier !== undefined) {
+            const source = settings.chat_completion_source;
+            if (['nanogpt', 'openrouter'].includes(source)) settings[`${source}_service_tier`] = overridePayload.service_tier;
+        }
+        for (const key of ['nanogpt_provider', 'nanogpt_allowed_providers', 'nanogpt_ignored_providers', 'nanogpt_payg_override']) {
+            if (Object.hasOwn(overridePayload, key)) settings[key] = overridePayload[key];
         }
         if (overridePayload.reverse_proxy !== undefined) {
             settings.reverse_proxy = overridePayload.reverse_proxy;
@@ -788,6 +804,9 @@ export class ChatCompletionService {
         }
         if (shouldUseConnectionProfileField('verbosity')) {
             overridePayload.verbosity = payload.verbosity;
+        }
+        if (shouldUseConnectionProfileField('service_tier')) {
+            overridePayload.service_tier = payload.service_tier;
         }
         delete overridePayload.__connectionProfileRequestFields;
         delete overridePayload.modelOverride;

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -18,7 +18,7 @@ import { getSecretLabelById } from '../../secrets.js';
 import { chat_completion_sources, maybeApplyModelSamplingProfile, oai_settings, selected_custom_endpoint_preset, syncCustomEndpointPresetSelectionBySecretId } from '../../openai.js';
 import { performFuzzySearch } from '/scripts/power-user.js';
 import { StreamingDisplay } from '/scripts/streaming-display.js';
-import { ConnectionManagerRequestService } from '../shared.js';
+import { ConnectionManagerRequestService, getProfileServiceTier } from '../shared.js';
 import { formatReasoning } from '/scripts/reasoning.js';
 
 const MODULE_NAME = 'connection-manager';
@@ -64,6 +64,7 @@ const CC_COMMANDS = [
     'custom-endpoint-profile',
     'api-url',
     'model',
+    'service-tier',
     'proxy',
     'stop-strings',
     'start-reply-with',
@@ -93,6 +94,7 @@ const TC_COMMANDS = [
     'preset',
     'api-url',
     'model',
+    'service-tier',
     'sysprompt',
     'sysprompt-state',
     'instruct',
@@ -111,6 +113,7 @@ const FANCY_NAMES = {
     'api-url': 'Server URL',
     'preset': 'Settings Preset',
     'model': 'Model',
+    'service-tier': 'Flex + Priority',
     'proxy': 'Proxy Preset',
     'custom-endpoint-profile': 'Custom Endpoint Profile',
     'sysprompt-state': 'Use System Prompt',
@@ -1008,6 +1011,10 @@ async function applyConnectionProfile(profile) {
             }
 
             let argument = profile[command];
+            if (command === 'service-tier') {
+                const tier = getProfileServiceTier(profile);
+                argument = tier === '' ? 'default' : tier;
+            }
             const allowEmpty = ALLOW_EMPTY.includes(command);
             // SillyBunny: a profile without a proxy value means "no proxy". Reset the
             // proxy preset instead of skipping, otherwise the previous profile's proxy

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -56,6 +56,17 @@ function getProfileCompletionPreset(profile) {
     }
 }
 
+export function getProfileServiceTier(profile) {
+    const api = CONNECT_API_MAP[profile.api];
+    const source = api?.source || api?.type;
+    if (!['nanogpt', 'openrouter'].includes(source)) return undefined;
+    if (profile.exclude?.includes('service-tier')) return undefined;
+    // Older profiles inherit an explicitly bound preset choice, never the active UI's paid tier.
+    const presetTier = api.selected === 'openai' ? getProfileCompletionPreset(profile)?.[`${source}_service_tier`] : undefined;
+    const tier = profile['service-tier'] ?? presetTier;
+    return tier === 'default' ? '' : (tier ?? '');
+}
+
 export function getChatCompletionProfileRequestOverrides(profile, overridePayload) {
     const overrides = {};
     const profileFieldNames = [];
@@ -576,10 +587,14 @@ export class ConnectionManagerRequestService {
                         // so recover reverse proxy fields from the profile preset or current proxy state.
                         ...reverseProxyFields,
                         custom_prompt_post_processing: profile['prompt-post-processing'],
+                        service_tier: getProfileServiceTier(profile),
                         // SillyBunny: persist profile-scoped reasoning and image request settings through the shared request path.
                         ...profileRequestOverrides.overrides,
                         ...overridePayload,
-                        __connectionProfileRequestFields: profileRequestOverrides.profileFieldNames,
+                        __connectionProfileRequestFields: [
+                            ...profileRequestOverrides.profileFieldNames,
+                            ...(!Object.hasOwn(overridePayload, 'service_tier') ? ['service_tier'] : []),
+                        ],
                     };
 
                     // Only set the URL field for the actual API source to avoid contaminating
@@ -619,6 +634,7 @@ export class ConnectionManagerRequestService {
                         max_tokens: maxTokens,
                         model: profile.model,
                         api_type: selectedApiMap.type,
+                        service_tier: getProfileServiceTier(profile),
                         api_server: profile['api-url'],
                         secret_id: profile['secret-id'],
                         ...overridePayload,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -86,6 +86,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { setOpenRouterProviders, syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { getNanoGptServiceTiers, isNanoGptPayg, updateServiceTierOptions } from './service-tiers.js';
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
 import {
@@ -226,6 +227,7 @@ const textCompletionModels = [
 
 let biasCache = undefined;
 export let model_list = [];
+let nanoGptModelList = [];
 let openAiStaticModelGroups = null;
 let hasShownPresetConnectionBindingReminder = false;
 let settingsPresetChangeGeneration = 0;
@@ -454,6 +456,7 @@ export const settingsToUpdate = {
     openrouter_group_models: ['#openrouter_group_models', 'openrouter_group_models', false, true],
     openrouter_sort_models: ['#openrouter_sort_models', 'openrouter_sort_models', false, true],
     openrouter_providers: ['#openrouter_providers_chat', 'openrouter_providers', false, true],
+    openrouter_service_tier: ['#openrouter_service_tier_chat', 'openrouter_service_tier', false, true],
     openrouter_quantizations: ['#openrouter_quantizations_chat', 'openrouter_quantizations', false, true],
     openrouter_allow_fallbacks: ['#openrouter_allow_fallbacks', 'openrouter_allow_fallbacks', true, true],
     openrouter_middleout: ['#openrouter_middleout', 'openrouter_middleout', false, true],
@@ -477,6 +480,7 @@ export const settingsToUpdate = {
     nanogpt_allowed_providers: ['#nanogpt_allowed_providers', 'nanogpt_allowed_providers', false, true],
     nanogpt_ignored_providers: ['#nanogpt_ignored_providers', 'nanogpt_ignored_providers', false, true],
     nanogpt_payg_override: ['#nanogpt_payg_override', 'nanogpt_payg_override', true, true],
+    nanogpt_service_tier: ['#nanogpt_service_tier', 'nanogpt_service_tier', false, true],
     deepseek_model: ['#model_deepseek_select', 'deepseek_model', false, true],
     aimlapi_model: ['#model_aimlapi_select', 'aimlapi_model', false, true],
     xai_model: ['#model_xai_select', 'xai_model', false, true],
@@ -605,6 +609,7 @@ const default_settings = {
     nanogpt_allowed_providers: [],
     nanogpt_ignored_providers: [],
     nanogpt_payg_override: false,
+    nanogpt_service_tier: '',
     deepseek_model: 'deepseek-v4-flash',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
@@ -633,6 +638,7 @@ const default_settings = {
     openrouter_group_models: false,
     openrouter_sort_models: 'alphabetically',
     openrouter_providers: [],
+    openrouter_service_tier: '',
     openrouter_quantizations: [],
     openrouter_allow_fallbacks: true,
     openrouter_middleout: openrouter_middleout_types.ON,
@@ -2805,7 +2811,7 @@ function bindInlineSelectPickerSelect(select, control) {
     select.classList.add('sb-inline-select-picker-control');
 
     // SillyBunny: repaint an open provider menu after async updates without saving settings.
-    if (select.classList.contains('openrouter_providers')) {
+    if (select.classList.contains('openrouter_providers') || ['nanogpt_allowed_providers', 'nanogpt_ignored_providers'].includes(select.id)) {
         $(select).on('change.select2', () => {
             const menu = document.getElementById(`${select.id}_menu`);
             if (shouldUseInlineModelSelectPicker() && menu && !menu.hidden) {
@@ -4618,6 +4624,7 @@ function saveModelList(data) {
 
     if (oai_settings.chat_completion_source == chat_completion_sources.NANOGPT) {
         $('#model_nanogpt_select').empty();
+        nanoGptModelList = model_list;
         model_list.forEach((model) => {
             $('#model_nanogpt_select').append(
                 $('<option>', {
@@ -5494,6 +5501,7 @@ export async function createGenerationParameters(settings, model, type, messages
         generate_data.top_a = Number(settings.top_a_openai);
         generate_data.use_fallback = settings.openrouter_use_fallback;
         generate_data.provider = settings.openrouter_providers;
+        generate_data.service_tier = settings.openrouter_service_tier || undefined;
         generate_data.quantizations = settings.openrouter_quantizations;
         generate_data.allow_fallbacks = settings.openrouter_allow_fallbacks;
         generate_data.middleout = settings.openrouter_middleout;
@@ -5635,6 +5643,7 @@ export async function createGenerationParameters(settings, model, type, messages
         generate_data.nanogpt_allowed_providers = settings.nanogpt_allowed_providers;
         generate_data.nanogpt_ignored_providers = settings.nanogpt_ignored_providers;
         generate_data.nanogpt_payg_override = settings.nanogpt_payg_override;
+        generate_data.service_tier = await getNanoGptServiceTier(settings, model);
         generate_data.top_k = settings.top_k_openai > 0 ? Number(settings.top_k_openai) : undefined;
         generate_data.min_p = Number(settings.min_p_openai);
         generate_data.repetition_penalty = Number(settings.repetition_penalty_openai);
@@ -7018,6 +7027,35 @@ function migrateChatCompletionSettings(settings) {
     }
 }
 
+export async function getNanoGptServiceTier(settings, modelId) {
+    const tier = settings.nanogpt_service_tier;
+    if (!tier) return undefined;
+    // Explicit API overrides still reach backend validation; only UI tiers need billing eligibility.
+    if (!['flex', 'priority'].includes(tier)) return tier;
+    let model = nanoGptModelList.find(model => model.id === modelId);
+    if (!model) {
+        // Background profile requests may run before NanoGPT has ever been connected in the UI.
+        const response = await fetch('/api/backends/chat-completions/status', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ chat_completion_source: chat_completion_sources.NANOGPT }),
+            signal: AbortSignal.timeout(10000),
+        });
+        const data = response.ok ? await response.json() : null;
+        if (!Array.isArray(data?.data)) throw new Error('service_tier');
+        nanoGptModelList = data.data;
+        model = nanoGptModelList.find(model => model.id === modelId);
+    }
+    if (!model) throw new Error('service_tier');
+    if (!isNanoGptPayg(model, settings)) return undefined;
+    if (!getNanoGptServiceTiers(model, settings).includes(tier)) throw new Error('service_tier');
+    return tier;
+}
+
+function updateNanoGptServiceTierControl() {
+    updateServiceTierOptions('#nanogpt_service_tier', getNanoGptServiceTiers(nanoGptModelList.find(model => model.id === oai_settings.nanogpt_model), oai_settings));
+}
+
 function updateNanoGptProviderControls() {
     for (const key of ['nanogpt_allowed_providers', 'nanogpt_ignored_providers']) {
         const select = document.getElementById(key);
@@ -7033,6 +7071,8 @@ function updateNanoGptProviderControls() {
         $(`#${key}_picker`).text(Array.from(select.selectedOptions, option => option.text).join(', ') || t`Select providers`);
     }
     $('#nanogpt_payg_override').prop('checked', oai_settings.nanogpt_payg_override === true);
+    $('#nanogpt_service_tier').val(oai_settings.nanogpt_service_tier);
+    updateNanoGptServiceTierControl();
     updateNanoGptProvidersWarning('#nanogpt_allowed_providers');
 }
 
@@ -8673,6 +8713,7 @@ async function onModelChange() {
         console.log('NanoGPT model changed to', value);
         oai_settings.nanogpt_model = value;
         syncNanoGptProvidersForModel(value, '#nanogpt_allowed_providers');
+        updateNanoGptServiceTierControl();
     }
 
     if ($(this).is('#model_workers_ai_select')) {
@@ -10367,6 +10408,29 @@ function registerChatCompletionProfileSlashCommand({ name, callback, description
 }
 
 function registerChatCompletionProfileSlashCommands() {
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'service-tier',
+        callback: (args, value) => {
+            const selector = main_api === 'textgenerationwebui'
+                ? ($('#textgen_type').val() === 'openrouter' ? '#openrouter_service_tier_text' : null)
+                : main_api === 'openai' && ({ nanogpt: '#nanogpt_service_tier', openrouter: '#openrouter_service_tier_chat' })[oai_settings.chat_completion_source];
+            if (!selector) return '';
+            if (hasSlashCommandValue(args, value)) {
+                const tier = getSlashCommandStringValue(value).trim();
+                getSlashCommandEnumValue(tier, ['default', 'flex', 'priority'], 'service-tier');
+                $(selector).val(tier === 'default' ? '' : tier).trigger('change');
+            }
+            return document.querySelector(selector)?.value || 'default';
+        },
+        returns: t`current value`,
+        unnamedArgumentList: [SlashCommandArgument.fromProps({
+            description: 'Flex + Priority',
+            typeList: [ARGUMENT_TYPE.STRING],
+            enumList: ['default', 'flex', 'priority'],
+            forceEnum: true,
+        })],
+        helpString: 'Flex + Priority',
+    }));
     registerChatCompletionProfileSlashCommand({
         name: 'request-reasoning',
         callback: runBooleanChatCompletionSettingCallback('request-reasoning', 'show_thoughts', '#openai_show_thoughts', setToolReasoningControls),
@@ -11290,6 +11354,13 @@ export function initOpenAI() {
 
     $('#nanogpt_payg_override').on('input', function () {
         oai_settings.nanogpt_payg_override = this.checked;
+        updateNanoGptServiceTierControl();
+        saveSettingsDebounced();
+    });
+
+    $('#nanogpt_service_tier, #openrouter_service_tier_chat').on('change', function () {
+        const key = this.id === 'nanogpt_service_tier' ? 'nanogpt_service_tier' : 'openrouter_service_tier';
+        oai_settings[key] = this.value;
         saveSettingsDebounced();
     });
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -1111,6 +1111,7 @@ class PresetManager {
             'featherless_model',
             'max_tokens_second',
             'openrouter_providers',
+            'openrouter_service_tier',
             'openrouter_quantizations',
             'openrouter_allow_fallbacks',
             'tabby_model',

--- a/public/scripts/service-tiers.js
+++ b/public/scripts/service-tiers.js
@@ -1,0 +1,24 @@
+export function isNanoGptPayg(model, settings) {
+    const hasProviderLists = Object.hasOwn(settings, 'nanogpt_allowed_providers') || Object.hasOwn(settings, 'nanogpt_ignored_providers');
+    return model?.subscription?.included === false || settings.nanogpt_payg_override === true
+        || settings.nanogpt_allowed_providers?.length > 0 || settings.nanogpt_ignored_providers?.length > 0
+        || (!hasProviderLists && typeof settings.nanogpt_provider === 'string' && settings.nanogpt_provider.trim().length > 0);
+}
+
+export function getNanoGptServiceTiers(model, settings) {
+    const tiers = model?.supported_service_tiers;
+    return isNanoGptPayg(model, settings) && Array.isArray(tiers)
+        ? [...new Set(tiers.map(tier => tier === 'fast' ? 'priority' : tier))].filter(tier => ['flex', 'priority'].includes(tier))
+        : [];
+}
+
+export function updateServiceTierOptions(selector, tiers = []) {
+    const select = document.querySelector(selector);
+    if (!select) return;
+    // Keep saved choices visible and let the user return to Default, even when support disappears.
+    const value = select.value;
+    for (const option of select.options) {
+        option.disabled = Boolean(option.value) && !tiers.includes(option.value);
+    }
+    select.disabled = tiers.length === 0 && !value;
+}

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -8,6 +8,7 @@ import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { localizePagination, PAGINATION_TEMPLATE, textValueMatcher } from './utils.js';
 import { isMobile } from './RossAscends-mods.js';
+import { updateServiceTierOptions } from './service-tiers.js';
 
 let mancerModels = [];
 let togetherModels = [];
@@ -27,362 +28,16 @@ function shouldUseNativeApiSelects() {
 // SillyBunny: share in-flight catalogue requests, not a hardcoded provider list.
 let openRouterProvidersRequest = null;
 
-/**
- * List of NanoGPT providers.
- * Providers endpoint: https://nano-gpt.com/api/models/providers
- * @type {{id: string, label: string}[]}
- */
-const NANOGPT_PROVIDERS = [
-    {
-        'id': 'aionlabs',
-        'label': 'Aion',
-    },
-    {
-        'id': 'aoru',
-        'label': 'Aoru AI',
-    },
-    {
-        'id': 'akash',
-        'label': 'Akash',
-    },
-    {
-        'id': 'alibaba',
-        'label': 'Alibaba',
-    },
-    {
-        'id': 'ambient',
-        'label': 'Ambient',
-    },
-    {
-        'id': 'anthropic',
-        'label': 'Anthropic',
-    },
-    {
-        'id': 'arliai',
-        'label': 'ArliAI',
-    },
-    {
-        'id': 'aster',
-        'label': 'Aster',
-    },
-    {
-        'id': 'aster-fast',
-        'label': 'Aster Fast',
-    },
-    {
-        'id': 'atlascloud',
-        'label': 'AtlasCloud',
-    },
-    {
-        'id': 'azure',
-        'label': 'Azure',
-    },
-    {
-        'id': 'awsbedrock',
-        'label': 'Amazon Bedrock',
-    },
-    {
-        'id': 'baidu',
-        'label': 'Baidu',
-    },
-    {
-        'id': 'baseten',
-        'label': 'BaseTen',
-    },
-    {
-        'id': 'cerebras',
-        'label': 'Cerebras',
-    },
-    {
-        'id': 'chutes',
-        'label': 'Chutes',
-    },
-    {
-        'id': 'clarifai',
-        'label': 'Clarifai',
-    },
-    {
-        'id': 'cloudflare',
-        'label': 'Cloudflare',
-    },
-    {
-        'id': 'coreweave',
-        'label': 'CoreWeave',
-    },
-    {
-        'id': 'crofai',
-        'label': 'CrofAI',
-    },
-    {
-        'id': 'crusoe',
-        'label': 'Crusoe',
-    },
-    {
-        'id': 'decart',
-        'label': 'Decart',
-    },
-    {
-        'id': 'dekallm',
-        'label': 'DekaLLM',
-    },
-    {
-        'id': 'deepinfra',
-        'label': 'DeepInfra',
-    },
-    {
-        'id': 'deepseek',
-        'label': 'DeepSeek',
-    },
-    {
-        'id': 'darkbloom',
-        'label': 'Darkbloom',
-    },
-    {
-        'id': 'engy',
-        'label': 'EngyAI',
-    },
-    {
-        'id': 'fireworks',
-        'label': 'Fireworks',
-    },
-    {
-        'id': 'fireworks-fast',
-        'label': 'Fireworks Fast',
-    },
-    {
-        'id': 'friendli',
-        'label': 'Friendli',
-    },
-    {
-        'id': 'gerra',
-        'label': 'Gerra',
-    },
-    {
-        'id': 'gmicloud',
-        'label': 'GMICloud',
-    },
-    {
-        'id': 'lilac',
-        'label': 'Lilac',
-    },
-    {
-        'id': 'llmtech',
-        'label': 'LLM Tech',
-    },
-    {
-        'id': 'lucidity',
-        'label': 'Lucidity',
-    },
-    {
-        'id': 'heabsy',
-        'label': 'Heabsy',
-    },
-    {
-        'id': 'google',
-        'label': 'Google',
-    },
-    {
-        'id': 'groq',
-        'label': 'Groq',
-    },
-    {
-        'id': 'hyperbolic',
-        'label': 'Hyperbolic',
-    },
-    {
-        'id': 'ionet',
-        'label': 'io.net',
-    },
-    {
-        'id': 'inceptron',
-        'label': 'Inceptron',
-    },
-    {
-        'id': 'mancer',
-        'label': 'Mancer',
-    },
-    {
-        'id': 'mara',
-        'label': 'Mara',
-    },
-    {
-        'id': 'meganova',
-        'label': 'MegaNova',
-    },
-    {
-        'id': 'meta',
-        'label': 'Meta',
-    },
-    {
-        'id': 'mixlayer',
-        'label': 'Mixlayer',
-    },
-    {
-        'id': 'minimax',
-        'label': 'MiniMax',
-    },
-    {
-        'id': 'modal',
-        'label': 'Modal',
-    },
-    {
-        'id': 'modelrun',
-        'label': 'ModelRun',
-    },
-    {
-        'id': 'moonshot',
-        'label': 'Moonshot',
-    },
-    {
-        'id': 'morph',
-        'label': 'Morph',
-    },
-    {
-        'id': 'ncompass',
-        'label': 'NCompass',
-    },
-    {
-        'id': 'nebius',
-        'label': 'Nebius',
-    },
-    {
-        'id': 'neuralwatt',
-        'label': 'NeuralWatt',
-    },
-    {
-        'id': 'neuralwatt-fast',
-        'label': 'NeuralWatt Fast',
-    },
-    {
-        'id': 'neuralwatt-flex',
-        'label': 'NeuralWatt Flex',
-    },
-    {
-        'id': 'nube',
-        'label': 'Nube',
-    },
-    {
-        'id': 'tensorix',
-        'label': 'TensorX',
-    },
-    {
-        'id': 'nextbit',
-        'label': 'NextBit',
-    },
-    {
-        'id': 'novita',
-        'label': 'Novita',
-    },
-    {
-        'id': 'openai',
-        'label': 'OpenAI',
-    },
-    {
-        'id': 'parasail',
-        'label': 'Parasail',
-    },
-    {
-        'id': 'phala',
-        'label': 'Phala',
-    },
-    {
-        'id': 'plubo',
-        'label': 'Plubo AI',
-    },
-    {
-        'id': 'pokee',
-        'label': 'Pokee',
-    },
-    {
-        'id': 'abliteration',
-        'label': 'Abliteration.ai',
-    },
-    {
-        'id': 'redpill',
-        'label': 'Redpill',
-    },
-    {
-        'id': 'runware',
-        'label': 'Runware',
-    },
-    {
-        'id': 'sailresearch-asap',
-        'label': 'Sail Research (ASAP)',
-    },
-    {
-        'id': 'sailresearch-priority',
-        'label': 'Sail Research (Priority)',
-    },
-    {
-        'id': 'sailresearch-standard',
-        'label': 'Sail Research (Standard)',
-    },
-    {
-        'id': 'sambanova',
-        'label': 'SambaNova',
-    },
-    {
-        'id': 'sambanova-high-throughput',
-        'label': 'SambaNova (High Throughput)',
-    },
-    {
-        'id': 'siliconflow',
-        'label': 'SiliconFlow',
-    },
-    {
-        'id': 'streamlake',
-        'label': 'StreamLake',
-    },
-    {
-        'id': 'tinfoil',
-        'label': 'Tinfoil',
-    },
-    {
-        'id': 'together',
-        'label': 'Together',
-    },
-    {
-        'id': 'uomi',
-        'label': 'Uomi',
-    },
-    {
-        'id': 'venice',
-        'label': 'Venice',
-    },
-    {
-        'id': 'wandb',
-        'label': 'Weights & Biases',
-    },
-    {
-        'id': 'wafer',
-        'label': 'Wafer',
-    },
-    {
-        'id': 'xai',
-        'label': 'SpaceXAI',
-    },
-    {
-        'id': 'xiaomi',
-        'label': 'Xiaomi',
-    },
-    {
-        'id': 'zai',
-        'label': 'Z.AI',
-    },
-    {
-        'id': 'zenmux',
-        'label': 'ZenMux',
-    },
-];
-
 const OPENROUTER_PROVIDER_WARNING_SELECTORS = {
     '#openrouter_providers_text': {
         fallbackSelector: '#openrouter_allow_fallbacks_textgenerationwebui',
         warningSelector: '#openrouter_provider_warning_text',
+        tierSelector: '#openrouter_service_tier_text',
     },
     '#openrouter_providers_chat': {
         fallbackSelector: '#openrouter_allow_fallbacks',
         warningSelector: '#openrouter_provider_warning_chat',
+        tierSelector: '#openrouter_service_tier_chat',
     },
 };
 
@@ -413,19 +68,26 @@ export function updateOpenRouterProvidersWarning(providersSelector) {
  * @param {string[]} [providerNames]
  */
 export function setOpenRouterProviders(providersSelector, selectedProviders, providerNames) {
+    setProviderOptions(providersSelector, selectedProviders, providerNames?.map(name => ({ id: name, label: name })));
+    updateOpenRouterProvidersWarning(providersSelector);
+}
+
+function setProviderOptions(providersSelector, selectedProviders, providers) {
     const select = $(providersSelector)[0];
     if (!select) return;
 
     const options = new Map(Array.from(select.options, option => [option.value, option]));
     const selected = Array.isArray(selectedProviders) ? selectedProviders.filter(name => typeof name === 'string' && name.trim()) : [];
-    const names = (providerNames ?? [...options.keys()]).filter(name => !selected.includes(name)).sort((a, b) => a.localeCompare(b));
+    const labels = new Map(providers?.map(provider => [provider.id, provider.label]));
+    const names = (providers?.map(provider => provider.id) ?? [...options.keys()]).filter(name => !selected.includes(name))
+        .sort((a, b) => (labels.get(a) ?? a).localeCompare(labels.get(b) ?? b));
     select.replaceChildren(...Array.from(new Set([...names, ...selected]), name => {
         const option = options.get(name) ?? new Option(name, name);
+        option.text = labels.get(name) ?? option.text;
         option.selected = selected.includes(name);
         return option;
     }));
     $(select).trigger('change.select2');
-    updateOpenRouterProvidersWarning(providersSelector);
 }
 
 export async function syncOpenRouterProvidersForModel(modelId, providersSelector) {
@@ -435,6 +97,11 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
     // SillyBunny: a late catalogue or model response must not overwrite a newer selection.
     const request = {};
     $providers.data('openrouterRequest', request);
+    const tierSelector = OPENROUTER_PROVIDER_WARNING_SELECTORS[providersSelector]?.tierSelector;
+    if ($providers.data('openrouterModel') !== modelId) {
+        updateServiceTierOptions(tierSelector);
+        $providers.data('openrouterModel', modelId);
+    }
 
     const refreshWarningState = () => {
         updateOpenRouterProvidersWarning(providersSelector);
@@ -474,7 +141,7 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
         const response = await fetch('/api/openrouter/models/providers', {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({ model: modelId }),
+            body: JSON.stringify({ model: modelId, include_service_tiers: true }),
         });
 
         if ($providers.data('openrouterRequest') !== request) return;
@@ -484,8 +151,10 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
             return;
         }
 
-        const providerNames = await response.json();
+        const data = await response.json();
         if ($providers.data('openrouterRequest') !== request) return;
+        const providerNames = Array.isArray(data) ? data : data?.providers;
+        if (Array.isArray(data?.service_tiers)) updateServiceTierOptions(tierSelector, data.service_tiers);
 
         if (!Array.isArray(providerNames) || providerNames.length === 0) {
             $providers.find('option').prop('disabled', false);
@@ -508,6 +177,7 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
 }
 
 let nanoGptProvidersRequest = 0;
+let nanoGptCatalogueRequest = null;
 
 export async function syncNanoGptProvidersForModel(modelId, providersSelector) {
     const requestId = ++nanoGptProvidersRequest;
@@ -520,7 +190,30 @@ export async function syncNanoGptProvidersForModel(modelId, providersSelector) {
     $providers.removeData('supportsProviderSelection').find('option').prop('disabled', false);
     $providers.trigger('change.select2');
     refreshWarningState();
-    if (!modelId) return;
+
+    try {
+        nanoGptCatalogueRequest ??= fetch('/api/nanogpt/providers', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+        }).then(async response => {
+            if (!response.ok) throw new Error(`NanoGPT providers request failed: ${response.status}`);
+            const providers = await response.json();
+            if (!Array.isArray(providers) || !providers.length || !providers.every(provider => typeof provider?.id === 'string' && provider.id.trim() && typeof provider.label === 'string' && provider.label.trim())) {
+                throw new Error('Invalid NanoGPT providers response');
+            }
+            return providers;
+        }).finally(() => {
+            nanoGptCatalogueRequest = null;
+        });
+        const providers = await nanoGptCatalogueRequest;
+        if (requestId !== nanoGptProvidersRequest) return;
+        for (const select of $providers.add('#nanogpt_ignored_providers')) {
+            setProviderOptions(`#${select.id}`, Array.from(select.selectedOptions, option => option.value), providers);
+        }
+    } catch (error) {
+        console.warn('Failed to refresh NanoGPT provider catalogue', error);
+    }
+    if (requestId !== nanoGptProvidersRequest || !modelId) return;
 
     try {
         const response = await fetch('/api/nanogpt/models/providers', {
@@ -554,7 +247,7 @@ export async function syncNanoGptProvidersForModel(modelId, providersSelector) {
             $(this).prop('disabled', !isAvailable);
         });
 
-        $providers.trigger('change.select2');
+        $providers.add('#nanogpt_ignored_providers').trigger('change.select2');
         refreshWarningState();
     } catch (error) {
         console.error('Failed to fetch NanoGPT providers for model', error);
@@ -1474,12 +1167,7 @@ export function initTextGenModels() {
     }
 
     const nanoGptProvidersSelect = $('#nanogpt_allowed_providers, #nanogpt_ignored_providers');
-    for (const provider of NANOGPT_PROVIDERS) {
-        nanoGptProvidersSelect.append($('<option>', {
-            value: provider.id,
-            text: provider.label,
-        }));
-    }
+    void syncNanoGptProvidersForModel('', '#nanogpt_allowed_providers');
 
     if (shouldUseNativeApiSelects()) {
         return;
@@ -1589,7 +1277,7 @@ export function initTextGenModels() {
         closeOnSelect: false,
     });
     // SillyBunny: refresh open results after async updates, surviving shell reinitialisation.
-    $(document).on('change.select2', '.openrouter_providers', function () {
+    $(document).on('change.select2', '.openrouter_providers, #nanogpt_allowed_providers, #nanogpt_ignored_providers', function () {
         const select2 = $(this).data('select2');
         if (select2?.isOpen()) {
             select2.trigger('query', { term: select2.selection.$search.val() || '' });

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -273,6 +273,7 @@ export const textgenerationwebui_settings = {
     ollama_model: '',
     openrouter_model: 'openrouter/auto',
     openrouter_providers: [],
+    openrouter_service_tier: '',
     openrouter_quantizations: [],
     vllm_model: '',
     aphrodite_model: '',
@@ -682,6 +683,7 @@ export async function loadTextGenSettings(data, loadedSettings) {
     $('#textgen_type').val(textgenerationwebui_settings.type);
     // SillyBunny: restore saved providers without waiting for the live catalogue or saving an empty selection.
     setOpenRouterProviders('#openrouter_providers_text', textgenerationwebui_settings.openrouter_providers);
+    $('#openrouter_service_tier_text').val(textgenerationwebui_settings.openrouter_service_tier);
     $('#openrouter_quantizations_text').val(textgenerationwebui_settings.openrouter_quantizations).trigger('change');
     showSamplerControls(textgenerationwebui_settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
@@ -1164,6 +1166,11 @@ export function initTextGenSettings() {
         textgenerationwebui_settings.openrouter_providers = Array.from(this.selectedOptions, option => option.value);
 
         updateOpenRouterProvidersWarning('#openrouter_providers_text');
+        saveSettingsDebounced();
+    });
+
+    $('#openrouter_service_tier_text').on('change', function () {
+        textgenerationwebui_settings.openrouter_service_tier = this.value;
         saveSettingsDebounced();
     });
 
@@ -1845,6 +1852,7 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
 
     if (settings.type === OPENROUTER) {
         params.provider = settings.openrouter_providers;
+        params.service_tier = settings.openrouter_service_tier || undefined;
         params.quantizations = settings.openrouter_quantizations;
         params.allow_fallbacks = settings.openrouter_allow_fallbacks;
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -383,6 +383,7 @@ export const FEATHERLESS_HEADERS = {
 };
 
 export const OPENROUTER_KEYS = [
+    'service_tier', // SillyBunny: retain explicit Flex/Priority routing in Text Completion.
     'max_tokens',
     'temperature',
     'top_k',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -3284,6 +3284,15 @@ export async function handleChatCompletionsGenerate(request, response) {
             return response.status(400).send({ error: true });
         }
 
+        // SillyBunny: service tiers are explicit routing choices on these two aggregators.
+        if ([CHAT_COMPLETION_SOURCES.NANOGPT, CHAT_COMPLETION_SOURCES.OPENROUTER].includes(request.body.chat_completion_source)
+            && request.body.service_tier !== undefined) {
+            if (!['auto', 'default', 'flex', 'priority'].includes(request.body.service_tier)) {
+                return response.status(400).json({ error: true, field: 'service_tier' });
+            }
+            bodyParams.service_tier = request.body.service_tier;
+        }
+
         // A few of OpenAIs reasoning models support reasoning effort
         const shouldUseDefaultOpenAiReasoningEffort = request.body.chat_completion_source !== CHAT_COMPLETION_SOURCES.CUSTOM
             || !hasCustomReasoningParamConfig(request.body);

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -422,6 +422,10 @@ export async function handleTextCompletionsGenerate(request, response) {
         }
 
         if (request.body.api_type === TEXTGEN_TYPES.OPENROUTER) {
+            // SillyBunny: validate before the OpenRouter whitelist and upstream request.
+            if (request.body.service_tier !== undefined && !['auto', 'default', 'flex', 'priority'].includes(request.body.service_tier)) {
+                return response.status(400).json({ error: true, field: 'service_tier' });
+            }
             if (Array.isArray(request.body.provider) && request.body.provider.length > 0) {
                 request.body.provider = {
                     allow_fallbacks: request.body.allow_fallbacks ?? true,

--- a/src/endpoints/nanogpt.js
+++ b/src/endpoints/nanogpt.js
@@ -5,6 +5,29 @@ import { readSecret, SECRET_KEYS } from './secrets.js';
 export const router = express.Router();
 const API_NANOGPT = 'https://nano-gpt.com/api';
 
+router.post('/providers', async (_req, res) => {
+    try {
+        const response = await fetch(`${API_NANOGPT}/models/providers`, {
+            headers: { 'Accept': 'application/json' },
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!response.ok) return res.sendStatus(502);
+
+        /** @type {any} */
+        const data = await response.json();
+        if (!Array.isArray(data?.providers)) return res.sendStatus(502);
+        const providers = new Map(data.providers
+            .filter(provider => typeof provider?.id === 'string' && provider.id.trim() && typeof provider.label === 'string' && provider.label.trim())
+            .map(({ id, label }) => [id, { id, label }]));
+        if (!providers.size) return res.sendStatus(502);
+
+        return res.json([...providers.values()].sort((a, b) => a.label.localeCompare(b.label)));
+    } catch (error) {
+        console.warn('Failed to fetch NanoGPT provider catalogue', error);
+        return res.sendStatus(502);
+    }
+});
+
 /**
  * Parses a numeric API value, returning 0 for missing or invalid values.
  * @param {unknown} value Value to parse.
@@ -118,7 +141,7 @@ router.post('/models/providers', async (req, res) => {
         });
 
         if (!response.ok) {
-            return res.json({ supportsProviderSelection: false, providers: [] });
+            return res.sendStatus(502);
         }
 
         /** @type {any} */

--- a/src/endpoints/openrouter.js
+++ b/src/endpoints/openrouter.js
@@ -33,21 +33,31 @@ router.post('/providers', async (_req, res) => {
 router.post('/models/providers', async (req, res) => {
     try {
         const { model } = req.body;
-        const response = await fetch(`${API_OPENROUTER}/models/${model}/endpoints`, {
+        if (typeof model !== 'string' || !model.trim()) return res.sendStatus(400);
+        const response = await fetch(`${API_OPENROUTER}/models/${model.split('/').map(encodeURIComponent).join('/')}/endpoints`, {
             method: 'GET',
             headers: {
                 'Accept': 'application/json',
             },
+            signal: AbortSignal.timeout(10000),
         });
 
         if (!response.ok) {
-            return res.json([]);
+            return req.body.include_service_tiers ? res.sendStatus(502) : res.json([]);
         }
 
         /** @type {any} */
         const data = await response.json();
-        const endpoints = data?.data?.endpoints || [];
-        const providerNames = endpoints.map(e => e.provider_name);
+        const endpoints = data?.data?.endpoints;
+        if (!Array.isArray(endpoints)) return res.sendStatus(502);
+        const providerNames = [...new Set(endpoints.map(e => e?.provider_name).filter(name => typeof name === 'string' && name.trim()))];
+
+        // SillyBunny: keep the legacy array response for extensions; tier discovery shares this fetch.
+        if (req.body.include_service_tiers === true) {
+            const tiers = endpoints.map(e => typeof e?.tag === 'string' ? e.tag.match(/\/(flex|fast|priority)$/)?.[1] : null)
+                .filter(Boolean).map(tier => tier === 'fast' ? 'priority' : tier);
+            return res.json({ providers: providerNames, service_tiers: [...new Set(tiers)] });
+        }
 
         return res.json(providerNames);
     } catch (error) {

--- a/tests/connection-profile-request-fields.test.js
+++ b/tests/connection-profile-request-fields.test.js
@@ -4,7 +4,12 @@ const mockOpenAiSettings = {};
 const mockProxies = [];
 
 await jest.unstable_mockModule('../public/script.js', () => ({
-    CONNECT_API_MAP: {},
+    CONNECT_API_MAP: {
+        nanogpt: { selected: 'openai', source: 'nanogpt' },
+        openrouter: { selected: 'openai', source: 'openrouter' },
+        'openrouter-text': { selected: 'textgenerationwebui', type: 'openrouter' },
+        openai: { selected: 'openai', source: 'openai' },
+    },
     createModelIcon: jest.fn(),
     getRequestHeaders: jest.fn(() => ({})),
 }));
@@ -59,6 +64,7 @@ await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
 const {
     getChatCompletionProfileRequestOverrides,
     getChatCompletionProfileReverseProxy,
+    getProfileServiceTier,
 } = await import('../public/scripts/extensions/shared.js');
 
 const mappedRequestFieldNames = [
@@ -110,6 +116,18 @@ beforeEach(() => {
         delete mockOpenAiSettings[key];
     }
     mockProxies.splice(0, mockProxies.length);
+});
+
+test('service tiers stay scoped to the profile or its bound preset, including explicit Default', () => {
+    mockOpenAiSettings.nanogpt_service_tier = 'priority';
+    mockPresets.set('tier-preset', { nanogpt_service_tier: 'flex', openrouter_service_tier: 'priority' });
+    expect(getProfileServiceTier({ api: 'nanogpt' })).toBe('');
+    expect(getProfileServiceTier({ api: 'nanogpt', preset: 'tier-preset' })).toBe('flex');
+    expect(getProfileServiceTier({ api: 'openrouter', preset: 'tier-preset' })).toBe('priority');
+    expect(getProfileServiceTier({ api: 'nanogpt', preset: 'tier-preset', 'service-tier': 'default' })).toBe('');
+    expect(getProfileServiceTier({ api: 'openrouter-text', 'service-tier': 'flex' })).toBe('flex');
+    expect(getProfileServiceTier({ api: 'openai', 'service-tier': 'priority' })).toBeUndefined();
+    expect(getProfileServiceTier({ api: 'nanogpt', exclude: ['service-tier'] })).toBeUndefined();
 });
 
 describe('Connection Profile chat-completion request field mapping', () => {
@@ -303,4 +321,3 @@ describe('reasoning settings from the profile preset', () => {
         expect(getChatCompletionProfileRequestOverrides(base, {}).overrides).toEqual({});
     });
 });
-

--- a/tests/nanogpt-controls.e2e.js
+++ b/tests/nanogpt-controls.e2e.js
@@ -8,11 +8,11 @@ test.use({ serviceWorkers: 'block' });
 const BILLING_WARNING = 'Using allowed and/or ignored providers forces PAYG and adds a 5% markup.';
 const HTML_PAYLOAD = '<img data-nanogpt-injected src=x onerror="window.__nanogptInjected=true">';
 const NEW_PROVIDER = 'future-provider-2026';
-const ROUTING_KEYS = ['nanogpt_provider', 'nanogpt_allowed_providers', 'nanogpt_ignored_providers', 'nanogpt_payg_override'];
+const ROUTING_KEYS = ['nanogpt_provider', 'nanogpt_allowed_providers', 'nanogpt_ignored_providers', 'nanogpt_payg_override', 'nanogpt_service_tier'];
 const MODEL_CASES = [
-    { id: 'gpt-4o-mini', name: 'Nano Tiny', subscription: { included: true, inputTokenMultiplier: 1 }, badge: ['Sub'] },
+    { id: 'gpt-4o-mini', name: 'Nano Tiny', subscription: { included: true, inputTokenMultiplier: 1 }, supported_service_tiers: ['flex'], badge: ['Sub'] },
     { id: 'deepseek/deepseek-v3.1', name: 'DeepSeek Friendly', subscription: { included: true, inputTokenMultiplier: 2 }, badge: ['Sub (2x)'] },
-    { id: 'openai/gpt-4.1', name: 'Premium Friendly', subscription: { included: false, note: 'Not included in subscription' }, badge: ['Not in Sub'] },
+    { id: 'openai/gpt-4.1', name: 'Premium Friendly', subscription: { included: false, note: 'Not included in subscription' }, supported_service_tiers: ['flex', 'fast', 'priority'], badge: ['Not in Sub'] },
     { id: 'qwen/qwen3-32b', name: 'No Subscription Metadata', badge: [] },
     { id: 'test/unsafe-fields', name: `Unsafe ${HTML_PAYLOAD}`, context_length: HTML_PAYLOAD, subscription: { included: HTML_PAYLOAD, inputTokenMultiplier: HTML_PAYLOAD, note: HTML_PAYLOAD }, badge: [] },
     { id: 'test/unsafe-multiplier', name: 'Malformed Multiplier', subscription: { included: true, inputTokenMultiplier: HTML_PAYLOAD }, badge: ['Sub'] },
@@ -36,12 +36,14 @@ async function installRoutes(page, baseURL) {
         [MODELS[3].id, { status: 503, json: { error: 'Discovery unavailable' } }],
     ]);
     const held = [];
+    const catalogue = { json: [{ id: 'chutes', label: 'Chutes' }, { id: 'cerebras', label: 'Cerebras' }] };
     await page.context().route('**/*', async route => {
         const url = new URL(route.request().url());
         if (url.origin !== origin) return route.abort();
         if (url.pathname === '/api/backends/chat-completions/status') {
             return route.fulfill({ json: { data: MODELS } });
         }
+        if (url.pathname === '/api/nanogpt/providers') return route.fulfill(catalogue);
         if (url.pathname === '/api/nanogpt/models/providers') {
             const response = discovery.get(route.request().postDataJSON().model);
             if (response === 'hold') {
@@ -61,7 +63,7 @@ async function installRoutes(page, baseURL) {
         }
         return route.continue();
     });
-    return { discovery, held };
+    return { discovery, held, catalogue };
 }
 
 async function openApi(page) {
@@ -216,6 +218,51 @@ for (const mobile of [false, true]) {
             expect(await page.evaluate(() => window.__nanogptInjected)).toBeUndefined();
             await chooseModel(page, mobile, MODELS[1]);
             expect(await page.evaluate(async () => (await import('/scripts/openai.js')).oai_settings.nanogpt_model)).toBe(MODELS[1].id);
+        });
+
+        test('live catalogues and service tiers respect saved choices and PAYG eligibility', async ({ page, baseURL }, testInfo) => {
+            const routes = await setupNanoGpt(page, baseURL);
+            const tier = page.locator('#nanogpt_service_tier');
+            await expect(tier).toBeDisabled();
+            await page.locator('#nanogpt_payg_override').check();
+            await expect(tier.locator('option[value="flex"]')).toBeEnabled();
+            await expect(tier.locator('option[value="priority"]')).toBeDisabled();
+            await tier.selectOption('flex');
+            const getTier = () => page.evaluate(async () => {
+                const { getNanoGptServiceTier, oai_settings } = await import('/scripts/openai.js');
+                return (await getNanoGptServiceTier(oai_settings, oai_settings.nanogpt_model)) ?? null;
+            });
+            expect(await getTier()).toBe('flex');
+            await page.locator('#nanogpt_payg_override').uncheck();
+            expect(await getTier()).toBeNull();
+            await expect(tier.locator('option[value="flex"]')).toBeDisabled();
+            await toggleProvider(page, mobile, 'ignored', 'Cerebras');
+            expect(await getTier()).toBe('flex');
+            await expect(page.locator('#nanogpt_payg_override')).not.toBeChecked();
+
+            routes.catalogue.json = [{ id: 'brand-new', label: 'Live Provider' }];
+            const refresh = () => page.evaluate(async () => {
+                const { syncNanoGptProvidersForModel } = await import('/scripts/textgen-models.js');
+                await syncNanoGptProvidersForModel('', '#nanogpt_allowed_providers');
+            });
+            await refresh();
+            await expect(page.locator('#nanogpt_allowed_providers option[value="brand-new"]')).toHaveText('Live Provider');
+            await expect(page.locator('#nanogpt_ignored_providers option[value="brand-new"]')).toHaveText('Live Provider');
+            await expectRouting(page, [], ['cerebras'], false);
+            routes.catalogue.status = 502;
+            await refresh();
+            await expect(page.locator('#nanogpt_allowed_providers option[value="brand-new"]')).toHaveCount(1);
+            await expectRouting(page, [], ['cerebras'], false);
+            routes.catalogue.status = 200;
+            await toggleProvider(page, mobile, 'ignored', 'Cerebras', true);
+            await chooseModel(page, mobile, MODELS[2]);
+            await expect(tier.locator('option[value="priority"]')).toBeEnabled();
+            await tier.selectOption('priority');
+            expect(await getTier()).toBe('priority');
+            await expect(page.locator('#nanogpt_payg_override')).not.toBeChecked();
+            await tier.scrollIntoViewIfNeeded();
+            expect((await tier.boundingBox()).height).toBeGreaterThanOrEqual(44);
+            await screenshot(page, testInfo, `${layout}-service-tiers`);
         });
 
         test('provider controls preserve restrictions through discovery, reload and removal', async ({ page, baseURL }, testInfo) => {
@@ -426,4 +473,54 @@ test('NanoGPT runtime settings and presets retain defaults, legacy migration and
     });
     await page.locator('dialog[open]').filter({ hasText: 'Preset name already exists. Overwrite?' }).locator('.popup-button-ok').click();
     await expectRouting(page, ['chutes'], [], false);
+});
+
+test('tier payloads preserve preset precedence and isolate background connections', async ({ page, baseURL }) => {
+    await setupNanoGpt(page, baseURL);
+    const requests = [];
+    await page.route('**/api/backends/*/generate', route => {
+        requests.push(route.request().postDataJSON());
+        return route.fulfill({ json: { choices: [{ message: { content: 'ok' }, text: 'ok' }] } });
+    });
+    const tiers = await page.evaluate(async ({ paidModel, subscriptionModel }) => {
+        const { oai_settings } = await import('/scripts/openai.js');
+        const { textgenerationwebui_settings } = await import('/scripts/textgen-settings.js');
+        const { ChatCompletionService, TextCompletionService } = await import('/scripts/custom-request.js');
+        const { ConnectionManagerRequestService } = await import('/scripts/extensions/shared.js');
+        const context = window.SillyTavern.getContext();
+        oai_settings.nanogpt_service_tier = oai_settings.openrouter_service_tier = 'priority';
+        textgenerationwebui_settings.openrouter_service_tier = 'priority';
+        const preset = { chat_completion_source: 'nanogpt', nanogpt_model: paidModel, nanogpt_service_tier: 'flex' };
+        const convert = (preset, overrides = {}) => ChatCompletionService.presetToGeneratePayload(preset, {}, { model: preset.nanogpt_model ?? paidModel, messages: [], ...overrides });
+        const payloads = [
+            await convert({ ...preset, nanogpt_service_tier: undefined }),
+            await convert(preset),
+            await convert(preset, { service_tier: '', __connectionProfileRequestFields: ['service_tier'] }),
+            await convert({ ...preset, nanogpt_model: subscriptionModel }),
+            await convert({ ...preset, nanogpt_model: subscriptionModel }, { nanogpt_ignored_providers: ['cerebras'] }),
+            await convert({ chat_completion_source: 'openrouter', openrouter_model: paidModel, openrouter_service_tier: 'flex' }),
+            await TextCompletionService.presetToGeneratePayload({}, {}, { api_type: 'openrouter', model: paidModel, prompt: 'test' }),
+            await TextCompletionService.presetToGeneratePayload({}, {}, { api_type: 'openrouter', model: paidModel, prompt: 'test', service_tier: 'flex' }),
+        ];
+        for (const source of ['nanogpt', 'openrouter', 'openrouter-text']) {
+            const text = source === 'openrouter-text';
+            const api = Object.entries(context.CONNECT_API_MAP).find(([, entry]) => text
+                ? entry.selected === 'textgenerationwebui' && entry.type === 'openrouter'
+                : entry.selected === 'openai' && entry.source === source)?.[0];
+            const profile = { id: 'tier-test', api, model: paidModel, 'api-url': 'https://openrouter.ai/api' };
+            context.extensionSettings.connectionManager.profiles.push(profile);
+            for (const tier of [undefined, 'flex', 'default']) {
+                profile['service-tier'] = tier;
+                await ConnectionManagerRequestService.sendRequest(profile.id, 'test', 1, { includePreset: false, includeInstruct: false });
+            }
+            context.extensionSettings.connectionManager.profiles.pop();
+        }
+        const legacyRequest = { chat_completion_source: 'nanogpt', model: subscriptionModel, messages: [], service_tier: 'flex', nanogpt_provider: 'cerebras' };
+        await ChatCompletionService.sendRequest(legacyRequest);
+        await ChatCompletionService.sendRequest({ ...legacyRequest, nanogpt_allowed_providers: [], nanogpt_ignored_providers: [] });
+        return payloads.map(payload => payload.service_tier ?? null);
+    }, { paidModel: MODELS[2].id, subscriptionModel: MODELS[0].id });
+    expect(tiers).toEqual([null, 'flex', null, null, 'flex', 'flex', null, 'flex']);
+    expect(requests.map(request => request.service_tier ?? null)).toEqual([null, 'flex', null, null, 'flex', null, null, 'flex', null, 'flex', null]);
+    expect(requests.every(request => !Object.hasOwn(request, '__connectionProfileRequestFields'))).toBe(true);
 });

--- a/tests/nanogpt-reasoning-effort.test.js
+++ b/tests/nanogpt-reasoning-effort.test.js
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
 import { setConfigFilePath } from '../src/util.js';
 
-const actualNodeFetch = (await import('node-fetch')).default;
+const { default: actualNodeFetch, Response: FetchResponse } = await import('node-fetch');
 const nodeFetchMock = jest.fn((url, options) => actualNodeFetch(url, options));
 await jest.unstable_mockModule('node-fetch', () => ({
     default: nodeFetchMock,
@@ -31,6 +31,7 @@ describe('outgoing chat completions', () => {
         setConfigFilePath(configPath);
 
         const { router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js');
+        const { router: textCompletionsRouter } = await import('../src/endpoints/backends/text-completions.js');
         const { SecretManager, SECRET_KEYS } = await import('../src/endpoints/secrets.js');
         const userRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-effort-user-'));
         tempDirs.push(userRoot);
@@ -48,6 +49,7 @@ describe('outgoing chat completions', () => {
             next();
         });
         app.use('/api/backends/chat-completions', chatCompletionsRouter);
+        app.use('/api/backends/text-completions', textCompletionsRouter);
 
         await new Promise((resolve) => {
             appServer = app.listen(0, '127.0.0.1', resolve);
@@ -85,7 +87,7 @@ describe('outgoing chat completions', () => {
     });
 
     function makeRequest(source, overrides = {}) {
-        return fetch(`${baseUrl}/api/backends/chat-completions/generate`, {
+        return fetch(`${baseUrl}/api/backends/${source === 'openrouter-text' ? 'text' : 'chat'}-completions/generate`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -94,10 +96,58 @@ describe('outgoing chat completions', () => {
                 stream: false,
                 max_tokens: 128,
                 messages: [{ role: 'user', content: 'Question' }],
+                ...(source === 'openrouter-text' ? { api_type: 'openrouter', api_server: 'https://openrouter.ai/api', prompt: 'Question' } : {}),
                 ...overrides,
             }),
         });
     }
+
+    describe.each([CHAT_COMPLETION_SOURCES.NANOGPT, CHAT_COMPLETION_SOURCES.OPENROUTER, 'openrouter-text'])('%s service tiers', source => {
+        test.each(['flex', 'priority', 'auto', 'default'])('forwards %s without altering provider or billing choices', async tier => {
+            const response = await makeRequest(source, {
+                service_tier: tier,
+                provider: ['OpenAI'], allow_fallbacks: false, quantizations: ['bf16'],
+                nanogpt_allowed_providers: ['unlisted-provider'], nanogpt_payg_override: false,
+            });
+            expect(response.status).toBe(200);
+            expect(capturedBody.service_tier).toBe(tier);
+            expect(capturedBody.provider).toEqual(source === CHAT_COMPLETION_SOURCES.NANOGPT
+                ? { only: ['unlisted-provider'] }
+                : { order: ['OpenAI'], allow_fallbacks: false, quantizations: ['bf16'] });
+            expect(capturedBody.billing_mode).toBeUndefined();
+            expect(capturedHeaders['X-Billing-Mode']).toBeUndefined();
+            expect(nodeFetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        test('omits the tier by default', async () => {
+            expect((await makeRequest(source)).status).toBe(200);
+            expect(capturedBody).not.toHaveProperty('service_tier');
+        });
+
+        test.each(['', 'fast', 'unsupported', null, [], {}, true, 1])('rejects malformed tier %p before forwarding', async tier => {
+            expect((await makeRequest(source, { service_tier: tier })).status).toBe(400);
+            expect(nodeFetchMock).not.toHaveBeenCalled();
+        });
+
+        test('keeps the tier on streamed requests', async () => {
+            nodeFetchMock.mockImplementationOnce(async (_url, options) => {
+                capturedBody = JSON.parse(options.body);
+                return new FetchResponse('data: [DONE]\n\n', { headers: { 'Content-Type': 'text/event-stream' } });
+            });
+            const response = await makeRequest(source, { service_tier: 'flex', stream: true });
+            expect(response.status).toBe(200);
+            expect(await response.text()).toContain('[DONE]');
+            expect(capturedBody.service_tier).toBe('flex');
+        });
+
+        test('does not retry an upstream tier rejection', async () => {
+            nodeFetchMock.mockResolvedValueOnce(new FetchResponse('{"error":{"message":"tier unavailable"}}', { status: 400 }));
+            const response = await makeRequest(source, { service_tier: 'flex' });
+            await response.text();
+            expect(nodeFetchMock).toHaveBeenCalledTimes(1);
+            expect(JSON.parse(nodeFetchMock.mock.calls[0][1].body).service_tier).toBe('flex');
+        });
+    });
 
     test.each([
         {},

--- a/tests/openrouter-providers.e2e.js
+++ b/tests/openrouter-providers.e2e.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const models = readFileSync(new URL('../public/scripts/textgen-models.js', import.meta.url), 'utf8');
 const openai = readFileSync(new URL('../public/scripts/openai.js', import.meta.url), 'utf8');
+const tierCode = readFileSync(new URL('../public/scripts/service-tiers.js', import.meta.url), 'utf8').replaceAll('export ', '');
 const providerCode = models.slice(models.indexOf('const OPENROUTER_PROVIDER_WARNING_SELECTORS'), models.indexOf('let nanoGptProvidersRequest')).replaceAll('export ', '');
 const pickerCode = openai.slice(openai.indexOf('function getInlineSelectPickerEntries('), openai.indexOf('function bindInlineSelectPickerControl('));
 const desktopCode = models.slice(models.indexOf('    providersSelect.select2({'), models.indexOf('    nanoGptProvidersSelect.select2({'));
@@ -12,7 +13,8 @@ const desktopCode = models.slice(models.indexOf('    providersSelect.select2({')
 for (const mobile of [false, true]) {
     test(`live provider catalogue preserves choices and ignores stale responses (${mobile ? 'mobile' : 'desktop'})`, async ({ page }) => {
         await page.setViewportSize({ width: mobile ? 390 : 1440, height: 900 });
-        await page.setContent(['text', 'chat'].map(mode => `<div><select multiple class="openrouter_providers" id="openrouter_providers_${mode}"></select></div>`).join(''));
+        await page.setContent(['text', 'chat'].map(mode => `<div><select multiple class="openrouter_providers" id="openrouter_providers_${mode}"></select>
+            <select id="openrouter_service_tier_${mode}"><option value="">Default</option><option value="flex">Flex</option><option value="priority">Priority</option></select></div>`).join(''));
         await page.addScriptTag({ path: fileURLToPath(new URL('../public/lib/jquery-3.5.1.min.js', import.meta.url)) });
         await page.addScriptTag({ path: fileURLToPath(new URL('../public/lib/select2.min.js', import.meta.url)) });
         await page.addScriptTag({ content: `
@@ -25,6 +27,7 @@ for (const mobile of [false, true]) {
             const scrollElementIntoNearestPanelScroller = () => {};
             window.pending = [];
             window.fetch = (url, options) => new Promise(resolve => pending.push({ url, options, resolve }));
+            ${tierCode}
             ${providerCode}
             ${pickerCode}
             const providersSelect = $('.openrouter_providers');
@@ -58,11 +61,13 @@ for (const mobile of [false, true]) {
         });
         await expect.poll(() => page.evaluate(() => window.pending.length)).toBe(2);
         await page.evaluate(async () => {
-            for (const request of window.pending.splice(0)) request.resolve({ ok: true, json: async () => ['Alpha', 'Zeta'] });
+            for (const request of window.pending.splice(0)) request.resolve({ ok: true, json: async () => ({ providers: ['Alpha', 'Zeta'], service_tiers: ['flex', 'priority'] }) });
             await window.loading;
         });
         for (const mode of ['text', 'chat']) {
             await expect(page.locator(`#openrouter_providers_${mode} option`)).toHaveCount(4);
+            await expect(page.locator(`#openrouter_service_tier_${mode}`)).toBeEnabled();
+            await page.locator(`#openrouter_service_tier_${mode}`).selectOption('flex');
         }
         expect(await page.evaluate(() => Array.from(document.querySelector('#openrouter_providers_chat').selectedOptions, option => option.value))).toEqual(['Missing', 'Zeta']);
         await expect(page.locator('img')).toHaveCount(0);
@@ -91,13 +96,16 @@ for (const mobile of [false, true]) {
         });
         await expect.poll(() => page.evaluate(() => window.pending.length)).toBe(2);
         await page.evaluate(async () => {
-            window.pending.pop().resolve({ ok: true, json: async () => ['Alpha'] });
+            window.pending.pop().resolve({ ok: true, json: async () => ({ providers: ['Alpha'], service_tiers: ['priority'] }) });
             await window.newer;
-            window.pending.pop().resolve({ ok: true, json: async () => ['Zeta'] });
+            window.pending.pop().resolve({ ok: true, json: async () => ({ providers: ['Zeta'], service_tiers: ['flex'] }) });
             await window.old;
         });
         await expect(page.locator('#openrouter_providers_chat option')).toHaveCount(4);
         expect(await page.locator('#openrouter_providers_chat option:enabled').allTextContents()).toEqual(['Alpha']);
         expect(await page.evaluate(() => window.changes)).toBe(changes);
+        await expect(page.locator('#openrouter_service_tier_chat')).toHaveValue('flex');
+        await expect(page.locator('#openrouter_service_tier_chat option[value="flex"]')).toBeDisabled();
+        await expect(page.locator('#openrouter_service_tier_chat option[value="priority"]')).toBeEnabled();
     });
 }

--- a/tests/openrouter-providers.test.js
+++ b/tests/openrouter-providers.test.js
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { readFileSync } from 'node:fs';
 import { runInNewContext } from 'node:vm';
 
-const source = readFileSync(new URL('../src/endpoints/openrouter.js', import.meta.url), 'utf8');
-const routeSource = source.slice(source.indexOf('const API_OPENROUTER ='), source.indexOf('router.post(\'/models/providers\''));
-
-describe('OpenRouter POST /providers', () => {
+describe.each(['openrouter', 'nanogpt'])('%s POST /providers', (provider) => {
+    const nano = provider === 'nanogpt';
+    const source = readFileSync(new URL(`../src/endpoints/${provider}.js`, import.meta.url), 'utf8');
+    const routeSource = source.slice(source.indexOf(`const API_${provider.toUpperCase()} =`), source.indexOf(`router.post('${nano ? '/credits' : '/models/providers'}'`));
     let fetch;
     let handler;
     let res;
@@ -26,12 +26,18 @@ describe('OpenRouter POST /providers', () => {
     test('uses the fixed public URL without auth and returns sorted, deduplicated valid names', async () => {
         fetch.mockResolvedValue({
             ok: true,
-            json: async () => ({
+            json: async () => nano ? {
+                providers: [
+                    { id: 'z', label: 'Zeta', secret: 'strip-me' }, { id: 'a', label: 'Alpha' },
+                    { id: 'z', label: 'Zeta' }, { id: 'b', label: 'Beta' }, null, {},
+                    { id: 42, label: 'No' }, { id: 'no-label' }, { id: ' ', label: 'No' },
+                ],
+            } : {
                 data: [
                     { name: 'Zeta' }, { name: 'Alpha' }, { name: 'Zeta' }, { name: 'Beta' },
                     null, {}, { name: 42 }, { name: '' }, { name: '   ' },
                 ],
-            }),
+            },
         });
 
         await handler({
@@ -41,13 +47,13 @@ describe('OpenRouter POST /providers', () => {
 
         expect(fetch).toHaveBeenCalledTimes(1);
         const [url, options] = fetch.mock.calls[0];
-        expect(url).toBe('https://openrouter.ai/api/v1/providers');
+        expect(url).toBe(nano ? 'https://nano-gpt.com/api/models/providers' : 'https://openrouter.ai/api/v1/providers');
         expect(options.headers).toEqual({ Accept: 'application/json' });
         expect(options.method ?? 'GET').toBe('GET');
         expect(options.body).toBeUndefined();
         expect(options.signal).toBeInstanceOf(AbortSignal);
         expect(res.json).toHaveBeenCalledTimes(1);
-        expect(res.json).toHaveBeenCalledWith(['Alpha', 'Beta', 'Zeta']);
+        expect(res.json).toHaveBeenCalledWith(nano ? [{ id: 'a', label: 'Alpha' }, { id: 'b', label: 'Beta' }, { id: 'z', label: 'Zeta' }] : ['Alpha', 'Beta', 'Zeta']);
         expect(res.sendStatus).not.toHaveBeenCalled();
     });
 
@@ -78,4 +84,28 @@ describe('OpenRouter POST /providers', () => {
         expect(res.sendStatus).toHaveBeenCalledWith(502);
         expect(res.json).not.toHaveBeenCalled();
     });
+});
+
+test('OpenRouter endpoint discovery exposes documented tiers and preserves its legacy response', async () => {
+    const source = readFileSync(new URL('../src/endpoints/openrouter.js', import.meta.url), 'utf8');
+    const code = source.slice(source.indexOf("router.post('/models/providers'"), source.indexOf("router.post('/models/multimodal'"));
+    const post = jest.fn();
+    const fetch = jest.fn(async () => ({ ok: true, json: async () => ({ data: { endpoints: [
+        { provider_name: 'OpenAI', tag: 'openai/flex' },
+        { provider_name: 'OpenAI', tag: 'openai/fast' },
+        { provider_name: 'Azure', tag: 'azure/priority' },
+        { provider_name: 'Other', tag: 'other-fast' },
+        null,
+    ] } }) }));
+    runInNewContext(code, { router: { post }, fetch, API_OPENROUTER: 'https://openrouter.ai/api/v1', AbortSignal, console });
+    const handler = post.mock.calls[0][1];
+    const res = { json: jest.fn(), sendStatus: jest.fn() };
+    await handler({ body: { model: 'author/model?query#fragment', include_service_tiers: true } }, res);
+    expect(fetch.mock.calls[0][0]).toBe('https://openrouter.ai/api/v1/models/author/model%3Fquery%23fragment/endpoints');
+    expect(res.json).toHaveBeenLastCalledWith({ providers: ['OpenAI', 'Azure', 'Other'], service_tiers: ['flex', 'priority'] });
+    await handler({ body: { model: 'author/model' } }, res);
+    expect(res.json).toHaveBeenLastCalledWith(['OpenAI', 'Azure', 'Other']);
+    fetch.mockResolvedValueOnce({ ok: false });
+    await handler({ body: { model: 'author/model', include_service_tiers: true } }, res);
+    expect(res.sendStatus).toHaveBeenLastCalledWith(502);
 });


### PR DESCRIPTION
As the title says. Same with OpenRouter, providers will no longer be hardcoded since Nano changes providers constantly.
And models such as the new GPTs and Gemini Flashes have flex and priority endpoints which give either a discount or uses more credits, which applies to both NanoGPT and OpenRouter. Added.